### PR TITLE
Switch of the single newsletter AB test

### DIFF
--- a/cypress/integration/onboarding_flow.spec.js
+++ b/cypress/integration/onboarding_flow.spec.js
@@ -773,7 +773,7 @@ describe('Onboarding flow', () => {
     });
   });
 
-  context('AB Test - Single Newsletter test', () => {
+  context.skip('AB Test - Single Newsletter test', () => {
     context('Contact Options Page', () => {
       beforeEach(() => {
         setAuthCookies();

--- a/src/shared/model/experiments/abSwitches.ts
+++ b/src/shared/model/experiments/abSwitches.ts
@@ -1,3 +1,3 @@
 export const switches = {
-  abSingleNewsletterTest: true,
+  abSingleNewsletterTest: false,
 };


### PR DESCRIPTION
## What does this change?
- Switches of the newsletter AB test by setting the switch to false, and skipping the cypress test
- Keeping the AB test code around in the project until the results are analysed, if the test is successful we'll roll out the test, otherwise we'll remove it
