### PR TITLE
rename play session

### DIFF
--- a/src/server/lib/playSessionCookie.ts
+++ b/src/server/lib/playSessionCookie.ts
@@ -10,10 +10,10 @@ import { logger } from '@/server/lib/logger';
 const { playSessionCookieSecret } = getConfiguration();
 
 const getCookieFromPlaySession: (req: Request) => any = (req) => {
-  if (req.cookies['PLAY_SESSION']) {
+  if (req.cookies['PLAY_SESSION_2']) {
     try {
       const session: any = verifyJWT(
-        req.cookies['PLAY_SESSION'],
+        req.cookies['PLAY_SESSION_2'],
         playSessionCookieSecret,
       );
       return session.data;


### PR DESCRIPTION
## What does this change?
This PR updates the Play session cookie name from 'PLAY_SESSION' to 'PLAY_SESSION_2'.

For context, there are two places where the Play session cookie is set under the profile.theguardian.com domain - on the frontend project and on the identity-frontend project. They each use their own key to encrypt the session, and gateway uses the same key as identity-frontend to decrypt the cookie. To prevent clashes between the two Play sessions, we have renamed the identity-frontend session to 'PLAY_SESSION_2' which means this change also needs to happen in gateway. 

Differentiating the names also provides clarity around which session is being accessed.

## How to test
This can be tested in CODE, by going through the registration process and then going to the reset password page which is currently the only page on gateway that tries to extract information from the Play session cookie
