### PR TITLE
Eslint/Prettier/Codeowner Changes

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -31,6 +31,14 @@
     "no-param-reassign": "error",
     "prefer-const": "error"
   },
+  "overrides": [
+    {
+      "files": ["*.stories.tsx"],
+      "rules": {
+        "functional/immutable-data": 0
+      }
+    }
+  ],
   "settings": {
     "react": {
       "version": "detect"

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @guardian/identity

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,2 @@
 webpack.config.js
+build

--- a/src/client/components/NavBar.stories.tsx
+++ b/src/client/components/NavBar.stories.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable functional/immutable-data */
 import React from 'react';
 import { css } from '@emotion/react';
 import { Meta } from '@storybook/react';

--- a/src/client/pages/ConsentsConfirmation.stories.tsx
+++ b/src/client/pages/ConsentsConfirmation.stories.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable functional/immutable-data */
 import React from 'react';
 import { Meta } from '@storybook/react';
 

--- a/src/client/pages/NotFound.stories.tsx
+++ b/src/client/pages/NotFound.stories.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable functional/immutable-data */
 import React from 'react';
 import { Meta } from '@storybook/react';
 

--- a/src/client/pages/ResetPassword.stories.tsx
+++ b/src/client/pages/ResetPassword.stories.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable functional/immutable-data */
 import React from 'react';
 import { Meta } from '@storybook/react';
 


### PR DESCRIPTION
## What does this change?
- Disable `functional/immutable-data` for `*.stories.tsx` in eslint so that we don't need to include `/* eslint-disable functional/immutable-data */` at the top of every file
- Add `build` folder to `.prettierignore` so that it isn't checked by prettier when running the husky git hook
- Add identity team as CODEOWNERS