### PR TITLE
touch serverjs to prevent nodemon error

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test": "yarn tsc && yarn test:unit",
     "test:unit": "jest --ci",
     "tsc": "tsc --noEmit --skipLibCheck",
-    "watch:server": "nodemon --inspect ./build/server.js",
+    "watch:server": "mkdir -p ./build && touch ./build/server.js && nodemon --inspect ./build/server.js",
     "watch": "webpack --watch --config webpack.development.js",
     "wait-on:server": "wait-on http://localhost:8861/healthcheck",
     "wait-on:mock-server": "wait-on http://localhost:9000/healthcheck",


### PR DESCRIPTION
v small tweak to avoid error on nodemon start when `server.js` doesn't exist. fix was to `touch server.js` which will create a stub until the real file is created by the webpack build