### PR TITLE
Inline `Header` and `Footer`

### DIFF
--- a/src/client/app.tsx
+++ b/src/client/app.tsx
@@ -7,7 +7,7 @@ import { GatewayRoutes } from './routes';
 import { tests } from '@/shared/model/experiments/abTests';
 import { useAB } from '@guardian/ab-react';
 
-export const Main = (props: ClientState) => {
+export const App = (props: ClientState) => {
   // initalise the AB Test Framework:
   // load the AB Hook
   const ABTestAPI = useAB();

--- a/src/client/layouts/Main.tsx
+++ b/src/client/layouts/Main.tsx
@@ -1,6 +1,4 @@
 import React, { useContext } from 'react';
-import { Header } from '@/client/components/Header';
-import { Footer } from '@/client/components/Footer';
 import { SubHeader } from '@/client/components/SubHeader';
 import { ClientState } from '@/shared/model/ClientState';
 import { ClientStateContext } from '@/client/components/ClientState';
@@ -30,21 +28,16 @@ const sectionStyles = css`
   margin: 0 auto;
 `;
 
-export const Layout = ({ subTitle, children }: Props) => {
+export const Main = ({ subTitle, children }: Props) => {
   const clientState: ClientState = useContext(ClientStateContext);
   const { globalMessage: { error, success } = {} } = clientState;
 
   return (
-    <>
-      <Header />
-      <main css={mainStyles}>
-        <SubHeader title={subTitle} />
-        {error && <GlobalError error={error} link={getErrorLink(error)} />}
-        {success && <GlobalSuccess success={success} />}
-        <section css={sectionStyles}>{children}</section>
-      </main>
-
-      <Footer />
-    </>
+    <main css={mainStyles}>
+      <SubHeader title={subTitle} />
+      {error && <GlobalError error={error} link={getErrorLink(error)} />}
+      {success && <GlobalSuccess success={success} />}
+      <section css={sectionStyles}>{children}</section>
+    </main>
   );
 };

--- a/src/client/pages/ChangePassword.tsx
+++ b/src/client/pages/ChangePassword.tsx
@@ -13,7 +13,9 @@ import { PageHeader } from '@/client/components/PageHeader';
 import { PageBody } from '@/client/components/PageBody';
 import { PageBodyText } from '@/client/components/PageBodyText';
 import { button, form, textInput } from '@/client/styles/Shared';
-import { Layout } from '@/client/layouts/Layout';
+import { Main } from '@/client/layouts/Main';
+import { Header } from '@/client/components/Header';
+import { Footer } from '@/client/components/Footer';
 import { CsrfFormField } from '@/client/components/CsrfFormField';
 import {
   LengthValidationComponent,
@@ -257,102 +259,106 @@ export const ChangePassword = ({
   } = usePasswordValidationHooks(idapiBaseUrl);
 
   return (
-    <Layout subTitle="Sign in">
-      <PageBox>
-        <PageHeader>Reset Password</PageHeader>
-        <PageBody>
-          <PageBodyText>
-            Please enter your new password for {email}
-          </PageBodyText>
-          <form
-            css={form}
-            method="post"
-            action={submitUrl}
-            onSubmit={(e) => {
-              // prevent the form from submitting if there are validation errors
-              if (
-                validationResult !== PasswordValidationResult.VALID_PASSWORD
-              ) {
-                setRedError(validationResult);
-                e.preventDefault();
-              } else if (password !== passwordConfirm) {
-                setShowPasswordNotMatchingEvenIfSubstring(true);
-                e.preventDefault();
-              }
-            }}
-          >
-            <CsrfFormField />
-
-            <PasswordInput
-              css={textInput}
-              label="New Password"
-              name="password"
-              error={
-                longRedErrorMessage ??
-                fieldErrors.find(
-                  (fieldError) => fieldError.field === 'password',
-                )?.message
-              }
-              onChange={(e) => {
-                setPassword(e.target.value);
-              }}
-            />
-
-            <div
-              css={css`
-                margin-bottom: ${space[9]}px;
-              `}
-            >
-              {/* we don't render length validation success output if the password is breached */}
-              {!isCommonPassword ? (
-                <LengthValidationComponent
-                  validationStyling={lengthValidationStyle}
-                  lengthResult={lastLengthError}
-                />
-              ) : null}
-              {isCommonPassword ? <WeakPasswordComponent /> : null}
-            </div>
-
-            <PasswordInput
-              css={textInput}
-              label="Repeat Password"
-              name="password_confirm"
-              success={passwordConfirmSuccessMessage}
-              error={
-                passwordConfirmationErrorMessage ??
-                fieldErrors.find(
-                  (fieldError) => fieldError.field === 'password_confirm',
-                )?.message
-              }
-              onFocus={() => {
-                setIsPasswordConfirmSelected(true);
-                // if there are validation issues in the first password input and the user selects the confirm password box,
-                // display a red error message
+    <>
+      <Header />
+      <Main subTitle="Sign in">
+        <PageBox>
+          <PageHeader>Reset Password</PageHeader>
+          <PageBody>
+            <PageBodyText>
+              Please enter your new password for {email}
+            </PageBodyText>
+            <form
+              css={form}
+              method="post"
+              action={submitUrl}
+              onSubmit={(e) => {
+                // prevent the form from submitting if there are validation errors
                 if (
-                  longRedErrorMessage === undefined &&
                   validationResult !== PasswordValidationResult.VALID_PASSWORD
                 ) {
                   setRedError(validationResult);
+                  e.preventDefault();
+                } else if (password !== passwordConfirm) {
+                  setShowPasswordNotMatchingEvenIfSubstring(true);
+                  e.preventDefault();
                 }
               }}
-              onBlur={() => {
-                setIsPasswordConfirmSelected(false);
-              }}
-              onChange={(e) => {
-                setPasswordConfirm(e.target.value);
-              }}
-            />
-            <Button
-              css={button}
-              type="submit"
-              icon={<SvgArrowRightStraight />}
-              iconSide="right"
             >
-              Save Password
-            </Button>
-          </form>
-        </PageBody>
-      </PageBox>
-    </Layout>
+              <CsrfFormField />
+
+              <PasswordInput
+                css={textInput}
+                label="New Password"
+                name="password"
+                error={
+                  longRedErrorMessage ??
+                  fieldErrors.find(
+                    (fieldError) => fieldError.field === 'password',
+                  )?.message
+                }
+                onChange={(e) => {
+                  setPassword(e.target.value);
+                }}
+              />
+
+              <div
+                css={css`
+                  margin-bottom: ${space[9]}px;
+                `}
+              >
+                {/* we don't render length validation success output if the password is breached */}
+                {!isCommonPassword ? (
+                  <LengthValidationComponent
+                    validationStyling={lengthValidationStyle}
+                    lengthResult={lastLengthError}
+                  />
+                ) : null}
+                {isCommonPassword ? <WeakPasswordComponent /> : null}
+              </div>
+
+              <PasswordInput
+                css={textInput}
+                label="Repeat Password"
+                name="password_confirm"
+                success={passwordConfirmSuccessMessage}
+                error={
+                  passwordConfirmationErrorMessage ??
+                  fieldErrors.find(
+                    (fieldError) => fieldError.field === 'password_confirm',
+                  )?.message
+                }
+                onFocus={() => {
+                  setIsPasswordConfirmSelected(true);
+                  // if there are validation issues in the first password input and the user selects the confirm password box,
+                  // display a red error message
+                  if (
+                    longRedErrorMessage === undefined &&
+                    validationResult !== PasswordValidationResult.VALID_PASSWORD
+                  ) {
+                    setRedError(validationResult);
+                  }
+                }}
+                onBlur={() => {
+                  setIsPasswordConfirmSelected(false);
+                }}
+                onChange={(e) => {
+                  setPasswordConfirm(e.target.value);
+                }}
+              />
+              <Button
+                css={button}
+                type="submit"
+                icon={<SvgArrowRightStraight />}
+                iconSide="right"
+              >
+                Save Password
+              </Button>
+            </form>
+          </PageBody>
+        </PageBox>
+      </Main>
+      <Footer />
+    </>
   );
 };

--- a/src/client/pages/ChangePasswordComplete.tsx
+++ b/src/client/pages/ChangePasswordComplete.tsx
@@ -5,7 +5,9 @@ import { PageHeader } from '@/client/components/PageHeader';
 import { PageBodyText } from '@/client/components/PageBodyText';
 import { PageBody } from '@/client/components/PageBody';
 import { linkButton } from '@/client/styles/Shared';
-import { Layout } from '@/client/layouts/Layout';
+import { Main } from '@/client/layouts/Main';
+import { Header } from '@/client/components/Header';
+import { Footer } from '@/client/components/Footer';
 import { SvgArrowRightStraight } from '@guardian/src-icons';
 
 type ChangePasswordCompleteProps = {
@@ -16,28 +18,32 @@ export const ChangePasswordComplete = ({
   returnUrl,
 }: ChangePasswordCompleteProps) => {
   return (
-    <Layout subTitle="Sign in">
-      <PageBox>
-        <PageHeader>Password Changed</PageHeader>
-        <PageBody>
-          <PageBodyText>
-            Thank you! Your password has been changed.
-          </PageBodyText>
-          <PageBodyText>
-            You&rsquo;ve completed updating your Guardian account. Please click
-            the button below to jump back to the Guardian.
-          </PageBodyText>
-        </PageBody>
-        <LinkButton
-          css={linkButton}
-          iconSide="right"
-          nudgeIcon={true}
-          icon={<SvgArrowRightStraight />}
-          href={returnUrl}
-        >
-          Continue to The Guardian
-        </LinkButton>
-      </PageBox>
-    </Layout>
+    <>
+      <Header />
+      <Main subTitle="Sign in">
+        <PageBox>
+          <PageHeader>Password Changed</PageHeader>
+          <PageBody>
+            <PageBodyText>
+              Thank you! Your password has been changed.
+            </PageBodyText>
+            <PageBodyText>
+              You&rsquo;ve completed updating your Guardian account. Please
+              click the button below to jump back to the Guardian.
+            </PageBodyText>
+          </PageBody>
+          <LinkButton
+            css={linkButton}
+            iconSide="right"
+            nudgeIcon={true}
+            icon={<SvgArrowRightStraight />}
+            href={returnUrl}
+          >
+            Continue to The Guardian
+          </LinkButton>
+        </PageBox>
+      </Main>
+      <Footer />
+    </>
   );
 };

--- a/src/client/pages/NotFoundPage.tsx
+++ b/src/client/pages/NotFoundPage.tsx
@@ -6,26 +6,32 @@ import { PageBox } from '@/client/components/PageBox';
 import { PageHeader } from '@/client/components/PageHeader';
 import { PageBody } from '@/client/components/PageBody';
 import { PageBodyText } from '@/client/components/PageBodyText';
-import { Layout } from '@/client/layouts/Layout';
+import { Main } from '@/client/layouts/Main';
+import { Header } from '@/client/components/Header';
+import { Footer } from '@/client/components/Footer';
 
 const link = css`
   display: inline-block;
 `;
 
 export const NotFoundPage = () => (
-  <Layout subTitle="Sign in">
-    <PageBox>
-      <PageHeader>Sorry – the page does not exist</PageHeader>
-      <PageBody>
-        <PageBodyText>
-          You may have followed an outdated link, or have mistyped a URL. If you
-          believe this to be an error, please{' '}
-          <Link css={link} href={locations.REPORT_ISSUE}>
-            report it
-          </Link>
-          .
-        </PageBodyText>
-      </PageBody>
-    </PageBox>
-  </Layout>
+  <>
+    <Header />
+    <Main subTitle="Sign in">
+      <PageBox>
+        <PageHeader>Sorry – the page does not exist</PageHeader>
+        <PageBody>
+          <PageBodyText>
+            You may have followed an outdated link, or have mistyped a URL. If
+            you believe this to be an error, please{' '}
+            <Link css={link} href={locations.REPORT_ISSUE}>
+              report it
+            </Link>
+            .
+          </PageBodyText>
+        </PageBody>
+      </PageBox>
+    </Main>
+    <Footer />
+  </>
 );

--- a/src/client/pages/Registration.tsx
+++ b/src/client/pages/Registration.tsx
@@ -3,7 +3,9 @@ import { TextInput } from '@guardian/src-text-input';
 import { Button } from '@guardian/src-button';
 import { Routes } from '@/shared/model/Routes';
 import { PageTitle } from '@/shared/model/PageTitle';
-import { Layout } from '@/client/layouts/Layout';
+import { Main } from '@/client/layouts/Main';
+import { Header } from '@/client/components/Header';
+import { Footer } from '@/client/components/Footer';
 import { PageBox } from '@/client/components/PageBox';
 import { PageBody } from '@/client/components/PageBody';
 import { CsrfFormField } from '@/client/components/CsrfFormField';
@@ -13,25 +15,34 @@ import { SocialButtons } from '@/client/components/SocialButtons';
 import { button, form, textInput } from '@/client/styles/Shared';
 
 export const Registration = () => (
-  <Layout subTitle={PageTitle.REGISTRATION}>
-    <PageBox>
-      <PageBody>
-        <form css={form} method="post" action={`${Routes.REGISTRATION}`}>
-          <CsrfFormField />
-          <TextInput css={textInput} label="Email" name="email" type="email" />
-          <Button css={button} type="submit">
-            Register
-          </Button>
-        </form>
-        <Divider
-          size="full"
-          spaceAbove="loose"
-          displayText="or continue with"
-        />
-        <SocialButtons />
-        <Divider size="full" spaceAbove="tight" />
-        <Terms />
-      </PageBody>
-    </PageBox>
-  </Layout>
+  <>
+    <Header />
+    <Main subTitle={PageTitle.REGISTRATION}>
+      <PageBox>
+        <PageBody>
+          <form css={form} method="post" action={`${Routes.REGISTRATION}`}>
+            <CsrfFormField />
+            <TextInput
+              css={textInput}
+              label="Email"
+              name="email"
+              type="email"
+            />
+            <Button css={button} type="submit">
+              Register
+            </Button>
+          </form>
+          <Divider
+            size="full"
+            spaceAbove="loose"
+            displayText="or continue with"
+          />
+          <SocialButtons />
+          <Divider size="full" spaceAbove="tight" />
+          <Terms />
+        </PageBody>
+      </PageBox>
+    </Main>
+    <Footer />
+  </>
 );

--- a/src/client/pages/ResendEmailVerification.tsx
+++ b/src/client/pages/ResendEmailVerification.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
-import { Layout } from '@/client/layouts/Layout';
+import { Main } from '@/client/layouts/Main';
+import { Header } from '@/client/components/Header';
+import { Footer } from '@/client/components/Footer';
 import { LinkButton, Button } from '@guardian/src-button';
 import { PageBody } from '@/client/components/PageBody';
 import { PageBodyText } from '@/client/components/PageBodyText';
@@ -112,17 +114,21 @@ export const ResendEmailVerification = ({
   inboxName,
 }: ResendEmailVerificationProps) => {
   return (
-    <Layout subTitle="Sign in">
-      {email ? (
-        <LoggedIn
-          email={email}
-          successText={successText}
-          inboxLink={inboxLink}
-          inboxName={inboxName}
-        />
-      ) : (
-        <LoggedOut signInPageUrl={signInPageUrl} />
-      )}
-    </Layout>
+    <>
+      <Header />
+      <Main subTitle="Sign in">
+        {email ? (
+          <LoggedIn
+            email={email}
+            successText={successText}
+            inboxLink={inboxLink}
+            inboxName={inboxName}
+          />
+        ) : (
+          <LoggedOut signInPageUrl={signInPageUrl} />
+        )}
+      </Main>
+      <Footer />
+    </>
   );
 };

--- a/src/client/pages/ResetPassword.tsx
+++ b/src/client/pages/ResetPassword.tsx
@@ -9,7 +9,9 @@ import { PageBody } from '@/client/components/PageBody';
 import { PageBodyText } from '@/client/components/PageBodyText';
 import { form, textInput, button } from '@/client/styles/Shared';
 import { CsrfFormField } from '@/client/components/CsrfFormField';
-import { Layout } from '@/client/layouts/Layout';
+import { Main } from '@/client/layouts/Main';
+import { Header } from '@/client/components/Header';
+import { Footer } from '@/client/components/Footer';
 
 interface ResetPasswordProps {
   email?: string;
@@ -26,30 +28,38 @@ export const ResetPassword = ({
   buttonText,
   queryString = '',
 }: ResetPasswordProps) => (
-  <Layout subTitle="Sign in">
-    <PageBox>
-      <PageHeader>{headerText}</PageHeader>
-      <PageBody>
-        <PageBodyText>{bodyText}</PageBodyText>
-        <form css={form} method="post" action={`${Routes.RESET}${queryString}`}>
-          <CsrfFormField />
-          <TextInput
-            css={textInput}
-            label="Email address"
-            name="email"
-            type="email"
-            defaultValue={email}
-          />
-          <Button
-            css={button}
-            type="submit"
-            icon={<SvgArrowRightStraight />}
-            iconSide="right"
+  <>
+    <Header />
+    <Main subTitle="Sign in">
+      <PageBox>
+        <PageHeader>{headerText}</PageHeader>
+        <PageBody>
+          <PageBodyText>{bodyText}</PageBodyText>
+          <form
+            css={form}
+            method="post"
+            action={`${Routes.RESET}${queryString}`}
           >
-            {buttonText}
-          </Button>
-        </form>
-      </PageBody>
-    </PageBox>
-  </Layout>
+            <CsrfFormField />
+            <TextInput
+              css={textInput}
+              label="Email address"
+              name="email"
+              type="email"
+              defaultValue={email}
+            />
+            <Button
+              css={button}
+              type="submit"
+              icon={<SvgArrowRightStraight />}
+              iconSide="right"
+            >
+              {buttonText}
+            </Button>
+          </form>
+        </PageBody>
+      </PageBox>
+    </Main>
+    <Footer />
+  </>
 );

--- a/src/client/pages/ResetSent.tsx
+++ b/src/client/pages/ResetSent.tsx
@@ -5,7 +5,9 @@ import { PageBox } from '@/client/components/PageBox';
 import { PageBody } from '@/client/components/PageBody';
 import { PageBodyText } from '@/client/components/PageBodyText';
 import { linkButton } from '@/client/styles/Shared';
-import { Layout } from '@/client/layouts/Layout';
+import { Main } from '@/client/layouts/Main';
+import { Header } from '@/client/components/Header';
+import { Footer } from '@/client/components/Footer';
 import { SvgArrowRightStraight } from '@guardian/src-icons';
 
 type ResetSentProps = {
@@ -15,32 +17,36 @@ type ResetSentProps = {
 
 export const ResetSent = ({ inboxLink, inboxName }: ResetSentProps) => {
   return (
-    <Layout subTitle="Sign in">
-      <PageBox>
-        <PageHeader>Please check your inbox</PageHeader>
-        <PageBody>
-          <PageBodyText>
-            We’ve sent you an email – please open it up and click on the button.
-            This is so we can verify it’s you and help you create a password to
-            complete your Guardian account.
-          </PageBodyText>
-          <PageBodyText>
-            Note that the link is only valid for 30 minutes, so be sure to open
-            it soon! Thank you.
-          </PageBodyText>
-        </PageBody>
-        {inboxLink && inboxName && (
-          <LinkButton
-            css={linkButton}
-            href={inboxLink}
-            priority="tertiary"
-            icon={<SvgArrowRightStraight />}
-            iconSide="right"
-          >
-            Go to your {inboxName} inbox
-          </LinkButton>
-        )}
-      </PageBox>
-    </Layout>
+    <>
+      <Header />
+      <Main subTitle="Sign in">
+        <PageBox>
+          <PageHeader>Please check your inbox</PageHeader>
+          <PageBody>
+            <PageBodyText>
+              We’ve sent you an email – please open it up and click on the
+              button. This is so we can verify it’s you and help you create a
+              password to complete your Guardian account.
+            </PageBodyText>
+            <PageBodyText>
+              Note that the link is only valid for 30 minutes, so be sure to
+              open it soon! Thank you.
+            </PageBodyText>
+          </PageBody>
+          {inboxLink && inboxName && (
+            <LinkButton
+              css={linkButton}
+              href={inboxLink}
+              priority="tertiary"
+              icon={<SvgArrowRightStraight />}
+              iconSide="right"
+            >
+              Go to your {inboxName} inbox
+            </LinkButton>
+          )}
+        </PageBox>
+      </Main>
+      <Footer />
+    </>
   );
 };

--- a/src/client/pages/SignIn.tsx
+++ b/src/client/pages/SignIn.tsx
@@ -3,15 +3,21 @@ import { PageHeader } from '@/client/components/PageHeader';
 import { PageBox } from '@/client/components/PageBox';
 import { PageBody } from '@/client/components/PageBody';
 import { PageBodyText } from '@/client/components/PageBodyText';
-import { Layout } from '@/client/layouts/Layout';
+import { Main } from '@/client/layouts/Main';
+import { Header } from '@/client/components/Header';
+import { Footer } from '@/client/components/Footer';
 
 export const SignIn = () => (
-  <Layout subTitle="Sign in">
-    <PageBox>
-      <PageHeader>Sign in</PageHeader>
-      <PageBody>
-        <PageBodyText>Body text</PageBodyText>
-      </PageBody>
-    </PageBox>
-  </Layout>
+  <>
+    <Header />
+    <Main subTitle="Sign in">
+      <PageBox>
+        <PageHeader>Sign in</PageHeader>
+        <PageBody>
+          <PageBodyText>Body text</PageBodyText>
+        </PageBody>
+      </PageBox>
+    </Main>
+    <Footer />
+  </>
 );

--- a/src/client/pages/UnexpectedErrorPage.tsx
+++ b/src/client/pages/UnexpectedErrorPage.tsx
@@ -6,25 +6,31 @@ import { PageBox } from '@/client/components/PageBox';
 import { PageHeader } from '@/client/components/PageHeader';
 import { PageBody } from '@/client/components/PageBody';
 import { PageBodyText } from '@/client/components/PageBodyText';
-import { Layout } from '@/client/layouts/Layout';
+import { Main } from '@/client/layouts/Main';
+import { Header } from '@/client/components/Header';
+import { Footer } from '@/client/components/Footer';
 
 const link = css`
   display: inline-block;
 `;
 
 export const UnexpectedErrorPage = () => (
-  <Layout subTitle="Sign in">
-    <PageBox>
-      <PageHeader>Sorry – an unexpected error occurred</PageHeader>
-      <PageBody>
-        <PageBodyText>
-          An error occurred, please try again or{' '}
-          <Link css={link} href={locations.REPORT_ISSUE}>
-            report it
-          </Link>
-          .
-        </PageBodyText>
-      </PageBody>
-    </PageBox>
-  </Layout>
+  <>
+    <Header />
+    <Main subTitle="Sign in">
+      <PageBox>
+        <PageHeader>Sorry – an unexpected error occurred</PageHeader>
+        <PageBody>
+          <PageBodyText>
+            An error occurred, please try again or{' '}
+            <Link css={link} href={locations.REPORT_ISSUE}>
+              report it
+            </Link>
+            .
+          </PageBodyText>
+        </PageBody>
+      </PageBox>
+    </Main>
+    <Footer />
+  </>
 );

--- a/src/client/static/hydration.tsx
+++ b/src/client/static/hydration.tsx
@@ -4,7 +4,7 @@ import { ABProvider } from '@guardian/ab-react';
 import { StaticRouter } from 'react-router-dom';
 import { hydrate } from 'react-dom';
 import { RoutingConfig } from '@/client/routes';
-import { Main } from '@/client/main';
+import { App } from '@/client/app';
 import { tests } from '@/shared/model/experiments/abTests';
 import { switches } from '@/shared/model/experiments/abSwitches';
 
@@ -29,7 +29,7 @@ export const hydrateApp = () => {
       forcedTestVariants={forcedTestVariants}
     >
       <StaticRouter location={`${routingConfig.location}`} context={{}}>
-        <Main {...clientState} />
+        <App {...clientState} />
       </StaticRouter>
     </ABProvider>,
     document.getElementById('app'),

--- a/src/server/lib/renderer.tsx
+++ b/src/server/lib/renderer.tsx
@@ -2,7 +2,7 @@ import { ClientState } from '@/shared/model/ClientState';
 import ReactDOMServer from 'react-dom/server';
 import React from 'react';
 import { StaticRouter } from 'react-router-dom';
-import { Main } from '@/client/main';
+import { App } from '@/client/app';
 import { brandBackground } from '@guardian/src-foundations/palette';
 import qs from 'query-string';
 import { getConfiguration } from '@/server/lib/getConfiguration';
@@ -110,7 +110,7 @@ export const renderer: (url: string, opts: RendererOpts) => string = (
       forcedTestVariants={forcedTestVariants}
     >
       <StaticRouter location={location} context={context}>
-        <Main {...clientState}></Main>
+        <App {...clientState}></App>
       </StaticRouter>
     </ABProvider>,
   );


### PR DESCRIPTION
## What does this change?
This PR refactors the `Layout` file to extract out the `Header` and `Footer` components so that they can be inlined in each page.

After doing the the name of `Layout` made less sense so I renamed it to `Main` to reflect that this component now sets the `main` element on the page.

There was another component also called `Main` which I renamed to `App` to prevent clashes. Also, as the react root element `app` is the conventional name normally used here.

## Why?
Because the `Layout` abstraction is no longer working. We now have a use case where we sometimes want to use `SubHeader` but at other times use a `Nav` component (Sign In / Register tabs). Rather than introduce more props and conditional logic to `Layout` I think it is better to solve problems like this by inlining things more and using composition.

## But what about the extra duplication?
It's true that by inlining code we create duplication. But not all duplication should be abstracted, keeping the same code in multiple places makes changing this code later to support new use cases (see above) much simpler and therefore makes the codebase more flexible and scalable. Every abstraction is also a chain, tying us down.