### PR TITLE
`MaxWidth` > `Breakpoints`

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,14 +1,14 @@
 import { breakpoints } from '@guardian/src-foundations/mq';
-import { MaxWidth } from '@/client/models/Style';
+import { Breakpoints } from '@/client/models/Style';
 
 const viewports = {};
-for (let breakpoint in MaxWidth) {
+for (let breakpoint in Breakpoints) {
   if (isNaN(Number(breakpoint))) {
-    // MaxWidth is an enum, not an object, so it also loops the values which we want to avoid here
+    // Breakpoints is an enum, not an object, so it also loops the values which we want to avoid here
     viewports[breakpoint] = {
-      name: `${breakpoint} (${MaxWidth[breakpoint]})`,
+      name: `${breakpoint} (${Breakpoints[breakpoint]})`,
       styles: {
-        width: `${MaxWidth[breakpoint]}px`,
+        width: `${Breakpoints[breakpoint]}px`,
         height: '100vh',
       },
     };

--- a/src/client/components/Footer.tsx
+++ b/src/client/components/Footer.tsx
@@ -3,7 +3,7 @@ import { css } from '@emotion/react';
 import { brand, palette, space } from '@guardian/src-foundations';
 import locations from '@/client/lib/locations';
 import { textSans } from '@guardian/src-foundations/typography';
-import { MaxWidth } from '@/client/models/Style';
+import { Breakpoints } from '@/client/models/Style';
 import { from } from '@guardian/src-foundations/mq';
 
 const footer = css`
@@ -14,7 +14,7 @@ const footer = css`
 
 const container = css`
   width: 100%;
-  max-width: ${MaxWidth.DESKTOP}px;
+  max-width: ${Breakpoints.DESKTOP}px;
   margin: 0 auto;
   display: flex;
   flex-direction: column;

--- a/src/client/components/PageBody.tsx
+++ b/src/client/components/PageBody.tsx
@@ -1,11 +1,11 @@
 import React, { FunctionComponent } from 'react';
 import { css } from '@emotion/react';
 import { space } from '@guardian/src-foundations';
-import { MinWidth } from '@/client/models/Style';
+import { MaxWidth } from '@/client/models/Style';
 
 const pageBody = css`
   padding: ${space[3]}px 0;
-  max-width: ${MinWidth.TABLET}px;
+  max-width: ${MaxWidth.MOBILE_LANDSCAPE}px;
   width: 100%;
 `;
 

--- a/src/client/components/PageBody.tsx
+++ b/src/client/components/PageBody.tsx
@@ -1,11 +1,11 @@
 import React, { FunctionComponent } from 'react';
 import { css } from '@emotion/react';
 import { space } from '@guardian/src-foundations';
-import { MaxWidth } from '@/client/models/Style';
+import { Breakpoints } from '@/client/models/Style';
 
 const pageBody = css`
   padding: ${space[3]}px 0;
-  max-width: ${MaxWidth.MOBILE_LANDSCAPE}px;
+  max-width: ${Breakpoints.MOBILE_LANDSCAPE}px;
   width: 100%;
 `;
 

--- a/src/client/components/SignInHeader.tsx
+++ b/src/client/components/SignInHeader.tsx
@@ -3,7 +3,7 @@ import { css } from '@emotion/react';
 import { brand, space, neutral } from '@guardian/src-foundations';
 import { headline } from '@guardian/src-foundations/typography';
 import { from } from '@guardian/src-foundations/mq';
-import { MaxWidth } from '@/client/models/Style';
+import { Breakpoints } from '@/client/models/Style';
 
 const header = css`
   width: 100%;
@@ -27,7 +27,7 @@ const header = css`
 `;
 
 const div = css`
-  max-width: ${MaxWidth.TABLET}px;
+  max-width: ${Breakpoints.TABLET}px;
   width: 100%;
   padding: 0 ${space[3]}px;
   margin-right: 0;

--- a/src/client/layouts/SignInLayout.tsx
+++ b/src/client/layouts/SignInLayout.tsx
@@ -7,14 +7,14 @@ import { ClientStateContext } from '@/client/components/ClientState';
 import { GlobalError } from '@/client/components/GlobalError';
 import { css } from '@emotion/react';
 import { space } from '@guardian/src-foundations';
-import { MaxWidth } from '@/client/models/Style';
+import { Breakpoints } from '@/client/models/Style';
 import { getErrorLink } from '@/client/lib/ErrorLink';
 import { GlobalSuccess } from '@/client/components/GlobalSuccess';
 
 const main = css`
   flex: 1 0 auto;
   padding: ${space[6]}px ${space[3]}px;
-  max-width: ${MaxWidth.TABLET}px;
+  max-width: ${Breakpoints.TABLET}px;
   width: 100%;
   margin: 0 auto;
   display: flex;

--- a/src/client/models/Style.ts
+++ b/src/client/models/Style.ts
@@ -1,6 +1,6 @@
 // sourced from https://theguardian.design/2a1e5182b/p/41be19-grids
 
-export enum MaxWidth {
+export enum Breakpoints {
   WIDE = 1300,
   DESKTOP = 980,
   TABLET = 740,

--- a/src/client/models/Style.ts
+++ b/src/client/models/Style.ts
@@ -6,15 +6,5 @@ export enum MaxWidth {
   TABLET = 740,
   // mobile breakpoints differ
   MOBILE = 660,
-}
-
-export enum MinWidth {
-  WIDE = 980,
-  DESKTOP = 740,
-  TABLET = 480,
-  // mobile breakpoints differ
-  PHABLET = 660,
   MOBILE_LANDSCAPE = 480,
-  MOBILE_MEDIUM = 375,
-  MOBILE = 320,
 }


### PR DESCRIPTION
## What?
This PR removes `MinWidth` and renames `MaxWidth` to `Breakpoints`.

```ts
export enum Breakpoints {
  WIDE = 1300,
  DESKTOP = 980,
  TABLET = 740,
  MOBILE = 660,
  MOBILE_LANDSCAPE = 480,
}
```

## Why?
I removed `MinWidth` because in the one place it was used it was being applied to `max-width`. That left `MaxWidth` which made sense and was fine but I thought it might be more scalable / flexible if it were exported as `Breakpoints`. Having a property named like this means it is not so tied to the css property name and is useful as a declaration that these are the breakpoints we work to