### PR TITLE
Refactoring Error Handling

### DIFF
--- a/src/server/lib/getAssets.ts
+++ b/src/server/lib/getAssets.ts
@@ -46,7 +46,7 @@ export const getAssets = (isLegacy = false): Assets => {
       runtime,
     };
   } catch (e) {
-    logger.error(e);
+    logger.error('Error retrieving assets', e);
     throw new Error('Invalid assets file');
   }
 };

--- a/src/server/lib/idapi/auth.ts
+++ b/src/server/lib/idapi/auth.ts
@@ -48,6 +48,7 @@ export const read = async (
   sc_gu_la: string,
   ip: string,
 ): Promise<IDAPIAuthRedirect> => {
+  const url = '/auth/redirect';
   const options = APIAddClientAccessToken(
     APIForwardSessionIdentifier(APIGetOptions(), sc_gu_u),
     ip,
@@ -58,13 +59,13 @@ export const read = async (
   };
   try {
     return responseToEntity(
-      (await idapiFetch('/auth/redirect', {
+      (await idapiFetch(url, {
         ...options,
         headers: { ...headers },
       })) as APIResponse,
     );
   } catch (e) {
-    logger.error(e);
+    logger.error(`IDAPI Error auth read ${url}`, e);
     return handleError(e);
   }
 };
@@ -74,6 +75,7 @@ export const authenticate = async (
   password: string,
   ip: string,
 ) => {
+  const url = '/auth?format=cookies';
   const options = APIPostOptions({
     email,
     password,
@@ -81,11 +83,12 @@ export const authenticate = async (
 
   try {
     const response = await idapiFetch(
-      '/auth?format=cookies',
+      url,
       APIAddClientAccessToken(options, ip),
     );
     return response.cookies;
   } catch (e) {
+    logger.error(`IDAPI Error auth authenticate ${url}`, e);
     handleError(e);
   }
 };

--- a/src/server/lib/idapi/changePassword.ts
+++ b/src/server/lib/idapi/changePassword.ts
@@ -11,6 +11,7 @@ import {
   IdapiErrorMessages,
   ChangePasswordErrors,
 } from '@/shared/model/Errors';
+import { logger } from '../logger';
 
 const handleError = ({ error, status = 500 }: IDAPIError) => {
   if (error.status === 'error' && error.errors?.length) {
@@ -42,13 +43,13 @@ export async function validate(
 
   const qs = stringify(params);
 
+  const url = `${ApiRoutes.CHANGE_PASSWORD_TOKEN_VALIDATION}?${qs}`;
+
   try {
-    const result = await idapiFetch(
-      `${ApiRoutes.CHANGE_PASSWORD_TOKEN_VALIDATION}?${qs}`,
-      APIAddClientAccessToken(options, ip),
-    );
+    const result = await idapiFetch(url, APIAddClientAccessToken(options, ip));
     return result.user?.primaryEmailAddress;
   } catch (error) {
+    logger.error(`IDAPI Error changePassword validate ${url}`, error);
     handleError(error);
   }
 }
@@ -67,6 +68,10 @@ export async function change(password: string, token: string, ip: string) {
     );
     return result.cookies;
   } catch (error) {
+    logger.error(
+      `IDAPI Error changePassword change ${ApiRoutes.CHANGE_PASSWORD}`,
+      error,
+    );
     handleError(error);
   }
 }

--- a/src/server/lib/idapi/consents.ts
+++ b/src/server/lib/idapi/consents.ts
@@ -10,8 +10,6 @@ import { ConsentsErrors } from '@/shared/model/Errors';
 import { Consent } from '@/shared/model/Consent';
 import { UserConsent } from '@/shared/model/User';
 
-const API_ROUTE = '/users/me/consents';
-
 const handleError = (): never => {
   throw { message: ConsentsErrors.GENERIC, status: 500 };
 };
@@ -34,13 +32,14 @@ const responseToEntity = (consent: ConsentAPIResponse): Consent => {
 };
 
 export const read = async (): Promise<Consent[]> => {
+  const url = '/consents';
   const options = APIGetOptions();
   try {
-    return (
-      (await idapiFetch('/consents', options)) as ConsentAPIResponse[]
-    ).map(responseToEntity);
+    return ((await idapiFetch(url, options)) as ConsentAPIResponse[]).map(
+      responseToEntity,
+    );
   } catch (e) {
-    logger.error(e);
+    logger.error(`IDAPI Error consents read ${url}`, e);
     return handleError();
   }
 };
@@ -50,15 +49,16 @@ export const update = async (
   sc_gu_u: string,
   payload: UserConsent[],
 ) => {
+  const url = '/users/me/consents';
   const options = APIForwardSessionIdentifier(
     APIAddClientAccessToken(APIPatchOptions(payload), ip),
     sc_gu_u,
   );
   try {
-    await idapiFetch(API_ROUTE, options);
+    await idapiFetch(url, options);
     return;
   } catch (e) {
-    logger.error(e);
+    logger.error(`IDAPI Error consents update ${url}`, e);
     return handleError();
   }
 };

--- a/src/server/lib/idapi/newsletters.ts
+++ b/src/server/lib/idapi/newsletters.ts
@@ -37,13 +37,14 @@ const responseToEntity = (newsletter: NewsletterAPIResponse): NewsLetter => {
 };
 
 export const read = async (): Promise<NewsLetter[]> => {
+  const url = '/newsletters';
   const options = APIGetOptions();
   try {
-    return (
-      (await idapiFetch('/newsletters', options)) as NewsletterAPIResponse[]
-    ).map(responseToEntity);
+    return ((await idapiFetch(url, options)) as NewsletterAPIResponse[]).map(
+      responseToEntity,
+    );
   } catch (e) {
-    logger.error(e);
+    logger.error(`IDAPI Error newsletters read ${url}`, e);
     return handleError();
   }
 };
@@ -62,7 +63,7 @@ export const update = async (
     await idapiFetch(API_ROUTE, options);
     return;
   } catch (e) {
-    logger.error(e);
+    logger.error(`IDAPI Error newsletters update ${API_ROUTE}`, e);
     return handleError();
   }
 };
@@ -82,7 +83,7 @@ export const readUserNewsletters = async (ip: string, sc_gu_u: string) => {
       (s: Subscription) => s.listId.toString(),
     );
   } catch (e) {
-    logger.error(e);
+    logger.error(`IDAPI Error readUserNewsletters ${API_ROUTE}`, e);
     return handleError();
   }
 };

--- a/src/server/lib/idapi/user.ts
+++ b/src/server/lib/idapi/user.ts
@@ -49,28 +49,31 @@ const responseToEntity = (response: APIResponse): User => {
 };
 
 export const read = async (ip: string, sc_gu_u: string): Promise<User> => {
+  const url = '/user/me';
   const options = APIForwardSessionIdentifier(
     APIAddClientAccessToken(APIGetOptions(), ip),
     sc_gu_u,
   );
   try {
-    const response = (await idapiFetch('/user/me', options)) as APIResponse;
+    const response = (await idapiFetch(url, options)) as APIResponse;
     return responseToEntity(response);
   } catch (e) {
-    logger.error(e);
+    logger.error(`IDAPI Error user read ${url}`, e);
     return handleError(e);
   }
 };
 
 export const create = async (email: string, password: string, ip: string) => {
+  const url = '/user';
   const options = APIPostOptions({
     primaryEmailAddress: email,
     password,
   });
 
   try {
-    return await idapiFetch('/user', APIAddClientAccessToken(options, ip));
+    return await idapiFetch(url, APIAddClientAccessToken(options, ip));
   } catch (e) {
+    logger.error(`IDAPI Error user create ${url}`, e);
     handleError(e);
   }
 };

--- a/src/server/lib/idapi/verifyEmail.ts
+++ b/src/server/lib/idapi/verifyEmail.ts
@@ -33,16 +33,14 @@ const handleError = ({ error, status = 500 }: IDAPIError) => {
 };
 
 export async function verifyEmail(token: string, ip: string) {
+  const url = `${ApiRoutes.VERIFY_EMAIL}/${token}`;
   const options = APIPostOptions();
 
   try {
-    const result = await idapiFetch(
-      `${ApiRoutes.VERIFY_EMAIL}/${token}`,
-      APIAddClientAccessToken(options, ip),
-    );
+    const result = await idapiFetch(url, APIAddClientAccessToken(options, ip));
     return result.cookies;
   } catch (error) {
-    logger.error(error);
+    logger.error(`IDAPI Error verifyEmail ${url}`, error);
     handleError(error);
   }
 }
@@ -55,7 +53,10 @@ export async function send(ip: string, sc_gu_u: string) {
   try {
     await idapiFetch(ApiRoutes.RESEND_VERIFY_EMAIL, options);
   } catch (error) {
-    logger.error(error);
+    logger.error(
+      `IDAPI Error verifyEmail send ${ApiRoutes.RESEND_VERIFY_EMAIL}`,
+      error,
+    );
     return handleError(error);
   }
 }

--- a/src/server/lib/logger.ts
+++ b/src/server/lib/logger.ts
@@ -15,12 +15,12 @@ export const logger: Logger = {
     if (error && error.stack && typeof error.message === 'string') {
       return logger.log(
         LogLevel.ERROR,
-        `${message} ${error.message} ${error.stack}`,
+        `${message} | ${error.message} | ${error.stack}`,
       );
     }
 
     if (error) {
-      return logger.log(LogLevel.ERROR, `${message} ${error}`);
+      return logger.log(LogLevel.ERROR, `${message} | ${error}`);
     }
 
     return logger.log(LogLevel.ERROR, message);

--- a/src/server/lib/middleware/login.ts
+++ b/src/server/lib/middleware/login.ts
@@ -7,6 +7,7 @@ import { getProfileUrl } from '@/server/lib/getProfileUrl';
 import { Routes } from '@/shared/model/Routes';
 import { trackMetric } from '@/server/lib/trackMetric';
 import { Metrics } from '@/server/models/Metrics';
+import { logger } from '../logger';
 
 const profileUrl = getProfileUrl();
 
@@ -65,6 +66,7 @@ export const loginMiddleware = async (
       return redirectAuth(auth);
     }
   } catch (e) {
+    logger.error('loginMiddlewareFailure', e);
     trackMetric(Metrics.LOGIN_MIDDLEWARE_FAILURE);
     res.redirect(generateRedirectUrl(FATAL_ERROR_REDIRECT_URL));
   }

--- a/src/server/lib/trackMetric.ts
+++ b/src/server/lib/trackMetric.ts
@@ -51,7 +51,7 @@ export const trackMetric = (
           'AWS Credentials Expired. Have you added `Identity` Janus credentials?',
         );
       } else {
-        logger.error(error.message);
+        logger.error('Track Metric Error', error);
       }
     });
 };

--- a/src/server/routes/changePassword.ts
+++ b/src/server/routes/changePassword.ts
@@ -82,7 +82,8 @@ router.get(
         },
       });
     } catch (error) {
-      logger.error(error);
+      logger.error(`${req.method} ${req.originalUrl}  Error`, error);
+
       return res.type('html').send(
         renderer(Routes.RESET_RESEND, {
           requestState: state,
@@ -143,7 +144,7 @@ router.post(
       setIDAPICookies(res, cookies);
     } catch (error) {
       const { message, status } = error;
-      logger.error(error);
+      logger.error(`${req.method} ${req.originalUrl}  Error`, error);
 
       trackMetric(Metrics.CHANGE_PASSWORD_FAILURE);
 

--- a/src/server/routes/consents.ts
+++ b/src/server/routes/consents.ts
@@ -42,6 +42,7 @@ import { IDAPIError } from '@/server/lib/IDAPIFetch';
 import { getConfiguration } from '@/server/lib/getConfiguration';
 import { Configuration } from '@/server/models/Configuration';
 import { PageTitle } from '@/shared/model/PageTitle';
+import { logger } from '../lib/logger';
 
 const router = Router();
 
@@ -131,20 +132,14 @@ export const consentPages: ConsentPage[] = [
   {
     page: Routes.CONSENTS_COMMUNICATION.slice(1),
     pageTitle: CONSENTS_PAGES.CONTACT,
-    read: async (ip, sc_gu_u) => {
-      try {
-        return {
-          consents: await getUserConsentsForPage(
-            CONSENTS_COMMUNICATION_PAGE,
-            ip,
-            sc_gu_u,
-          ),
-          page: Routes.CONSENTS_COMMUNICATION.slice(1),
-        };
-      } catch (error) {
-        throw error;
-      }
-    },
+    read: async (ip, sc_gu_u) => ({
+      consents: await getUserConsentsForPage(
+        CONSENTS_COMMUNICATION_PAGE,
+        ip,
+        sc_gu_u,
+      ),
+      page: Routes.CONSENTS_COMMUNICATION.slice(1),
+    }),
     update: async (ip, sc_gu_u, body) => {
       const consents = CONSENTS_COMMUNICATION_PAGE.map((id) => ({
         id,
@@ -157,21 +152,15 @@ export const consentPages: ConsentPage[] = [
   {
     page: Routes.CONSENTS_NEWSLETTERS.slice(1),
     pageTitle: CONSENTS_PAGES.NEWSLETTERS,
-    read: async (ip, sc_gu_u, geo) => {
-      try {
-        return {
-          page: Routes.CONSENTS_NEWSLETTERS.slice(1),
-          newsletters: await getUserNewsletterSubscriptions(
-            NewsletterMap.get(geo) as string[],
-            ip,
-            sc_gu_u,
-          ),
-          previousPage: Routes.CONSENTS_COMMUNICATION.slice(1),
-        };
-      } catch (error) {
-        throw error;
-      }
-    },
+    read: async (ip, sc_gu_u, geo) => ({
+      page: Routes.CONSENTS_NEWSLETTERS.slice(1),
+      newsletters: await getUserNewsletterSubscriptions(
+        NewsletterMap.get(geo) as string[],
+        ip,
+        sc_gu_u,
+      ),
+      previousPage: Routes.CONSENTS_COMMUNICATION.slice(1),
+    }),
     update: async (ip, sc_gu_u, body) => {
       const userNewsletterSubscriptions = await getUserNewsletterSubscriptions(
         ALL_NEWSLETTER_IDS,
@@ -212,21 +201,11 @@ export const consentPages: ConsentPage[] = [
   {
     page: Routes.CONSENTS_DATA.slice(1),
     pageTitle: CONSENTS_PAGES.YOUR_DATA,
-    read: async (ip, sc_gu_u) => {
-      try {
-        return {
-          consents: await getUserConsentsForPage(
-            CONSENTS_DATA_PAGE,
-            ip,
-            sc_gu_u,
-          ),
-          page: Routes.CONSENTS_DATA.slice(1),
-          previousPage: Routes.CONSENTS_NEWSLETTERS.slice(1),
-        };
-      } catch (error) {
-        throw error;
-      }
-    },
+    read: async (ip, sc_gu_u) => ({
+      consents: await getUserConsentsForPage(CONSENTS_DATA_PAGE, ip, sc_gu_u),
+      page: Routes.CONSENTS_DATA.slice(1),
+      previousPage: Routes.CONSENTS_NEWSLETTERS.slice(1),
+    }),
     update: async (ip, sc_gu_u, body) => {
       const consents = CONSENTS_DATA_PAGE.map((id) => ({
         id,
@@ -403,6 +382,7 @@ function getABTestGETHandler(
       });
       status = 200;
     } catch (error) {
+      logger.error(`consents getABTestGETHandler error`, error);
       [status, state] = getErrorResponse(error, state);
     }
 
@@ -434,6 +414,7 @@ function getABTestPOSTHandler(
       res.redirect(303, url);
       return;
     } catch (e) {
+      logger.error(`consents getABTestPOSTHandler error`, e);
       [status, state] = getErrorResponse(e, state);
     }
 
@@ -520,6 +501,7 @@ router.get(
         },
       } as RequestState);
     } catch (e) {
+      logger.error(`${req.method} ${req.originalUrl}  Error`, e);
       status = e.status;
       state = deepmerge(state, {
         globalMessage: {
@@ -577,6 +559,7 @@ router.post(
       }
       return res.redirect(303, url);
     } catch (e) {
+      logger.error(`${req.method} ${req.originalUrl}  Error`, e);
       status = e.status;
       state = deepmerge(state, {
         globalMessage: {

--- a/src/server/routes/magicLink.ts
+++ b/src/server/routes/magicLink.ts
@@ -32,8 +32,8 @@ router.post(
         `TODO: Implement the logic to send the magic link to ${email} here`,
       );
     } catch (error) {
+      logger.error(`${req.method} ${req.originalUrl}  Error`, error);
       const { message, status } = error;
-      logger.error(error);
 
       trackMetric(Metrics.SEND_MAGIC_LINK_FAILURE);
 

--- a/src/server/routes/register.ts
+++ b/src/server/routes/register.ts
@@ -41,8 +41,8 @@ router.post(
       const cookies = await authenticate(email, password, req.ip);
       setIDAPICookies(res, cookies);
     } catch (error) {
+      logger.error(`${req.method} ${req.originalUrl}  Error`, error);
       const { message, status } = error;
-      logger.error(error);
 
       trackMetric(Metrics.REGISTER_FAILURE);
 

--- a/src/server/routes/reset.ts
+++ b/src/server/routes/reset.ts
@@ -45,8 +45,8 @@ router.post(
     try {
       await resetPassword(email, req.ip, returnUrl);
     } catch (error) {
+      logger.error(`${req.method} ${req.originalUrl}  Error`, error);
       const { message, status } = error;
-      logger.error(error);
 
       trackMetric(Metrics.SEND_PASSWORD_RESET_FAILURE);
 

--- a/src/server/routes/signIn.ts
+++ b/src/server/routes/signIn.ts
@@ -50,8 +50,8 @@ router.post(
 
       setIDAPICookies(res, cookies);
     } catch (error) {
+      logger.error(`${req.method} ${req.originalUrl}  Error`, error);
       const { message, status } = error;
-      logger.error(error);
 
       trackMetric(Metrics.SIGN_IN_FAILURE);
 

--- a/src/server/routes/verifyEmail.ts
+++ b/src/server/routes/verifyEmail.ts
@@ -55,6 +55,7 @@ router.get(
         },
       });
     } catch (error) {
+      logger.error(`${req.method} ${req.originalUrl}  Error`, error);
       status = error.status;
 
       if (status === 500) {
@@ -106,6 +107,7 @@ router.post(
         },
       });
     } catch (error) {
+      logger.error(`${req.method} ${req.originalUrl}  Error`, error);
       trackMetric(Metrics.SEND_VALIDATION_EMAIL_FAILURE);
       status = error.status;
       state = deepmerge(state, {
@@ -134,7 +136,7 @@ router.get(
       trackMetric(Metrics.EMAIL_VALIDATED_SUCCESS);
       setIDAPICookies(res, cookies);
     } catch (error) {
-      logger.error(error);
+      logger.error(`${req.method} ${req.originalUrl}  Error`, error);
 
       if (error.message === VerifyEmailErrors.USER_ALREADY_VALIDATED) {
         return res.redirect(


### PR DESCRIPTION
## What does this change?
@QuarpT noted in https://github.com/guardian/gateway/pull/638#discussion_r668628677 that it would be useful to log the stack trace of a specific error.

However I noticed that we were using the `logger.error` method wrong the entire time. In https://github.com/guardian/gateway/blob/496851c636f1d1b17f9ea341fcc78b9dfce973fb/src/server/lib/logger.ts#L14 the first parameter is a message, and the second the error. However we were passing the error as the first argument, which was just sent as a useless string.

This PR refactors and adds errors throughout the project with a useful message, and the error in the correct parameter.

It also removes unnecessary try catch blocks too.