### PR TITLE
Refactor AWS

### DIFF
--- a/src/server/lib/AWS.ts
+++ b/src/server/lib/AWS.ts
@@ -26,7 +26,7 @@ const standardAwsConfig = {
 
 const CloudWatch = new AWS.CloudWatch(standardAwsConfig);
 
-export const defaultDimensions = {
+const defaultDimensions = {
   Stage,
   // ApiMode is the service name, using both ApiMode and Stage will keep
   // gateway in line with other identity metrics

--- a/src/server/lib/awsConfig.ts
+++ b/src/server/lib/awsConfig.ts
@@ -1,0 +1,14 @@
+import * as AWS from 'aws-sdk';
+
+const AWS_REGION = 'eu-west-1';
+const PROFILE = 'identity';
+
+const CREDENTIAL_PROVIDER = new AWS.CredentialProviderChain([
+  () => new AWS.SharedIniFileCredentials({ profile: PROFILE }),
+  ...AWS.CredentialProviderChain.defaultProviders,
+]);
+
+export const awsConfig = {
+  region: AWS_REGION,
+  credentialProvider: CREDENTIAL_PROVIDER,
+};

--- a/src/server/lib/middleware/login.ts
+++ b/src/server/lib/middleware/login.ts
@@ -4,7 +4,7 @@ import { IDAPIAuthRedirect, IDAPIAuthStatus } from '@/shared/model/IDAPIAuth';
 import { getConfiguration } from '@/server/lib/getConfiguration';
 import { getProfileUrl } from '@/server/lib/getProfileUrl';
 import { Routes } from '@/shared/model/Routes';
-import { trackMetric } from '@/server/lib/AWS';
+import { trackMetric } from '@/server/lib/trackMetric';
 import { Metrics } from '@/server/models/Metrics';
 
 const profileUrl = getProfileUrl();

--- a/src/server/lib/trackMetric.ts
+++ b/src/server/lib/trackMetric.ts
@@ -1,30 +1,17 @@
 import * as AWS from 'aws-sdk';
 import { Metrics } from '@/server/models/Metrics';
-import { getConfiguration } from '@/server/lib/getConfiguration';
 import { logger } from '@/server/lib/logger';
 import { AWSError } from 'aws-sdk';
+import { getConfiguration } from '@/server/lib/getConfiguration';
+import { awsConfig } from '@/server/lib/awsConfig';
 
+const { stage: Stage } = getConfiguration();
 // metric dimensions is a k-v pair
 interface MetricDimensions {
   [name: string]: string;
 }
 
-const { stage: Stage } = getConfiguration();
-
-const AWS_REGION = 'eu-west-1';
-const PROFILE = 'identity';
-
-const CREDENTIAL_PROVIDER = new AWS.CredentialProviderChain([
-  () => new AWS.SharedIniFileCredentials({ profile: PROFILE }),
-  ...AWS.CredentialProviderChain.defaultProviders,
-]);
-
-const standardAwsConfig = {
-  region: AWS_REGION,
-  credentialProvider: CREDENTIAL_PROVIDER,
-};
-
-const CloudWatch = new AWS.CloudWatch(standardAwsConfig);
+const CloudWatch = new AWS.CloudWatch(awsConfig);
 
 const defaultDimensions = {
   Stage,

--- a/src/server/routes/changePassword.ts
+++ b/src/server/routes/changePassword.ts
@@ -8,7 +8,7 @@ import {
 } from '@/server/lib/idapi/changePassword';
 import { ChangePasswordErrors } from '@/shared/model/Errors';
 import { ResponseWithRequestState } from '@/server/models/Express';
-import { trackMetric } from '@/server/lib/AWS';
+import { trackMetric } from '@/server/lib/trackMetric';
 import { Metrics } from '@/server/models/Metrics';
 import { removeNoCache } from '@/server/lib/middleware/cache';
 import { PageTitle } from '@/shared/model/PageTitle';

--- a/src/server/routes/consents.ts
+++ b/src/server/routes/consents.ts
@@ -25,7 +25,7 @@ import {
   ResponseWithRequestState,
 } from '@/server/models/Express';
 import { VERIFY_EMAIL } from '@/shared/model/Success';
-import { trackMetric } from '@/server/lib/AWS';
+import { trackMetric } from '@/server/lib/trackMetric';
 import { consentsPageMetric } from '@/server/models/Metrics';
 import { addReturnUrlToPath } from '@/server/lib/queryParams';
 import { GeoLocation } from '@/shared/model/Geolocation';

--- a/src/server/routes/magicLink.ts
+++ b/src/server/routes/magicLink.ts
@@ -2,7 +2,7 @@ import { Router, Request } from 'express';
 import { Routes } from '@/shared/model/Routes';
 import { logger } from '@/server/lib/logger';
 import { renderer } from '@/server/lib/renderer';
-import { trackMetric } from '@/server/lib/AWS';
+import { trackMetric } from '@/server/lib/trackMetric';
 import { Metrics } from '@/server/models/Metrics';
 import { PageTitle } from '@/shared/model/PageTitle';
 import { ResponseWithRequestState } from '@/server/models/Express';

--- a/src/server/routes/reset.ts
+++ b/src/server/routes/reset.ts
@@ -5,7 +5,7 @@ import { renderer } from '@/server/lib/renderer';
 import { Routes } from '@/shared/model/Routes';
 import { getEmailFromPlaySessionCookie } from '@/server/lib/playSessionCookie';
 import { ResponseWithRequestState } from '@/server/models/Express';
-import { trackMetric } from '@/server/lib/AWS';
+import { trackMetric } from '@/server/lib/trackMetric';
 import { Metrics } from '@/server/models/Metrics';
 import { removeNoCache } from '@/server/lib/middleware/cache';
 import { PageTitle } from '@/shared/model/PageTitle';

--- a/src/server/routes/signIn.ts
+++ b/src/server/routes/signIn.ts
@@ -4,7 +4,7 @@ import { logger } from '@/server/lib/logger';
 import { renderer } from '@/server/lib/renderer';
 import { Routes } from '@/shared/model/Routes';
 import { ResponseWithRequestState } from '@/server/models/Express';
-import { trackMetric } from '@/server/lib/AWS';
+import { trackMetric } from '@/server/lib/trackMetric';
 import { Metrics } from '@/server/models/Metrics';
 import { PageTitle } from '@/shared/model/PageTitle';
 import { handleAsyncErrors } from '@/server/lib/expressWrappers';

--- a/src/server/routes/verifyEmail.ts
+++ b/src/server/routes/verifyEmail.ts
@@ -12,7 +12,7 @@ import { read as getUser } from '@/server/lib/idapi/user';
 import { ConsentsErrors, VerifyEmailErrors } from '@/shared/model/Errors';
 import { getConfiguration } from '@/server/lib/getConfiguration';
 import { getProfileUrl } from '@/server/lib/getProfileUrl';
-import { trackMetric } from '@/server/lib/AWS';
+import { trackMetric } from '@/server/lib/trackMetric';
 import { Metrics } from '@/server/models/Metrics';
 import { addReturnUrlToPath } from '@/server/lib/queryParams';
 import { PageTitle } from '@/shared/model/PageTitle';


### PR DESCRIPTION
## What?
This PR refactors the `AWS.ts` file to break out the logic for tracking cloudwatch metrics from the core AWS config 

## Why?
This will make it easier to build on top of this logic for things like sending emails. By having the logic separate we now have the ability to import it into different files as needed.