### PR TITLE
Social Borders

### DIFF
--- a/src/client/components/SocialButtons.tsx
+++ b/src/client/components/SocialButtons.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { css } from '@emotion/react';
-import { space, sport } from '@guardian/src-foundations';
+import { space, brand } from '@guardian/src-foundations';
 import { Button } from '@guardian/src-button';
 import { SvgGoogle } from '../icons/SvgGoogle';
 import { SvgApple } from '../icons/SvgApple';
@@ -15,7 +15,7 @@ const containerStyles = css`
 `;
 
 const buttonOverrides = css`
-  border-color: ${sport[500]};
+  border-color: ${brand[400]};
   justify-content: flex-end;
   min-width: 145px;
 `;


### PR DESCRIPTION
## What does this change?
Moves from sport.500 to brand.400 for the border colour on social buttons

### Before
<img width="525" alt="Screenshot 2021-05-21 at 09 49 14" src="https://user-images.githubusercontent.com/1336821/119110505-235ac780-ba1a-11eb-96df-c7261dd53344.png">


### After
<img width="525" alt="Screenshot 2021-05-21 at 09 48 59" src="https://user-images.githubusercontent.com/1336821/119110495-205fd700-ba1a-11eb-991d-5f78718f55e8.png">
