### PR TITLE
Password reset validation

### DIFF
--- a/cypress/integration/change_password.spec.js
+++ b/cypress/integration/change_password.spec.js
@@ -18,7 +18,7 @@ describe('Password change flow', () => {
     const atLeast6 = 'At least 6 characters';
     const mixtureOfUpperLower = 'A mixture of lower and upper case letters';
     const symbolOrNumber = 'A symbol or a number';
-    const matchingRepeated = 'A matching repeated password';
+    const matchingRepeated = 'Passwords match';
 
     it('shows which constraints have been met as the user types', () => {
       cy.idapiMock(200);
@@ -27,25 +27,21 @@ describe('Password change flow', () => {
       cy.contains(atLeast6).should('have.css', 'color', failureColour);
       cy.contains(mixtureOfUpperLower).should('have.css', 'color', failureColour);
       cy.contains(symbolOrNumber).should('have.css', 'color', failureColour);
-      cy.contains(matchingRepeated).should('have.css', 'color', failureColour);
 
       page.inputPasswordText('aaaaaa', '');
       cy.contains(atLeast6).should('have.css', 'color', successColour);
       cy.contains(mixtureOfUpperLower).should('have.css', 'color', failureColour);
       cy.contains(symbolOrNumber).should('have.css', 'color', failureColour);
-      cy.contains(matchingRepeated).should('have.css', 'color', failureColour);
 
       page.inputPasswordText('A', '');
       cy.contains(atLeast6).should('have.css', 'color', successColour);
       cy.contains(mixtureOfUpperLower).should('have.css', 'color', successColour);
       cy.contains(symbolOrNumber).should('have.css', 'color', failureColour);
-      cy.contains(matchingRepeated).should('have.css', 'color', failureColour);
 
       page.inputPasswordText('1', '');
       cy.contains(atLeast6).should('have.css', 'color', successColour);
       cy.contains(mixtureOfUpperLower).should('have.css', 'color', successColour);
       cy.contains(symbolOrNumber).should('have.css', 'color', successColour);
-      cy.contains(matchingRepeated).should('have.css', 'color', failureColour);
 
       page.inputPasswordText('', 'aaaaaaA1');
       cy.contains(atLeast6).should('have.css', 'color', successColour);

--- a/cypress/support/pages/change_password_page.js
+++ b/cypress/support/pages/change_password_page.js
@@ -3,7 +3,7 @@ class ChangePasswordPage {
   static CONTENT = {
     ERRORS: {
       GENERIC: 'There was a problem changing your password, please try again.',
-      PASSWORD_MISMATCH: 'This password isn\'t valid. Please include a matching repeated password',
+      PASSWORD_MISMATCH: 'The passwords don\'t match. Please review your password',
       PASSWORD_INVALID_LENGTH: 'This password isn\'t valid. Please include at least 6 characters.',
       PASSWORD_MISSING_NUMBER: 'This password isn\'t valid. Please include a symbol or a number.',
       PASSWORD_MULTIPLE_ERRORS: 'This password isn\'t valid. Please make sure it matches the required criteria.',

--- a/cypress/support/pages/change_password_page.js
+++ b/cypress/support/pages/change_password_page.js
@@ -3,8 +3,12 @@ class ChangePasswordPage {
   static CONTENT = {
     ERRORS: {
       GENERIC: 'There was a problem changing your password, please try again.',
-      PASSWORD_MISMATCH: 'The passwords do not match, please try again',
-      PASSWORD_INVALID_LENGTH: 'Password must be between 6 and 72 characters',
+      PASSWORD_MISMATCH: 'This password isn\'t valid. Please include a matching repeated password',
+      PASSWORD_INVALID_LENGTH: 'This password isn\'t valid. Please include at least 6 characters.',
+      PASSWORD_MISSING_NUMBER: 'This password isn\'t valid. Please include a symbol or a number.',
+      PASSWORD_MULTIPLE_ERRORS: 'This password isn\'t valid. Please make sure it matches the required criteria.',
+      PASSWORD_MISSING_UPPER_LOWERCASE: 'This password isn\'t valid. Please include a mixture of lower and upper case letters.',
+      PASSWORD_TOO_LONG: 'This password isn\'t valid. Please include up to 72 characters.',
     },
     PASSWORD_CHANGE_SUCCESS_TITLE: 'Thank you! Your password has been changed.',
     CONTINUE_BUTTON_TEXT: 'Continue to The Guardian',
@@ -31,9 +35,13 @@ class ChangePasswordPage {
   }
 
   submitPasswordChange(password0, password1) {
-    cy.get('input[name="password"]').type(password0);
-    cy.get('input[name="password_confirm"]').type(password1);
+    this.inputPasswordText(password0, password1);
     this.clickPasswordChange();
+  }
+
+  inputPasswordText(password0, password1) {
+    if (password0) cy.get('input[name="password"]').type(password0);
+    if (password1) cy.get('input[name="password_confirm"]').type(password1);
   }
 }
 

--- a/src/client/components/PasswordValidation.tsx
+++ b/src/client/components/PasswordValidation.tsx
@@ -1,23 +1,16 @@
 import React from 'react';
 import {
-  passwordValidatorsCss,
   validationInfoCss,
   ValidationStyling,
 } from '@/client/styles/PasswordValidationStyles';
 import { css } from '@emotion/core';
 import { SvgCheckmark } from '@guardian/src-icons';
-import { palette } from '@guardian/src-foundations';
+import { palette, space } from '@guardian/src-foundations';
 import { SvgCross } from '@guardian/src-icons';
 import {
   passwordValidation,
   PasswordValidationText,
 } from '@/shared/lib/PasswordValidation';
-
-export type PasswordValidationProps = {
-  password: string;
-  passwordRepeated: string;
-  hasFailedToSubmit: boolean;
-};
 
 const ValidationSymbol = ({
   validationStyling,
@@ -48,24 +41,25 @@ const ValidationSymbol = ({
   return <div css={style}>{symbol}</div>;
 };
 
-export const PasswordValidationComponent = (props: PasswordValidationProps) => {
+export const PasswordValidationComponent = (props: {
+  password: string;
+  showRedValidationErrors: boolean;
+}) => {
   let lengthValidationText = PasswordValidationText.AT_LEAST_6;
-  const failureStyling: ValidationStyling = props.hasFailedToSubmit
+  const failureStyling: ValidationStyling = props.showRedValidationErrors
     ? 'error'
     : 'failure';
 
   let lengthValidationStyling: ValidationStyling = failureStyling;
   let upperAndLowercaseValidationStyling: ValidationStyling = failureStyling;
   let symbolValidationStyling: ValidationStyling = failureStyling;
-  let matchingStyling: ValidationStyling = failureStyling;
 
   const {
     sixOrMore,
     lessThan72,
     upperAndLowercase,
     symbolOrNumber,
-    matching,
-  } = passwordValidation(props.password, props.passwordRepeated);
+  } = passwordValidation(props.password);
 
   if (sixOrMore) lengthValidationStyling = 'success';
   if (!lessThan72) {
@@ -74,10 +68,13 @@ export const PasswordValidationComponent = (props: PasswordValidationProps) => {
   }
   if (upperAndLowercase) upperAndLowercaseValidationStyling = 'success';
   if (symbolOrNumber) symbolValidationStyling = 'success';
-  if (matching) matchingStyling = 'success';
 
   return (
-    <div css={passwordValidatorsCss}>
+    <div
+      css={css`
+        margin-bottom: ${space[9]}px;
+      `}
+    >
       <div>
         <ValidationSymbol validationStyling={lengthValidationStyling} />
         <div css={validationInfoCss(lengthValidationStyling)}>
@@ -98,11 +95,32 @@ export const PasswordValidationComponent = (props: PasswordValidationProps) => {
           {PasswordValidationText.SYMBOL_OR_NUMBER}
         </div>
       </div>
-      <div>
-        <ValidationSymbol validationStyling={matchingStyling} />
-        <div css={validationInfoCss(matchingStyling)}>
-          {PasswordValidationText.MATCHING_REPEATED}
-        </div>
+    </div>
+  );
+};
+
+export const PasswordMatchingValidationComponent = ({
+  password,
+  passwordRepeated,
+  display,
+}: {
+  password: string;
+  passwordRepeated: string;
+  display: boolean;
+}) => {
+  const matchingStyling: ValidationStyling =
+    password === passwordRepeated ? 'success' : 'error';
+
+  const style = css`
+    margin-bottom: ${space[3]}px;
+    visibility: ${display ? 'visible' : 'hidden'};
+  `;
+
+  return (
+    <div css={style}>
+      <ValidationSymbol validationStyling={matchingStyling} />
+      <div css={validationInfoCss(matchingStyling)}>
+        {PasswordValidationText.MATCHING_REPEATED}
       </div>
     </div>
   );

--- a/src/client/components/PasswordValidation.tsx
+++ b/src/client/components/PasswordValidation.tsx
@@ -1,0 +1,109 @@
+import React from 'react';
+import {
+  passwordValidatorsCss,
+  validationInfoCss,
+  ValidationStyling,
+} from '@/client/styles/PasswordValidationStyles';
+import { css } from '@emotion/core';
+import { SvgCheckmark } from '@guardian/src-icons';
+import { palette } from '@guardian/src-foundations';
+import { SvgCross } from '@guardian/src-icons';
+import {
+  passwordValidation,
+  PasswordValidationText,
+} from '@/shared/lib/PasswordValidation';
+
+export type PasswordValidationProps = {
+  password: string;
+  passwordRepeated: string;
+  hasFailedToSubmit: boolean;
+};
+
+const ValidationSymbol = ({
+  validationStyling,
+}: {
+  validationStyling: ValidationStyling;
+}) => {
+  let fillColour = palette.neutral['7'];
+  let symbol = <SvgCross />;
+
+  if (validationStyling === 'success') {
+    fillColour = palette.success['400'];
+    symbol = <SvgCheckmark />;
+  } else if (validationStyling === 'error') {
+    fillColour = palette.error['400'];
+  }
+
+  const style = css`
+    display: inline-block;
+    position: relative;
+    top: 3px;
+    svg {
+      width: 16px;
+      height: 16px;
+      fill: ${fillColour};
+    }
+  `;
+
+  return <div css={style}>{symbol}</div>;
+};
+
+export const PasswordValidationComponent = (props: PasswordValidationProps) => {
+  let lengthValidationText = PasswordValidationText.AT_LEAST_6;
+  const failureStyling: ValidationStyling = props.hasFailedToSubmit
+    ? 'error'
+    : 'failure';
+
+  let lengthValidationStyling: ValidationStyling = failureStyling;
+  let upperAndLowercaseValidationStyling: ValidationStyling = failureStyling;
+  let symbolValidationStyling: ValidationStyling = failureStyling;
+  let matchingStyling: ValidationStyling = failureStyling;
+
+  const {
+    sixOrMore,
+    lessThan72,
+    upperAndLowercase,
+    symbolOrNumber,
+    matching,
+  } = passwordValidation(props.password, props.passwordRepeated);
+
+  if (sixOrMore) lengthValidationStyling = 'success';
+  if (!lessThan72) {
+    lengthValidationStyling = failureStyling;
+    lengthValidationText = PasswordValidationText.UP_TO_72;
+  }
+  if (upperAndLowercase) upperAndLowercaseValidationStyling = 'success';
+  if (symbolOrNumber) symbolValidationStyling = 'success';
+  if (matching) matchingStyling = 'success';
+
+  return (
+    <div css={passwordValidatorsCss}>
+      <div>
+        <ValidationSymbol validationStyling={lengthValidationStyling} />
+        <div css={validationInfoCss(lengthValidationStyling)}>
+          {lengthValidationText}
+        </div>
+      </div>
+      <div>
+        <ValidationSymbol
+          validationStyling={upperAndLowercaseValidationStyling}
+        />
+        <div css={validationInfoCss(upperAndLowercaseValidationStyling)}>
+          {PasswordValidationText.MIXTURE_OF_CASES}
+        </div>
+      </div>
+      <div>
+        <ValidationSymbol validationStyling={symbolValidationStyling} />
+        <div css={validationInfoCss(symbolValidationStyling)}>
+          {PasswordValidationText.SYMBOL_OR_NUMBER}
+        </div>
+      </div>
+      <div>
+        <ValidationSymbol validationStyling={matchingStyling} />
+        <div css={validationInfoCss(matchingStyling)}>
+          {PasswordValidationText.MATCHING_REPEATED}
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/client/components/PasswordValidation.tsx
+++ b/src/client/components/PasswordValidation.tsx
@@ -102,25 +102,36 @@ export const PasswordValidationComponent = (props: {
 export const PasswordMatchingValidationComponent = ({
   password,
   passwordRepeated,
-  display,
+  canDisplay,
 }: {
   password: string;
   passwordRepeated: string;
-  display: boolean;
+  canDisplay: boolean;
 }) => {
-  const matchingStyling: ValidationStyling =
-    password === passwordRepeated ? 'success' : 'error';
+  const matches = password === passwordRepeated;
+
+  const matchingStyling: ValidationStyling = matches ? 'success' : 'error';
+
+  let isVisible = false;
+  if (
+    canDisplay &&
+    (!password.startsWith(passwordRepeated) || password === passwordRepeated)
+  ) {
+    isVisible = true;
+  }
 
   const style = css`
     margin-bottom: ${space[3]}px;
-    visibility: ${display ? 'visible' : 'hidden'};
+    visibility: ${isVisible ? 'visible' : 'hidden'};
   `;
 
   return (
     <div css={style}>
       <ValidationSymbol validationStyling={matchingStyling} />
       <div css={validationInfoCss(matchingStyling)}>
-        {PasswordValidationText.MATCHING_REPEATED}
+        {matches
+          ? PasswordValidationText.MATCHING_REPEATED
+          : PasswordValidationText.NOT_MATCHING_REPEATED}
       </div>
     </div>
   );

--- a/src/client/lib/ErrorLink.ts
+++ b/src/client/lib/ErrorLink.ts
@@ -1,5 +1,4 @@
 import locations from '@/client/lib/locations';
-import { ChangePasswordErrors } from '@/shared/model/Errors';
 
 interface ErrorLink {
   link: string;
@@ -16,12 +15,7 @@ const DEFAULT_ERROR_LINK: ErrorLink = {
   linkText: linkText.DEFAULT,
 };
 
-const CUSTOM_ERROR_LINKS = new Map<string, ErrorLink>([
-  [
-    ChangePasswordErrors.PASSWORD_NO_MATCH,
-    { link: locations.HELP, linkText: linkText.PASSWORD },
-  ],
-]);
+const CUSTOM_ERROR_LINKS = new Map<string, ErrorLink>([]);
 
 const getErrorLink = (error: string): ErrorLink => {
   return CUSTOM_ERROR_LINKS.get(error) || DEFAULT_ERROR_LINK;

--- a/src/client/pages/ChangePassword.tsx
+++ b/src/client/pages/ChangePassword.tsx
@@ -30,9 +30,6 @@ export const ChangePasswordPage = () => {
   const [password, setPassword] = useState('');
   const [passwordRepeated, setPasswordRepeated] = useState('');
   const [showRedValidationErrors, setRedValidationErrors] = useState(false);
-  const [showMatchingPasswordOutput, setShowMatchPasswordOutput] = useState(
-    false,
-  );
 
   const serverErrorMessage: string | undefined = fieldErrors.find(
     (fieldError) => fieldError.field === 'password',
@@ -52,16 +49,14 @@ export const ChangePasswordPage = () => {
     repeatedPasswordServerErrorMessage || '',
   );
 
-  if (!showRedValidationErrors && validationErrorMessage !== '') {
-    setRedValidationErrors(true);
-  }
+  const validationResult = passwordValidation(password);
 
   if (
-    !showMatchingPasswordOutput &&
-    password !== '' &&
-    password === passwordRepeated
+    !showRedValidationErrors &&
+    validationErrorMessage !== '' &&
+    password.length > 0
   ) {
-    setShowMatchPasswordOutput(true);
+    setRedValidationErrors(true);
   }
 
   const onSubmit = (e: React.FormEvent<HTMLFormElement>) => {
@@ -105,7 +100,11 @@ export const ChangePasswordPage = () => {
               onChange={(e) => {
                 setPassword(e.target.value);
               }}
-              onBlur={() => setRedValidationErrors(true)}
+              onBlur={() =>
+                setRedValidationErrors((previous) => {
+                  return previous || password.length > 0;
+                })
+              }
             />
             <PasswordValidationComponent
               password={password}
@@ -118,12 +117,11 @@ export const ChangePasswordPage = () => {
               type="password"
               error={matchingErrorMessage}
               onChange={(e) => setPasswordRepeated(e.target.value)}
-              onBlur={() => setShowMatchPasswordOutput(true)}
             />
             <PasswordMatchingValidationComponent
               password={password}
               passwordRepeated={passwordRepeated}
-              display={showMatchingPasswordOutput}
+              canDisplay={!validationResult.containsError}
             />
             <Button
               css={button}

--- a/src/client/styles/PasswordValidationStyles.ts
+++ b/src/client/styles/PasswordValidationStyles.ts
@@ -1,0 +1,27 @@
+import { css } from '@emotion/core';
+import { palette } from '@guardian/src-foundations';
+import { textSans } from '@guardian/src-foundations/typography';
+
+export type ValidationStyling = 'success' | 'failure' | 'error';
+
+export const passwordValidatorsCss = css`
+  margin-bottom: 10px;
+`;
+
+export const validationInfoCss = (styling: ValidationStyling) => {
+  let color = palette.neutral['7'];
+
+  if (styling === 'success') {
+    color = palette.success['400'];
+  } else if (styling === 'error') {
+    color = palette.error['400'];
+  }
+
+  return css`
+    ${textSans.small()}
+    margin-bottom: 4px;
+    margin-left: 3px;
+    display: inline-block;
+    color: ${color};
+  `;
+};

--- a/src/client/styles/PasswordValidationStyles.ts
+++ b/src/client/styles/PasswordValidationStyles.ts
@@ -4,10 +4,6 @@ import { textSans } from '@guardian/src-foundations/typography';
 
 export type ValidationStyling = 'success' | 'failure' | 'error';
 
-export const passwordValidatorsCss = css`
-  margin-bottom: 10px;
-`;
-
 export const validationInfoCss = (styling: ValidationStyling) => {
   let color = palette.neutral['7'];
 

--- a/src/server/routes/changePassword.ts
+++ b/src/server/routes/changePassword.ts
@@ -13,7 +13,10 @@ import { Metrics } from '@/server/models/Metrics';
 import { removeNoCache } from '@/server/lib/middleware/cache';
 import { PageTitle } from '@/shared/model/PageTitle';
 import { setIDAPICookies } from '@/server/lib/setIDAPICookies';
-import { passwordValidation } from '@/shared/lib/PasswordValidation';
+import {
+  passwordValidation,
+  PasswordValidationText,
+} from '@/shared/lib/PasswordValidation';
 
 const router = Router();
 
@@ -26,17 +29,24 @@ const validatePasswordChangeFields = (
   password: string,
   passwordConfirm: string,
 ): Array<FieldError> => {
-  const validationResult = passwordValidation(password, passwordConfirm);
+  const validationResult = passwordValidation(password);
+  const errors: Array<FieldError> = [];
+
   if (validationResult.failedMessage) {
-    return [
-      {
-        field: 'password',
-        message: validationResult.failedMessage,
-      },
-    ];
+    errors.push({
+      field: 'password',
+      message: validationResult.failedMessage,
+    });
   }
 
-  return [];
+  if (password !== passwordConfirm) {
+    errors.push({
+      field: 'password_confirm',
+      message: PasswordValidationText.DO_NOT_MATCH_ERROR,
+    });
+  }
+
+  return errors;
 };
 
 router.get(

--- a/src/shared/__tests__/PasswordValidation.test.ts
+++ b/src/shared/__tests__/PasswordValidation.test.ts
@@ -1,0 +1,86 @@
+import { passwordValidation } from '@/shared/lib/PasswordValidation';
+
+describe('password validation', () => {
+  it('should fail six or more constraint', () => {
+    const result = passwordValidation('Abc12', 'Abc12');
+    expect(result).toStrictEqual({
+      sixOrMore: false,
+      lessThan72: true,
+      upperAndLowercase: true,
+      symbolOrNumber: true,
+      matching: true,
+      failedMessage:
+        "This password isn't valid. Please include at least 6 characters.",
+    });
+  });
+
+  it('should fail less than 72 constraint', () => {
+    const longPassword = `A1${'a'.repeat(71)}`;
+    const result = passwordValidation(longPassword, longPassword);
+    expect(result).toStrictEqual({
+      sixOrMore: true,
+      lessThan72: false,
+      upperAndLowercase: true,
+      symbolOrNumber: true,
+      matching: true,
+      failedMessage:
+        "This password isn't valid. Please include up to 72 characters.",
+    });
+  });
+
+  it('should fail upper and lowercase constraint', () => {
+    const result = passwordValidation('abc123', 'abc123');
+
+    expect(result).toStrictEqual({
+      sixOrMore: true,
+      lessThan72: true,
+      upperAndLowercase: false,
+      symbolOrNumber: true,
+      matching: true,
+      failedMessage:
+        "This password isn't valid. Please include a mixture of lower and upper case letters.",
+    });
+  });
+
+  it('should fail symbol or number constraint', () => {
+    const result = passwordValidation('Abcaaa', 'Abcaaa');
+
+    expect(result).toStrictEqual({
+      sixOrMore: true,
+      lessThan72: true,
+      upperAndLowercase: true,
+      symbolOrNumber: false,
+      matching: true,
+      failedMessage:
+        "This password isn't valid. Please include a symbol or a number.",
+    });
+  });
+
+  it('should fail matching constraint', () => {
+    const result = passwordValidation('Abc123', 'Abc1234');
+
+    expect(result).toStrictEqual({
+      sixOrMore: true,
+      lessThan72: true,
+      upperAndLowercase: true,
+      symbolOrNumber: true,
+      matching: false,
+      failedMessage:
+        "This password isn't valid. Please include a matching repeated password.",
+    });
+  });
+
+  it('should fail multiple constraints with a different error message', () => {
+    const result = passwordValidation('abc12', 'Abc1234');
+
+    expect(result).toStrictEqual({
+      sixOrMore: false,
+      lessThan72: true,
+      upperAndLowercase: false,
+      symbolOrNumber: true,
+      matching: false,
+      failedMessage:
+        "This password isn't valid. Please make sure it matches the required criteria.",
+    });
+  });
+});

--- a/src/shared/__tests__/PasswordValidation.test.ts
+++ b/src/shared/__tests__/PasswordValidation.test.ts
@@ -1,9 +1,22 @@
 import { passwordValidation } from '@/shared/lib/PasswordValidation';
 
 describe('password validation', () => {
+  it('should pass with a valid password', () => {
+    const result = passwordValidation('Abc123');
+    expect(result).toStrictEqual({
+      containsError: false,
+      failedMessage: undefined,
+      sixOrMore: true,
+      lessThan72: true,
+      upperAndLowercase: true,
+      symbolOrNumber: true,
+    });
+  });
+
   it('should fail six or more constraint', () => {
     const result = passwordValidation('Abc12');
     expect(result).toStrictEqual({
+      containsError: true,
       sixOrMore: false,
       lessThan72: true,
       upperAndLowercase: true,
@@ -17,6 +30,7 @@ describe('password validation', () => {
     const longPassword = `A1${'a'.repeat(71)}`;
     const result = passwordValidation(longPassword);
     expect(result).toStrictEqual({
+      containsError: true,
       sixOrMore: true,
       lessThan72: false,
       upperAndLowercase: true,
@@ -30,6 +44,7 @@ describe('password validation', () => {
     const result = passwordValidation('abc123');
 
     expect(result).toStrictEqual({
+      containsError: true,
       sixOrMore: true,
       lessThan72: true,
       upperAndLowercase: false,
@@ -43,6 +58,7 @@ describe('password validation', () => {
     const result = passwordValidation('Abcaaa');
 
     expect(result).toStrictEqual({
+      containsError: true,
       sixOrMore: true,
       lessThan72: true,
       upperAndLowercase: true,
@@ -56,6 +72,7 @@ describe('password validation', () => {
     const result = passwordValidation('abc12');
 
     expect(result).toStrictEqual({
+      containsError: true,
       sixOrMore: false,
       lessThan72: true,
       upperAndLowercase: false,

--- a/src/shared/__tests__/PasswordValidation.test.ts
+++ b/src/shared/__tests__/PasswordValidation.test.ts
@@ -2,13 +2,12 @@ import { passwordValidation } from '@/shared/lib/PasswordValidation';
 
 describe('password validation', () => {
   it('should fail six or more constraint', () => {
-    const result = passwordValidation('Abc12', 'Abc12');
+    const result = passwordValidation('Abc12');
     expect(result).toStrictEqual({
       sixOrMore: false,
       lessThan72: true,
       upperAndLowercase: true,
       symbolOrNumber: true,
-      matching: true,
       failedMessage:
         "This password isn't valid. Please include at least 6 characters.",
     });
@@ -16,69 +15,51 @@ describe('password validation', () => {
 
   it('should fail less than 72 constraint', () => {
     const longPassword = `A1${'a'.repeat(71)}`;
-    const result = passwordValidation(longPassword, longPassword);
+    const result = passwordValidation(longPassword);
     expect(result).toStrictEqual({
       sixOrMore: true,
       lessThan72: false,
       upperAndLowercase: true,
       symbolOrNumber: true,
-      matching: true,
       failedMessage:
         "This password isn't valid. Please include up to 72 characters.",
     });
   });
 
   it('should fail upper and lowercase constraint', () => {
-    const result = passwordValidation('abc123', 'abc123');
+    const result = passwordValidation('abc123');
 
     expect(result).toStrictEqual({
       sixOrMore: true,
       lessThan72: true,
       upperAndLowercase: false,
       symbolOrNumber: true,
-      matching: true,
       failedMessage:
         "This password isn't valid. Please include a mixture of lower and upper case letters.",
     });
   });
 
   it('should fail symbol or number constraint', () => {
-    const result = passwordValidation('Abcaaa', 'Abcaaa');
+    const result = passwordValidation('Abcaaa');
 
     expect(result).toStrictEqual({
       sixOrMore: true,
       lessThan72: true,
       upperAndLowercase: true,
       symbolOrNumber: false,
-      matching: true,
       failedMessage:
         "This password isn't valid. Please include a symbol or a number.",
     });
   });
 
-  it('should fail matching constraint', () => {
-    const result = passwordValidation('Abc123', 'Abc1234');
-
-    expect(result).toStrictEqual({
-      sixOrMore: true,
-      lessThan72: true,
-      upperAndLowercase: true,
-      symbolOrNumber: true,
-      matching: false,
-      failedMessage:
-        "This password isn't valid. Please include a matching repeated password.",
-    });
-  });
-
   it('should fail multiple constraints with a different error message', () => {
-    const result = passwordValidation('abc12', 'Abc1234');
+    const result = passwordValidation('abc12');
 
     expect(result).toStrictEqual({
       sixOrMore: false,
       lessThan72: true,
       upperAndLowercase: false,
       symbolOrNumber: true,
-      matching: false,
       failedMessage:
         "This password isn't valid. Please make sure it matches the required criteria.",
     });

--- a/src/shared/lib/PasswordValidation.ts
+++ b/src/shared/lib/PasswordValidation.ts
@@ -1,0 +1,96 @@
+const sixCharactersRegex = /^.{6,}$/;
+const lessThan72CharactersRegex = /^.{0,72}$/;
+const upperAndLowercaseRegex = /[a-z].*[A-Z]|[A-Z].*[a-z]/;
+const symbolOrNumberRegex = /[^a-zA-Z]/;
+
+export enum PasswordValidationText {
+  AT_LEAST_6 = 'At least 6 characters',
+  UP_TO_72 = 'Up to 72 characters',
+  SYMBOL_OR_NUMBER = 'A symbol or a number',
+  MIXTURE_OF_CASES = 'A mixture of lower and upper case letters',
+  MATCHING_REPEATED = 'A matching repeated password',
+}
+
+const multipleErrorsText =
+  "This password isn't valid. Please make sure it matches the required criteria.";
+const singleErrorPrefix = "This password isn't valid. Please include";
+
+type PasswordMatch = {
+  matchesPassword: boolean;
+  description: string;
+};
+
+type PasswordMatches = {
+  sixOrMore: PasswordMatch;
+  lessThan72: PasswordMatch;
+  upperAndLowercase: PasswordMatch;
+  symbolOrNumber: PasswordMatch;
+  matching: PasswordMatch;
+};
+
+const matchPassword = (
+  password: string,
+  passwordRepeated: string,
+): PasswordMatches => {
+  return {
+    sixOrMore: {
+      matchesPassword: !!password.match(sixCharactersRegex),
+      description: PasswordValidationText.AT_LEAST_6,
+    },
+    lessThan72: {
+      matchesPassword: !!password.match(lessThan72CharactersRegex),
+      description: PasswordValidationText.UP_TO_72,
+    },
+    upperAndLowercase: {
+      matchesPassword: !!password.match(upperAndLowercaseRegex),
+      description: PasswordValidationText.MIXTURE_OF_CASES,
+    },
+    symbolOrNumber: {
+      matchesPassword: !!password.match(symbolOrNumberRegex),
+      description: PasswordValidationText.SYMBOL_OR_NUMBER,
+    },
+    matching: {
+      matchesPassword: password !== '' && password === passwordRepeated,
+      description: PasswordValidationText.MATCHING_REPEATED,
+    },
+  };
+};
+
+export type ValidationResult = {
+  sixOrMore: boolean;
+  lessThan72: boolean;
+  upperAndLowercase: boolean;
+  symbolOrNumber: boolean;
+  matching: boolean;
+  failedMessage?: string;
+};
+
+export const passwordValidation = (
+  password: string,
+  passwordRepeated: string,
+): ValidationResult => {
+  let failedMessage: string | undefined;
+  const passwordMatches = matchPassword(password, passwordRepeated);
+
+  const errorCount = Object.values(passwordMatches).filter(
+    (passwordMatch) => !passwordMatch.matchesPassword,
+  ).length;
+  const informationMessage = Object.values(passwordMatches).find(
+    (passwordMatch) => !passwordMatch.matchesPassword,
+  )?.description;
+
+  if (errorCount === 1) {
+    failedMessage = `${singleErrorPrefix} ${informationMessage?.toLowerCase()}.`;
+  } else if (errorCount > 1) {
+    failedMessage = multipleErrorsText;
+  }
+
+  return {
+    sixOrMore: passwordMatches.sixOrMore.matchesPassword,
+    lessThan72: passwordMatches.lessThan72.matchesPassword,
+    upperAndLowercase: passwordMatches.upperAndLowercase.matchesPassword,
+    symbolOrNumber: passwordMatches.symbolOrNumber.matchesPassword,
+    matching: passwordMatches.matching.matchesPassword,
+    failedMessage,
+  };
+};

--- a/src/shared/lib/PasswordValidation.ts
+++ b/src/shared/lib/PasswordValidation.ts
@@ -9,6 +9,7 @@ export enum PasswordValidationText {
   SYMBOL_OR_NUMBER = 'A symbol or a number',
   MIXTURE_OF_CASES = 'A mixture of lower and upper case letters',
   MATCHING_REPEATED = 'Passwords match',
+  NOT_MATCHING_REPEATED = "Passwords don't match",
   DO_NOT_MATCH_ERROR = "The passwords don't match. Please review your password",
 }
 
@@ -55,6 +56,7 @@ export type ValidationResult = {
   upperAndLowercase: boolean;
   symbolOrNumber: boolean;
   failedMessage?: string;
+  containsError: boolean;
 };
 
 export const passwordValidation = (password: string): ValidationResult => {
@@ -81,5 +83,6 @@ export const passwordValidation = (password: string): ValidationResult => {
     upperAndLowercase: passwordMatches.upperAndLowercase.matchesPassword,
     symbolOrNumber: passwordMatches.symbolOrNumber.matchesPassword,
     failedMessage,
+    containsError: errorCount > 0,
   };
 };

--- a/src/shared/lib/PasswordValidation.ts
+++ b/src/shared/lib/PasswordValidation.ts
@@ -8,7 +8,8 @@ export enum PasswordValidationText {
   UP_TO_72 = 'Up to 72 characters',
   SYMBOL_OR_NUMBER = 'A symbol or a number',
   MIXTURE_OF_CASES = 'A mixture of lower and upper case letters',
-  MATCHING_REPEATED = 'A matching repeated password',
+  MATCHING_REPEATED = 'Passwords match',
+  DO_NOT_MATCH_ERROR = "The passwords don't match. Please review your password",
 }
 
 const multipleErrorsText =
@@ -25,13 +26,9 @@ type PasswordMatches = {
   lessThan72: PasswordMatch;
   upperAndLowercase: PasswordMatch;
   symbolOrNumber: PasswordMatch;
-  matching: PasswordMatch;
 };
 
-const matchPassword = (
-  password: string,
-  passwordRepeated: string,
-): PasswordMatches => {
+const matchPassword = (password: string): PasswordMatches => {
   return {
     sixOrMore: {
       matchesPassword: !!password.match(sixCharactersRegex),
@@ -49,10 +46,6 @@ const matchPassword = (
       matchesPassword: !!password.match(symbolOrNumberRegex),
       description: PasswordValidationText.SYMBOL_OR_NUMBER,
     },
-    matching: {
-      matchesPassword: password !== '' && password === passwordRepeated,
-      description: PasswordValidationText.MATCHING_REPEATED,
-    },
   };
 };
 
@@ -61,16 +54,13 @@ export type ValidationResult = {
   lessThan72: boolean;
   upperAndLowercase: boolean;
   symbolOrNumber: boolean;
-  matching: boolean;
   failedMessage?: string;
 };
 
-export const passwordValidation = (
-  password: string,
-  passwordRepeated: string,
-): ValidationResult => {
+export const passwordValidation = (password: string): ValidationResult => {
   let failedMessage: string | undefined;
-  const passwordMatches = matchPassword(password, passwordRepeated);
+
+  const passwordMatches = matchPassword(password);
 
   const errorCount = Object.values(passwordMatches).filter(
     (passwordMatch) => !passwordMatch.matchesPassword,
@@ -90,7 +80,6 @@ export const passwordValidation = (
     lessThan72: passwordMatches.lessThan72.matchesPassword,
     upperAndLowercase: passwordMatches.upperAndLowercase.matchesPassword,
     symbolOrNumber: passwordMatches.symbolOrNumber.matchesPassword,
-    matching: passwordMatches.matching.matchesPassword,
     failedMessage,
   };
 };

--- a/src/shared/model/Errors.ts
+++ b/src/shared/model/Errors.ts
@@ -16,10 +16,6 @@ export enum ResetPasswordErrors {
 export enum ChangePasswordErrors {
   GENERIC = 'There was a problem changing your password, please try again.',
   INVALID_TOKEN = 'The token that was supplied has expired, please try again.',
-  PASSWORD_BLANK = 'Password field must not be blank',
-  REPEAT_PASSWORD_BLANK = 'Repeat Password field must not be blank',
-  PASSWORD_NO_MATCH = 'The passwords do not match, please try again',
-  PASSWORD_LENGTH = 'Password must be between 6 and 72 characters',
 }
 
 export enum VerifyEmailErrors {


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Add password validation to password reset form.
https://trello.com/c/ti5zCP5Z/2457-add-basic-password-validation-to-reset-password-creation-page-on-gateway-m

Tests for the constraints 
- between 6 and 72 characters
- upper and lowercase characters
- a symbol or number
- repeated password matches


## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

reset your password an test the validation works in realtime

users without JavaScript should also be able to reset their password and see the rules.


# Why

Make passwords at the Guardian stronger and less susceptible to password spraying attacks

# video

![passworddemogif](https://user-images.githubusercontent.com/29203769/96137453-91736500-0ef4-11eb-8d2c-625fe57644e9.gif)
