### PR TITLE
Header focus halo

### DIFF
--- a/src/client/components/Logo.tsx
+++ b/src/client/components/Logo.tsx
@@ -112,6 +112,8 @@ export const Logo = ({ logoType = 'standard' }: Props) => (
     title="The Guardian Homepage"
     subdued={true}
     cssOverrides={css`
+      /* Adding block display here so that the focus halo correctly covers the content */
+      display: block;
       color: ${brandText.primary};
       :hover {
         color: ${brandText.primary};


### PR DESCRIPTION
## What does this change?
Ensures the focus halo looks right

### Before
<img width="728" alt="Screenshot 2021-08-20 at 15 59 30" src="https://user-images.githubusercontent.com/1336821/130253093-63088c50-83f4-4e9c-b513-ac64f423947a.png">

### After
<img width="728" alt="Screenshot 2021-08-20 at 15 58 30" src="https://user-images.githubusercontent.com/1336821/130253050-592dff9d-c620-4e92-b345-abc5ab7f7ae5.png">
