### PR TITLE
Update reset password page design

### DIFF
--- a/src/client/main.tsx
+++ b/src/client/main.tsx
@@ -21,10 +21,12 @@ const p = css`
 `;
 
 const main = css`
-  flex-grow: 1;
-  width: 100%;
+  flex: 1;
   max-width: ${MaxWidth.TABLET}px;
   margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  align-items: left;
 `;
 
 export const Main = (props: GlobalState) => {

--- a/src/client/models/Style.ts
+++ b/src/client/models/Style.ts
@@ -4,3 +4,7 @@ export enum MaxWidth {
   TABLET = 740,
   MOBILE = 660,
 }
+
+export enum MinWidth {
+  MOBILE = 320,
+}

--- a/src/client/pages/ResetPasswordPage.tsx
+++ b/src/client/pages/ResetPasswordPage.tsx
@@ -3,38 +3,21 @@ import { TextInput } from '@guardian/src-text-input';
 import { Button, buttonReaderRevenue } from '@guardian/src-button';
 import { SvgArrowRightStraight } from '@guardian/src-svgs';
 import { css } from '@emotion/core';
-import { space, brandAlt, neutral } from '@guardian/src-foundations';
-import { textSans } from '@guardian/src-foundations/typography';
+import { space } from '@guardian/src-foundations';
 import { ThemeProvider } from 'emotion-theming';
-import { from } from '@guardian/src-foundations/mq';
 import { GlobalState } from '@/shared/model/GlobalState';
 import { GlobalStateContext } from '@/client/components/GlobalState';
 import { Routes } from '@/shared/model/Routes';
-
-const border = `2px solid ${neutral[86]}`;
+import {
+  resetPasswordBox,
+  header,
+  main,
+  pHeader,
+  pMain,
+} from '@/client/styles/Reset';
 
 const textInput = css`
   margin-bottom: ${space[3]}px;
-`;
-
-const header = css`
-  background-color: ${brandAlt[400]};
-  padding: ${space[2]}px ${space[3]}px;
-  border: 2px solid transparent;
-
-  ${from.tablet} {
-    margin-top: ${space[12]}px;
-  }
-`;
-
-const main = css`
-  padding: ${space[3]}px ${space[3]}px;
-  border: ${border};
-`;
-
-const p = css`
-  margin: 0;
-  ${textSans.medium({ fontWeight: 'bold', lineHeight: 'regular' })}
 `;
 
 const form = css`
@@ -46,12 +29,12 @@ export const ResetPasswordPage = () => {
   const { email = '' } = globalState;
 
   return (
-    <>
+    <div css={resetPasswordBox}>
       <div css={header}>
-        <p css={p}>Forgotten or need to set your password?</p>
+        <p css={pHeader}>Forgotten or need to set your password?</p>
       </div>
       <div css={main}>
-        <p css={p}>We will email you a link to reset it.</p>
+        <p css={pMain}>We will email you a link to reset it.</p>
         <form css={form} method="post" action={Routes.RESET}>
           <TextInput
             css={textInput}
@@ -71,6 +54,6 @@ export const ResetPasswordPage = () => {
           </ThemeProvider>
         </form>
       </div>
-    </>
+    </div>
   );
 };

--- a/src/client/pages/ResetSentPage.tsx
+++ b/src/client/pages/ResetSentPage.tsx
@@ -1,39 +1,15 @@
 import React, { useContext } from 'react';
-import { css } from '@emotion/core';
-import { space, brandAlt, neutral } from '@guardian/src-foundations';
-import { textSans } from '@guardian/src-foundations/typography';
-import { from } from '@guardian/src-foundations/mq';
 import { getProviderById } from '@/shared/lib/emailProvider';
 import { LinkButton } from '@guardian/src-button';
 import { GlobalState } from '@/shared/model/GlobalState';
 import { GlobalStateContext } from '@/client/components/GlobalState';
-
-const border = `2px solid ${neutral[86]}`;
-
-const header = css`
-  background-color: ${brandAlt[400]};
-  padding: ${space[2]}px ${space[3]}px;
-  border: 2px solid transparent;
-
-  ${from.tablet} {
-    margin-top: ${space[12]}px;
-  }
-`;
-
-const main = css`
-  padding: ${space[3]}px ${space[3]}px;
-  border: ${border};
-`;
-
-const p = css`
-  margin-top: 0;
-  ${textSans.medium({ lineHeight: 'regular' })}
-`;
-
-const headerP = css`
-  margin: 0;
-  ${textSans.medium({ fontWeight: 'bold', lineHeight: 'regular' })}
-`;
+import {
+  resetPasswordBox,
+  header,
+  main,
+  pHeader,
+  pMain,
+} from '@/client/styles/Reset';
 
 export const ResetSentPage = () => {
   const globalState: GlobalState = useContext(GlobalStateContext);
@@ -41,17 +17,17 @@ export const ResetSentPage = () => {
   const emailProvider = getProviderById(emailProviderId);
 
   return (
-    <>
+    <div css={resetPasswordBox}>
       <div css={header}>
-        <p css={headerP}>Please check your inbox</p>
+        <p css={pHeader}>Please check your inbox</p>
       </div>
       <div css={main}>
-        <p css={p}>
+        <p css={pMain}>
           We’ve sent you an email – please open it up and click on the button.
           This is so we can verify it’s you and help you create a password to
           complete your Guardian account.
         </p>
-        <p css={p}>
+        <p css={pMain}>
           Note that the link is only valid for 30 minutes, so be sure to open it
           soon! Thank you.
         </p>
@@ -65,6 +41,6 @@ export const ResetSentPage = () => {
           </LinkButton>
         )}
       </div>
-    </>
+    </div>
   );
 };

--- a/src/client/styles/Reset.ts
+++ b/src/client/styles/Reset.ts
@@ -1,0 +1,40 @@
+import { neutral } from '@guardian/src-foundations';
+import { css } from '@emotion/core';
+import { MinWidth } from '@/client/models/Style';
+import { space, brandAlt } from '@guardian/src-foundations';
+import { textSans } from '@guardian/src-foundations/typography';
+
+export const resetPasswordBorder = `2px solid ${neutral[86]}`;
+
+export const resetPasswordBox = css`
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  max-width: ${MinWidth.MOBILE}px;
+`;
+
+export const header = css`
+  background-color: ${brandAlt[400]};
+  padding: ${space[2]}px ${space[3]}px;
+  border: 2px solid transparent;
+  width: 100%;
+`;
+
+export const main = css`
+  padding: ${space[3]}px ${space[3]}px;
+  border: ${resetPasswordBorder};
+  width: 100%;
+`;
+
+export const pHeader = css`
+  margin: 0;
+  ${textSans.medium({ fontWeight: 'bold', lineHeight: 'regular' })}
+`;
+
+export const pMain = css`
+  margin: 0;
+  ${textSans.medium({ lineHeight: 'regular' })}
+`;


### PR DESCRIPTION
Updating the styling of the reset password, and reset password email sent pages based on design feedback.

## Screenshots:
Mobile 320px:
![localhost_8861_reset(iPhone 5_SE)](https://user-images.githubusercontent.com/13315440/82914524-8a5cb200-9f67-11ea-8316-51a72fd69455.png)

Mobile 375px:
![localhost_8861_reset(iPhone 6_7_8) (1)](https://user-images.githubusercontent.com/13315440/82914895-f7704780-9f67-11ea-850c-2e46f24d8d29.png)

Desktop 1440x900:
![localhost_8861_reset](https://user-images.githubusercontent.com/13315440/82914783-d7408880-9f67-11ea-8402-4b578f503a48.png)

Desktop 1920x1080:
![localhost_8861_reset (1)](https://user-images.githubusercontent.com/13315440/82914820-e32c4a80-9f67-11ea-92a8-3e589e38619a.png)

404 page remains the same:
![localhost_8861_fsafasf(iPhone 6_7_8)](https://user-images.githubusercontent.com/13315440/82914977-11aa2580-9f68-11ea-82c0-950d4818a780.png)
