### PR TITLE
Provide better error context for AWS metrics

### DIFF
--- a/src/server/lib/trackMetric.ts
+++ b/src/server/lib/trackMetric.ts
@@ -46,6 +46,12 @@ export const trackMetric = (
   })
     .promise()
     .catch((error: AWSError) => {
-      logger.error(error.message);
+      if (error.code === 'ExpiredToken' && Stage === 'DEV') {
+        logger.warn(
+          'AWS Credentials Expired. Have you added `Identity` Janus credentials?',
+        );
+      } else {
+        logger.error(error.message);
+      }
     });
 };


### PR DESCRIPTION
## What does this change?
- Output a warning to the console if the Janus credentials are missing