### PR TITLE
Fix isLegacy not defined error in webpack.development.js

### DIFF
--- a/webpack.development.js
+++ b/webpack.development.js
@@ -36,7 +36,7 @@ const serverConfig = {
   }
 }
 
-const browserConfig = {
+const browserConfig = (isLegacy = false) => ({
   module: {
     rules: [
       {
@@ -54,15 +54,15 @@ const browserConfig = {
     ]
   },
   plugins: [
-    ...isLegacy ? [] : [new ForkTsCheckerWebpackPlugin({
+    ...(isLegacy ? [] : [new ForkTsCheckerWebpackPlugin({
       async: true,
       typescript: {
         mode: 'write-references' // for better babel-loader perf.
       }
-    })],
+    })]),
     new ForkTsCheckerNotifierWebpackPlugin({ excludeWarnings: true, skipFirstNotification: true }),
   ]
-};
+});
 
 const baseServerConfig = baseConfig[0];
 const baseBrowserLegacyConfig = baseConfig[1];
@@ -89,11 +89,11 @@ module.exports = [
   merge(
     baseBrowserLegacyConfig,
     common,
-    browserConfig,
+    browserConfig(true),
   ),
   merge(
     baseBrowserConfig,
     common,
-    browserConfig,
+    browserConfig(false),
   )
 ]


### PR DESCRIPTION
## What does this change?
I got a `ReferenceError: isLegacy is not defined` when running `make dev`/`yarn dev` because `isLegacy` was not in scope in `webpack.development.js`.

This PR wraps the object in a function which takes `isLegacy` as a parameter to solve this.

In some cases it appeared to run the spread operator on `isLegacy` itself rather than the outcome of the ternary operator, wrapping this in brackets solves this.