### PR TITLE
CMP Cookie Consent Banner integration tests

### DIFF
--- a/cypress/integration/change_password.spec.js
+++ b/cypress/integration/change_password.spec.js
@@ -11,6 +11,10 @@ describe('Password change flow', () => {
     cy.idapiMockPurge();
   });
 
+  beforeEach(() => {
+    cy.consentBannerChoiceMade();
+  });
+
   context('An expired/invalid token is used', () => {
     it('shows a resend password page', () => {
       cy.idapiMock(500, {

--- a/cypress/integration/cmp_banner.spec.js
+++ b/cypress/integration/cmp_banner.spec.js
@@ -4,16 +4,38 @@ const PageResetPassword = require('../support/pages/reset_password_page');
 
 describe('Consents banner integration', () => {
   const page = new PageResetPassword();
+  const BANNER_HEADING = 'Your privacy';
+  const ACCEPT_BUTTON_TEXT = `I'm OK with that`;
+  const OPTIONS_BUTTON_TEXT = 'Options';
+  const OPTIONS_HEADING = 'Your privacy options';
+  const OPTIONS_ACCEPT_BUTTON = 'Save and close';
 
   beforeEach(() => {
     page.goto();
   });
 
-  it('shows the banner, which if accepted, is dismissed and does not appear again.', () => {
-    const BANNER_HEADING = 'Your privacy';
-    const BUTTON_TEXT = `I'm OK with that`;
+  it('always shows the banner, until if accepted, is dismissed and does not appear again.', () => {
     cy.contains(BANNER_HEADING);
-    cy.contains(BUTTON_TEXT).click();
+    cy.reload();
+    cy.contains(BANNER_HEADING);
+    cy.contains(ACCEPT_BUTTON_TEXT).click();
+    cy.contains(BANNER_HEADING).should('not.exist');
+    cy.reload();
+    cy.contains(BANNER_HEADING).should('not.exist');
+  });
+
+  it('always shows the banner, until options are selected, is dismissed and does not appear again', () => {
+    cy.contains(BANNER_HEADING);
+    cy.reload();
+    cy.contains(BANNER_HEADING);
+    cy.contains(OPTIONS_BUTTON_TEXT).click();
+    cy.contains(OPTIONS_HEADING);
+    cy.get('input[type="radio"][value="on"]')
+      .each((el) => {
+        cy.wrap(el).click();
+      })
+      .end();
+    cy.contains(OPTIONS_ACCEPT_BUTTON).click();
     cy.contains(BANNER_HEADING).should('not.exist');
     cy.reload();
     cy.contains(BANNER_HEADING).should('not.exist');

--- a/cypress/integration/cmp_banner.spec.js
+++ b/cypress/integration/cmp_banner.spec.js
@@ -1,0 +1,21 @@
+/// <reference types='cypress' />
+
+const PageResetPassword = require('../support/pages/reset_password_page');
+
+describe('Consents banner integration', () => {
+  const page = new PageResetPassword();
+
+  beforeEach(() => {
+    page.goto();
+  });
+
+  it('shows the banner, which if accepted, is dismissed and does not appear again.', () => {
+    const BANNER_HEADING = 'Your privacy';
+    const BUTTON_TEXT = `I'm OK with that`;
+    cy.contains(BANNER_HEADING);
+    cy.contains(BUTTON_TEXT).click();
+    cy.contains(BANNER_HEADING).should('not.exist');
+    cy.reload();
+    cy.contains(BANNER_HEADING).should('not.exist');
+  });
+});

--- a/cypress/integration/reset_password.spec.js
+++ b/cypress/integration/reset_password.spec.js
@@ -12,6 +12,7 @@ describe('Password reset flow', () => {
   });
 
   beforeEach(function () {
+    cy.consentBannerChoiceMade();
     page.goto();
   });
 

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -23,3 +23,7 @@ Cypress.Commands.add('idapiMock', (status, body) => {
 Cypress.Commands.add('idapiMockPurge', () => {
   cy.request(MOCKING_ENDPOINT + '/purge');
 });
+
+Cypress.Commands.add('consentBannerChoiceMade', () => {
+  cy.setCookie('euconsent', 'consents-management-platform-cookie');
+});

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -7,17 +7,16 @@
 const MOCKING_ENDPOINT = 'localhost:9000/mock';
 
 Cypress.Commands.add('idapiMock', (status, body) => {
-
   const getMockOptions = (status, body = {}) => ({
     headers: {
       'Content-Type': 'application/json',
-      "x-status": status,
+      'x-status': status,
     },
     method: 'POST',
     body: JSON.stringify(body),
-    url: MOCKING_ENDPOINT, 
+    url: MOCKING_ENDPOINT,
   });
-  
+
   cy.request(getMockOptions(status, body));
 });
 

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -15,8 +15,3 @@
 
 // Import commands.js using ES2015 syntax:
 import './commands';
-
-// disable the consents management platform from appearing using this cookie
-beforeEach(() => {
-  cy.setCookie('euconsent', 'consents-management-platform-cookie');
-});


### PR DESCRIPTION
## Description
Integration tests that the cookie consent banner is correctly functioning within Gateway

## Changes
* Adds cypress command `consentBannerChoiceMade` that puts the test into a state where the banner has had a choice made on it (and shouldn't appear).
* Adds tests for making sure the banner appears and stays hidden once preferences selected.