### PR TITLE
`Nav`

### DIFF
--- a/src/client/components/Nav.stories.tsx
+++ b/src/client/components/Nav.stories.tsx
@@ -1,0 +1,105 @@
+import React from 'react';
+import { Meta } from '@storybook/react';
+
+import { Header } from './Header';
+import { Nav } from './Nav';
+
+export default {
+  title: 'Components/Nav',
+  component: Nav,
+  parameters: { layout: 'fullscreen' },
+} as Meta;
+
+export const Register = () => (
+  <>
+    <Header />
+    <Nav
+      tabs={[
+        {
+          displayText: 'Sign in',
+          linkTo: '',
+          isActive: false,
+        },
+        {
+          displayText: 'Register',
+          linkTo: '',
+          isActive: true,
+        },
+      ]}
+    />
+  </>
+);
+Register.storyName = 'with register active';
+
+export const SignIn = () => (
+  <>
+    <Header />
+    <Nav
+      tabs={[
+        {
+          displayText: 'Sign in',
+          linkTo: '',
+          isActive: true,
+        },
+        {
+          displayText: 'Register',
+          linkTo: '',
+          isActive: false,
+        },
+      ]}
+    />
+  </>
+);
+SignIn.storyName = 'with signin active';
+
+export const Wide = () => (
+  <>
+    <Header />
+    <Nav
+      tabs={[
+        {
+          displayText: 'Sign in',
+          linkTo: '',
+          isActive: true,
+        },
+        {
+          displayText: 'Register',
+          linkTo: '',
+          isActive: false,
+        },
+      ]}
+    />
+  </>
+);
+Wide.storyName = 'at wide breakpoint';
+Wide.parameters = {
+  viewport: {
+    defaultViewport: 'WIDE',
+  },
+};
+
+export const NoBreakpoint = () => (
+  <>
+    <Header />
+    <Nav
+      tabs={[
+        {
+          displayText: 'Sign in',
+          linkTo: '',
+          isActive: true,
+        },
+        {
+          displayText: 'Register',
+          linkTo: '',
+          isActive: false,
+        },
+      ]}
+    />
+  </>
+);
+NoBreakpoint.storyName = 'at full width';
+NoBreakpoint.parameters = {
+  viewport: {
+    defaultViewport: 'does_not_exist',
+  },
+};

--- a/src/client/components/Nav.stories.tsx
+++ b/src/client/components/Nav.stories.tsx
@@ -51,6 +51,9 @@ export const SignIn = () => (
   </>
 );
 SignIn.storyName = 'with signin active';
+SignIn.parameters = {
+  chromatic: { viewports: [480] },
+};
 
 export const Wide = () => (
   <>
@@ -76,6 +79,7 @@ Wide.parameters = {
   viewport: {
     defaultViewport: 'WIDE',
   },
+  chromatic: { viewports: [1300] },
 };
 
 export const NoBreakpoint = () => (
@@ -102,4 +106,5 @@ NoBreakpoint.parameters = {
   viewport: {
     defaultViewport: 'does_not_exist',
   },
+  chromatic: { disable: true },
 };

--- a/src/client/components/Nav.tsx
+++ b/src/client/components/Nav.tsx
@@ -58,7 +58,6 @@ const activeBarStyles = css`
   :after {
     border-top: 4px solid ${brandAltBackground.primary};
     left: 0;
-    left: -20px;
     right: 0;
     top: -5px;
     content: '';

--- a/src/client/components/Nav.tsx
+++ b/src/client/components/Nav.tsx
@@ -1,0 +1,168 @@
+import * as React from 'react';
+import { css } from '@emotion/react';
+import {
+  brandBackground,
+  space,
+  text,
+  brandAltBackground,
+  brandLine,
+} from '@guardian/src-foundations';
+import { headline } from '@guardian/src-foundations/typography';
+import { Container } from '@guardian/src-layout';
+import { from } from '@guardian/src-foundations/mq';
+
+type Props = {
+  tabs: TabType[];
+};
+
+type TabType = {
+  displayText: string;
+  linkTo: string;
+  isActive?: boolean;
+  isFirst?: boolean;
+};
+
+const backgroundStyles = css`
+  background-color: ${brandBackground.primary};
+`;
+
+// TODO: Remove these once https://github.com/guardian/source/pull/820 is merged and published
+//       after which we can use `topBorder` and `borderColor` instead.
+const borderOverrides = css`
+  border-top-width: 1px !important;
+  border-top-color: ${brandLine.primary} !important;
+  border-left-color: ${brandLine.primary} !important;
+  border-right-color: ${brandLine.primary} !important;
+  border-top-style: solid !important;
+`;
+
+const paddingLeftOverrides = css`
+  padding-left: 0 !important;
+`;
+
+const tabRowStyles = css`
+  display: flex;
+  flex-direction: row;
+`;
+
+const forceActiveBar = css`
+  :after {
+    transform: translateY(5px);
+  }
+`;
+
+const activeBarStyles = css`
+  overflow: hidden;
+  position: relative;
+  :after {
+    border-top: 4px solid ${brandAltBackground.primary};
+    left: 0;
+    left: -20px;
+    right: 0;
+    top: -5px;
+    content: '';
+    display: block;
+    position: absolute;
+    transition: transform 0.3s ease-in-out;
+  }
+`;
+
+const tabPaddingStyles = (isFirst?: boolean) => {
+  if (isFirst) {
+    return css`
+      padding-left: 12px;
+      ${from.tablet} {
+        padding-left: 20px;
+      }
+    `;
+  }
+  return css`
+    padding-left: 9px;
+  `;
+};
+
+const tabDividerStyles = css`
+  :before {
+    content: '';
+    display: block;
+    position: absolute;
+    right: 0;
+    top: 0;
+    bottom: 0;
+    width: 1px;
+    background-color: ${brandLine.primary};
+    ${from.tablet} {
+      bottom: 13px;
+    }
+  }
+`;
+
+const tabStyles = css`
+  /* Spacing */
+  padding-top: ${space[2]}px;
+  padding-bottom: ${space[1]}px;
+  padding-right: 20px;
+  min-width: 80px;
+  ${from.tablet} {
+    min-width: 160px;
+  }
+
+  /* Text */
+  color: ${text.ctaPrimary};
+  ${headline.xxxsmall({ fontWeight: 'bold', lineHeight: 'tight' })}
+  ${from.tablet} {
+    ${headline.xsmall({ fontWeight: 'bold', lineHeight: 'regular' })}
+  }
+
+  /* a tag overrides */
+  text-decoration: none;
+  :hover {
+    text-decoration: none;
+  }
+
+  /* When to show active bar */
+  :focus:after {
+    transform: translateY(5px);
+  }
+  :hover:after {
+    transform: translateY(5px);
+  }
+`;
+
+const Tab = ({ displayText, linkTo, isActive, isFirst }: TabType) => {
+  return (
+    <a
+      href={linkTo}
+      css={[
+        tabStyles,
+        tabPaddingStyles(isFirst),
+        activeBarStyles,
+        tabDividerStyles,
+        isActive && forceActiveBar,
+      ]}
+    >
+      {displayText}
+    </a>
+  );
+};
+
+export const Nav = ({ tabs }: Props) => (
+  <nav css={backgroundStyles}>
+    <Container
+      border={true}
+      cssOverrides={[borderOverrides, paddingLeftOverrides]}
+    >
+      <div css={tabRowStyles}>
+        {tabs.map((tab, index) => (
+          <Tab
+            key={index}
+            displayText={tab.displayText}
+            linkTo={tab.linkTo}
+            isActive={tab.isActive}
+            isFirst={index === 0}
+          />
+        ))}
+      </div>
+    </Container>
+  </nav>
+);

--- a/src/client/components/Nav.tsx
+++ b/src/client/components/Nav.tsx
@@ -10,6 +10,7 @@ import {
 import { headline } from '@guardian/src-foundations/typography';
 import { Container } from '@guardian/src-layout';
 import { from } from '@guardian/src-foundations/mq';
+import { Link } from '@guardian/src-link';
 
 type Props = {
   tabs: TabType[];
@@ -117,6 +118,7 @@ const tabStyles = css`
   /* a tag overrides */
   text-decoration: none;
   :hover {
+    color: ${text.ctaPrimary};
     text-decoration: none;
   }
 
@@ -131,7 +133,7 @@ const tabStyles = css`
 
 const Tab = ({ displayText, linkTo, isActive, isFirst }: TabType) => {
   return (
-    <a
+    <Link
       href={linkTo}
       css={[
         tabStyles,
@@ -142,7 +144,7 @@ const Tab = ({ displayText, linkTo, isActive, isFirst }: TabType) => {
       ]}
     >
       {displayText}
-    </a>
+    </Link>
   );
 };
 


### PR DESCRIPTION
## What does this change?
Adds the `Nav` component.

The active bar state shows on focus:
![2021-05-24 15 31 19](https://user-images.githubusercontent.com/1336821/119363031-451baf00-bca5-11eb-946c-5e0102bf8de7.gif)


The active bar state shows on hover
![2021-05-24 14 55 16](https://user-images.githubusercontent.com/1336821/119358377-747bed00-bca0-11eb-8bae-5c62045a96d7.gif)

Styles change above and below tablet
![2021-05-24 14 49 45](https://user-images.githubusercontent.com/1336821/119358380-75148380-bca0-11eb-9e71-943e87b6d10b.gif)

## This is the same as Pillar nav!
Yes, it is. The main pillar section nav control is very similar to this component. In fact I used a lot of the styling from that code here. Could we eventually centralise this logic? Maybe, this is not something we need to action straight away but should keep this possibility in mind as we learn this use case.

## We're now using `Container`
`Container` is a [layout component from Source](https://theguardian.design/2a1e5182b/p/440a83-container/b/2402e9) that centralises the logic around how to position things on the page. There's still [an open PR ](https://github.com/guardian/source/pull/820)around enhancing this to better serve our needs but for now I'm using css overrides as workarounds

## No local state
This PR has no local state included (for which tab is active). We could refactor this in later or use a parent component. I'm leaving this choice out of this PR for now because I'm not certain how we will do routing.
