### PR TITLE
Marketing consents to use checkboxes.

### DIFF
--- a/src/client/layouts/ConsentsLayout.tsx
+++ b/src/client/layouts/ConsentsLayout.tsx
@@ -77,14 +77,16 @@ export const ConsentsLayout: FunctionComponent<ConsentsLayoutProps> = ({
         </main>
         <ConsentsBlueBackground>
           <div css={[gridItem(gridItemColumnConsents), controls]}>
-            <Button
-              iconSide="right"
-              nudgeIcon={true}
-              icon={<SvgArrowRightStraight />}
-              type="submit"
-            >
-              Save and continue
-            </Button>
+            {!error && (
+              <Button
+                iconSide="right"
+                nudgeIcon={true}
+                icon={<SvgArrowRightStraight />}
+                type="submit"
+              >
+                Save and continue
+              </Button>
+            )}
             {previousPage && (
               <LinkButton
                 css={linkButton}

--- a/src/client/pages/ConsentsCommunication.tsx
+++ b/src/client/pages/ConsentsCommunication.tsx
@@ -39,51 +39,59 @@ export const ConsentsCommunicationPage = () => {
 
   const market_research_optout = consents.find(
     (consent) => consent.id === Consents.MARKET_RESEARCH,
-  ) || { consented: true };
+  );
 
   const consentsWithoutOptout = consents.filter(
     (consent) => !consent.id.includes('_optout'),
   );
 
   const label = (
-    <span css={checkboxLabel}>{market_research_optout.description}</span>
+    <span css={checkboxLabel}>{market_research_optout?.description}</span>
   );
 
   return (
     <ConsentsLayout title="Stay in touch" current={CONSENTS_PAGES.CONTACT}>
-      <h3 css={[heading, autoRow()]}>Guardian products, services & events</h3>
-      <p css={[text, autoRow()]}>
-        Stay informed and up to date with all that The Guardian has to offer.
-        From time to time we can send you information about our latest products,
-        services and events.
-      </p>
-      <div css={[communicationCardContainer, autoRow()]}>
-        {consentsWithoutOptout.map((consent) => (
-          <CommunicationCard
-            key={consent.id}
-            title={consent.name}
-            body={consent.description}
-            value={consent.id}
-            checked={!!consent.consented}
-          />
-        ))}
-      </div>
-      <h3 css={[heading, autoRow()]}>Using your data for market research</h3>
-      <p css={[text, autoRow()]}>
-        From time to time we may contact you for market research purposes
-        inviting you to complete a survey, or take part in a group discussion.
-        Normally, this invitation would be sent via email, but we may also
-        contact you by phone.
-      </p>
-      <fieldset css={[fieldset, autoRow()]}>
-        <CheckboxGroup name={market_research_optout.id}>
-          <Checkbox
-            value="consent-option"
-            label={label}
-            defaultChecked={market_research_optout.consented}
-          />
-        </CheckboxGroup>
-      </fieldset>
+      {market_research_optout && (
+        <>
+          <h3 css={[heading, autoRow()]}>
+            Guardian products, services & events
+          </h3>
+          <p css={[text, autoRow()]}>
+            Stay informed and up to date with all that The Guardian has to
+            offer. From time to time we can send you information about our
+            latest products, services and events.
+          </p>
+          <div css={[communicationCardContainer, autoRow()]}>
+            {consentsWithoutOptout.map((consent) => (
+              <CommunicationCard
+                key={consent.id}
+                title={consent.name}
+                body={consent.description}
+                value={consent.id}
+                checked={!!consent.consented}
+              />
+            ))}
+          </div>
+          <h3 css={[heading, autoRow()]}>
+            Using your data for market research
+          </h3>
+          <p css={[text, autoRow()]}>
+            From time to time we may contact you for market research purposes
+            inviting you to complete a survey, or take part in a group
+            discussion. Normally, this invitation would be sent via email, but
+            we may also contact you by phone.
+          </p>
+          <fieldset css={[fieldset, autoRow()]}>
+            <CheckboxGroup name={market_research_optout.id}>
+              <Checkbox
+                value="consent-option"
+                label={label}
+                defaultChecked={market_research_optout.consented}
+              />
+            </CheckboxGroup>
+          </fieldset>
+        </>
+      )}
     </ConsentsLayout>
   );
 };

--- a/src/client/pages/ConsentsCommunication.tsx
+++ b/src/client/pages/ConsentsCommunication.tsx
@@ -3,7 +3,6 @@ import { ConsentsLayout } from '@/client/layouts/ConsentsLayout';
 import { textSans } from '@guardian/src-foundations/typography';
 import { css } from '@emotion/core';
 import { space, neutral } from '@guardian/src-foundations';
-import { RadioGroup, Radio } from '@guardian/src-radio';
 import { getAutoRow, gridItemColumnConsents } from '@/client/styles/Grid';
 import { CommunicationCard } from '@/client/components/ConsentsCommunicationCard';
 import { CONSENTS_PAGES } from '@/client/models/ConsentsPages';
@@ -11,6 +10,7 @@ import { heading, text } from '@/client/styles/Consents';
 import { GlobalState } from '@/shared/model/GlobalState';
 import { GlobalStateContext } from '@/client/components/GlobalState';
 import { Consents } from '@/shared/model/Consent';
+import { Checkbox, CheckboxGroup } from '@guardian/src-checkbox';
 
 const fieldset = css`
   border: 0;
@@ -19,10 +19,8 @@ const fieldset = css`
   ${textSans.medium()}
 `;
 
-const legend = css`
+const checkboxLabel = css`
   color: ${neutral[46]};
-  margin: 0 0 ${space[1]}px 0;
-  padding: 0;
 `;
 
 const communicationCardContainer = css`
@@ -45,6 +43,10 @@ export const ConsentsCommunicationPage = () => {
 
   const consentsWithoutOptout = consents.filter(
     (consent) => !consent.id.includes('_optout'),
+  );
+
+  const label = (
+    <span css={checkboxLabel}>{market_research_optout.description}</span>
   );
 
   return (
@@ -74,22 +76,13 @@ export const ConsentsCommunicationPage = () => {
         contact you by phone.
       </p>
       <fieldset css={[fieldset, autoRow()]}>
-        <legend css={legend}>
-          I am happy for The Guardian to use my personal data for market
-          research purposes
-        </legend>
-        <RadioGroup orientation="horizontal" name={Consents.MARKET_RESEARCH}>
-          <Radio
-            value="false"
-            label="Yes"
-            defaultChecked={!market_research_optout.consented}
-          />
-          <Radio
-            value="true"
-            label="No"
+        <CheckboxGroup name={market_research_optout.id}>
+          <Checkbox
+            value="consent-option"
+            label={label}
             defaultChecked={market_research_optout.consented}
           />
-        </RadioGroup>
+        </CheckboxGroup>
       </fieldset>
     </ConsentsLayout>
   );

--- a/src/client/pages/ConsentsData.tsx
+++ b/src/client/pages/ConsentsData.tsx
@@ -36,46 +36,53 @@ export const ConsentsDataPage = () => {
     (consent) => consent.id === Consents.PROFILING,
   );
 
-  const label = <span css={checkboxLabel}>{profiling_optout.description}</span>;
+  const label = (
+    <span css={checkboxLabel}>{profiling_optout?.description}</span>
+  );
 
   return (
     <ConsentsLayout title="Your data" current={CONSENTS_PAGES.YOUR_DATA}>
-      <h3 css={[heading, autoRow()]}>Our commitment to you</h3>
-      <p css={[text, autoRow()]}>
-        We think carefully about our use of personal data and use it
-        responsibly. We never share it without your permission and we have a
-        team who are dedicated to keeping any data we collect safe and secure.
-        You can find out more about how The Guardian aims to safeguard users
-        data by going to the{' '}
-        <Link
-          href={Locations.PRIVACY}
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Privacy
-        </Link>{' '}
-        section of the website.
-      </p>
-      <h3 css={[heading, headingMarginSpace6, autoRow()]}>
-        Using your data for marketing analysis
-      </h3>
-      <p css={[text, autoRow()]}>
-        From time to time we may use your personal data for marketing analysis.
-        That includes looking at what products or services you have bought from
-        us and what pages you have been viewing on theguardian.com and other
-        Guardian websites (e.g. Guardian Jobs or Guardian Holidays). We do this
-        to understand your interests and preferences so that we can make our
-        marketing communication more relevant to you.
-      </p>
-      <fieldset css={[fieldset, autoRow()]}>
-        <CheckboxGroup name={profiling_optout.id}>
-          <Checkbox
-            value="consent-option"
-            label={label}
-            defaultChecked={profiling_optout.consented}
-          />
-        </CheckboxGroup>
-      </fieldset>
+      {profiling_optout && (
+        <>
+          <h3 css={[heading, autoRow()]}>Our commitment to you</h3>
+          <p css={[text, autoRow()]}>
+            We think carefully about our use of personal data and use it
+            responsibly. We never share it without your permission and we have a
+            team who are dedicated to keeping any data we collect safe and
+            secure. You can find out more about how The Guardian aims to
+            safeguard users data by going to the{' '}
+            <Link
+              href={Locations.PRIVACY}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Privacy
+            </Link>{' '}
+            section of the website.
+          </p>
+          <h3 css={[heading, headingMarginSpace6, autoRow()]}>
+            Using your data for marketing analysis
+          </h3>
+          <p css={[text, autoRow()]}>
+            From time to time we may use your personal data for marketing
+            analysis. That includes looking at what products or services you
+            have bought from us and what pages you have been viewing on
+            theguardian.com and other Guardian websites (e.g. Guardian Jobs or
+            Guardian Holidays). We do this to understand your interests and
+            preferences so that we can make our marketing communication more
+            relevant to you.
+          </p>
+          <fieldset css={[fieldset, autoRow()]}>
+            <CheckboxGroup name={profiling_optout.id}>
+              <Checkbox
+                value="consent-option"
+                label={label}
+                defaultChecked={profiling_optout.consented}
+              />
+            </CheckboxGroup>
+          </fieldset>
+        </>
+      )}
     </ConsentsLayout>
   );
 };

--- a/src/client/pages/ConsentsData.tsx
+++ b/src/client/pages/ConsentsData.tsx
@@ -4,7 +4,6 @@ import { ConsentsLayout } from '@/client/layouts/ConsentsLayout';
 import { textSans } from '@guardian/src-foundations/typography';
 import { css } from '@emotion/core';
 import { space, neutral } from '@guardian/src-foundations';
-import { RadioGroup, Radio } from '@guardian/src-radio';
 import { GlobalStateContext } from '@/client/components/GlobalState';
 import { getAutoRow, gridItemColumnConsents } from '@/client/styles/Grid';
 import { CONSENTS_PAGES } from '@/client/models/ConsentsPages';
@@ -12,6 +11,7 @@ import { heading, text, headingMarginSpace6 } from '@/client/styles/Consents';
 import { GlobalState } from '@/shared/model/GlobalState';
 import { Consents } from '@/shared/model/Consent';
 import { Link } from '@guardian/src-link';
+import { Checkbox, CheckboxGroup } from '@guardian/src-checkbox';
 
 const fieldset = css`
   border: 0;
@@ -20,10 +20,8 @@ const fieldset = css`
   ${textSans.medium()}
 `;
 
-const legend = css`
+const checkboxLabel = css`
   color: ${neutral[46]};
-  margin: 0 0 ${space[1]}px 0;
-  padding: 0;
 `;
 
 export const ConsentsDataPage = () => {
@@ -36,7 +34,9 @@ export const ConsentsDataPage = () => {
 
   const profiling_optout = consents.find(
     (consent) => consent.id === Consents.PROFILING,
-  ) || { consented: true };
+  );
+
+  const label = <span css={checkboxLabel}>{profiling_optout.description}</span>;
 
   return (
     <ConsentsLayout title="Your data" current={CONSENTS_PAGES.YOUR_DATA}>
@@ -68,22 +68,13 @@ export const ConsentsDataPage = () => {
         marketing communication more relevant to you.
       </p>
       <fieldset css={[fieldset, autoRow()]}>
-        <legend css={legend}>
-          I am happy for The Guardian to use my personal data for marketing
-          analysis purposes.
-        </legend>
-        <RadioGroup orientation="horizontal" name={Consents.PROFILING}>
-          <Radio
-            value="false"
-            label="Yes"
-            defaultChecked={!profiling_optout.consented}
-          />
-          <Radio
-            value="true"
-            label="No"
+        <CheckboxGroup name={profiling_optout.id}>
+          <Checkbox
+            value="consent-option"
+            label={label}
             defaultChecked={profiling_optout.consented}
           />
-        </RadioGroup>
+        </CheckboxGroup>
       </fieldset>
     </ConsentsLayout>
   );


### PR DESCRIPTION
## Description
Uses the checkbox style marketing consents with the corresponding text from IDAPI

## Changes
* Replace radio components with checkbox components on Data as well as Communications pages.
* Marketing consents on Data and Communications pages now uses description from IDAPI.
* Change `ConsentsLayout` to hide the save and continue button if the page is in error state.
