### PR TITLE
Simple Switchboard Setup

### DIFF
--- a/docs/ab-testing.md
+++ b/docs/ab-testing.md
@@ -29,7 +29,7 @@ To create a new test, create a new file, and the test definition using the [info
 
 In the [abTests.ts](../src/shared/model/experiments/abTests.ts) file, import and add the new test to the `tests` array. This will make it available to the ab testing library and api.
 
-Finally you have to add a switch for the test in the [abSwitches.ts](../src/shared/model/experiments/abSwitches.ts) file, in the `switches` object. The `key` should be `ab` + the `id` from the test definition. For example, if the `id` in the test definition is `ExampleTest`, then the switch key should be `abExampleTest`. The `value` should be a `boolean`, with `true` if the test is enabled, and `false` if the test is disabled.
+Finally you have to add a switch for the test in the [abSwitches.ts](../src/shared/model/experiments/abSwitches.ts) file, in the `abSwitches` object. The `key` should be `ab` + the `id` from the test definition. For example, if the `id` in the test definition is `ExampleTest`, then the switch key should be `abExampleTest`. The `value` should be a `boolean`, with `true` if the test is enabled, and `false` if the test is disabled.
 
 The [AB Testing Library](https://github.com/guardian/ab-testing) has more information available to setup tests with.
 

--- a/src/client/static/hydration.tsx
+++ b/src/client/static/hydration.tsx
@@ -6,7 +6,7 @@ import { hydrate } from 'react-dom';
 import { RoutingConfig } from '@/client/routes';
 import { App } from '@/client/app';
 import { tests } from '@/shared/model/experiments/abTests';
-import { switches } from '@/shared/model/experiments/abSwitches';
+import { abSwitches } from '@/shared/model/experiments/abSwitches';
 
 export const hydrateApp = () => {
   const routingConfig: RoutingConfig = JSON.parse(
@@ -21,7 +21,7 @@ export const hydrateApp = () => {
   hydrate(
     <ABProvider
       arrayOfTestObjects={tests}
-      abTestSwitches={switches}
+      abTestSwitches={abSwitches}
       pageIsSensitive={false}
       mvtMaxValue={1000000}
       mvtId={mvtId}

--- a/src/server/lib/renderer.tsx
+++ b/src/server/lib/renderer.tsx
@@ -12,7 +12,7 @@ import { RequestState } from '@/server/models/Express';
 import { CsrfErrors } from '@/shared/model/Errors';
 import { ABProvider } from '@guardian/ab-react';
 import { tests } from '@/shared/model/experiments/abTests';
-import { switches } from '@/shared/model/experiments/abSwitches';
+import { abSwitches } from '@/shared/model/experiments/abSwitches';
 import { resets } from '@guardian/src-foundations/utils';
 
 const assets = getAssets();
@@ -89,7 +89,7 @@ export const renderer: (url: string, opts: RendererOpts) => string = (
   const react = ReactDOMServer.renderToString(
     <ABProvider
       arrayOfTestObjects={tests}
-      abTestSwitches={switches}
+      abTestSwitches={abSwitches}
       pageIsSensitive={false}
       mvtMaxValue={1000000}
       mvtId={mvtId}

--- a/src/shared/lib/featureSwitches.ts
+++ b/src/shared/lib/featureSwitches.ts
@@ -1,0 +1,15 @@
+/**
+ * Interface for FeatureSwitches.
+ * Add feature switch name as the key, and type usually as `boolean`.
+ * We use an interface instead of a plain object so that if
+ * a property is removed/missing, typescript will complain.
+ *
+ * @interface FeatureSwitches
+ */
+interface FeatureSwitches {
+  demoSwitch: boolean;
+}
+
+export const featureSwitches: FeatureSwitches = {
+  demoSwitch: false,
+};

--- a/src/shared/model/experiments/abSwitches.ts
+++ b/src/shared/model/experiments/abSwitches.ts
@@ -1,3 +1,3 @@
-export const switches = {
+export const abSwitches = {
   abSingleNewsletterTest: false,
 };

--- a/src/shared/model/experiments/abTests.ts
+++ b/src/shared/model/experiments/abTests.ts
@@ -1,5 +1,5 @@
 import { AB, ABTest, Participations } from '@guardian/ab-core';
-import { switches } from './abSwitches';
+import { abSwitches } from './abSwitches';
 import { singleNewsletterTest } from './tests/singleNewsletterTest';
 
 interface ABTestConfiguration {
@@ -13,7 +13,7 @@ interface ABTestConfiguration {
 export const tests: ABTest[] = [singleNewsletterTest];
 
 export const getDefaultABTestConfiguration = (): ABTestConfiguration => ({
-  abTestSwitches: switches,
+  abTestSwitches: abSwitches,
   arrayOfTestObjects: tests,
   mvtMaxValue: 1000000,
   pageIsSensitive: false,


### PR DESCRIPTION
## What does this change?
In preparation for #638, we'd like to have a feature switch available to toggle certain parts of the application.

This PR adds a simple key-value pair used as the feature switch.

## Changes
- [x] Refactor `switches` to `abSwitches` so we know those are AB test switches and not feature switches
- [x] Add `featureSwitches` to `src/shared/model`

## Notes
The `demoSwitch` isn't used anywhere, it's just for an example of how the interface should look.