### PR TITLE
handle uncaught errors in gateway to avoid tcp connection leaks

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -90,6 +90,29 @@ router.use(noCache, queryParamsMiddleware, reset);
 
 The route should now be accessible.
 
+### Async routes error handling
+
+When writing async routes, wrap the handler in the helper function `handleAsyncErrors`
+
+E.g. 
+
+```ts
+import { handleAsyncErrors } from '@/server/lib/expressWrappers';
+
+router.get(
+  '/route',
+  handleAsyncErrors(async (req: Request, res: ResponseWithRequestState) => {
+    ...
+  }),
+);
+```
+
+`handleAsyncErrors` calls `next()` when the router async handler function fails. This invokes the default error handler, logging the error and returning an error page.
+
+#### Why?
+
+In Express 4, async handlers which fail to call next() (or specific functions on the response) leave the TCP connection open (indicating a leak) and don't return any data.
+
 ## State Management
 
 ### Request State Locals and Client State

--- a/src/client/pages/UnexpectedError.tsx
+++ b/src/client/pages/UnexpectedError.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { css } from '@emotion/core';
+import locations from '@/client/lib/locations';
+import { Link } from '@guardian/src-link';
+import { PageBox } from '@/client/components/PageBox';
+import { PageHeader } from '@/client/components/PageHeader';
+import { PageBody } from '@/client/components/PageBody';
+import { PageBodyText } from '@/client/components/PageBodyText';
+import { SignInLayout } from '@/client/layouts/SignInLayout';
+
+const link = css`
+  display: inline-block;
+`;
+
+export const UnexpectedError = () => (
+  <SignInLayout>
+    <PageBox>
+      <PageHeader>Sorry – an unexpected error occurred</PageHeader>
+      <PageBody>
+        <PageBodyText>
+          An error occurred, please try again or{' '}
+          <Link css={link} href={locations.REPORT_ISSUE}>
+            report it
+          </Link>
+          .
+        </PageBodyText>
+      </PageBody>
+    </PageBox>
+  </SignInLayout>
+);

--- a/src/client/routes.tsx
+++ b/src/client/routes.tsx
@@ -13,6 +13,7 @@ import { ConsentsNewslettersPage } from '@/client/pages/ConsentsNewsletters';
 import { ConsentsConfirmationPage } from '@/client/pages/ConsentsConfirmation';
 import { ResendEmailVerificationPage } from '@/client/pages/ResendEmailVerification';
 import { ClientState } from '@/shared/model/ClientState';
+import { UnexpectedError } from '@/client/pages/UnexpectedError';
 
 export type RoutingConfig = {
   clientState: ClientState;
@@ -53,6 +54,9 @@ export const GatewayRoutes = () => (
     </Route>
     <Route exact path={Routes.VERIFY_EMAIL}>
       <ResendEmailVerificationPage />
+    </Route>
+    <Route exact path={Routes.UNEXPECTED_ERROR}>
+      <UnexpectedError />
     </Route>
     <Route>
       <NotFound />

--- a/src/server/lib/__tests__/handleAsyncErrors.test.ts
+++ b/src/server/lib/__tests__/handleAsyncErrors.test.ts
@@ -1,0 +1,37 @@
+import { handleAsyncErrors } from '@/server/lib/expressWrappers';
+import { NextFunction, Request, Response } from 'express';
+import { ResponseWithRequestState } from '@/server/models/Express';
+import Mock = jest.Mock;
+
+describe('handleAsyncErrors', () => {
+  it('should execute the provided function and return the result', async () => {
+    const wrappedHandler = handleAsyncErrors(
+      (req: Request, res: ResponseWithRequestState) => {
+        return Promise.resolve(res);
+      },
+    );
+
+    const request: Request = <Request>{};
+    const response: Response = <Response>{};
+    const next: NextFunction = jest.fn();
+
+    expect(await wrappedHandler(request, response, next)).toBe(response);
+    expect((<Mock>next).mock.calls.length).toBe(0);
+  });
+
+  it('should call the provided function and handle failures by calling next', async () => {
+    const error = new Error('some error');
+
+    const wrappedHandler = handleAsyncErrors(() => {
+      return Promise.reject(error);
+    });
+
+    const request: Request = <Request>{};
+    const response: Response = <Response>{};
+    const next: NextFunction = jest.fn();
+
+    expect(await wrappedHandler(request, response, next)).toBe(undefined);
+    expect((<Mock>next).mock.calls.length).toBe(1);
+    expect((<Mock>next).mock.calls[0][0]).toBe(error);
+  });
+});

--- a/src/server/lib/expressWrappers.ts
+++ b/src/server/lib/expressWrappers.ts
@@ -1,0 +1,16 @@
+import { NextFunction, Request, Response } from 'express';
+import { ResponseWithRequestState } from '@/server/models/Express';
+
+type AsyncHandler = (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) => Promise<ResponseWithRequestState | void>;
+
+export const handleAsyncErrors = (handler: AsyncHandler) => {
+  return (req: Request, res: Response, next: NextFunction) => {
+    return handler(req, res, next).catch((error) => {
+      next(error);
+    });
+  };
+};

--- a/src/server/lib/logger.ts
+++ b/src/server/lib/logger.ts
@@ -9,8 +9,21 @@ export const logger: Logger = {
   log(level: LogLevel, message: string) {
     winstonLogger.log(level, message);
   },
-  error(message: string) {
-    logger.log(LogLevel.ERROR, message);
+  // errors can be anything
+  // eslint-disable-next-line
+  error(message: string, error?: any) {
+    if (error && error.stack && typeof error.message === 'string') {
+      return logger.log(
+        LogLevel.ERROR,
+        `${message} ${error.message} ${error.stack}`,
+      );
+    }
+
+    if (error) {
+      return logger.log(LogLevel.ERROR, `${message} ${error}`);
+    }
+
+    return logger.log(LogLevel.ERROR, message);
   },
   warn(message: string) {
     logger.log(LogLevel.INFO, message);

--- a/src/server/lib/middleware/errorHandler.ts
+++ b/src/server/lib/middleware/errorHandler.ts
@@ -1,6 +1,10 @@
 import { NextFunction, Request } from 'express';
 import { ResponseWithRequestState } from '@/server/models/Express';
 import { getCsrfPageUrl } from '../getCsrfPageUrl';
+import { renderer } from '@/server/lib/renderer';
+import { Routes } from '@/shared/model/Routes';
+import { PageTitle } from '@/shared/model/PageTitle';
+import { logger } from '@/server/lib/logger';
 
 const appendQueryParameter = (url: string, parameters: string) => {
   if (url.split('?').pop()?.includes(parameters)) {
@@ -28,7 +32,14 @@ export const routeErrorHandler = (
       303,
       appendQueryParameter(getCsrfPageUrl(req), 'csrfError=true'),
     );
+    return next(err);
   }
 
-  return next(err);
+  logger.error('unexpected error', err);
+
+  const html = renderer(`${Routes.UNEXPECTED_ERROR}`, {
+    requestState: res.locals,
+    pageTitle: PageTitle.UNEXPECTED_ERROR,
+  });
+  return res.status(500).type('html').send(html);
 };

--- a/src/server/models/Logger.ts
+++ b/src/server/models/Logger.ts
@@ -2,7 +2,9 @@ export interface Logger {
   log(logLevel: LogLevel, message: string): void;
   info(message: string): void;
   warn(message: string): void;
-  error(message: string): void;
+  // errors can be anything
+  // eslint-disable-next-line
+  error(message: string, error?: any): void;
 }
 
 export enum LogLevel {

--- a/src/server/routes/changePassword.ts
+++ b/src/server/routes/changePassword.ts
@@ -17,6 +17,7 @@ import {
   PasswordValidationResult,
   validatePasswordLength,
 } from '@/shared/lib/PasswordValidation';
+import { handleAsyncErrors } from '@/server/lib/expressWrappers';
 import { getBrowserNameFromUserAgent } from '@/server/lib/getBrowserName';
 
 const router = Router();
@@ -67,7 +68,7 @@ const validatePasswordChangeFields = (
 
 router.get(
   `${Routes.CHANGE_PASSWORD}${Routes.CHANGE_PASSWORD_TOKEN}`,
-  async (req: Request, res: ResponseWithRequestState) => {
+  handleAsyncErrors(async (req: Request, res: ResponseWithRequestState) => {
     let state = res.locals;
     const { token } = req.params;
 
@@ -102,12 +103,12 @@ router.get(
       pageTitle: PageTitle.CHANGE_PASSWORD,
     });
     return res.type('html').send(html);
-  },
+  }),
 );
 
 router.post(
   `${Routes.CHANGE_PASSWORD}${Routes.CHANGE_PASSWORD_TOKEN}`,
-  async (req: Request, res: ResponseWithRequestState) => {
+  handleAsyncErrors(async (req: Request, res: ResponseWithRequestState) => {
     let state = res.locals;
 
     const { token } = req.params;
@@ -179,7 +180,7 @@ router.post(
     });
 
     return res.type('html').send(html);
-  },
+  }),
 );
 
 router.get(

--- a/src/server/routes/consents.ts
+++ b/src/server/routes/consents.ts
@@ -28,6 +28,7 @@ import { GeoLocation } from '@/shared/model/Geolocation';
 import { NewsletterMap } from '@/shared/lib/newsletter';
 import { CONSENTS_PAGES } from '@/client/models/ConsentsPages';
 import { fourZeroFourRender } from '@/server/lib/middleware/404';
+import { handleAsyncErrors } from '@/server/lib/expressWrappers';
 
 const router = Router();
 
@@ -263,7 +264,7 @@ router.get(Routes.CONSENTS, loginMiddleware, (_: Request, res: Response) => {
 router.get(
   `${Routes.CONSENTS}/:page`,
   loginMiddleware,
-  async (req: Request, res: ResponseWithRequestState) => {
+  handleAsyncErrors(async (req: Request, res: ResponseWithRequestState) => {
     let state = res.locals;
     const sc_gu_u = req.cookies.SC_GU_U;
 
@@ -323,13 +324,13 @@ router.get(
       .type('html')
       .status(status ?? 500)
       .send(html);
-  },
+  }),
 );
 
 router.post(
   `${Routes.CONSENTS}/:page`,
   loginMiddleware,
-  async (req: Request, res: ResponseWithRequestState) => {
+  handleAsyncErrors(async (req: Request, res: ResponseWithRequestState) => {
     let state = res.locals;
 
     const sc_gu_u = req.cookies.SC_GU_U;
@@ -381,7 +382,7 @@ router.post(
       .type('html')
       .status(status ?? 500)
       .send(html);
-  },
+  }),
 );
 
 export default router;

--- a/src/server/routes/reset.ts
+++ b/src/server/routes/reset.ts
@@ -10,6 +10,7 @@ import { trackMetric } from '@/server/lib/AWS';
 import { Metrics } from '@/server/models/Metrics';
 import { removeNoCache } from '@/server/lib/middleware/cache';
 import { PageTitle } from '@/shared/model/PageTitle';
+import { handleAsyncErrors } from '@/server/lib/expressWrappers';
 
 const router = Router();
 
@@ -36,8 +37,9 @@ router.get(Routes.RESET, (req: Request, res: ResponseWithRequestState) => {
 
 router.post(
   Routes.RESET,
-  async (req: Request, res: ResponseWithRequestState) => {
+  handleAsyncErrors(async (req: Request, res: ResponseWithRequestState) => {
     let state = res.locals;
+
     const { email = '' } = req.body;
 
     const { returnUrl } = res.locals.queryParams;
@@ -83,7 +85,7 @@ router.post(
       pageTitle: PageTitle.RESET_SENT,
     });
     return res.type('html').send(html);
-  },
+  }),
 );
 
 router.get(

--- a/src/server/routes/verifyEmail.ts
+++ b/src/server/routes/verifyEmail.ts
@@ -18,6 +18,7 @@ import { Metrics } from '@/server/models/Metrics';
 import { addReturnUrlToPath } from '@/server/lib/queryParams';
 import { PageTitle } from '@/shared/model/PageTitle';
 import { ResponseWithRequestState } from '@/server/models/Express';
+import { handleAsyncErrors } from '@/server/lib/expressWrappers';
 
 const router = Router();
 
@@ -26,7 +27,7 @@ const profileUrl = getProfileUrl();
 
 router.get(
   Routes.VERIFY_EMAIL,
-  async (req: Request, res: ResponseWithRequestState) => {
+  handleAsyncErrors(async (req: Request, res: ResponseWithRequestState) => {
     let state = res.locals;
 
     state = {
@@ -76,12 +77,12 @@ router.get(
     });
 
     return res.status(status).type('html').send(html);
-  },
+  }),
 );
 
 router.post(
   Routes.VERIFY_EMAIL,
-  async (req: Request, res: ResponseWithRequestState) => {
+  handleAsyncErrors(async (req: Request, res: ResponseWithRequestState) => {
     let state = res.locals;
     let status = 200;
 
@@ -143,12 +144,12 @@ router.post(
     });
 
     return res.status(status).type('html').send(html);
-  },
+  }),
 );
 
 router.get(
   `${Routes.VERIFY_EMAIL}${Routes.VERIFY_EMAIL_TOKEN}`,
-  async (req: Request, res: Response) => {
+  handleAsyncErrors(async (req: Request, res: Response) => {
     const { token } = req.params;
 
     try {
@@ -180,7 +181,7 @@ router.get(
         res.locals.queryParams.returnUrl,
       ),
     );
-  },
+  }),
 );
 
 export default router;

--- a/src/shared/model/PageTitle.ts
+++ b/src/shared/model/PageTitle.ts
@@ -1,5 +1,6 @@
 export enum PageTitle {
   NOT_FOUND = 'Not Found',
+  UNEXPECTED_ERROR = 'Unexpected Error',
   RESET = 'Reset Password',
   RESET_SENT = 'Check Your Inbox',
   RESET_RESEND = 'Resend Reset Password',

--- a/src/shared/model/Routes.ts
+++ b/src/shared/model/Routes.ts
@@ -13,6 +13,7 @@ export enum Routes {
   CONSENTS_COMMUNICATION = '/communication',
   CONSENTS_NEWSLETTERS = '/newsletters',
   CONSENTS_REVIEW = '/review',
+  UNEXPECTED_ERROR = '/error',
 }
 
 export enum ApiRoutes {


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

- Create a helper function to call `next()` when the router async handler function fails. Synchronous errors are already handled by express 4.

- Return an error page using the default error handler and log the error.


## Why?

In Express 4, async handlers which fail to call `next()` (or specific functions on the response) leave the TCP connection open (indicating a leak) and don't return any data. 

## Notes

This error handling is provided by default in express 5 (which has been in alpha for years).

I'll add unit tests if developers approve this approach.

My initial plan was to wrap methods such as router.get. The approach in this PR is more simple to implement since the router http methods are very broadly typed.



## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
![image](https://user-images.githubusercontent.com/29203769/103653883-0e930100-4f5d-11eb-8261-0a8e76225990.png)
