### PR TITLE
Change US Newsletters to default set

### DIFF
--- a/src/shared/lib/newsletter.ts
+++ b/src/shared/lib/newsletter.ts
@@ -44,9 +44,9 @@ export const NewsletterMap = new Map<GeoLocation | undefined, Newsletters[]>([
     'US' as GeoLocation,
     [
       Newsletters.TODAY_US,
-      Newsletters.US_MORNING_BRIEFING,
-      Newsletters.MINUTE_US,
+      Newsletters.THE_LONG_READ,
       Newsletters.GREENLIGHT,
+      Newsletters.BOOKMARKS,
     ] as Newsletters[],
   ],
 ]);


### PR DESCRIPTION
## What does this change?
The US Election is over.
- Remove the US Morning Briefing and Minute US newsletters
- Add The Long Read and Bookmarks
