### PR TITLE
Add alarm names.

### DIFF
--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -334,6 +334,7 @@ Resources:
   HighLatencyAlarm:
     Type: AWS::CloudWatch::Alarm
     Properties:
+      AlarmName: !Sub '${App}-${Stage} high load balancer latency'
       AlarmDescription: !Sub
         - 'Scale-Up if latency is greater than ${Threshold} seconds over last ${Period} seconds'
         - Period: !FindInMap [StageVariables, !Ref 'Stage', LatencyAlarmPeriod]
@@ -373,6 +374,7 @@ Resources:
     Condition: IsProd
     Properties:
       ActionsEnabled: 'true'
+      AlarmName: !Sub '${App}-${Stage} insufficient healthy hosts'
       AlarmDescription: There are insufficient healthy hosts
       ComparisonOperator: LessThanThreshold
       EvaluationPeriods: 1
@@ -400,6 +402,7 @@ Resources:
     Condition: IsProd
     Properties:
       ActionsEnabled: 'true'
+      AlarmName: !Sub '${App}-${Stage} high 5xx errors'
       AlarmDescription: 'Server errors detected'
       AlarmActions:
         - !Ref 'TopicSendEmail'


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
As the first step of our alerting review, we are making sure that when alarms arrive in our inboxes that 
- the description for the alarm
- the codebase the alarm belongs to
appear in the email

We've been doing this by making sure that the AlarmName and AlarmDescription are up to date, and by sending alerts via the existing SNS topic rather than pagerduty.

Gateway's alarms were added recently and never sent alerts via pagerduty, so there's not much to do here! But we might as well make the alarm names match conventions introduced elsewhere (include stage and app name and then a human readable name for the alarm) 

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
#### pre-merge

- [x] When I deploy to CODE, then the alarm name for the high latency alarm in CODE should be updated

#### post-merge

- [ ] The other alarm names in prod should also be updated
