### PR TITLE
Improve error logging and remove removeNoCache

### DIFF
--- a/src/server/lib/logger.ts
+++ b/src/server/lib/logger.ts
@@ -1,34 +1,47 @@
 import { Logger, LogLevel } from '@/server/models/Logger';
 import { createLogger, transports } from 'winston';
+import { format } from 'util';
 
 const winstonLogger = createLogger({
   transports: [new transports.Console()],
 });
 
 export const logger: Logger = {
-  log(level: LogLevel, message: string) {
-    winstonLogger.log(level, message);
-  },
-  // errors can be anything
   // eslint-disable-next-line
-  error(message: string, error?: any) {
-    if (error && error.stack && typeof error.message === 'string') {
-      return logger.log(
-        LogLevel.ERROR,
-        `${message} | ${error.message} | ${error.stack}`,
+  log(level: LogLevel, message: string, error?: any) {
+    if (
+      error &&
+      typeof error === 'object' &&
+      error.stack &&
+      typeof error.message === 'string'
+    ) {
+      return winstonLogger.log(
+        level,
+        `${format(message)} - ${format(error.message)} - ${format(
+          error.stack,
+        )}`,
       );
     }
 
     if (error) {
-      return logger.log(LogLevel.ERROR, `${message} | ${error}`);
+      return winstonLogger.log(level, `${format(message)} - ${format(error)}`);
     }
 
-    return logger.log(LogLevel.ERROR, message);
+    return winstonLogger.log(level, `${format(message)}`);
   },
-  warn(message: string) {
-    logger.log(LogLevel.INFO, message);
+
+  // eslint-disable-next-line
+  error(message: string, error?: any) {
+    return logger.log(LogLevel.ERROR, message, error);
   },
-  info(message: string) {
-    logger.log(LogLevel.INFO, message);
+
+  // eslint-disable-next-line
+  warn(message: string, error?: any) {
+    return logger.log(LogLevel.WARN, message, error);
+  },
+
+  // eslint-disable-next-line
+  info(message: string, error?: any) {
+    logger.log(LogLevel.INFO, message, error);
   },
 };

--- a/src/server/lib/middleware/cache.ts
+++ b/src/server/lib/middleware/cache.ts
@@ -8,14 +8,3 @@ export const noCache = (_: Request, res: Response, next: NextFunction) => {
 
   next();
 };
-
-export const removeNoCache = (
-  _: Request,
-  res: Response,
-  next: NextFunction,
-) => {
-  res.removeHeader('Cache-Control');
-  res.removeHeader('Pragma');
-
-  next();
-};

--- a/src/server/lib/playSessionCookie.ts
+++ b/src/server/lib/playSessionCookie.ts
@@ -18,7 +18,7 @@ const getCookieFromPlaySession: (req: Request) => any = (req) => {
       );
       return session.data;
     } catch (error) {
-      logger.warn(error);
+      logger.warn('getCookieFromPlaySession failed', error);
     }
   }
 };

--- a/src/server/models/Logger.ts
+++ b/src/server/models/Logger.ts
@@ -1,8 +1,10 @@
 export interface Logger {
-  log(logLevel: LogLevel, message: string): void;
-  info(message: string): void;
-  warn(message: string): void;
-  // errors can be anything
+  // eslint-disable-next-line
+  log(logLevel: LogLevel, message: string, error?: any): void;
+  // eslint-disable-next-line
+  info(message: string, error?: any): void;
+  // eslint-disable-next-line
+  warn(message: string, error?: any): void;
   // eslint-disable-next-line
   error(message: string, error?: any): void;
 }

--- a/src/server/routes/changePassword.ts
+++ b/src/server/routes/changePassword.ts
@@ -11,7 +11,6 @@ import { ChangePasswordErrors } from '@/shared/model/Errors';
 import { ResponseWithRequestState } from '@/server/models/Express';
 import { trackMetric } from '@/server/lib/trackMetric';
 import { Metrics } from '@/server/models/Metrics';
-import { removeNoCache } from '@/server/lib/middleware/cache';
 import { PageTitle } from '@/shared/model/PageTitle';
 import { setIDAPICookies } from '@/server/lib/setIDAPICookies';
 import { handleAsyncErrors } from '@/server/lib/expressWrappers';
@@ -150,16 +149,12 @@ router.get(
   },
 );
 
-router.get(
-  Routes.RESET_RESEND,
-  removeNoCache,
-  (_: Request, res: ResponseWithRequestState) => {
-    const html = renderer(Routes.RESET_RESEND, {
-      pageTitle: PageTitle.RESET_RESEND,
-      requestState: res.locals,
-    });
-    res.type('html').send(html);
-  },
-);
+router.get(Routes.RESET_RESEND, (_: Request, res: ResponseWithRequestState) => {
+  const html = renderer(Routes.RESET_RESEND, {
+    pageTitle: PageTitle.RESET_RESEND,
+    requestState: res.locals,
+  });
+  res.type('html').send(html);
+});
 
 export default router;

--- a/src/server/routes/magicLink.ts
+++ b/src/server/routes/magicLink.ts
@@ -8,7 +8,6 @@ import { Metrics } from '@/server/models/Metrics';
 import { PageTitle } from '@/shared/model/PageTitle';
 import { ResponseWithRequestState } from '@/server/models/Express';
 import { handleAsyncErrors } from '@/server/lib/expressWrappers';
-import { removeNoCache } from '@/server/lib/middleware/cache';
 
 const router = Router();
 
@@ -58,7 +57,6 @@ router.post(
 
 router.get(
   Routes.MAGIC_LINK_SENT,
-  removeNoCache,
   (_: Request, res: ResponseWithRequestState) => {
     const html = renderer(Routes.MAGIC_LINK_SENT, {
       pageTitle: PageTitle.MAGIC_LINK,


### PR DESCRIPTION
## What does this change and why?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
- Improve error logging format by wrapping the objects passed in with `util.format`. This will pretty print objects which are currently logged as `[object]` in the logs. `util.format` is wrapped on individual logging parameters to avoid string placeholders from being accidentally parsed.
- Also allow error objects to be passed to warn and info since this is useful.
- remove removeNoCache for safety. No responses should be cached for Gateway in case engineers accidentally introduce personal information into state, and forget to remove `removeNoCache`. Right now `removeNoCache` doesn't seem to cache, since no cache headers are set.
