### PR TITLE
Fullscreen stories

### DIFF
--- a/src/client/pages/ChangePassword.stories.tsx
+++ b/src/client/pages/ChangePassword.stories.tsx
@@ -6,6 +6,7 @@ import { ChangePassword } from './ChangePassword';
 export default {
   title: 'Pages/ChangePassword',
   component: ChangePassword,
+  parameters: { layout: 'fullscreen' },
 } as Meta;
 
 export const Default = () => (

--- a/src/client/pages/ChangePasswordComplete.stories.tsx
+++ b/src/client/pages/ChangePasswordComplete.stories.tsx
@@ -7,6 +7,7 @@ import { ChangePasswordComplete } from './ChangePasswordComplete';
 export default {
   title: 'Pages/ChangePasswordComplete',
   component: ChangePasswordComplete,
+  parameters: { layout: 'fullscreen' },
 } as Meta;
 
 export const Default = () => (

--- a/src/client/pages/ConsentsCommunication.stories.tsx
+++ b/src/client/pages/ConsentsCommunication.stories.tsx
@@ -6,6 +6,7 @@ import { ConsentsCommunication } from './ConsentsCommunication';
 export default {
   title: 'Pages/ConsentsCommunication',
   component: ConsentsCommunication,
+  parameters: { layout: 'fullscreen' },
 } as Meta;
 
 export const NoConsent = () => (

--- a/src/client/pages/ConsentsConfirmation.stories.tsx
+++ b/src/client/pages/ConsentsConfirmation.stories.tsx
@@ -6,6 +6,7 @@ import { ConsentsConfirmation } from './ConsentsConfirmation';
 export default {
   title: 'Pages/ConsentsConfirmation',
   component: ConsentsConfirmation,
+  parameters: { layout: 'fullscreen' },
 } as Meta;
 
 export const NoConsent = () => (

--- a/src/client/pages/ConsentsData.stories.tsx
+++ b/src/client/pages/ConsentsData.stories.tsx
@@ -7,6 +7,7 @@ import { ConsentsData } from './ConsentsData';
 export default {
   title: 'Pages/ConsentsData',
   component: ConsentsData,
+  parameters: { layout: 'fullscreen' },
 } as Meta;
 
 export const NoDescription = () => <ConsentsData />;

--- a/src/client/pages/ConsentsFollowUp.stories.tsx
+++ b/src/client/pages/ConsentsFollowUp.stories.tsx
@@ -7,6 +7,7 @@ import { ConsentsFollowUp } from './ConsentsFollowUp';
 export default {
   title: 'Pages/ConsentsFollowUp',
   component: ConsentsFollowUp,
+  parameters: { layout: 'fullscreen' },
 } as Meta;
 
 export const NewsLetter = () => (

--- a/src/client/pages/ConsentsNewsletters.stories.tsx
+++ b/src/client/pages/ConsentsNewsletters.stories.tsx
@@ -7,6 +7,7 @@ import { ConsentsNewsletters } from './ConsentsNewsletters';
 export default {
   title: 'Pages/ConsentsNewsletters',
   component: ConsentsNewsletters,
+  parameters: { layout: 'fullscreen' },
 } as Meta;
 
 export const NoNewsletters = () => (

--- a/src/client/pages/NotFoundPage.stories.tsx
+++ b/src/client/pages/NotFoundPage.stories.tsx
@@ -6,6 +6,7 @@ import { NotFoundPage } from './NotFoundPage';
 export default {
   title: 'Pages/NotFoundPage',
   component: NotFoundPage,
+  parameters: { layout: 'fullscreen' },
 } as Meta;
 
 export const Default = () => <NotFoundPage />;

--- a/src/client/pages/Registration.stories.tsx
+++ b/src/client/pages/Registration.stories.tsx
@@ -6,6 +6,7 @@ import { Registration } from './Registration';
 export default {
   title: 'Pages/Registration',
   component: Registration,
+  parameters: { layout: 'fullscreen' },
 } as Meta;
 
 export const Default = () => <Registration />;

--- a/src/client/pages/ResendEmailVerification.stories.tsx
+++ b/src/client/pages/ResendEmailVerification.stories.tsx
@@ -7,6 +7,7 @@ import { ResendEmailVerification } from './ResendEmailVerification';
 export default {
   title: 'Pages/ResendEmailVerification',
   component: ResendEmailVerification,
+  parameters: { layout: 'fullscreen' },
 } as Meta;
 
 export const LoggedIn = () => (

--- a/src/client/pages/ResetPassword.stories.tsx
+++ b/src/client/pages/ResetPassword.stories.tsx
@@ -6,6 +6,7 @@ import { ResetPassword } from './ResetPassword';
 export default {
   title: 'Pages/ResetPassword',
   component: ResetPassword,
+  parameters: { layout: 'fullscreen' },
 } as Meta;
 
 export const Default = () => (

--- a/src/client/pages/ResetSent.stories.tsx
+++ b/src/client/pages/ResetSent.stories.tsx
@@ -7,6 +7,7 @@ import { ResetSent } from './ResetSent';
 export default {
   title: 'Pages/ResetSent',
   component: ResetSent,
+  parameters: { layout: 'fullscreen' },
 } as Meta;
 
 export const NoInboxDetails = () => <ResetSent />;

--- a/src/client/pages/SignIn.stories.tsx
+++ b/src/client/pages/SignIn.stories.tsx
@@ -6,6 +6,7 @@ import { SignIn } from './SignIn';
 export default {
   title: 'Pages/SignIn',
   component: SignIn,
+  parameters: { layout: 'fullscreen' },
 } as Meta;
 
 export const Default = () => <SignIn />;

--- a/src/client/pages/UnexpectedErrorPage.stories.tsx
+++ b/src/client/pages/UnexpectedErrorPage.stories.tsx
@@ -7,6 +7,7 @@ import { UnexpectedErrorPage } from './UnexpectedErrorPage';
 export default {
   title: 'Pages/UnexpectedErrorPage',
   component: UnexpectedErrorPage,
+  parameters: { layout: 'fullscreen' },
 } as Meta;
 
 export const Default = () => <UnexpectedErrorPage />;


### PR DESCRIPTION
## What does this change?
Storybook adds a `1em` margin on the `body` by default which is nice for component stories but looks off for page stories so this PR removes it in these cases

### Before
![Screenshot 2021-05-19 at 08 46 03](https://user-images.githubusercontent.com/1336821/118775274-a9daa200-b87e-11eb-9d0b-3f86d600ea82.jpg)


### After
![Screenshot 2021-05-19 at 08 43 16](https://user-images.githubusercontent.com/1336821/118775245-a1826700-b87e-11eb-8e85-6122de200fd1.jpg)
