### PR TITLE
Cloudformation | Set max instance count to 12

### DIFF
--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -68,7 +68,7 @@ Mappings:
     PROD:
       BaseUri: profile.theguardian.com
       DefaultReturnUri: https://theguardian.com
-      MaxInstances: 6
+      MaxInstances: 12
       MinInstances: 3
       LatencyAlarmThreshold: 0.5
       LatencyAlarmPeriod: 60


### PR DESCRIPTION
## What does this change?
- Set max instance count to 12 on prod, so that it's still possible to deploy the application even if the deployment has been scaled up
