### PR TITLE
AB Test: One consent card on communications page.

### DIFF
--- a/src/client/components/ConsentsCommunicationCard.tsx
+++ b/src/client/components/ConsentsCommunicationCard.tsx
@@ -5,8 +5,6 @@ import { space, palette } from '@guardian/src-foundations';
 import { CheckboxGroup, Checkbox } from '@guardian/src-checkbox';
 import { from } from '@guardian/src-foundations/mq';
 
-// @TODO: Special ABTest CSS File or object file
-
 interface CommunicationCardProps {
   title: string;
   body: string;

--- a/src/client/components/ConsentsCommunicationCard.tsx
+++ b/src/client/components/ConsentsCommunicationCard.tsx
@@ -1,9 +1,11 @@
 import React, { FunctionComponent } from 'react';
 import { titlepiece, textSans } from '@guardian/src-foundations/typography';
-import { css } from '@emotion/core';
+import { css, SerializedStyles } from '@emotion/core';
 import { space, palette } from '@guardian/src-foundations';
 import { CheckboxGroup, Checkbox } from '@guardian/src-checkbox';
 import { from } from '@guardian/src-foundations/mq';
+
+// @TODO: Special ABTest CSS File or object file
 
 interface CommunicationCardProps {
   title: string;
@@ -11,6 +13,7 @@ interface CommunicationCardProps {
   value: string;
   checked: boolean;
   image?: string;
+  cssOverrides?: SerializedStyles;
 }
 
 const communicationCard = css`
@@ -93,9 +96,10 @@ export const CommunicationCard: FunctionComponent<CommunicationCardProps> = ({
   value,
   image,
   checked,
+  cssOverrides,
 }) => {
   return (
-    <div css={communicationCard}>
+    <div css={[communicationCard, cssOverrides]}>
       <div css={communicationCardHeadingContainer(image)}>
         <h3 css={communicationCardHeadingText}>{title}</h3>
       </div>

--- a/src/client/pages/ConsentsCommunication.tsx
+++ b/src/client/pages/ConsentsCommunication.tsx
@@ -36,7 +36,7 @@ const communicationCardContainer = css`
 `;
 
 // @TODO: Need proper imported styles (no arbitrary pixel values)
-// @TODO: Could be import
+// @TODO: Could be import or duplicate page
 const abTestOneConsentCSS = {
   consentsCard: css`
     ${from.tablet} {
@@ -90,6 +90,12 @@ const abTestOneConsentCSS = {
   `,
 };
 
+const abTestOneConsentText = {
+  title: 'Thank you for registering',
+  paragraph:
+    'Would you like to join our mailing list to stay informed and up to date with all that The Guardian has to offer?',
+};
+
 export const ConsentsCommunicationPage = () => {
   const autoRow = getAutoRow(1, gridItemColumnConsents);
 
@@ -116,7 +122,8 @@ export const ConsentsCommunicationPage = () => {
     (consent) => !consent.id.includes('_optout'),
   );
 
-  // AB TEST: oneConsentTest. When test done, replace instances of this with consentsWithoutOptout
+  // @todo: AB TEST: oneConsentTest.
+  // When Finished: Replace instances of this with consentsWithoutOptout
   const consentsABTestOneConsentTest = consentsWithoutOptout.filter(
     (consent) => !isUserInTest || consent.id === Consents.SUPPORTER,
   );
@@ -130,7 +137,9 @@ export const ConsentsCommunicationPage = () => {
       {market_research_optout && (
         <>
           <h2 css={[heading, autoRow()]}>
-            Guardian products, services & events
+            {isUserInTest
+              ? abTestOneConsentText.title
+              : 'Guardian products, services & events'}
           </h2>
           <p
             css={[
@@ -139,9 +148,9 @@ export const ConsentsCommunicationPage = () => {
               consentsABTestOneConsentCSS()?.text,
             ]}
           >
-            Stay informed and up to date with all that The Guardian has to
-            offer. From time to time we can send you information about our
-            latest products, services and events.
+            {isUserInTest
+              ? abTestOneConsentText.paragraph
+              : 'Stay informed and up to date with all that The Guardian has to offer. From time to time we can send you information about our latest products, services and events.'}
           </p>
           <div
             css={[

--- a/src/client/pages/ConsentsCommunication.tsx
+++ b/src/client/pages/ConsentsCommunication.tsx
@@ -15,6 +15,7 @@ import { ClientState } from '@/shared/model/ClientState';
 import { ClientStateContext } from '@/client/components/ClientState';
 import { Consents } from '@/shared/model/Consent';
 import { Checkbox, CheckboxGroup } from '@guardian/src-checkbox';
+import { useAB } from '@guardian/ab-react';
 
 const fieldset = css`
   border: 0;
@@ -38,6 +39,9 @@ export const ConsentsCommunicationPage = () => {
 
   const clientState = useContext<ClientState>(ClientStateContext);
 
+  const ABTestAPI = useAB();
+  const isUserInTest = ABTestAPI.isUserInVariant('oneConsentTest', 'variant');
+
   const { pageData = {} } = clientState;
   const { consents = [] } = pageData;
 
@@ -47,6 +51,11 @@ export const ConsentsCommunicationPage = () => {
 
   const consentsWithoutOptout = consents.filter(
     (consent) => !consent.id.includes('_optout'),
+  );
+
+  // AB TEST: oneConsentTest. When test done, replace instances of this with consentsWithoutOptout
+  const consentsABTestOneConsentTest = consentsWithoutOptout.filter(
+    (consent) => !isUserInTest || consent.id === Consents.SUPPORTER,
   );
 
   const label = (
@@ -66,7 +75,7 @@ export const ConsentsCommunicationPage = () => {
             latest products, services and events.
           </p>
           <div css={[communicationCardContainer, autoRow()]}>
-            {consentsWithoutOptout.map((consent) => (
+            {consentsABTestOneConsentTest.map((consent) => (
               <CommunicationCard
                 key={consent.id}
                 title={consent.name}

--- a/src/client/pages/ConsentsCommunication.tsx
+++ b/src/client/pages/ConsentsCommunication.tsx
@@ -47,7 +47,7 @@ const abTestOneConsentCSS = {
       width: 100%;
     }
 
-    & div:first-of-type {
+    & > div:first-of-type {
       ${from.tablet} {
         height: auto;
       }
@@ -59,8 +59,15 @@ const abTestOneConsentCSS = {
       letter-spacing: 0.3px;
     }
 
-    & div:nth-of-type(2) {
+    & > div:nth-of-type(2) {
       padding: 12px ${space[3]}px 6px ${space[3]}px;
+    }
+
+    & p {
+      margin: 0;
+      color: ${palette.neutral[20]};
+      ${textSans.medium()}
+      max-width: 640px;
     }
   `,
   consentsCardContainer: css`

--- a/src/client/pages/ConsentsCommunication.tsx
+++ b/src/client/pages/ConsentsCommunication.tsx
@@ -100,7 +100,7 @@ export const ConsentsCommunicationPage = () => {
   const clientState = useContext<ClientState>(ClientStateContext);
 
   const ABTestAPI = useAB();
-  const isUserInTest = ABTestAPI.isUserInVariant('oneConsentTest', 'variant');
+  const isUserInTest = ABTestAPI.isUserInVariant('OneConsentTest', 'variant');
   const consentsABTestOneConsentCSS = () => {
     if (isUserInTest) {
       return abTestOneConsentCSS;
@@ -120,7 +120,7 @@ export const ConsentsCommunicationPage = () => {
     (consent) => !consent.id.includes('_optout'),
   );
 
-  // @TODO: AB TEST: oneConsentTest.
+  // @TODO: AB TEST: OneConsentTest.
   // When Finished: Replace instances of this with consentsWithoutOptout
   const consentsABTestOneConsentTest = consentsWithoutOptout.filter(
     (consent) => !isUserInTest || consent.id === Consents.SUPPORTER,

--- a/src/client/pages/ConsentsCommunication.tsx
+++ b/src/client/pages/ConsentsCommunication.tsx
@@ -60,7 +60,7 @@ const abTestOneConsentCSS = {
     }
 
     & > div:nth-of-type(2) {
-      padding: 12px ${space[3]}px 6px ${space[3]}px;
+      padding: ${space[3]}px ${space[3]}px 6px ${space[3]}px;
     }
 
     & p {
@@ -72,11 +72,11 @@ const abTestOneConsentCSS = {
   `,
   consentsCardContainer: css`
     ${from.desktop} {
-      margin: 20px 0 32px;
-      grid-column: 2 / span 9 !important;
+      margin: ${space[5]}px 0 32px;
+      grid-column: 2 / span 9;
     }
     ${from.wide} {
-      grid-column: 3 / span 9 !important;
+      grid-column: 3 / span 9;
     }
   `,
   text: css`
@@ -86,7 +86,7 @@ const abTestOneConsentCSS = {
     max-width: 640px;
   `,
   fieldset: css`
-    margin: 14px 0 4px 0;
+    margin: 14px 0 ${space[1]}px 0;
   `,
 };
 

--- a/src/client/pages/ConsentsCommunication.tsx
+++ b/src/client/pages/ConsentsCommunication.tsx
@@ -2,7 +2,7 @@ import React, { useContext } from 'react';
 import { ConsentsLayout } from '@/client/layouts/ConsentsLayout';
 import { textSans } from '@guardian/src-foundations/typography';
 import { css } from '@emotion/core';
-import { space, neutral } from '@guardian/src-foundations';
+import { space, neutral, palette } from '@guardian/src-foundations';
 import {
   getAutoRow,
   gridItemColumnConsents,
@@ -16,6 +16,7 @@ import { ClientStateContext } from '@/client/components/ClientState';
 import { Consents } from '@/shared/model/Consent';
 import { Checkbox, CheckboxGroup } from '@guardian/src-checkbox';
 import { useAB } from '@guardian/ab-react';
+import { from } from '@guardian/src-foundations/mq';
 
 const fieldset = css`
   border: 0;
@@ -34,6 +35,54 @@ const communicationCardContainer = css`
   margin: ${space[6]}px 0 ${space[2]}px;
 `;
 
+// @TODO: Need proper imported styles (no arbitrary pixel values)
+// @TODO: Could be import
+const abTestOneConsentCSS = {
+  consentsCard: css`
+    ${from.tablet} {
+      width: 100%;
+    }
+
+    ${from.desktop} {
+      width: 100%;
+    }
+
+    & div:first-of-type {
+      ${from.tablet} {
+        height: auto;
+      }
+      padding: 14px ${space[3]}px 14px ${space[3]}px;
+    }
+
+    & div h3 {
+      font-size: 20px;
+      letter-spacing: 0.3px;
+    }
+
+    & div:nth-of-type(2) {
+      padding: 12px ${space[3]}px 6px ${space[3]}px;
+    }
+  `,
+  consentsCardContainer: css`
+    ${from.desktop} {
+      margin: 20px 0 32px;
+      grid-column: 2 / span 9 !important;
+    }
+    ${from.wide} {
+      grid-column: 3 / span 9 !important;
+    }
+  `,
+  text: css`
+    margin: 0;
+    color: ${palette.neutral[20]};
+    ${textSans.medium()}
+    max-width: 640px;
+  `,
+  fieldset: css`
+    margin: 14px 0 4px 0;
+  `,
+};
+
 export const ConsentsCommunicationPage = () => {
   const autoRow = getAutoRow(1, gridItemColumnConsents);
 
@@ -41,6 +90,13 @@ export const ConsentsCommunicationPage = () => {
 
   const ABTestAPI = useAB();
   const isUserInTest = ABTestAPI.isUserInVariant('oneConsentTest', 'variant');
+  const consentsABTestOneConsentCSS = () => {
+    if (isUserInTest) {
+      return abTestOneConsentCSS;
+    } else {
+      return;
+    }
+  };
 
   const { pageData = {} } = clientState;
   const { consents = [] } = pageData;
@@ -69,12 +125,24 @@ export const ConsentsCommunicationPage = () => {
           <h2 css={[heading, autoRow()]}>
             Guardian products, services & events
           </h2>
-          <p css={[text, autoRow(consentsParagraphSpanDef)]}>
+          <p
+            css={[
+              text,
+              autoRow(consentsParagraphSpanDef),
+              consentsABTestOneConsentCSS()?.text,
+            ]}
+          >
             Stay informed and up to date with all that The Guardian has to
             offer. From time to time we can send you information about our
             latest products, services and events.
           </p>
-          <div css={[communicationCardContainer, autoRow()]}>
+          <div
+            css={[
+              communicationCardContainer,
+              autoRow(),
+              consentsABTestOneConsentCSS()?.consentsCardContainer,
+            ]}
+          >
             {consentsABTestOneConsentTest.map((consent) => (
               <CommunicationCard
                 key={consent.id}
@@ -82,19 +150,28 @@ export const ConsentsCommunicationPage = () => {
                 body={consent.description}
                 value={consent.id}
                 checked={!!consent.consented}
+                cssOverrides={consentsABTestOneConsentCSS()?.consentsCard}
               />
             ))}
           </div>
           <h2 css={[heading, autoRow()]}>
             Using your data for market research
           </h2>
-          <p css={[text, autoRow(consentsParagraphSpanDef)]}>
+          <p
+            css={[
+              text,
+              autoRow(consentsParagraphSpanDef),
+              consentsABTestOneConsentCSS()?.text,
+            ]}
+          >
             From time to time we may contact you for market research purposes
             inviting you to complete a survey, or take part in a group
             discussion. Normally, this invitation would be sent via email, but
             we may also contact you by phone.
           </p>
-          <fieldset css={[fieldset, autoRow()]}>
+          <fieldset
+            css={[fieldset, autoRow(), consentsABTestOneConsentCSS()?.fieldset]}
+          >
             <CheckboxGroup name={market_research_optout.id}>
               <Checkbox
                 value="consent-option"

--- a/src/client/pages/ConsentsCommunication.tsx
+++ b/src/client/pages/ConsentsCommunication.tsx
@@ -35,8 +35,6 @@ const communicationCardContainer = css`
   margin: ${space[6]}px 0 ${space[2]}px;
 `;
 
-// @TODO: Need proper imported styles (no arbitrary pixel values)
-// @TODO: Could be import or duplicate page
 const abTestOneConsentCSS = {
   consentsCard: css`
     ${from.tablet} {
@@ -122,7 +120,7 @@ export const ConsentsCommunicationPage = () => {
     (consent) => !consent.id.includes('_optout'),
   );
 
-  // @todo: AB TEST: oneConsentTest.
+  // @TODO: AB TEST: oneConsentTest.
   // When Finished: Replace instances of this with consentsWithoutOptout
   const consentsABTestOneConsentTest = consentsWithoutOptout.filter(
     (consent) => !isUserInTest || consent.id === Consents.SUPPORTER,

--- a/src/shared/model/experiments/abSwitches.ts
+++ b/src/shared/model/experiments/abSwitches.ts
@@ -1,3 +1,3 @@
 export const switches = {
-  abExampleTest: true,
+  abOneConsentTest: true,
 };

--- a/src/shared/model/experiments/abTests.ts
+++ b/src/shared/model/experiments/abTests.ts
@@ -1,6 +1,6 @@
 import { AB, ABTest, Participations } from '@guardian/ab-core';
 import { switches } from './abSwitches';
-import { exampleTest } from './tests/example-test';
+import { oneConsentTest } from './tests/oneConsentTest';
 
 interface ABTestConfiguration {
   abTestSwitches: Record<string, boolean>;
@@ -10,7 +10,7 @@ interface ABTestConfiguration {
 }
 
 // Add AB tests to run in this array
-export const tests: ABTest[] = [exampleTest];
+export const tests: ABTest[] = [oneConsentTest];
 
 export const getDefaultABTestConfiguration = (): ABTestConfiguration => ({
   abTestSwitches: switches,

--- a/src/shared/model/experiments/tests/oneConsentTest.ts
+++ b/src/shared/model/experiments/tests/oneConsentTest.ts
@@ -1,0 +1,31 @@
+import { ABTest } from '@guardian/ab-core';
+
+export const oneConsentTest: ABTest = {
+  id: 'oneConsentTest', // This ID must match the Server Side AB Test
+  start: '2020-12-14',
+  expiry: '2020-12-30', // Remember that the server side test expiry can be different
+  author: 'patrick.orrell@theguardian.com',
+  description:
+    'Testing the effect of having just one consent on the communications page',
+  audience: 0.1, // 0.01% (1 is 100%)
+  audienceOffset: 0, // 50% (1 is 100%). Prevent overlapping with other tests.
+  successMeasure: '@TODO',
+  audienceCriteria: '@TODO',
+  idealOutcome: '@TODO',
+  showForSensitive: true, // Should this A/B test run on sensitive articles?
+  canRun: () => true, // Check for things like user or page sections
+  variants: [
+    {
+      id: 'control',
+      test: (): string => {
+        return 'control';
+      },
+    },
+    {
+      id: 'variant',
+      test: (): string => {
+        return 'variant';
+      },
+    },
+  ],
+};

--- a/src/shared/model/experiments/tests/oneConsentTest.ts
+++ b/src/shared/model/experiments/tests/oneConsentTest.ts
@@ -1,7 +1,7 @@
 import { ABTest } from '@guardian/ab-core';
 
 export const oneConsentTest: ABTest = {
-  id: 'oneConsentTest', // This ID must match the Server Side AB Test
+  id: 'OneConsentTest', // This ID must match the Server Side AB Test
   start: '2020-12-14',
   expiry: '2021-01-11', // Remember that the server side test expiry can be different
   author: 'patrick.orrell@theguardian.com',
@@ -17,14 +17,14 @@ export const oneConsentTest: ABTest = {
   variants: [
     {
       id: 'control',
-      test: (): string => {
-        return 'control';
+      test: (): void => {
+        return;
       },
     },
     {
       id: 'variant',
-      test: (): string => {
-        return 'variant';
+      test: (): void => {
+        return;
       },
     },
   ],

--- a/src/shared/model/experiments/tests/oneConsentTest.ts
+++ b/src/shared/model/experiments/tests/oneConsentTest.ts
@@ -3,7 +3,7 @@ import { ABTest } from '@guardian/ab-core';
 export const oneConsentTest: ABTest = {
   id: 'oneConsentTest', // This ID must match the Server Side AB Test
   start: '2020-12-14',
-  expiry: '2020-01-11', // Remember that the server side test expiry can be different
+  expiry: '2021-01-11', // Remember that the server side test expiry can be different
   author: 'patrick.orrell@theguardian.com',
   description:
     'Testing the effect of having just one consent on the communications page',

--- a/src/shared/model/experiments/tests/oneConsentTest.ts
+++ b/src/shared/model/experiments/tests/oneConsentTest.ts
@@ -3,15 +3,15 @@ import { ABTest } from '@guardian/ab-core';
 export const oneConsentTest: ABTest = {
   id: 'oneConsentTest', // This ID must match the Server Side AB Test
   start: '2020-12-14',
-  expiry: '2020-12-30', // Remember that the server side test expiry can be different
+  expiry: '2020-01-11', // Remember that the server side test expiry can be different
   author: 'patrick.orrell@theguardian.com',
   description:
     'Testing the effect of having just one consent on the communications page',
-  audience: 0.1, // 0.01% (1 is 100%)
+  audience: 0.5, // 0.01% (1 is 100%)
   audienceOffset: 0, // 50% (1 is 100%). Prevent overlapping with other tests.
-  successMeasure: '@TODO',
-  audienceCriteria: '@TODO',
-  idealOutcome: '@TODO',
+  successMeasure: 'Various',
+  audienceCriteria: 'Half the audience using the consents flow',
+  idealOutcome: 'Various',
   showForSensitive: true, // Should this A/B test run on sensitive articles?
   canRun: () => true, // Check for things like user or page sections
   variants: [


### PR DESCRIPTION
## Description
For testing the effects of having just one communications consent card on the communications page. 

![localhost_8861_consents_communication_returnUrl=https%3A%2F%2Fm code dev-theguardian com ab-oneConsentTest=variant](https://user-images.githubusercontent.com/3016741/102204553-e0705300-3ec1-11eb-9b64-2de40ae8e348.png)
## Changes

* Add `cssOverides` prop and functionality to `ConsentsCommunicationCard`
* Add `oneConsentTest` AB Test
* Add  AB Testing temporary code to `ConsentCommunicationsPage`