### PR TITLE
Social positioning

### DIFF
--- a/src/client/components/SocialButtons.tsx
+++ b/src/client/components/SocialButtons.tsx
@@ -10,11 +10,14 @@ const containerStyles = css`
   display: flex;
   flex-direction: row;
   justify-content: center;
+  width: 100%;
   margin: ${space[9]}px 0;
 `;
 
-const borderColorStyles = css`
+const buttonOverrides = css`
   border-color: ${sport[500]};
+  justify-content: flex-end;
+  min-width: 145px;
 `;
 
 const Gap = () => (
@@ -29,7 +32,7 @@ export const SocialButtons = () => (
   <div css={containerStyles}>
     <Button
       priority="tertiary"
-      cssOverrides={borderColorStyles}
+      cssOverrides={buttonOverrides}
       icon={<SvgFacebook />}
     >
       Facebook
@@ -37,7 +40,7 @@ export const SocialButtons = () => (
     <Gap />
     <Button
       priority="tertiary"
-      cssOverrides={borderColorStyles}
+      cssOverrides={buttonOverrides}
       icon={<SvgGoogle />}
     >
       Google
@@ -45,7 +48,7 @@ export const SocialButtons = () => (
     <Gap />
     <Button
       priority="tertiary"
-      cssOverrides={borderColorStyles}
+      cssOverrides={buttonOverrides}
       icon={<SvgApple />}
     >
       Apple


### PR DESCRIPTION
## What does this change?
Sets a min width on the `SocialButtons` so that the variation in size is reduced (but not entirely irradicated).

With this min width we have more whitespace so we're also adjusting how items are positioned to balance things slightly

### Before
![Screenshot 2021-05-19 at 15 41 55](https://user-images.githubusercontent.com/1336821/118832967-fa6ef100-b8b8-11eb-976a-3cce9744e98a.jpg)


### After
![Screenshot 2021-05-19 at 15 41 34](https://user-images.githubusercontent.com/1336821/118832953-f6db6a00-b8b8-11eb-8dc8-36df8b5e9c81.jpg)
