### PR TITLE
Align `PasswordInput` focus ring

### DIFF
--- a/src/client/components/PasswordInput.tsx
+++ b/src/client/components/PasswordInput.tsx
@@ -91,7 +91,7 @@ export const PasswordInput = (props: TextInputProps) => {
     :active {
       border: none;
     }
-    width: calc(100% - ${spaceForEye}px);
+    padding-right: ${spaceForEye}px;
   `;
 
   const borderStyle = props.success


### PR DESCRIPTION
## What?
Uses a slightly different method to solve the problem of the eye spacing issue so that we show the focus ring in the correct position

### Before
<img width="505" alt="Screenshot 2021-06-01 at 11 26 28" src="https://user-images.githubusercontent.com/1336821/120308813-69424600-c2cc-11eb-9465-a5e9e3e7c885.png">

### After
<img width="505" alt="Screenshot 2021-06-01 at 11 26 09" src="https://user-images.githubusercontent.com/1336821/120308830-6c3d3680-c2cc-11eb-817e-91887e2bcabe.png">
