### PR TITLE
Add page titles onto rendered/served pages

### DIFF
--- a/src/server/routes/changePassword.ts
+++ b/src/server/routes/changePassword.ts
@@ -13,6 +13,7 @@ import { ResponseWithLocals } from '@/server/models/Express';
 import { trackMetric } from '@/server/lib/AWS';
 import { Metrics } from '@/server/models/Metrics';
 import { removeNoCache } from '@/server/lib/middleware/cache';
+import { PageTitle } from '@/shared/model/PageTitle';
 
 const { baseUri } = getConfiguration();
 
@@ -78,6 +79,7 @@ router.get(
         renderer(Routes.RESET_RESEND, {
           globalState: state,
           queryParams: res.locals.queryParams,
+          pageTitle: PageTitle.RESET_RESEND,
         }),
       );
     }
@@ -85,6 +87,7 @@ router.get(
     const html = renderer(`${Routes.CHANGE_PASSWORD}/${token}`, {
       globalState: state,
       queryParams: res.locals.queryParams,
+      pageTitle: PageTitle.CHANGE_PASSWORD,
     });
     return res.type('html').send(html);
   },
@@ -110,6 +113,7 @@ router.post(
         const html = renderer(`${Routes.CHANGE_PASSWORD}/${token}`, {
           globalState: state,
           queryParams: res.locals.queryParams,
+          pageTitle: PageTitle.CHANGE_PASSWORD,
         });
         return res.type('html').send(html);
       }
@@ -153,6 +157,7 @@ router.post(
       const html = renderer(`${Routes.CHANGE_PASSWORD}/${token}`, {
         globalState: state,
         queryParams: res.locals.queryParams,
+        pageTitle: PageTitle.CHANGE_PASSWORD,
       });
       return res.type('html').send(html);
     }
@@ -162,6 +167,7 @@ router.post(
     const html = renderer(Routes.CHANGE_PASSWORD_COMPLETE, {
       globalState: state,
       queryParams: res.locals.queryParams,
+      pageTitle: PageTitle.CHANGE_PASSWORD_COMPLETE,
     });
 
     return res.type('html').send(html);
@@ -173,6 +179,7 @@ router.get(
   (_: Request, res: ResponseWithLocals) => {
     const html = renderer(Routes.CHANGE_PASSWORD_COMPLETE, {
       queryParams: res.locals.queryParams,
+      pageTitle: PageTitle.CHANGE_PASSWORD_COMPLETE,
     });
     return res.type('html').send(html);
   },

--- a/src/server/routes/reset.ts
+++ b/src/server/routes/reset.ts
@@ -10,6 +10,7 @@ import { ResponseWithLocals } from '@/server/models/Express';
 import { trackMetric } from '@/server/lib/AWS';
 import { Metrics } from '@/server/models/Metrics';
 import { removeNoCache } from '@/server/lib/middleware/cache';
+import { PageTitle } from '@/shared/model/PageTitle';
 
 const router = Router();
 
@@ -24,6 +25,7 @@ router.get(Routes.RESET, (req: Request, res: ResponseWithLocals) => {
   const html = renderer(Routes.RESET, {
     globalState: state,
     queryParams: res.locals.queryParams,
+    pageTitle: PageTitle.RESET,
   });
   res.type('html').send(html);
 });
@@ -47,6 +49,7 @@ router.post(Routes.RESET, async (req: Request, res: ResponseWithLocals) => {
     const html = renderer(Routes.RESET, {
       globalState: state,
       queryParams: res.locals.queryParams,
+      pageTitle: PageTitle.RESET,
     });
     return res.type('html').send(html);
   }
@@ -61,6 +64,7 @@ router.post(Routes.RESET, async (req: Request, res: ResponseWithLocals) => {
   const html = renderer(Routes.RESET_SENT, {
     globalState: state,
     queryParams: res.locals.queryParams,
+    pageTitle: PageTitle.RESET_SENT,
   });
   return res.type('html').send(html);
 });
@@ -69,7 +73,9 @@ router.get(
   Routes.RESET_SENT,
   removeNoCache,
   (_: Request, res: ResponseWithLocals) => {
-    const html = renderer(Routes.RESET_SENT);
+    const html = renderer(Routes.RESET_SENT, {
+      pageTitle: PageTitle.RESET_SENT,
+    });
     res.type('html').send(html);
   },
 );

--- a/src/shared/model/PageTitle.ts
+++ b/src/shared/model/PageTitle.ts
@@ -1,0 +1,7 @@
+export enum PageTitle {
+  RESET = 'Reset Password',
+  RESET_SENT = 'Check Your Inbox',
+  RESET_RESEND = 'Resend Reset Password',
+  CHANGE_PASSWORD = 'Change Password',
+  CHANGE_PASSWORD_COMPLETE = 'Password Changed',
+}


### PR DESCRIPTION
## What does this change?
This PR adds the page title text for all the rendered routes. Before the title just used to be "Gateway | The Guardian", but now the title is related to the page, e.g. `/reset` will be "Reset Password | The Guardian".

The ability to set the page title was already added to the render method in #17 
