### PR TITLE
`ConsentConfirmation` Stories

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,5 +1,7 @@
 import { breakpoints } from '@guardian/src-foundations/mq';
 import { Breakpoints } from '@/client/models/Style';
+import { ABProvider } from '@guardian/ab-react';
+import { StaticRouter } from 'react-router-dom';
 
 const viewports = {};
 for (let breakpoint in Breakpoints) {
@@ -28,3 +30,21 @@ export const parameters = {
     defaultViewport: 'MOBILE',
   },
 };
+
+//Add global mocks for ABProvider and StaticRouter
+export const decorators = [
+  (Story) => (
+    <ABProvider
+      arrayOfTestObjects={[]}
+      abTestSwitches={{}}
+      pageIsSensitive={false}
+      mvtMaxValue={1000000}
+      mvtId={0}
+      forcedTestVariants={{}}
+    >
+      <StaticRouter location={''} context={{}}>
+        <Story />
+      </StaticRouter>
+    </ABProvider>
+  ),
+];

--- a/src/client/pages/ConsentsConfirmation.stories.tsx
+++ b/src/client/pages/ConsentsConfirmation.stories.tsx
@@ -1,0 +1,143 @@
+/* eslint-disable functional/immutable-data */
+import React from 'react';
+import { Meta } from '@storybook/react';
+import { ClientStateProvider } from '@/client/components/ClientState';
+import { Consents } from '@/shared/model/Consent';
+
+import { ConsentsConfirmationPage as ConsentsConfirmation } from './ConsentsConfirmation';
+
+export default {
+  title: 'Pages/ConsentsConfirmation',
+  component: ConsentsConfirmation,
+} as Meta;
+
+export const NoConsent = () => (
+  <ClientStateProvider
+    clientState={{
+      clientHosts: { idapiBaseUrl: '' },
+      pageData: {
+        consents: [],
+      },
+    }}
+  >
+    <ConsentsConfirmation />
+  </ClientStateProvider>
+);
+NoConsent.story = {
+  name: 'with no consent given',
+};
+
+export const Profiling = () => (
+  <ClientStateProvider
+    clientState={{
+      clientHosts: { idapiBaseUrl: '' },
+      pageData: {
+        consents: [
+          {
+            id: Consents.PROFILING,
+            name: '',
+            description: '',
+          },
+        ],
+      },
+    }}
+  >
+    <ConsentsConfirmation />
+  </ClientStateProvider>
+);
+Profiling.story = {
+  name: 'with consent given to profilling',
+};
+
+export const ProfilingMarketing = () => (
+  <ClientStateProvider
+    clientState={{
+      clientHosts: { idapiBaseUrl: '' },
+      pageData: {
+        consents: [
+          {
+            id: Consents.PROFILING,
+            name: '',
+            description: '',
+          },
+          {
+            id: Consents.MARKET_RESEARCH,
+            name: '',
+            description: '',
+          },
+        ],
+      },
+    }}
+  >
+    <ConsentsConfirmation />
+  </ClientStateProvider>
+);
+ProfilingMarketing.story = {
+  name: 'with consent given to profilling and marketing',
+};
+
+export const Newsletters = () => (
+  <ClientStateProvider
+    clientState={{
+      clientHosts: { idapiBaseUrl: '' },
+      pageData: {
+        newsletters: [
+          {
+            id: '',
+            description: '',
+            nameId: '',
+            subscribed: true,
+            name: 'Newsletter One',
+          },
+          {
+            id: '',
+            description: '',
+            nameId: '',
+            subscribed: true,
+            name: 'Newsletter Two',
+          },
+        ],
+      },
+    }}
+  >
+    <ConsentsConfirmation />
+  </ClientStateProvider>
+);
+Newsletters.story = {
+  name: 'with two newsletters subscribed to',
+};
+
+export const Products = () => (
+  <ClientStateProvider
+    clientState={{
+      clientHosts: { idapiBaseUrl: '' },
+      pageData: {
+        consents: [
+          {
+            id: '',
+            description: '',
+            consented: true,
+            name: 'Product One',
+          },
+          {
+            id: '',
+            description: '',
+            consented: true,
+            name: 'Product Two',
+          },
+          {
+            id: '',
+            description: '',
+            consented: true,
+            name: 'Product Three',
+          },
+        ],
+      },
+    }}
+  >
+    <ConsentsConfirmation />
+  </ClientStateProvider>
+);
+Products.story = {
+  name: 'with multiple products consented to',
+};

--- a/src/client/pages/ResetPassword.stories.tsx
+++ b/src/client/pages/ResetPassword.stories.tsx
@@ -1,0 +1,12 @@
+/* eslint-disable functional/immutable-data */
+import React from 'react';
+import { Meta } from '@storybook/react';
+
+import { ResetPasswordPage as ResetPassword } from './ResetPassword';
+
+export default {
+  title: 'Pages/ResetPassword',
+  component: ResetPassword,
+} as Meta;
+
+export const Default = () => <ResetPassword />;


### PR DESCRIPTION
## What?
Adds stories for the `ConsentConfirmation` page.

** Draft pending #496 **

### `ClientStateProvider`
I'm using this component to set the Context so that we can render the component in different states.

I _think_ I've got all the possible states covered but I had to read through the code to work out the various possible presentation states so I might have missed some!

## Why?
Having a visual snapshot is useful not just for if we want to do more development going forward but it also enables us to snapshot this page for visual regression in the future and also provided a visual document for the things Gateway does.
