### PR TITLE
`NoAccount` Email

### DIFF
--- a/src/email/index.ts
+++ b/src/email/index.ts
@@ -1,3 +1,4 @@
 import { sendResetPasswordEmail } from './templates/ResetPassword/sendResetPasswordEmail';
+import { sendNoAccountEmail } from './templates/NoAccount/sendNoAccountEmail';
 
-export { sendResetPasswordEmail };
+export { sendResetPasswordEmail, sendNoAccountEmail };

--- a/src/email/templates/NoAccount/NoAccount.stories.tsx
+++ b/src/email/templates/NoAccount/NoAccount.stories.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { Meta } from '@storybook/react';
+
+import { NoAccount } from './NoAccount';
+import { renderMJML } from '../../testUtils';
+
+export default {
+  title: 'Email/Templates/NoAccount',
+  component: NoAccount,
+  parameters: { layout: 'fullscreen' },
+} as Meta;
+
+export const Default = () => {
+  return renderMJML(<NoAccount />);
+};
+Default.storyName = 'with defaults';

--- a/src/email/templates/NoAccount/NoAccount.tsx
+++ b/src/email/templates/NoAccount/NoAccount.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+
+import { Routes } from '@/shared/model/Routes';
+import { Page } from '@/email/components/Page';
+import { Button } from '@/email/components/Button';
+import { Header } from '@/email/components/Header';
+import { SubHeader } from '@/email/components/SubHeader';
+import { Text } from '@/email/components/Text';
+import { Footer } from '@/email/components/Footer';
+
+export const NoAccount = () => {
+  return (
+    <Page>
+      <Header />
+      <SubHeader>You don&#39;t have an account</SubHeader>
+      <Text>
+        <p>Hello,</p>
+        <p>
+          <strong>You are not registered with The Guardian</strong>
+        </p>
+        <p>
+          It&#39;s quick an easy to create an account and we won&#39;t ask you
+          for personal details.
+        </p>
+        <p>Please click below to register.</p>
+      </Text>
+      <Button href={`https://profile.theguardian.com${Routes.REGISTRATION}`}>
+        Register with The Guardian
+      </Button>
+      <Footer />
+    </Page>
+  );
+};

--- a/src/email/templates/NoAccount/NoAccountText.ts
+++ b/src/email/templates/NoAccount/NoAccountText.ts
@@ -1,0 +1,23 @@
+import { Routes } from '@/shared/model/Routes';
+
+export const NoAccountText = () => `
+Hello,
+
+You are not registered with The Guardian.
+
+It's quick an easy to create an account and we won't ask you for personal details.
+
+Please click below to register.
+
+https://profile.theguardian.com${Routes.REGISTRATION}
+
+The Guardian
+
+If you have any queries about this email please contact our customer services team at userhelp@theguardian.com
+
+Your Data: To find out what personal data we collect and how we use it, please visit our privacy policy at https://www.theguardian.com/help/privacy-policy
+
+Terms & Conditions: By registering with theguardian.com you agreed to abide by our terms of service, as described at https://www.theguardian.com/help/terms-of-service
+
+Guardian News and Media Limited, Kings Place, 90 York Way, London, N1 9GU, United Kingdom
+`;

--- a/src/email/templates/NoAccount/sendNoAccountEmail.ts
+++ b/src/email/templates/NoAccount/sendNoAccountEmail.ts
@@ -1,0 +1,25 @@
+import { render } from 'mjml-react';
+import { send } from '@/email/lib/send';
+
+import { NoAccount } from './NoAccount';
+import { NoAccountText } from './NoAccountText';
+
+type Props = {
+  to: string;
+  subject?: string;
+};
+
+const plainText = NoAccountText();
+const { html } = render(NoAccount());
+
+export const sendNoAccountEmail = ({
+  to,
+  subject = 'Your attempt to sign up to theguardian.com',
+}: Props) => {
+  return send({
+    html,
+    plainText,
+    subject,
+    to,
+  });
+};


### PR DESCRIPTION
## What does this change?
Adds the `NoAccount` email. This email is sent when a reader attempts to reset the password of an email that does no exist in our system.

<img width="634" alt="Screenshot 2021-07-05 at 13 53 41" src="https://user-images.githubusercontent.com/1336821/124474439-6d182b00-dd98-11eb-9666-8a533e3c0546.png">

### Copy
This copy is still pending approval. Some things such as the assertion that personal data is not collected and the title case used for 'The Guardian' is under review.