### PR TITLE
Consents flow design amends

### DIFF
--- a/src/client/__tests__/__snapshots__/PageProgression.test.tsx.snap
+++ b/src/client/__tests__/__snapshots__/PageProgression.test.tsx.snap
@@ -237,7 +237,7 @@ exports[`PageProgression component when an active section is supplied marks the 
       />
     </svg>
     <div>
-      Communication
+      Stay in touch
     </div>
   </li>
   <li
@@ -591,7 +591,7 @@ exports[`PageProgression component when no active page is set shows the first st
       />
     </svg>
     <div>
-      Communication
+      Stay in touch
     </div>
   </li>
   <li
@@ -945,7 +945,7 @@ exports[`PageProgression component when on the last section marks the previous s
       />
     </svg>
     <div>
-      Communication
+      Stay in touch
     </div>
   </li>
   <li

--- a/src/client/components/ConsentsCommunicationCard.tsx
+++ b/src/client/components/ConsentsCommunicationCard.tsx
@@ -71,7 +71,7 @@ const communicationCardBodyContainer = css`
 const communicationCardBodyText = css`
   color: ${palette.text.primary};
   margin: 0;
-  ${textSans.small({ lineHeight: 'tight' })};
+  ${textSans.small()};
 `;
 
 const communicationCardCheckboxContainer = css`

--- a/src/client/components/ConsentsCommunicationCard.tsx
+++ b/src/client/components/ConsentsCommunicationCard.tsx
@@ -44,7 +44,7 @@ const communicationCardHeadingContainer = (image?: string) => css`
   display: flex;
   flex-direction: column;
   justify-content: flex-end;
-  padding: ${space[2]}px ${space[3]}px ${space[2]}px ${space[3]}px;
+  padding: ${space[6]}px ${space[3]}px ${space[2]}px ${space[3]}px;
 
   ${from.tablet} {
     height: calc(${space[24]}px + ${space[6]}px);

--- a/src/client/components/Lines.tsx
+++ b/src/client/components/Lines.tsx
@@ -12,7 +12,7 @@ export const Lines: FunctionComponent<LinesProps> = (props) => {
   const { n, margin } = props;
   const thickness = 1;
   const distance = 6;
-  const height = n * distance;
+  const height = (n - 1) * distance + thickness;
   const color = props.color ? props.color : 'black';
 
   return (

--- a/src/client/components/NewsletterCard.tsx
+++ b/src/client/components/NewsletterCard.tsx
@@ -113,7 +113,7 @@ const checkBoxBackgroundColorBugFix = css`
 
 const clockSVG = (
   <svg
-    css={{ fill: palette.neutral[60] }}
+    css={{ fill: brand[400] }}
     width="15px"
     height="15px"
     viewBox="0 0 11 11"

--- a/src/client/components/NewsletterCard.tsx
+++ b/src/client/components/NewsletterCard.tsx
@@ -64,7 +64,7 @@ const image = (id?: string) => {
 const h1 = css`
   color: ${brand[400]};
   ${titlepiece.small()};
-  margin: 0 0 ${space[1]}px 0;
+  margin: ${space[2]}px 0 ${space[1]}px 0;
   //Override
   font-size: 24px;
 `;

--- a/src/client/layouts/ConsentsLayout.tsx
+++ b/src/client/layouts/ConsentsLayout.tsx
@@ -91,7 +91,7 @@ export const ConsentsLayout: FunctionComponent<ConsentsLayoutProps> = ({
                 href={`${Routes.CONSENTS}/${previousPage}${returnUrlQuery}`}
                 priority="subdued"
               >
-                Go Back
+                Go back
               </LinkButton>
             )}
           </div>

--- a/src/client/layouts/shared/Consents.tsx
+++ b/src/client/layouts/shared/Consents.tsx
@@ -64,9 +64,10 @@ const content = css`
 
 const h1 = css`
   color: ${brand[400]};
-  margin: ${space[4]}px 0 ${space[12]}px 0;
+  margin: ${space[4]}px 0 52px 0;
   ${titlepiece.small({ fontWeight: 'bold' })};
-  ${gridItem(gridItemColumnConsents)}
+  ${gridItem(gridItemColumnConsents)};
+  line-height: 1;
 `;
 
 const h2 = css`

--- a/src/client/models/ConsentsPages.ts
+++ b/src/client/models/ConsentsPages.ts
@@ -1,6 +1,6 @@
 export enum CONSENTS_PAGES {
   YOUR_DATA = 'Your data',
-  CONTACT = 'Communication',
+  CONTACT = 'Stay in touch',
   NEWSLETTERS = 'Newsletters',
   REVIEW = 'Review',
 }

--- a/src/client/styles/Consents.ts
+++ b/src/client/styles/Consents.ts
@@ -23,5 +23,6 @@ export const headingWithMq = css`
 
 export const text = css`
   margin: 0;
+  color: ${palette.neutral[20]};
   ${textSans.medium()}
 `;

--- a/src/client/styles/Consents.ts
+++ b/src/client/styles/Consents.ts
@@ -6,7 +6,7 @@ import { from } from '@guardian/src-foundations/mq';
 export const heading = css`
   color: ${palette.text.ctaSecondary};
   margin: 0 0 ${space[3]}px;
-  ${headline.xxxsmall({ fontWeight: 'bold' })};
+  ${headline.xxsmall({ fontWeight: 'bold' })};
 `;
 
 export const headingMarginSpace6 = css`


### PR DESCRIPTION
## Description
Various requested design changes.

## Changes
* General body text to use correct color
* Page subtitles to use larger size
* Back buttons use correct text casing
* Consents cards to use standard text spacing
* Newsletters card frequency clock svg now blue
* Newsletter card titles have more top padding
* Consent card titles to have more top padding
* Fix bug with `Lines` component which added too much height in off-by-one error.
* Page headings to have line-height of 1 and slightly larger bottom margin.
