### PR TITLE
Fix Ophan Interaction Event

### DIFF
--- a/src/client/lib/ophan.ts
+++ b/src/client/lib/ophan.ts
@@ -6,11 +6,12 @@ export interface OphanInteraction {
   atomId?: string;
 }
 
-export interface OphanEvent {
+export interface OphanBase {
   experiences?: string;
   abTestRegister?: { [testId: string]: OphanABEvent };
-  interaction?: OphanInteraction;
 }
+
+export type OphanEvent = OphanBase & OphanInteraction;
 
 export const record = (event: OphanEvent) => {
   if (
@@ -22,5 +23,8 @@ export const record = (event: OphanEvent) => {
   }
 };
 
-export const sendOphanInteractionEvent = (interaction: OphanInteraction) =>
-  record({ interaction });
+export const sendOphanInteractionEvent = ({
+  component,
+  atomId,
+  value,
+}: OphanInteraction) => record({ component, atomId, value });

--- a/src/client/lib/ophan.ts
+++ b/src/client/lib/ophan.ts
@@ -11,7 +11,7 @@ export interface OphanBase {
   abTestRegister?: { [testId: string]: OphanABEvent };
 }
 
-export type OphanEvent = OphanBase & OphanInteraction;
+export type OphanEvent = OphanBase | OphanInteraction;
 
 export const record = (event: OphanEvent) => {
   if (


### PR DESCRIPTION
## What does this change?
Ophan Interaction Events were set up incorrectly in Gateway, in turn meaning that no interactions were showing up in the data lake. @QuarpT helpfully found that the record event doesn't take an `interaction` object, but rather the entries inside the interaction object, as seen in [identity-frontend](https://github.com/guardian/identity-frontend/blob/d2b43433054950f4349eb4265c4099e80eac93e1/public/components/ajax-step-flow/ajax-step-flow.js#L112).

This PR changes the types and method so that the `record` method pushes `interaction` events in the correct way.
