### PR TITLE
`Link` (for emails)

### DIFF
--- a/src/email/components/Footer.tsx
+++ b/src/email/components/Footer.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
-
 import { MjmlSection, MjmlColumn, MjmlText } from 'mjml-react';
+
 import { background, text } from '@guardian/src-foundations/palette';
+import { Link } from '@/email/components/Link';
 
 export const Footer = () => (
   <MjmlSection background-color={background.secondary} padding="0">
@@ -21,7 +22,9 @@ export const Footer = () => (
         <p>
           If you have any queries about this email please contact our customer
           services team at{' '}
-          <a href="mailto:userhelp@theguardian.com">userhelp@theguardian.com</a>
+          <Link href="mailto:userhelp@theguardian.com">
+            userhelp@theguardian.com
+          </Link>
           .
         </p>
         <p>
@@ -30,9 +33,9 @@ export const Footer = () => (
         <p>
           To find out what personal data we collect and how we use it, please
           visit our{' '}
-          <a href="https://www.theguardian.com/help/privacy-policy">
+          <Link href="https://www.theguardian.com/help/privacy-policy">
             privacy policy
-          </a>
+          </Link>
           .
         </p>
         <p>
@@ -41,9 +44,9 @@ export const Footer = () => (
         <p>
           By registering with theguardian.com you agreed to abide by our terms
           of service, as described at{' '}
-          <a href="https://www.theguardian.com/help/terms-of-service">
+          <Link href="https://www.theguardian.com/help/terms-of-service">
             https://www.theguardian.com/help/terms-of-service
-          </a>
+          </Link>
           .
         </p>
         <p>

--- a/src/email/components/Link.stories.tsx
+++ b/src/email/components/Link.stories.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { Meta } from '@storybook/react';
+
+import { Text } from './Text';
+import { Link } from './Link';
+import { renderMJMLComponent } from '../testUtils';
+
+export default {
+  title: 'Email/Components/Link',
+  component: Link,
+} as Meta;
+
+export const Default = () => {
+  return renderMJMLComponent(
+    <Text>
+      For more information <Link href="/">click here</Link>
+    </Text>,
+  );
+};
+Default.storyName = 'Default link';

--- a/src/email/components/Link.tsx
+++ b/src/email/components/Link.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+import { brand } from '@guardian/src-foundations/palette';
+
+type Props = { children: React.ReactNode; href: string };
+
+export const Link = ({ children, href }: Props) => (
+  <a
+    style={{
+      textDecoration: 'none !important',
+      color: brand[500],
+    }}
+    href={href}
+  >
+    {children}
+  </a>
+);


### PR DESCRIPTION
## What does this change?
Adds the `Link` component for emails and uses it in the `Footer`

We now use the `style` attribute to attempt to override the default a tag colour and underline text decoration. How things render in Storybook is not representative of real life. Success is dependant on how different email clients implement things.

I based the `text-decoration` code on [this SO answer](https://stackoverflow.com/questions/8998378/how-do-i-remove-link-underlining-in-my-html-email) but could no implement the full solution because you can't have multiple properties with the same name in JSX

### Before
<img width="486" alt="Screenshot 2021-07-01 at 13 14 14" src="https://user-images.githubusercontent.com/1336821/124122658-43949200-da6e-11eb-9057-4b559aa9ee32.png">

### After
<img width="486" alt="Screenshot 2021-07-01 at 13 14 02" src="https://user-images.githubusercontent.com/1336821/124122668-468f8280-da6e-11eb-93da-79dc508c53ca.png">


