### PR TITLE
Switch to Preact from React

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,10 +92,14 @@
     "ms": "^2.1.2",
     "node-fetch": "^2.6.1",
     "ophan-tracker-js": "^1.3.22",
+    "preact": "^10.5.5",
+    "preact-render-to-string": "^5.1.11",
     "query-string": "^6.13.6",
-    "react": "^16.13.1",
-    "react-dom": "^16.13.1",
     "react-router-dom": "^5.2.0",
     "winston": "^3.3.3"
+  },
+  "optionalDependencies": {
+    "react": "^16.13.1",
+    "react-dom": "^16.13.1"
   }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -99,6 +99,7 @@ const server = {
       "react": "preact/compat",
       "react-dom/test-utils": "preact/test-utils",
       "react-dom": "preact/compat",
+      "react-dom/server": "preact/compat",
     }
   },
   target: "node",
@@ -187,6 +188,7 @@ const client = {
       "react": "preact/compat",
       "react-dom/test-utils": "preact/test-utils",
       "react-dom": "preact/compat",
+      "react-dom/server": "preact/compat",
     }
   },
   target: "web",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -95,7 +95,10 @@ const server = {
   resolve: {
     extensions,
     alias: {
-      "@": path.join(__dirname, "src")
+      "@": path.join(__dirname, "src"),
+      "react": "preact/compat",
+      "react-dom/test-utils": "preact/test-utils",
+      "react-dom": "preact/compat",
     }
   },
   target: "node",
@@ -180,7 +183,10 @@ const client = {
   resolve: {
     extensions,
     alias: {
-      "@": path.join(__dirname, "src")
+      "@": path.join(__dirname, "src"),
+      "react": "preact/compat",
+      "react-dom/test-utils": "preact/test-utils",
+      "react-dom": "preact/compat",
     }
   },
   target: "web",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -174,7 +174,7 @@ const client = {
     }
   },
   output: {
-    filename: "[contenthash].bundle.js",
+    filename: "[name].[contenthash].bundle.js",
     chunkFilename: '[name].[contenthash].bundle.js',
     path: path.resolve(__dirname, "build/static/"),
     publicPath: 'gateway-static/'

--- a/yarn.lock
+++ b/yarn.lock
@@ -8628,6 +8628,18 @@ posix-character-classes@^0.1.0:
   resolved "https://registry.yarnpkg.com/posix-character-classes/-/posix-character-classes-0.1.1.tgz#01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab"
   integrity sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=
 
+preact-render-to-string@^5.1.11:
+  version "5.1.11"
+  resolved "https://registry.yarnpkg.com/preact-render-to-string/-/preact-render-to-string-5.1.11.tgz#7d8d77c23ef40ae6abc3d390b7430b3cb6206020"
+  integrity sha512-8DXkx8WzeUexYyh9ZjlBSsqcJVOndidw10t1MK1gLx6at4QxQE3RfqaObPgy5WOnw2piyh9kanNB7w7+dmaq4g==
+  dependencies:
+    pretty-format "^3.8.0"
+
+preact@^10.5.5:
+  version "10.5.5"
+  resolved "https://registry.yarnpkg.com/preact/-/preact-10.5.5.tgz#c6c172ca751df27483350b8ab622abc12956e997"
+  integrity sha512-5ONLNH1SXMzzbQoExZX4TELemNt+TEDb622xXFNfZngjjM9qtrzseJt+EfiUu4TZ6EJ95X5sE1ES4yqHFSIdhg==
+
 prelude-ls@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"
@@ -8684,6 +8696,11 @@ pretty-format@^26.0.0, pretty-format@^26.6.1:
     ansi-regex "^5.0.0"
     ansi-styles "^4.0.0"
     react-is "^17.0.1"
+
+pretty-format@^3.8.0:
+  version "3.8.0"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-3.8.0.tgz#bfbed56d5e9a776645f4b1ff7aa1a3ac4fa3c385"
+  integrity sha1-v77VbV6ad2ZF9LH/eqGjrE+jw4U=
 
 process-nextick-args@~2.0.0:
   version "2.0.1"


### PR DESCRIPTION
## What does this change?
- Switch to using [Preact](http://preactjs.com/) instead of [React](https://reactjs.org/) as the main framework library
- Utilizes `preact/compat` to maximise compatibility with `react`
- Uses webpack `alias` to minimise code changes by aliasing `react` to `preact/compat`
- Add `name` to bundles filenames to make them easier to reason about

## Why?
- Mainly to reduce the bundle size used when performing client side rendering
- Also offers some performance benefits too

## Difference
These differences are not `gzip`ped

### Preact bundle size production:
```
Entrypoint main [big] 408 KiB
runtime.ab81a73425605ae10fa3.bundle.js 1.36 KiB
vendors.c2e1d8db84eb8d577a52.bundle.js 360 KiB
main.0345e5983168ba462241.bundle.js 46.1 KiB
```

### React bundle size production:
```
Entrypoint main [big] 513 KiB
runtime.ab81a73425605ae10fa3.bundle.js 1.36 KiB
vendors.734dd6aa30710ec17502.bundle.js 465 KiB
main.82b0e1d7bfafbeef4959.bundle.js 46.1 KiB
```

### Difference:
```
vendors: 465 - 360 = 105 KiB
total: 513 - 408 = 105KiB
```