### PR TITLE
Layout bug on mobile safari

### DIFF
--- a/src/client/app.tsx
+++ b/src/client/app.tsx
@@ -37,7 +37,6 @@ export const App = (props: ClientState) => {
           }
           #app {
             min-height: 100%;
-            height: 100%;
             display: flex;
             flex-direction: column;
           }

--- a/src/client/layouts/Main.tsx
+++ b/src/client/layouts/Main.tsx
@@ -19,7 +19,6 @@ const mainStyles = css`
   display: flex;
   flex-grow: 1;
   flex-direction: column;
-  align-items: left;
 `;
 
 const sectionStyles = css`


### PR DESCRIPTION
## What does this change?
Fixes a bug on mobile safaris where a page layout bug was causing the footer to obscure the main content

This has been tested over a range of browsers and operating systems using BrowserStack.

## Before
![IMG_2565](https://user-images.githubusercontent.com/1336821/127996731-2f234c8f-12c0-47fb-9f24-acfd9edaa3b2.PNG)


## After
![IMG_2564](https://user-images.githubusercontent.com/1336821/127996566-cf971800-1f3f-438e-beb6-210c3bb3091b.PNG)

