### PR TITLE
Refactor `ConsentsHeader`

### DIFF
--- a/src/client/components/ConsentsHeader.tsx
+++ b/src/client/components/ConsentsHeader.tsx
@@ -1,6 +1,4 @@
 import React from 'react';
-import { brand } from '@guardian/src-foundations/palette';
-import { css } from '@emotion/react';
 import { GlobalError } from '@/client/components/GlobalError';
 import { GlobalSuccess } from '@/client/components/GlobalSuccess';
 import { Header } from '@/client/components/Header';
@@ -11,14 +9,10 @@ type Props = {
   success?: string;
 };
 
-const headerContainer = css`
-  background-color: ${brand[400]};
-`;
-
 export const ConsentsHeader = ({ error, success }: Props) => (
-  <div css={headerContainer}>
+  <>
     <Header />
     {error && <GlobalError error={error} link={getErrorLink(error)} left />}
     {success && <GlobalSuccess success={success} />}
-  </div>
+  </>
 );


### PR DESCRIPTION
## What does this change?
Removes an unused div that was being used to set the background colour

## Why?
We now set the background colour using `Header` so the div was redundant