### PR TITLE
Add Ophan tracking to Gateway

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
       - BASE_URI=${BASE_URI}
       - DEFAULT_RETURN_URI=${DEFAULT_RETURN_URI}
       - STAGE=${STAGE}
+      - SIGN_IN_PAGE_URL=${SIGN_IN_PAGE_URL}
     ports:
       - '${PORT}:${PORT}'
     volumes:

--- a/src/client/static/analytics/ophan.js
+++ b/src/client/static/analytics/ophan.js
@@ -1,1 +1,0 @@
-require('ophan-tracker-js');

--- a/src/client/static/analytics/ophan.ts
+++ b/src/client/static/analytics/ophan.ts
@@ -1,0 +1,56 @@
+import 'ophan-tracker-js';
+
+// the 'guardian.ophan' object is added by ophan-tracker-js
+// we extend the Window interface here to keep Typescript happy
+interface OphanWindow extends Window {
+  guardian: {
+    ophan: {
+      setEventEmitter: () => void;
+      trackComponentAttention: (
+        name: string,
+        el: Element,
+        visiblityThreshold: number,
+      ) => void;
+      record: ({}) => void;
+      viewId: string;
+      pageViewId: string;
+    };
+  };
+}
+
+declare let window: OphanWindow;
+
+interface OphanEvent {
+  experiences: string;
+  abTestRegister?: { [testId: string]: TestData };
+}
+
+interface TestData {
+  variantName: string;
+  complete: boolean;
+  campaignCodes?: Set<string>;
+}
+
+const record = (event: OphanEvent) => {
+  if (
+    window.guardian &&
+    window.guardian.ophan &&
+    window.guardian.ophan.record
+  ) {
+    window.guardian.ophan.record(event);
+  } else {
+    throw new Error("window.guardian.ophan.record doesn't exist");
+  }
+};
+
+export const init = () => {
+  record({
+    experiences: 'gateway',
+    abTestRegister: {
+      gateway: {
+        variantName: 'gateway',
+        complete: false,
+      },
+    },
+  });
+};

--- a/src/client/static/analytics/ophan.ts
+++ b/src/client/static/analytics/ophan.ts
@@ -38,8 +38,6 @@ const record = (event: OphanEvent) => {
     window.guardian.ophan.record
   ) {
     window.guardian.ophan.record(event);
-  } else {
-    throw new Error("window.guardian.ophan.record doesn't exist");
   }
 };
 

--- a/src/client/static/index.tsx
+++ b/src/client/static/index.tsx
@@ -14,12 +14,13 @@ import { getCountryCode } from './countryCode';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 import { init as gaInit } from './analytics/ga';
+import { init as ophanInit } from './analytics/ophan';
 
 // initialise source accessibility
 import './sourceAccessibility';
 
 // initalise ophan
-import './analytics/ophan';
+ophanInit();
 
 // initialise google analytics
 gaInit();


### PR DESCRIPTION
## What does this change?
This PR expands on the Ophan tracking in Gateway by adding the `gateway` to the `experiences` parameter and adding a static gateway `abTestRegister` entry. When we start running actual AB tests the latter field will be populated by the variants of those tests, but for now we are using it to differentiate between gateway and non-gateway traffic.

These parameters correspond to the `experiences` and `ab` fields in the Event module in Thrift - https://dashboard.ophan.co.uk/docs/thrift/event.html

There is also a small change to the docker compose file to get the local DEV environment working again.

## How to test
You can run gateway locally and monitor the network tab in developer tools for ophan traffic to see the parameters correctly coming through on the requests
