### PR TITLE
Use a token in the NoAccount email

### DIFF
--- a/src/email/templates/NoAccount/NoAccount.tsx
+++ b/src/email/templates/NoAccount/NoAccount.tsx
@@ -24,7 +24,9 @@ export const NoAccount = () => {
         </p>
         <p>Please click below to register.</p>
       </Text>
-      <Button href={`https://profile.theguardian.com${Routes.REGISTRATION}`}>
+      <Button
+        href={`https://profile.theguardian.com${Routes.REGISTRATION}/TOKEN_PLACEHOLDER`}
+      >
         Register with The Guardian
       </Button>
       <Footer />

--- a/src/email/templates/NoAccount/NoAccountText.ts
+++ b/src/email/templates/NoAccount/NoAccountText.ts
@@ -9,7 +9,7 @@ It's quick an easy to create an account and we won't ask you for personal detail
 
 Please click below to register.
 
-https://profile.theguardian.com${Routes.REGISTRATION}
+https://profile.theguardian.com${Routes.REGISTRATION}/TOKEN_PLACEHOLDER
 
 The Guardian
 

--- a/src/email/templates/NoAccount/sendNoAccountEmail.ts
+++ b/src/email/templates/NoAccount/sendNoAccountEmail.ts
@@ -6,6 +6,7 @@ import { NoAccountText } from './NoAccountText';
 
 type Props = {
   to: string;
+  token: string;
   subject?: string;
 };
 
@@ -14,11 +15,12 @@ const { html } = render(NoAccount());
 
 export const sendNoAccountEmail = ({
   to,
+  token,
   subject = 'Your attempt to sign up to theguardian.com',
 }: Props) => {
   return send({
-    html,
-    plainText,
+    html: html.replace('TOKEN_PLACEHOLDER', token),
+    plainText: plainText.replace('TOKEN_PLACEHOLDER', token),
     subject,
     to,
   });


### PR DESCRIPTION
## What does this change?
When reader's try to reset the password using an email that doesn't exist then the `NoAccount` email needs a token so that we can set their password when we land them in onboarding