### PR TITLE
`SubHeader` sizing

### DIFF
--- a/src/client/components/SubHeader.tsx
+++ b/src/client/components/SubHeader.tsx
@@ -14,14 +14,9 @@ const backgroundStyles = css`
 `;
 
 const paddingTop = css`
-  ${from.mobileMedium} {
-    padding-top: ${space[12]}px;
-  }
+  padding-top: ${space[9]}px;
   ${from.tablet} {
-    padding-top: ${space[24]}px;
-  }
-  ${from.desktop} {
-    padding-top: calc(${space[24]}px + ${space[6]}px);
+    padding-top: ${space[12]}px;
   }
 `;
 
@@ -36,7 +31,7 @@ const h1Styles = css`
   ${headline.xsmall({ fontWeight: 'bold', lineHeight: 'tight' })}
   ${from.tablet} {
     margin: 0;
-    ${headline.large({ fontWeight: 'bold', lineHeight: 'regular' })}
+    ${headline.small({ fontWeight: 'bold', lineHeight: 'regular' })}
   }
 `;
 


### PR DESCRIPTION
## What does this change?
Updates the `SubHeader` to allign with [the new designs](https://www.figma.com/file/ZDPonnBXbMhV2smf51Dylc/Sign-in-Journeys?node-id=772%3A1414).

Specifically:

1. Reduces padding above the text
2. Reduces text size above `tablet`

### Before
![2021-08-18 17 24 02](https://user-images.githubusercontent.com/1336821/129935507-66cb1753-b184-40e1-a5f0-dcb4d1e3224f.gif)


### After
![2021-08-18 17 22 57](https://user-images.githubusercontent.com/1336821/129935442-21054c0b-f00e-44bb-a10c-f3856dd04638.gif)
 