### PR TITLE
Mock ABProvider and StaticRouter in Storybook

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,5 +1,7 @@
 import { breakpoints } from '@guardian/src-foundations/mq';
 import { Breakpoints } from '@/client/models/Style';
+import { ABProvider } from '@guardian/ab-react';
+import { StaticRouter } from 'react-router-dom';
 
 const viewports = {};
 for (let breakpoint in Breakpoints) {
@@ -28,3 +30,21 @@ export const parameters = {
     defaultViewport: 'MOBILE',
   },
 };
+
+//Add global mocks for ABProvider and StaticRouter
+export const decorators = [
+  (Story) => (
+    <ABProvider
+      arrayOfTestObjects={[]}
+      abTestSwitches={{}}
+      pageIsSensitive={false}
+      mvtMaxValue={1000000}
+      mvtId={0}
+      forcedTestVariants={{}}
+    >
+      <StaticRouter location={''} context={{}}>
+        <Story />
+      </StaticRouter>
+    </ABProvider>
+  ),
+];


### PR DESCRIPTION
## What?
Uses the `preview.js` file in storybook to add global mocks for `ABProvider` and `StaticRouter`

See: https://storybook.js.org/docs/react/writing-stories/decorators#context-for-mocking

## Is this the right approach?
Typically when an app depends on global state such as Context the best solution is to isolate the component and only render the presentational elements. Then, to add stateful logic (things like `useContext` or `useAB`) you use a separate component and pass down state as props. This is an option here (and maybe we could take this approach?) but we can also use mocking as in this PR.

I'm a little on the fence which is the best approach. By creating a separation between presentation (via props) and Context we make testing a lot easier. This will arguably also make scaling things in the future easier too. But it adds additional components/layers and would mean we'd need to do some refactoring.