### PR TITLE
Ammendment to 5XX alarms

### DIFF
--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -445,7 +445,7 @@ Resources:
     Condition: IsProd
     Properties:
       ActionsEnabled: 'true'
-      AlarmName: !Sub '${App}-${Stage} high 5xx errors'
+      AlarmName: !Sub '${App}-${Stage} sustained 5xx errors'
       AlarmDescription: 'Sustained server errors detected'
       AlarmActions:
         - !Ref 'TopicSendEmail'


### PR DESCRIPTION
Relates to https://github.com/guardian/gateway/pull/753
Fixes CloudFormation error for duplicated alarm name