### PR TITLE
Refactor `background-color`

### DIFF
--- a/src/client/components/BackToTop.tsx
+++ b/src/client/components/BackToTop.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { css } from '@emotion/react';
 import {
-  brandBackground,
+  background,
   brandText,
   brandAlt,
 } from '@guardian/src-foundations/palette';
@@ -13,7 +13,7 @@ const iconContainer = css`
   position: relative;
   float: right;
   border-radius: 100%;
-  background-color: ${brandBackground.ctaPrimary};
+  background-color: ${background.primary};
   cursor: pointer;
   height: 42px;
   min-width: 42px;

--- a/src/email/components/Button.tsx
+++ b/src/email/components/Button.tsx
@@ -1,12 +1,16 @@
 import React from 'react';
 
 import { MjmlSection, MjmlButton, MjmlColumn } from 'mjml-react';
-import { brandBackground, brandText } from '@guardian/src-foundations/palette';
+import {
+  background,
+  brandBackground,
+  brandText,
+} from '@guardian/src-foundations/palette';
 
 type Props = { children: React.ReactNode; href: string };
 
 export const Button = ({ children, href }: Props) => (
-  <MjmlSection background-color="#FFFFFF" padding="0 50px">
+  <MjmlSection background-color={background.primary} padding="0 50px">
     <MjmlColumn>
       <MjmlButton
         background-color={brandBackground.primary}

--- a/src/email/components/SubHeader.tsx
+++ b/src/email/components/SubHeader.tsx
@@ -7,7 +7,7 @@ type Props = { children: React.ReactNode };
 
 export const SubHeader = ({ children }: Props) => (
   <>
-    <MjmlSection background-color={brandBackground} padding-bottom="0">
+    <MjmlSection background-color={brandBackground.primary} padding-bottom="0">
       <MjmlColumn>
         <MjmlDivider
           border-width="1px"
@@ -16,7 +16,7 @@ export const SubHeader = ({ children }: Props) => (
         />
       </MjmlColumn>
     </MjmlSection>
-    <MjmlSection background-color={brandBackground} padding="0">
+    <MjmlSection background-color={brandBackground.primary} padding="0">
       <MjmlColumn>
         <MjmlText
           padding="4px 48px"

--- a/src/email/components/SubHeader.tsx
+++ b/src/email/components/SubHeader.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
 
 import { MjmlSection, MjmlColumn, MjmlText, MjmlDivider } from 'mjml-react';
-import { brandBackground, text } from '@guardian/src-foundations/palette';
+import { background, text } from '@guardian/src-foundations/palette';
 
 type Props = { children: React.ReactNode };
 
 export const SubHeader = ({ children }: Props) => (
   <>
-    <MjmlSection background-color={brandBackground.primary} padding-bottom="0">
+    <MjmlSection background-color={background.primary} padding-bottom="0">
       <MjmlColumn>
         <MjmlDivider
           border-width="1px"
@@ -16,7 +16,7 @@ export const SubHeader = ({ children }: Props) => (
         />
       </MjmlColumn>
     </MjmlSection>
-    <MjmlSection background-color={brandBackground.primary} padding="0">
+    <MjmlSection background-color={background.primary} padding="0">
       <MjmlColumn>
         <MjmlText
           padding="4px 48px"

--- a/src/email/components/Text.tsx
+++ b/src/email/components/Text.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 
 import { MjmlSection, MjmlColumn, MjmlText } from 'mjml-react';
-import { brandBackground, text } from '@guardian/src-foundations/palette';
+import { background, text } from '@guardian/src-foundations/palette';
 
 type Props = { children: React.ReactNode };
 
 export const Text = ({ children }: Props) => (
-  <MjmlSection background-color={brandBackground} padding="0">
+  <MjmlSection background-color={background.primary} padding="0">
     <MjmlColumn>
       <MjmlText
         padding="0 48px"


### PR DESCRIPTION
## What does this change?
This PR fixes an issue where we were passing `brandBackground`, the entire object, to the `background-color` css property instead of choosing a particular field, like `brandBackground.primary`

I also tidied up some usage of colours for background along the way.