### PR TITLE
Use `Nav`

### DIFF
--- a/src/client/layouts/Main.tsx
+++ b/src/client/layouts/Main.tsx
@@ -10,7 +10,7 @@ import { getErrorLink } from '@/client/lib/ErrorLink';
 import { GlobalSuccess } from '@/client/components/GlobalSuccess';
 
 type Props = {
-  subTitle: string;
+  subTitle?: string;
   children: React.ReactNode;
 };
 
@@ -34,7 +34,7 @@ export const Main = ({ subTitle, children }: Props) => {
 
   return (
     <main css={mainStyles}>
-      <SubHeader title={subTitle} />
+      {subTitle && <SubHeader title={subTitle} />}
       {error && <GlobalError error={error} link={getErrorLink(error)} />}
       {success && <GlobalSuccess success={success} />}
       <section css={sectionStyles}>{children}</section>

--- a/src/client/pages/Registration.tsx
+++ b/src/client/pages/Registration.tsx
@@ -5,6 +5,7 @@ import { Routes } from '@/shared/model/Routes';
 import { PageTitle } from '@/shared/model/PageTitle';
 import { Main } from '@/client/layouts/Main';
 import { Header } from '@/client/components/Header';
+import { Nav } from '@/client/components/Nav';
 import { Footer } from '@/client/components/Footer';
 import { PageBox } from '@/client/components/PageBox';
 import { PageBody } from '@/client/components/PageBody';
@@ -17,7 +18,21 @@ import { button, form, textInput } from '@/client/styles/Shared';
 export const Registration = () => (
   <>
     <Header />
-    <Main subTitle={PageTitle.REGISTRATION}>
+    <Nav
+      tabs={[
+        {
+          displayText: PageTitle.SIGN_IN,
+          linkTo: '',
+          isActive: false,
+        },
+        {
+          displayText: PageTitle.REGISTRATION,
+          linkTo: '',
+          isActive: true,
+        },
+      ]}
+    />
+    <Main>
       <PageBox>
         <PageBody>
           <form css={form} method="post" action={`${Routes.REGISTRATION}`}>

--- a/src/client/pages/SignIn.tsx
+++ b/src/client/pages/SignIn.tsx
@@ -5,7 +5,7 @@ import { PageBody } from '@/client/components/PageBody';
 import { Main } from '@/client/layouts/Main';
 import { Header } from '@/client/components/Header';
 import { Footer } from '@/client/components/Footer';
-
+import { Nav } from '@/client/components/Nav';
 import { TextInput } from '@guardian/src-text-input';
 import { Button } from '@guardian/src-button';
 import { Routes } from '@/shared/model/Routes';
@@ -32,7 +32,21 @@ const Links = ({ children }: { children: React.ReactNode }) => (
 export const SignIn = () => (
   <>
     <Header />
-    <Main subTitle={PageTitle.SIGN_IN}>
+    <Nav
+      tabs={[
+        {
+          displayText: PageTitle.SIGN_IN,
+          linkTo: '',
+          isActive: true,
+        },
+        {
+          displayText: PageTitle.REGISTRATION,
+          linkTo: '',
+          isActive: false,
+        },
+      ]}
+    />
+    <Main>
       <PageBox>
         <PageBody>
           <form css={form} method="post" action={`${Routes.SIGN_IN}`}>


### PR DESCRIPTION
## What does this change?
Makes `SubHeader` optional and replaces it with `Nav` on the signin and register pages

### Before
<img width="695" alt="Screenshot 2021-05-27 at 09 26 21" src="https://user-images.githubusercontent.com/1336821/119792455-9e662700-becd-11eb-8f6d-d9ef27054fdc.png">


### After
<img width="695" alt="Screenshot 2021-05-27 at 09 26 06" src="https://user-images.githubusercontent.com/1336821/119792469-a0c88100-becd-11eb-812f-3b081f031bde.png">
