### PR TITLE
Cypress: `yarn cypress` cmd

### DIFF
--- a/cypress-open.sh
+++ b/cypress-open.sh
@@ -13,4 +13,4 @@ yarn mock-server &
 yarn wait-on:mock-server
 yarn start &
 yarn wait-on:server
-yarn cypress open --env $CI_ENV
+yarn cypress --env $CI_ENV

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "private": true,
   "scripts": {
     "build": "webpack --mode production && node scripts/copyNodeModules.js",
-    "cypress": "cypress",
+    "cypress": "cypress open",
     "cypress:ci": "cypress run",
     "e2e:server": "yarn mock-server & yarn start",
     "lint": "eslint . --ext .ts,.tsx",


### PR DESCRIPTION
## What does this change?
Move the `open` command that is used to run Cypress is headed mode out of the bash script and into `package.json

## Why?
Because this means we can now use both make and yarn to run Cypress