### PR TITLE
Add 375px and 320px breakpoints to assist with Storybook testing

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,4 +1,3 @@
-import { breakpoints } from '@guardian/src-foundations/mq';
 import { Breakpoints } from '@/client/models/Style';
 
 const viewports = {};

--- a/src/client/models/Style.ts
+++ b/src/client/models/Style.ts
@@ -7,4 +7,7 @@ export enum Breakpoints {
   // mobile breakpoints differ
   MOBILE = 660,
   MOBILE_LANDSCAPE = 480,
+  // for storybook use
+  MOBILE_375 = 375,
+  MOBILE_320 = 320,
 }


### PR DESCRIPTION
## What does this change?
- Adds `375px` and `320px` breakpoints

## Why?
This will assist in testing/developing pages for smaller devices using storybook. Previously the smallest breakpoints available were `660px` in portrait and `440px` in landspace.