### PR TITLE
Remove `form-action` CSP

### DIFF
--- a/src/client/pages/ChangePassword.tsx
+++ b/src/client/pages/ChangePassword.tsx
@@ -152,9 +152,8 @@ const usePasswordValidationHooks = (idapiBaseUrl: string) => {
   // errors go red color if the user has selected the confirm password input while the password criteria is not satisfied - or if the user submits the form and there are errors present
   // A user has to solve the problem indicated by the red error to make it go away
   // The red error is not necessarily the latest validation result - e.g. common password does not get solved by going beneath 8 characters
-  const [redError, setRedError, redErrorCurrently] = useRefState<
-    ErrorValidationResult | undefined
-  >(undefined);
+  const [redError, setRedError, redErrorCurrently] =
+    useRefState<ErrorValidationResult | undefined>(undefined);
 
   // store last length tick/cross error since we want to show it in green after it has been corrected (it can show either password too long, or too short)
   const [lastLengthError, setLastLengthError] =

--- a/src/client/pages/ChangePassword.tsx
+++ b/src/client/pages/ChangePassword.tsx
@@ -152,8 +152,9 @@ const usePasswordValidationHooks = (idapiBaseUrl: string) => {
   // errors go red color if the user has selected the confirm password input while the password criteria is not satisfied - or if the user submits the form and there are errors present
   // A user has to solve the problem indicated by the red error to make it go away
   // The red error is not necessarily the latest validation result - e.g. common password does not get solved by going beneath 8 characters
-  const [redError, setRedError, redErrorCurrently] =
-    useRefState<ErrorValidationResult | undefined>(undefined);
+  const [redError, setRedError, redErrorCurrently] = useRefState<
+    ErrorValidationResult | undefined
+  >(undefined);
 
   // store last length tick/cross error since we want to show it in green after it has been corrected (it can show either password too long, or too short)
   const [lastLengthError, setLastLengthError] =

--- a/src/server/lib/middleware/helmet.ts
+++ b/src/server/lib/middleware/helmet.ts
@@ -1,6 +1,5 @@
 import { default as helmet } from 'helmet';
 import { getConfiguration } from '@/server/lib/getConfiguration';
-import { Routes } from '@/shared/model/Routes';
 
 const { baseUri, gaUID, apiDomain, idapiBaseUrl } = getConfiguration();
 
@@ -28,12 +27,6 @@ const helmetConfig = {
     directives: {
       baseUri: [HELMET_OPTIONS.NONE],
       defaultSrc: [HELMET_OPTIONS.NONE],
-      formAction: [
-        `${baseUri}${Routes.RESET}`,
-        `${baseUri}${Routes.CHANGE_PASSWORD}/`,
-        `${baseUri}${Routes.CONSENTS}/`,
-        `${baseUri}${Routes.VERIFY_EMAIL}`,
-      ],
       frameAncestors: [HELMET_OPTIONS.NONE],
       styleSrc: [HELMET_OPTIONS.UNSAFE_INLINE],
       scriptSrc: [

--- a/src/server/lib/renderer.tsx
+++ b/src/server/lib/renderer.tsx
@@ -71,19 +71,6 @@ const clientStateFromRequestStateLocals = ({
   }
 };
 
-/* Needed if the inconsistant CSP standard for form-action redirects is a problem, most noticably with Chrome */
-export const redirectRenderer = (url: string): string => {
-  return `
-    <!DOCTYPE html>
-    <html>
-      <head>
-        <meta http-equiv="Refresh" content="0; URL=${url}">
-      </head>
-      <body onload="window.location='${url}'/>
-    </html>
-  `;
-};
-
 export const renderer: (url: string, opts: RendererOpts) => string = (
   url,
   { requestState, pageTitle },

--- a/src/server/routes/consents.ts
+++ b/src/server/routes/consents.ts
@@ -433,11 +433,7 @@ function getABTestPOSTHandler(
 
     try {
       await entitySetter(req.ip, sc_gu_u, req.body);
-      const html = renderer(url, {
-        pageTitle: PageTitle.RESET_SENT,
-        requestState: state,
-      });
-      res.type('html').send(html);
+      res.redirect(303, url);
       return;
     } catch (e) {
       [status, state] = getErrorResponse(e, state);

--- a/src/server/routes/consents.ts
+++ b/src/server/routes/consents.ts
@@ -1,6 +1,6 @@
 import { Router, Request, Response } from 'express';
 import { Routes } from '@/shared/model/Routes';
-import { redirectRenderer, renderer } from '@/server/lib/renderer';
+import { renderer } from '@/server/lib/renderer';
 import {
   update as patchConsents,
   read as readConsents,
@@ -433,7 +433,10 @@ function getABTestPOSTHandler(
 
     try {
       await entitySetter(req.ip, sc_gu_u, req.body);
-      const html = redirectRenderer(url);
+      const html = renderer(url, {
+        pageTitle: PageTitle.RESET_SENT,
+        requestState: state,
+      });
       res.type('html').send(html);
       return;
     } catch (e) {


### PR DESCRIPTION
## What does this change?
Removes the Content Security Policy for `form-action`

This allows the workaround component `redirectRenderer` to be removed.

## Why?
Because it was blocking redirects in Chrom. See [this w3c discussion](https://github.com/w3c/webappsec-csp/issues/8) for more information

By removing the CSP rule we no longer need to use the workaround of forcing the browser to redirect the page using javascript, which isn't a great UX for the reader

## Why not?
There's a case to say this change remove some level of protection on the page, and perhaps that protection is more important than the improvement to UX? I'm not sure
