### PR TITLE
fix high latency alarm reference

### DIFF
--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -363,6 +363,7 @@ Resources:
           Protocol: email
   HighLatencyAlarm:
     Type: AWS::CloudWatch::Alarm
+    Condition: IsProd
     Properties:
       AlarmName: !Sub '${App}-${Stage} high load balancer latency'
       AlarmDescription: !Sub
@@ -376,7 +377,7 @@ Resources:
       ComparisonOperator: GreaterThanOrEqualToThreshold
       Dimensions:
         - Name: LoadBalancer
-          Value: !Ref 'LoadBalancer'
+          Value: !GetAtt 'LoadBalancer.LoadBalancerFullName'
       Threshold:
         !FindInMap [StageVariables, !Ref 'Stage', LatencyAlarmThreshold]
       Period: !FindInMap [StageVariables, !Ref 'Stage', LatencyAlarmPeriod]


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Fixes the high latency alarm used by auto scaling. The parameter expects the LB name, not the ARN

