### PR TITLE
Make error links customisable and change password link

### DIFF
--- a/src/client/components/GlobalError.tsx
+++ b/src/client/components/GlobalError.tsx
@@ -3,10 +3,11 @@ import { css } from '@emotion/core';
 import { space, error, neutral } from '@guardian/src-foundations';
 import { textSans } from '@guardian/src-foundations/typography';
 import { SvgAlert } from '@guardian/src-icons';
-import locations from '@/client/lib/locations';
+import { ErrorLink } from '@/client/lib/ErrorLink';
 
 interface GlobalErrorProps {
   error: string;
+  link: ErrorLink;
 }
 
 const errorDiv = css`
@@ -38,14 +39,14 @@ const svg = css`
   width: 30px;
 `;
 
-export const GlobalError = ({ error }: GlobalErrorProps) => (
+export const GlobalError = ({ error, link }: GlobalErrorProps) => (
   <div css={errorDiv}>
     <p css={errorP}>
       <SvgAlert css={svg} />
       {error}
       &nbsp;
-      <a css={errorLink} href={locations.REPORT_ISSUE}>
-        Report this error
+      <a css={errorLink} href={link.link}>
+        {link.linkText}
       </a>
     </p>
   </div>

--- a/src/client/layouts/ConsentsLayout.tsx
+++ b/src/client/layouts/ConsentsLayout.tsx
@@ -4,6 +4,7 @@ import { Footer } from '@/client/components/Footer';
 import { GlobalState } from '@/shared/model/GlobalState';
 import { GlobalStateContext } from '@/client/components/GlobalState';
 import { GlobalError } from '@/client/components/GlobalError';
+import { getErrorLink } from '@/client/lib/ErrorLink';
 import { brand } from '@guardian/src-foundations/palette';
 import { css } from '@emotion/core';
 import { space } from '@guardian/src-foundations';
@@ -67,7 +68,7 @@ export const ConsentsLayout: FunctionComponent<ConsentsLayoutProps> = ({
   return (
     <>
       <Header />
-      {error && <GlobalError error={error} />}
+      {error && <GlobalError error={error} link={getErrorLink(error)} />}
       <ConsentsHeader title={title} />
       <form css={form} action={`${Routes.CONSENTS}/${page}`} method="post">
         <main css={[mainBackground, ieFlexFix]}>

--- a/src/client/layouts/SignInLayout.tsx
+++ b/src/client/layouts/SignInLayout.tsx
@@ -8,6 +8,7 @@ import { GlobalError } from '@/client/components/GlobalError';
 import { css } from '@emotion/core';
 import { space } from '@guardian/src-foundations';
 import { MaxWidth } from '@/client/models/Style';
+import { getErrorLink } from '@/client/lib/ErrorLink';
 
 const main = css`
   flex: 1 0 auto;
@@ -28,7 +29,7 @@ export const SignInLayout: FunctionComponent = (props) => {
     <>
       <Header />
       <Titlepiece />
-      {error && <GlobalError error={error} />}
+      {error && <GlobalError error={error} link={getErrorLink(error)} />}
       <main css={main}>{props.children}</main>
       <Footer />
     </>

--- a/src/client/lib/ErrorLink.ts
+++ b/src/client/lib/ErrorLink.ts
@@ -1,0 +1,30 @@
+import locations from '@/client/lib/locations';
+import { ChangePasswordErrors } from '@/shared/model/Errors';
+
+interface ErrorLink {
+  link: string;
+  linkText: string;
+}
+
+enum linkText {
+  DEFAULT = 'Report this error',
+  PASSWORD = 'Password FAQs',
+}
+
+const DEFAULT_ERROR_LINK: ErrorLink = {
+  link: locations.REPORT_ISSUE,
+  linkText: linkText.DEFAULT,
+};
+
+const CUSTOM_ERROR_LINKS = new Map<string, ErrorLink>([
+  [
+    ChangePasswordErrors.PASSWORD_NO_MATCH,
+    { link: locations.HELP, linkText: linkText.PASSWORD },
+  ],
+]);
+
+const getErrorLink = (error: string): ErrorLink => {
+  return CUSTOM_ERROR_LINKS.get(error) || DEFAULT_ERROR_LINK;
+};
+
+export { ErrorLink, getErrorLink };

--- a/src/client/pages/ConsentsConfirmation.tsx
+++ b/src/client/pages/ConsentsConfirmation.tsx
@@ -26,6 +26,7 @@ import { Footer } from '@/client/components/Footer';
 import { headingWithMq, text } from '@/client/styles/Consents';
 import { Link } from '@guardian/src-link';
 import { Consents } from '@/shared/model/Consent';
+import { getErrorLink } from '@/client/lib/ErrorLink';
 
 const homepageCardContainer = css`
   display: flex;
@@ -198,7 +199,7 @@ export const ConsentsConfirmationPage = () => {
   return (
     <>
       <Header />
-      {error && <GlobalError error={error} />}
+      {error && <GlobalError error={error} link={getErrorLink(error)} />}
       <ConsentsHeader title="Your registration is complete" />
       <main css={[mainBackground, ieFlexFix]}>
         <ConsentsContent>


### PR DESCRIPTION
## What does this change?
Currently all errors have a 'Report this error' link which links to the `/info/tech-feedback page`, but in cases such as when a user's passwords don't match in the password reset flow, this is the wrong link and should instead point to the `/help/identity-faq` page. This PR makes the help link and link text customisable for each error, defaulting to the tech-feedback page where no link or link text has been specified.

## How to test
This can be tested in `CODE` by going through the reset flow and entering non-matching passwords

## How can we measure success?
Fewer people should contact user help when they can't log in because of user input error.

## Have we considered potential risks?

## Images
