### PR TITLE
Change 5XX alarms

### DIFF
--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -440,6 +440,53 @@ Resources:
     DependsOn:
       - TargetGroup
       - LoadBalancer
+  Alarm5XXSustained:
+    Type: AWS::CloudWatch::Alarm
+    Condition: IsProd
+    Properties:
+      ActionsEnabled: 'true'
+      AlarmName: !Sub '${App}-${Stage} high 5xx errors'
+      AlarmDescription: 'Sustained server errors detected'
+      AlarmActions:
+        - !Ref 'TopicSendEmail'
+      OKActions:
+        - !Ref 'TopicSendEmail'
+      InsufficientDataActions:
+        - !Ref 'TopicSendEmail'
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      Threshold: 3
+      EvaluationPeriods: 5
+      TreatMissingData: notBreaching
+      Metrics:
+        - Id: total5XXCount
+          Expression: backend5XXCount + elb5XXCount
+          Label: 'Count of Backend AND ELB 5XX'
+        - Id: backend5XXCount
+          MetricStat:
+            Metric:
+              Namespace: AWS/ApplicationELB
+              MetricName: HTTPCode_Target_5XX_Count
+              Dimensions:
+                - Name: LoadBalancer
+                  Value: !GetAtt LoadBalancer.LoadBalancerFullName
+                - Name: TargetGroup
+                  Value: !GetAtt TargetGroup.TargetGroupFullName
+            Period: 60
+            Stat: Sum
+            Unit: Count
+          ReturnData: false
+        - Id: elb5XXCount
+          MetricStat:
+            Metric:
+              Namespace: AWS/ApplicationELB
+              MetricName: HTTPCode_ELB_5XX_Count
+              Dimensions:
+                - Name: LoadBalancer
+                  Value: !GetAtt LoadBalancer.LoadBalancerFullName
+            Period: 60
+            Stat: Sum
+            Unit: Count
+          ReturnData: false
   Alarm5XXHigh:
     Type: AWS::CloudWatch::Alarm
     Condition: IsProd
@@ -454,8 +501,8 @@ Resources:
       InsufficientDataActions:
         - !Ref 'TopicSendEmail'
       ComparisonOperator: GreaterThanOrEqualToThreshold
-      Threshold: 3
-      EvaluationPeriods: 2
+      Threshold: 30
+      EvaluationPeriods: 1
       TreatMissingData: notBreaching
       Metrics:
         - Id: total5XXCount


### PR DESCRIPTION
## What does this change and why?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Split 5XX alarm into 2 alarms:
- Alarm5XXSustained goes off if more than 3 5XX errors 5 minutes in a row
- Alarm5XXHigh if 30 errors in 1 minute

Previously the configuration was 3 5XX errors in 2 minutes in a row. Making the changes since Braze API errors keep triggering this alarm and the alert emails are getting ignored.