### PR TITLE
Add document/page title to consents routes

### DIFF
--- a/src/server/lib/middleware/routes.ts
+++ b/src/server/lib/middleware/routes.ts
@@ -1,6 +1,7 @@
 import { Express, Request, Response } from 'express';
 import { default as routes } from '@/server/routes';
 import { renderer } from '@/server/lib/renderer';
+import { PageTitle } from '@/shared/model/PageTitle';
 
 export const applyRoutes = (server: Express): void => {
   // all routes from routes folder
@@ -8,7 +9,9 @@ export const applyRoutes = (server: Express): void => {
 
   // 404 default route
   server.use((_: Request, res: Response) => {
-    const html = renderer('/404');
+    const html = renderer('/404', {
+      pageTitle: PageTitle.NOT_FOUND,
+    });
     res.type('html');
     res.status(404).send(html);
   });

--- a/src/server/routes/changePassword.ts
+++ b/src/server/routes/changePassword.ts
@@ -165,7 +165,9 @@ router.get(
   Routes.RESET_RESEND,
   removeNoCache,
   (_: Request, res: ResponseWithLocals) => {
-    const html = renderer(Routes.RESET_RESEND);
+    const html = renderer(Routes.RESET_RESEND, {
+      pageTitle: PageTitle.RESET_RESEND,
+    });
     res.type('html').send(html);
   },
 );

--- a/src/server/routes/consents.ts
+++ b/src/server/routes/consents.ts
@@ -29,7 +29,6 @@ import { trackMetric } from '@/server/lib/AWS';
 import { consentsPageMetric } from '@/server/models/Metrics';
 import { addReturnUrlToPath } from '@/server/lib/queryParams';
 import { CONSENTS_PAGES } from '@/client/models/ConsentsPages';
-import { PageTitle } from '@/shared/model/PageTitle';
 
 const router = Router();
 

--- a/src/server/routes/consents.ts
+++ b/src/server/routes/consents.ts
@@ -28,11 +28,14 @@ import { VERIFY_EMAIL } from '@/shared/model/Success';
 import { trackMetric } from '@/server/lib/AWS';
 import { consentsPageMetric } from '@/server/models/Metrics';
 import { addReturnUrlToPath } from '@/server/lib/queryParams';
+import { CONSENTS_PAGES } from '@/client/models/ConsentsPages';
+import { PageTitle } from '@/shared/model/PageTitle';
 
 const router = Router();
 
 interface ConsentPage {
   page: string;
+  pageTitle: string;
   read: (ip: string, sc_gu_u: string) => Promise<PageData>;
   update?: (
     ip: string,
@@ -107,6 +110,7 @@ const getUserNewsletterSubscriptions = async (
 export const consentPages: ConsentPage[] = [
   {
     page: Routes.CONSENTS_NEWSLETTERS.slice(1),
+    pageTitle: CONSENTS_PAGES.NEWSLETTERS,
     read: async (ip, sc_gu_u) => {
       try {
         return {
@@ -132,6 +136,7 @@ export const consentPages: ConsentPage[] = [
   },
   {
     page: Routes.CONSENTS_COMMUNICATION.slice(1),
+    pageTitle: CONSENTS_PAGES.CONTACT,
     read: async (ip, sc_gu_u) => {
       try {
         return {
@@ -158,6 +163,7 @@ export const consentPages: ConsentPage[] = [
   },
   {
     page: Routes.CONSENTS_DATA.slice(1),
+    pageTitle: CONSENTS_PAGES.YOUR_DATA,
     read: async (ip, sc_gu_u) => {
       try {
         return {
@@ -184,6 +190,7 @@ export const consentPages: ConsentPage[] = [
   },
   {
     page: Routes.CONSENTS_REVIEW.slice(1),
+    pageTitle: CONSENTS_PAGES.REVIEW,
     read: async (ip, sc_gu_u) => {
       const ALL_CONSENT = [
         ...CONSENTS_DATA_PAGE,
@@ -233,8 +240,11 @@ router.get(
       return res.redirect(404, `${Routes.CONSENTS}/${page}`);
     }
 
+    let pageTitle;
+
     try {
-      const { read } = consentPages[pageIndex];
+      const { read, pageTitle: _pageTitle } = consentPages[pageIndex];
+      pageTitle = _pageTitle;
 
       state.pageData = await read(req.ip, sc_gu_u);
       state.pageData.returnUrl = res.locals?.queryParams?.returnUrl;
@@ -243,7 +253,10 @@ router.get(
       state.error = e.message;
     }
 
-    const html = renderer(`${Routes.CONSENTS}/${page}`, { globalState: state });
+    const html = renderer(`${Routes.CONSENTS}/${page}`, {
+      globalState: state,
+      pageTitle,
+    });
 
     trackMetric(consentsPageMetric(page, 'Get', status === 200));
 
@@ -266,8 +279,11 @@ router.post(`${Routes.CONSENTS}/:page`, loginMiddleware, async (req, res) => {
     return res.redirect(404, `${Routes.CONSENTS}/${page}`);
   }
 
+  let pageTitle;
+
   try {
-    const { update } = consentPages[pageIndex];
+    const { update, pageTitle: _pageTitle } = consentPages[pageIndex];
+    pageTitle = _pageTitle;
 
     if (update) {
       await update(req.ip, sc_gu_u, req.body);
@@ -287,7 +303,10 @@ router.post(`${Routes.CONSENTS}/:page`, loginMiddleware, async (req, res) => {
 
   trackMetric(consentsPageMetric(page, 'Post', false));
 
-  const html = renderer(`${Routes.CONSENTS}/${page}`, { globalState: state });
+  const html = renderer(`${Routes.CONSENTS}/${page}`, {
+    globalState: state,
+    pageTitle,
+  });
   res
     .type('html')
     .status(status ?? 500)

--- a/src/server/routes/verifyEmail.ts
+++ b/src/server/routes/verifyEmail.ts
@@ -17,6 +17,7 @@ import { getProviderForEmail } from '@/shared/lib/emailProvider';
 import { trackMetric } from '@/server/lib/AWS';
 import { Metrics } from '@/server/models/Metrics';
 import { addReturnUrlToPath } from '@/server/lib/queryParams';
+import { PageTitle } from '@/shared/model/PageTitle';
 
 const router = Router();
 
@@ -51,6 +52,7 @@ router.get(Routes.VERIFY_EMAIL, async (req: Request, res: Response) => {
 
   const html = renderer(Routes.VERIFY_EMAIL, {
     globalState: state,
+    pageTitle: PageTitle.VERIFY_EMAIL,
   });
 
   return res.status(status).type('html').send(html);
@@ -91,6 +93,7 @@ router.post(Routes.VERIFY_EMAIL, async (req: Request, res: Response) => {
 
   const html = renderer(Routes.VERIFY_EMAIL, {
     globalState: state,
+    pageTitle: PageTitle.VERIFY_EMAIL,
   });
 
   return res.status(status).type('html').send(html);

--- a/src/shared/model/PageTitle.ts
+++ b/src/shared/model/PageTitle.ts
@@ -1,7 +1,9 @@
 export enum PageTitle {
+  NOT_FOUND = 'Not Found',
   RESET = 'Reset Password',
   RESET_SENT = 'Check Your Inbox',
   RESET_RESEND = 'Resend Reset Password',
   CHANGE_PASSWORD = 'Change Password',
   CHANGE_PASSWORD_COMPLETE = 'Password Changed',
+  VERIFY_EMAIL = 'Verify Email',
 }


### PR DESCRIPTION
## What does this change?
- Adds the `document.title` (`<head><title>...</title></head>`) to routes which didn't have one previously which before were being set to the default (`Gateway | The Guardian`)
  - 404 -> "Not Found | The Guardian"
  - consents routes -> Name of consents page + " | The Guardian"
  - /verify-email -> "Verify Email | The Guardian"

## Why
- Better metadata about the page the user is on
- Meaningful information about the page