### PR TITLE
Initialise Google Analytics only if we have CMP consents

### DIFF
--- a/src/client/static/analytics/ga.js
+++ b/src/client/static/analytics/ga.js
@@ -40,10 +40,14 @@ export const init = () => {
 };
 
 export const customMetric = (event) => {
+  if (window.ga === undefined) return;
+
   window.ga(gaTracker + '.send', 'event', buildGoogleAnalyticsEvent(event));
 };
 
 export const fetchTracker = (callback) => {
+  if (window.ga === undefined) return;
+
   window.ga(function () {
     const tracker = window.ga.getByName(gaTracker);
     return callback(tracker);
@@ -51,5 +55,7 @@ export const fetchTracker = (callback) => {
 };
 
 export const pageView = (path = location.pathname) => {
+  if (window.ga === undefined) return;
+
   window.ga(gaTracker + '.send', 'pageview', path);
 };

--- a/src/client/static/index.tsx
+++ b/src/client/static/index.tsx
@@ -35,8 +35,6 @@ hydrateApp();
 // initalise ophan
 ophanInit();
 
-initGoogleAnalyticsWhenConsented();
-
 // don't load this if running in cypress
 if (!window.Cypress) {
   // load cmp if it should show
@@ -46,3 +44,5 @@ if (!window.Cypress) {
     cmp.init({ country });
   })();
 }
+
+initGoogleAnalyticsWhenConsented();

--- a/src/client/static/index.tsx
+++ b/src/client/static/index.tsx
@@ -1,7 +1,11 @@
 import { hydrateApp } from '@/client/static/hydration';
 
 // method to check if the cmp should show
-import { cmp } from '@guardian/consent-management-platform';
+import {
+  cmp,
+  getConsentFor,
+  onConsentChange,
+} from '@guardian/consent-management-platform';
 
 // country code helper
 import { getCountryCode } from './countryCode';
@@ -15,13 +19,23 @@ import { init as ophanInit } from './analytics/ophan';
 // initialise source accessibility
 import './sourceAccessibility';
 
+const initGoogleAnalyticsWhenConsented = () => {
+  onConsentChange((consentState) => {
+    if (
+      getConsentFor('google-analytics', consentState) &&
+      window.ga === undefined
+    ) {
+      gaInit();
+    }
+  });
+};
+
 hydrateApp();
 
 // initalise ophan
 ophanInit();
 
-// initialise google analytics
-gaInit();
+initGoogleAnalyticsWhenConsented();
 
 // don't load this if running in cypress
 if (!window.Cypress) {

--- a/src/client/window.guardian.d.ts
+++ b/src/client/window.guardian.d.ts
@@ -14,6 +14,7 @@ declare global {
       };
     };
     Cypress: unknown;
+    ga: unknown;
   }
 }
 


### PR DESCRIPTION
## Changes

Initialise google analytics only if we have the google-analytics CMP consent

## Why

We need consents from the user before we can start collecting Google Analytics
