### PR TITLE
Fix flakiness on gateway startup

### DIFF
--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -172,6 +172,16 @@ Resources:
             touch /var/log/identity-gateway.log
             chown identity-gateway:identity-gateway /var/log/identity-gateway.log
 
+            # Try multiple times to get parameter store values. The SSM command can fail when called immediately on instance startup.
+            while true; do
+                if \
+                  IDAPI_CLIENT_ACCESS_TOKEN=$(aws ssm get-parameter --name '/${Stack}/${App}/${Stage}/idapi-client-access-token' --with-decryption --region eu-west-1 --query="Parameter.Value" --output="text") && \
+                  PLAY_SESSION_COOKIE_SECRET=$(aws ssm get-parameter --name '/${Stack}/${App}/${Stage}/frontendPlaySecret' --with-decryption --region eu-west-1 --query="Parameter.Value" --output="text")
+
+                  then break
+                fi
+            done
+
             # systemd setup
             cat > /etc/systemd/system/identity-gateway.service <<EOL
             [Service]
@@ -184,11 +194,11 @@ Resources:
             Group=identity-gateway
             Environment=NODE_ENV=production
             Environment=PORT=9233
-            Environment=IDAPI_CLIENT_ACCESS_TOKEN=$(aws ssm get-parameter --name '/${Stack}/${App}/${Stage}/idapi-client-access-token' --with-decryption --region eu-west-1 --query="Parameter.Value" --output="text")
+            Environment=IDAPI_CLIENT_ACCESS_TOKEN=$IDAPI_CLIENT_ACCESS_TOKEN
             Environment=IDAPI_BASE_URL=${IdapiBaseUrl}
             Environment=SIGN_IN_PAGE_URL=${SignInPageUrl}
             Environment=BASE_URI=${BaseUri}
-            Environment=PLAY_SESSION_COOKIE_SECRET=$(aws ssm get-parameter --name '/${Stack}/${App}/${Stage}/frontendPlaySecret' --with-decryption --region eu-west-1 --query="Parameter.Value" --output="text")
+            Environment=PLAY_SESSION_COOKIE_SECRET=$PLAY_SESSION_COOKIE_SECRET
             Environment=DEFAULT_RETURN_URI=${DefaultReturnUri}
             Environment=STAGE=${Stage}
 

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -180,6 +180,8 @@ Resources:
 
                   then break
                 fi
+
+                sleep 1
             done
 
             # systemd setup


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Retry get parameter store values on instance initialisation

# Why?

The SSM command can fail when called immediately on instance startup, so we keep calling it until it is successful.

This is causing RiffRaff deploys to frequently fail, and can potentially cause issues replacing unhealthy instances or scaling up.