### PR TITLE
Logging and no cache improvements

### DIFF
--- a/src/server/lib/logger.ts
+++ b/src/server/lib/logger.ts
@@ -1,10 +1,21 @@
 import { Logger, LogLevel } from '@/server/models/Logger';
 import { createLogger, transports } from 'winston';
-import { format } from 'util';
+import { formatWithOptions, InspectOptions } from 'util';
 
 const winstonLogger = createLogger({
   transports: [new transports.Console()],
 });
+
+const loggingOptions: InspectOptions = {
+  depth: 10,
+  breakLength: 2000,
+  maxStringLength: 2000,
+  compact: true,
+};
+
+// eslint-disable-next-line
+const formatLogParam = (message?: any) =>
+  formatWithOptions(loggingOptions, message);
 
 export const logger: Logger = {
   // eslint-disable-next-line
@@ -17,17 +28,20 @@ export const logger: Logger = {
     ) {
       return winstonLogger.log(
         level,
-        `${format(message)} - ${format(error.message)} - ${format(
-          error.stack,
-        )}`,
+        `${formatLogParam(message)} - ${formatLogParam(
+          error.message,
+        )} - ${formatLogParam(error.stack)}`,
       );
     }
 
     if (error) {
-      return winstonLogger.log(level, `${format(message)} - ${format(error)}`);
+      return winstonLogger.log(
+        level,
+        `${formatLogParam(message)} - ${formatLogParam(error)}`,
+      );
     }
 
-    return winstonLogger.log(level, `${format(message)}`);
+    return winstonLogger.log(level, `${formatLogParam(message)}`);
   },
 
   // eslint-disable-next-line

--- a/src/server/lib/logger.ts
+++ b/src/server/lib/logger.ts
@@ -7,7 +7,7 @@ const winstonLogger = createLogger({
 });
 
 const loggingOptions: InspectOptions = {
-  depth: 10,
+  depth: 20,
   breakLength: 2000,
   maxStringLength: 2000,
   compact: true,

--- a/src/server/routes/index.ts
+++ b/src/server/routes/index.ts
@@ -11,29 +11,35 @@ import { default as magicLink } from './magicLink';
 import { noCache } from '@/server/lib/middleware/cache';
 
 const router = Router();
+const uncachedRoutes = Router();
 
 // core routes for the app, e.g. healthcheck, static routes
 router.use(core);
 
+// all routes should be uncached except for the core (static) routes
+uncachedRoutes.use(noCache);
+
 // request reset password routes
-router.use(noCache, reset);
+uncachedRoutes.use(reset);
 
 // request sign in routes
-router.use(noCache, signIn);
+uncachedRoutes.use(signIn);
 
 // request registration routes
-router.use(noCache, register);
+uncachedRoutes.use(register);
 
 // change password routes
-router.use(noCache, changePassword);
+uncachedRoutes.use(changePassword);
 
 // consents routes
-router.use(noCache, consents);
+uncachedRoutes.use(consents);
 
 // verify email routes
-router.use(noCache, verifyEmail);
+uncachedRoutes.use(verifyEmail);
 
 // magic link routes
-router.use(noCache, magicLink);
+uncachedRoutes.use(magicLink);
+
+router.use(uncachedRoutes);
 
 export default router;

--- a/src/server/routes/index.ts
+++ b/src/server/routes/index.ts
@@ -17,6 +17,7 @@ const uncachedRoutes = Router();
 router.use(core);
 
 // all routes should be uncached except for the core (static) routes
+// to avoid caching sensitive page state
 uncachedRoutes.use(noCache);
 
 // request reset password routes


### PR DESCRIPTION
## What does this change?

Improve error logging by allowing deeper lookup (it was 2 by default so not printing some IDAPI error responses) and set maximum string length.

Logs will look like this:

```stage:CODE message:{"level":"error","message":"IDAPI Error changePassword validate /pwd-reset/user-for-token?token=XXXXXXXXXXXXXXXX - { error: { status: 'error', errors: [ { message: 'Invalid token', description: 'The token you supplied could not be parsed' } ] }, status: 403 }"} app:identity-gateway host:ip-10-10-10-10 @timestamp:Aug 5, 2021 @ 10:05:18.065 type:app @version:1 source_stream:identity ec2_instance:i-aaaaaaaaaaaaaa path:/var/log/identity-gateway.log stack:identity _id:aaaaaaaaaaaaaa _type:_doc _index:logstash-identity-2021.08.05 _score: -```

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Set noCache once in `src/server/routes/index.ts`