### PR TITLE
Use `Container` for `SubHeader`

### DIFF
--- a/src/client/components/SubHeader.stories.tsx
+++ b/src/client/components/SubHeader.stories.tsx
@@ -6,6 +6,7 @@ import { SubHeader } from './SubHeader';
 export default {
   title: 'Components/SubHeader',
   component: SubHeader,
+  parameters: { layout: 'fullscreen' },
 } as Meta;
 
 export const Default = () => <SubHeader title="Sub Header Title" />;

--- a/src/client/components/SubHeader.tsx
+++ b/src/client/components/SubHeader.tsx
@@ -1,69 +1,80 @@
 import * as React from 'react';
 import { css } from '@emotion/react';
-import { brand, space, neutral } from '@guardian/src-foundations';
+import { neutral, brand, space, brandLine } from '@guardian/src-foundations';
 import { headline } from '@guardian/src-foundations/typography';
+import { Container } from '@guardian/src-layout';
 import { from } from '@guardian/src-foundations/mq';
-import { Breakpoints } from '@/client/models/Style';
 
 type Props = {
   title: string;
 };
 
-const sectionStyles = css`
-  width: 100%;
-  padding-top: ${space[9]}px;
+const backgroundStyles = css`
   background-color: ${brand[300]};
-  display: flex;
-  align-items: flex-end;
-  justify-content: center;
+`;
 
+const paddingTop = css`
   ${from.mobileMedium} {
     padding-top: ${space[12]}px;
   }
-
   ${from.tablet} {
     padding-top: ${space[24]}px;
   }
-
   ${from.desktop} {
     padding-top: calc(${space[24]}px + ${space[6]}px);
   }
 `;
 
-const titleWrapperStyles = css`
-  max-width: ${Breakpoints.TABLET}px;
-  width: 100%;
-  padding: 0 ${space[3]}px;
-  margin-right: 0;
+// TODO: Remove these once https://github.com/guardian/source/pull/820 is merged and published
+//       after which we can use `topBorder` and `borderColor` instead.
+const borderOverrides = css`
+  border-top-width: 1px !important;
+  border-top-color: ${brandLine.primary} !important;
+  border-left-color: ${brandLine.primary} !important;
+  border-right-color: ${brandLine.primary} !important;
+  border-top-style: solid !important;
+`;
 
-  ${from.mobileMedium} {
-    margin-right: ${space[24]}px;
-  }
-
-  ${from.tablet} {
-    margin-right: 0;
-  }
+const paddingLeftOverrides = css`
+  padding-left: 0 !important;
 `;
 
 const h1Styles = css`
   width: 100%;
   margin: 0;
-  padding: ${space[1]}px ${space[2]}px;
+  padding-top: ${space[1]}px;
+  padding-bottom: ${space[1]}px;
+  padding-right: ${space[1]}px;
+  padding-left: ${space[3]}px;
+  ${from.tablet} {
+    padding-left: 20px;
+  }
   color: ${neutral[100]};
-  border: 1px solid ${brand[600]};
-  box-sizing: border-box;
-  ${headline.xsmall({ fontWeight: 'bold', lineHeight: 'tight' })}
 
+  ${headline.xsmall({ fontWeight: 'bold', lineHeight: 'tight' })}
   ${from.tablet} {
     margin: 0;
     ${headline.large({ fontWeight: 'bold', lineHeight: 'regular' })}
   }
 `;
 
+const paddingStyles = css`
+  padding-top: ${space[1]}px;
+  padding-bottom: ${space[1]}px;
+  padding-right: ${space[1]}px;
+  padding-left: ${space[3]}px;
+  ${from.tablet} {
+    padding-left: 20px;
+  }
+`;
+
 export const SubHeader = ({ title }: Props) => (
-  <header css={sectionStyles}>
-    <div css={titleWrapperStyles}>
-      <h1 css={h1Styles}>{title}</h1>
-    </div>
+  <header css={[backgroundStyles, paddingTop]}>
+    <Container
+      border={true}
+      cssOverrides={[borderOverrides, paddingLeftOverrides]}
+    >
+      <h1 css={[h1Styles, paddingStyles]}>{title}</h1>
+    </Container>
   </header>
 );


### PR DESCRIPTION
## What?
Replaces custom spacing with the `Container` component from source, using that for vertical positioning instead

## Why?
So that we have consistent vertical alignment throughput the page and with other pages on the site

### Before
<img width="1210" alt="Screenshot 2021-06-14 at 12 32 13" src="https://user-images.githubusercontent.com/1336821/121885846-92bb9280-cd0c-11eb-9a32-c65606fcaa37.png">


### After
<img width="1210" alt="Screenshot 2021-06-14 at 12 27 43" src="https://user-images.githubusercontent.com/1336821/121885797-859ea380-cd0c-11eb-8b6a-e8969762cee2.png">
