### PR TITLE
Give the instances the right to describe the tags of the autoscaling group

### DIFF
--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -118,6 +118,15 @@ Resources:
               - Effect: Allow
                 Action: cloudwatch:PutMetricData
                 Resource: '*'
+        - PolicyName: DescribeASG
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action:
+                  - autoscaling:DescribeAutoScalingGroups
+                  - autoscaling:DescribeAutoScalingInstances
+                Resource: '*'
   AutoScalingGroup:
     Type: AWS::AutoScaling::AutoScalingGroup
     Properties:


### PR DESCRIPTION
Wazuh is a new security and compliance platform the Guardian is integrating with. It requires an agent running on the machine (already added to the baked AMI), and that agent needs the capability to read the tags from the autoscaling group in order to properly report data to the mothership.