### PR TITLE
Update `Verify` email to new copy

### DIFF
--- a/src/email/templates/Verify/Verify.tsx
+++ b/src/email/templates/Verify/Verify.tsx
@@ -1,7 +1,5 @@
 import React from 'react';
 
-import { getProfileUrl } from '@/server/lib/getProfileUrl';
-import { Routes } from '@/shared/model/Routes';
 import { Page } from '@/email/components/Page';
 import { Button } from '@/email/components/Button';
 import { Header } from '@/email/components/Header';
@@ -9,23 +7,16 @@ import { SubHeader } from '@/email/components/SubHeader';
 import { Text } from '@/email/components/Text';
 import { Footer } from '@/email/components/Footer';
 
-const profileUrl = getProfileUrl();
-
 export const Verify = () => {
   return (
     <Page>
       <Header />
-      <SubHeader>Please verify your email</SubHeader>
+      <SubHeader>Thank you for $registerAction</SubHeader>
       <Text>
         <p>Welcome to the Guardian,</p>
-        <p>
-          Please click below to verify your emails address and complete your
-          registration.
-        </p>
+        <p>Please click below to complete your registration.</p>
       </Text>
-      <Button href={`${profileUrl}${Routes.WELCOME}`}>
-        Complete registration
-      </Button>
+      <Button href="$verificationLink">Complete registration</Button>
       <Footer />
     </Page>
   );

--- a/src/email/templates/Verify/VerifyText.ts
+++ b/src/email/templates/Verify/VerifyText.ts
@@ -1,11 +1,11 @@
-import { Routes } from '@/shared/model/Routes';
-
 export const VerifyText = () => `
+Thank you for $registerAction
+
 Welcome to the Guardian,
 
-Please click below to verify your emails address and complete your registration.
+Please click below to complete your registration.
 
-https://profile.theguardian.com${Routes.WELCOME}
+$verificationLink
 
 The Guardian
 


### PR DESCRIPTION
## What does this change?
![Screenshot_2021-07-30_at_10 40 40](https://user-images.githubusercontent.com/13315440/127660524-b066df0d-2af4-4333-ae1f-e1a3fdbb3e13.png)

Change the `Verify` email to use the updated copy.

It also switches to using `$variable` syntax for insertable variables for now, as this email will be being sent from Identity API for the time being, which expects variables in that format.

`$registerAction` will become one of `registering`, `your contribution`, or `subscribing` depending on the action that the user was taking.

`$verificationLink` will become the link to the check token/welcome page. This page has not been set up yet.
