### PR TITLE
Move `FieldError` type from `server` to `shared`

### DIFF
--- a/src/client/pages/ChangePassword.tsx
+++ b/src/client/pages/ChangePassword.tsx
@@ -33,7 +33,7 @@ import { ThrottledBreachedPasswordCheck } from '@/client/lib/ThrottledBreachedPa
 import sha1 from 'js-sha1';
 import { ChangePasswordErrors } from '@/shared/model/Errors';
 import { PasswordInput } from '@/client/components/PasswordInput';
-import { FieldError } from '@/server/routes/changePassword';
+import { FieldError } from '@/shared/model/ClientState';
 
 type ChangePasswordProps = {
   submitUrl: string;

--- a/src/server/lib/renderer.tsx
+++ b/src/server/lib/renderer.tsx
@@ -1,4 +1,4 @@
-import { ClientState } from '@/shared/model/ClientState';
+import { ClientState, FieldError } from '@/shared/model/ClientState';
 import ReactDOMServer from 'react-dom/server';
 import React from 'react';
 import { StaticRouter } from 'react-router-dom';
@@ -9,7 +9,6 @@ import { getConfiguration } from '@/server/lib/getConfiguration';
 import { RoutingConfig } from '@/client/routes';
 import { getAssets } from '@/server/lib/getAssets';
 import { RequestState } from '@/server/models/Express';
-import { FieldError } from '@/server/routes/changePassword';
 import { CsrfErrors } from '@/shared/model/Errors';
 import { ABProvider } from '@guardian/ab-react';
 import { tests } from '@/shared/model/experiments/abTests';

--- a/src/server/routes/changePassword.ts
+++ b/src/server/routes/changePassword.ts
@@ -20,13 +20,9 @@ import {
 } from '@/shared/lib/PasswordValidation';
 import { handleAsyncErrors } from '@/server/lib/expressWrappers';
 import { getBrowserNameFromUserAgent } from '@/server/lib/getBrowserName';
+import { FieldError } from '@/shared/model/ClientState';
 
 const router = Router();
-
-export interface FieldError {
-  field: string;
-  message: string;
-}
 
 const validatePasswordChangeFields = (
   password: string,

--- a/src/shared/model/ClientState.ts
+++ b/src/shared/model/ClientState.ts
@@ -1,9 +1,12 @@
-import { FieldError } from '@/server/routes/changePassword';
 import { Consent } from '@/shared/model/Consent';
 import { NewsLetter } from '@/shared/model/Newsletter';
 import { GeoLocation } from '@/shared/model/Geolocation';
 import { Participations } from '@guardian/ab-core';
 
+export interface FieldError {
+  field: string;
+  message: string;
+}
 interface ABTesting {
   mvtId?: number;
   participations?: Participations;


### PR DESCRIPTION
This is because that the shared folder should not inherit from either the client or server folder.

## Before
`FieldError` was in `@/server/routes/changePassword` however this was being used in the `shared` file `@/shared/model/ClientState`

## After
`FieldError` defined in `@/shared/model/ClientState`, everywhere else inherits from this.