### PR TITLE
Use `deepmerge` package to merge the state instead of using spread syntax

### DIFF
--- a/cypress/integration/sign_in.spec.js
+++ b/cypress/integration/sign_in.spec.js
@@ -15,9 +15,7 @@ describe('Sign in flow', () => {
     });
 
     it('Has no detectable a11y violations on sign in page with error', () => {
-      cy.visit(
-        '/signin',
-      );
+      cy.visit('/signin');
       cy.get('input[name="email"]').type('Invalid email');
       cy.get('input[name="password"]').type('Invalid password');
       cy.mockNext(500);

--- a/package.json
+++ b/package.json
@@ -115,6 +115,7 @@
     "compression": "^1.7.4",
     "cookie-parser": "^1.4.5",
     "csurf": "^1.11.0",
+    "deepmerge": "^4.2.2",
     "express": "^4.17.1",
     "helmet": "^4.6.0",
     "js-sha1": "^0.6.0",

--- a/src/server/routes/changePassword.ts
+++ b/src/server/routes/changePassword.ts
@@ -1,4 +1,5 @@
 import { Request, Router } from 'express';
+import deepmerge from 'deepmerge';
 import { Routes } from '@/shared/model/Routes';
 import { renderer } from '@/server/lib/renderer';
 import { logger } from '@/server/lib/logger';
@@ -72,22 +73,18 @@ router.get(
     let state = res.locals;
     const { token } = req.params;
 
-    state = {
-      ...state,
+    state = deepmerge(state, {
       pageData: {
-        ...state.pageData,
         browserName: getBrowserNameFromUserAgent(req.header('User-Agent')),
       },
-    };
+    });
 
     try {
-      state = {
-        ...state,
+      state = deepmerge(state, {
         pageData: {
-          ...state.pageData,
           email: await validateToken(token, req.ip),
         },
-      };
+      });
     } catch (error) {
       logger.error(error);
       return res.type('html').send(
@@ -115,13 +112,11 @@ router.post(
 
     const { password, password_confirm: passwordConfirm } = req.body;
 
-    state = {
-      ...state,
+    state = deepmerge(state, {
       pageData: {
-        ...state.pageData,
         browserName: getBrowserNameFromUserAgent(req.header('User-Agent')),
       },
-    };
+    });
 
     try {
       const fieldErrors = validatePasswordChangeFields(
@@ -130,14 +125,12 @@ router.post(
       );
 
       if (fieldErrors.length) {
-        state = {
-          ...state,
+        state = deepmerge(state, {
           pageData: {
-            ...state.pageData,
             email: await validateToken(token, req.ip),
             fieldErrors,
           },
-        };
+        });
         const html = renderer(`${Routes.CHANGE_PASSWORD}/${token}`, {
           requestState: state,
           pageTitle: PageTitle.CHANGE_PASSWORD,
@@ -158,13 +151,11 @@ router.post(
 
       trackMetric(Metrics.CHANGE_PASSWORD_FAILURE);
 
-      state = {
-        ...state,
+      state = deepmerge(state, {
         globalMessage: {
-          ...state.globalMessage,
           error: message,
         },
-      };
+      });
 
       const html = renderer(`${Routes.CHANGE_PASSWORD}/${token}`, {
         requestState: state,

--- a/src/server/routes/consents.ts
+++ b/src/server/routes/consents.ts
@@ -1,4 +1,5 @@
 import { Router, Request, Response } from 'express';
+import deepmerge from 'deepmerge';
 import { Routes } from '@/shared/model/Routes';
 import { renderer } from '@/server/lib/renderer';
 import {
@@ -282,13 +283,11 @@ function getErrorResponse(
   }
   return [
     status,
-    {
-      ...state,
+    deepmerge(state, {
       globalMessage: {
-        ...state.globalMessage,
         error: message,
       },
-    },
+    }),
   ];
 }
 
@@ -396,13 +395,11 @@ function getABTestGETHandler(
       if (isSubscribed(entities)) {
         res.redirect(303, getRedirectUrl(getConfiguration(), state));
       }
-      state = {
-        ...state,
+      state = deepmerge(state, {
         pageData: {
-          ...state.pageData,
           [entitiesName]: entities,
         },
-      };
+      });
       status = 200;
     } catch (error) {
       [status, state] = getErrorResponse(error, state);
@@ -494,13 +491,11 @@ router.get(
     const { emailVerified } = state.queryParams;
 
     if (emailVerified) {
-      state = {
-        ...state,
+      state = deepmerge(state, {
         globalMessage: {
-          ...state.globalMessage,
           success: VERIFY_EMAIL.SUCCESS,
         },
-      };
+      });
     }
 
     const { page } = req.params;
@@ -518,22 +513,18 @@ router.get(
       const { read, pageTitle: _pageTitle } = consentPages[pageIndex];
       pageTitle = _pageTitle;
 
-      state = {
-        ...state,
+      state = deepmerge(state, {
         pageData: {
-          ...state.pageData,
           ...(await read(req.ip, sc_gu_u, state.pageData.geolocation)),
         },
-      };
+      } as RequestState);
     } catch (e) {
       status = e.status;
-      state = {
-        ...state,
+      state = deepmerge(state, {
         globalMessage: {
-          ...state.globalMessage,
           error: e.message,
         },
-      };
+      });
     }
 
     const html = renderer(`${Routes.CONSENTS}/${page}`, {
@@ -586,13 +577,11 @@ router.post(
       return res.redirect(303, url);
     } catch (e) {
       status = e.status;
-      state = {
-        ...state,
+      state = deepmerge(state, {
         globalMessage: {
-          ...state.globalMessage,
           error: e.message,
         },
-      };
+      });
     }
 
     trackMetric(consentsPageMetric(page, 'Post', false));

--- a/src/server/routes/magicLink.ts
+++ b/src/server/routes/magicLink.ts
@@ -1,4 +1,5 @@
 import { Router, Request } from 'express';
+import deepmerge from 'deepmerge';
 import { Routes } from '@/shared/model/Routes';
 import { logger } from '@/server/lib/logger';
 import { renderer } from '@/server/lib/renderer';
@@ -7,7 +8,7 @@ import { Metrics } from '@/server/models/Metrics';
 import { PageTitle } from '@/shared/model/PageTitle';
 import { ResponseWithRequestState } from '@/server/models/Express';
 import { handleAsyncErrors } from '@/server/lib/expressWrappers';
-import { removeNoCache } from '../lib/middleware/cache';
+import { removeNoCache } from '@/server/lib/middleware/cache';
 
 const router = Router();
 
@@ -36,13 +37,11 @@ router.post(
 
       trackMetric(Metrics.SEND_MAGIC_LINK_FAILURE);
 
-      state = {
-        ...state,
+      state = deepmerge(state, {
         globalMessage: {
-          ...state.globalMessage,
           error: message,
         },
-      };
+      });
 
       const html = renderer(Routes.MAGIC_LINK, {
         requestState: state,

--- a/src/server/routes/register.ts
+++ b/src/server/routes/register.ts
@@ -10,6 +10,7 @@ import { Metrics } from '@/server/models/Metrics';
 import { PageTitle } from '@/shared/model/PageTitle';
 import { handleAsyncErrors } from '@/server/lib/expressWrappers';
 import { setIDAPICookies } from '@/server/lib/setIDAPICookies';
+import deepmerge from 'deepmerge';
 
 const router = Router();
 
@@ -45,17 +46,14 @@ router.post(
 
       trackMetric(Metrics.REGISTER_FAILURE);
 
-      state = {
-        ...state,
+      state = deepmerge(state, {
         globalMessage: {
-          ...state.globalMessage,
           error: message,
         },
         pageData: {
-          ...state.pageData,
           email,
         },
-      };
+      });
 
       const html = renderer(Routes.REGISTRATION, {
         requestState: state,

--- a/src/server/routes/reset.ts
+++ b/src/server/routes/reset.ts
@@ -1,4 +1,5 @@
 import { Request, Router } from 'express';
+import deepmerge from 'deepmerge';
 import { create as resetPassword } from '@/server/lib/idapi/resetPassword';
 import { logger } from '@/server/lib/logger';
 import { renderer } from '@/server/lib/renderer';
@@ -18,13 +19,11 @@ router.get(Routes.RESET, (req: Request, res: ResponseWithRequestState) => {
   const emailFromPlaySession = getEmailFromPlaySessionCookie(req);
 
   if (emailFromPlaySession) {
-    state = {
-      ...state,
+    state = deepmerge(state, {
       pageData: {
-        ...state.pageData,
         email: emailFromPlaySession,
       },
-    };
+    });
   }
 
   const html = renderer(Routes.RESET, {
@@ -51,13 +50,11 @@ router.post(
 
       trackMetric(Metrics.SEND_PASSWORD_RESET_FAILURE);
 
-      state = {
-        ...state,
+      state = deepmerge(state, {
         globalMessage: {
-          ...state.globalMessage,
           error: message,
         },
-      };
+      });
 
       const html = renderer(Routes.RESET, {
         requestState: state,

--- a/src/server/routes/signIn.ts
+++ b/src/server/routes/signIn.ts
@@ -1,4 +1,5 @@
 import { Request, Router } from 'express';
+import deepmerge from 'deepmerge';
 import { authenticate } from '@/server/lib/idapi/auth';
 import { logger } from '@/server/lib/logger';
 import { renderer } from '@/server/lib/renderer';
@@ -35,7 +36,7 @@ router.get(
 router.post(
   Routes.SIGN_IN,
   handleAsyncErrors(async (req: Request, res: ResponseWithRequestState) => {
-    let state = res.locals;
+    const state = res.locals;
 
     const { email = '' } = req.body;
     const { password = '' } = req.body;
@@ -54,18 +55,16 @@ router.post(
 
       trackMetric(Metrics.SIGN_IN_FAILURE);
 
-      state = {
-        ...state,
-        globalMessage: {
-          ...state.globalMessage,
-          error: message,
-        },
-      };
-
+      // re-render the sign in page on error
       const html = renderer(Routes.SIGN_IN, {
-        requestState: state,
+        requestState: deepmerge(res.locals, {
+          globalMessage: {
+            error: message,
+          },
+        }),
         pageTitle: PageTitle.SIGN_IN,
       });
+
       return res.status(status).type('html').send(html);
     }
 

--- a/src/shared/model/Success.ts
+++ b/src/shared/model/Success.ts
@@ -1,3 +1,7 @@
 export enum VERIFY_EMAIL {
   SUCCESS = 'Your email has been verified',
 }
+
+export enum EMAIL_SENT {
+  SUCCESS = 'Email Sent. Please check your inbox and follow the link.',
+}


### PR DESCRIPTION
## What does this change?
Following on from team conversations, using the spread syntax to modify the state works, but when merging object within objects (deep objects), as JS only merges at the top level by default, we have to spread the inner property too, this leads to nested spread syntax, as well as making it difficult to reason about what it being merged in, making it more prone to errors.

This PR introduces the [`deepmerge`](https://github.com/TehShrike/deepmerge) library, which is made to solve this exact problem when merging objects with deep enumerable properties. The API is very simple to use, and typescript is also able to reason about the properties of the objects being merged, which is very helpful in development. It also creates a new object by default rather than modifying an existing object, which means we don't have to worry about introducing mutability errors.
