### PR TITLE
Fix invalid token redirect issue

### DIFF
--- a/src/server/models/Metrics.ts
+++ b/src/server/models/Metrics.ts
@@ -7,6 +7,7 @@ export enum Metrics {
   LOGIN_MIDDLEWARE_FAILURE = 'LoginMiddleware::Failure',
   LOGIN_MIDDLEWARE_UNVERIFIED = 'LoginMiddlewareUnverified',
   LOGIN_MIDDLEWARE_NOT_RECENT = 'LoginMiddlewareNotRecent',
+  LOGIN_MIDDLEWARE_NOT_SIGNED_IN = 'LoginMiddlewareNotSignedIn',
   SEND_VALIDATION_EMAIL_SUCCESS = 'SendValidationEmail::Success',
   SEND_VALIDATION_EMAIL_FAILURE = 'SendValidationEmail::Failure',
   EMAIL_VALIDATED_SUCCESS = 'EmailValidated::Success',


### PR DESCRIPTION
## What does this change?
According to a [bug report](https://trello.com/c/kMyIHr2q/2707-bad-sign-in-redirect-when-token-invalidated-on-gateway-s), when a users identity token becomes invalid, Gateway redirects users to the wrong page. It redirects to the verify email page rather than the login page.

After doing some research, when an invalid token is submitted to IDAPI, it returns a JSON with the following format:
```js
{
  emailValidated: undefined,
  status: 'notSignedIn',
  redirect: {
    url: *URL OF LOGIN PAGE*
  }
}
```

From this we see that there is an `emailValidated` is `undefined` and `status` is `notSignedIn`. In the flow, Gateway would first run a check for `if (!auth.emailValidated) { ...`, this would mean that the above JSON would match, as `undefined` is a falsey value.

However  I noticed that we were not doing any checks for when the status was `notSignedIn` which should precede any other check for the response.

So I added a check in for ` if (auth.status === IDAPIAuthStatus.SIGNED_OUT) { ...` to catch this issue for when an invalid token was supplied, and redirect to the url if it was returned in the response or a default login url.

Since this redirect code was being used by the `if (auth.status === IDAPIAuthStatus.RECENT) {` check, I refactored this into a `redirectAuth` method so that it could be shared by both checks.

I then also added in an additional metric that would be fired if the signed out check passed.