### PR TITLE
Don't hide success

### DIFF
--- a/src/client/layouts/Main.tsx
+++ b/src/client/layouts/Main.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useState, useEffect } from 'react';
+import React, { useContext } from 'react';
 import { SubHeader } from '@/client/components/SubHeader';
 import { ClientState } from '@/shared/model/ClientState';
 import { ClientStateContext } from '@/client/components/ClientState';
@@ -31,15 +31,6 @@ const sectionStyles = css`
 export const Main = ({ subTitle, successOverride, children }: Props) => {
   const clientState: ClientState = useContext(ClientStateContext);
   const { globalMessage: { error, success } = {} } = clientState;
-  const [showSuccess, setShowSuccess] = useState<boolean>(true);
-
-  useEffect(() => {
-    const timer = setTimeout(() => {
-      setShowSuccess(false);
-    }, 3000);
-
-    return () => clearTimeout(timer);
-  }, []);
 
   const successMessage = success || successOverride;
 
@@ -47,9 +38,7 @@ export const Main = ({ subTitle, successOverride, children }: Props) => {
     <main css={mainStyles}>
       {subTitle && <SubHeader title={subTitle} />}
       {error && <GlobalError error={error} link={getErrorLink(error)} />}
-      {showSuccess && successMessage && (
-        <GlobalSuccess success={successMessage} />
-      )}
+      {successMessage && <GlobalSuccess success={successMessage} />}
       <section css={sectionStyles}>{children}</section>
     </main>
   );

--- a/src/client/pages/EmailSent.tsx
+++ b/src/client/pages/EmailSent.tsx
@@ -17,17 +17,25 @@ type Props = {
   previousPage?: string;
 };
 
-export const EmailSent = ({ email, previousPage }: Props) => {
+export const EmailSent = ({ email, previousPage = '/' }: Props) => {
   const [hasJS, setHasJS] = useState<boolean>(false);
+  const [loading, setLoading] = useState<boolean>(false);
 
   useEffect(() => {
     setHasJS(true);
   }, []);
 
+  const onResendClick = () => {
+    setLoading(true);
+  };
+
   return (
     <>
       <Header />
-      <Main subTitle="Sign in" successOverride="Email sent">
+      <Main
+        subTitle="Sign in"
+        successOverride={loading ? undefined : 'Email sent'}
+      >
         <PageBox>
           <PageHeader>Check your email inbox</PageHeader>
           <PageBody>
@@ -56,9 +64,10 @@ export const EmailSent = ({ email, previousPage }: Props) => {
                 <Button
                   css={button}
                   type="submit"
+                  onClick={onResendClick}
                   data-cy="resend-email-button"
                 >
-                  Resend email
+                  {loading ? 'Resending...' : 'Resend email'}
                 </Button>
                 <br />
                 <br />


### PR DESCRIPTION
## What does this change?
Shows the success message for longer

Previously, we removed the success message from the page after n seconds. Now we keep it on there all the time, only hiding it when Resend Email is clicked

### Before
![b](https://user-images.githubusercontent.com/1336821/130647652-b8efc034-89ac-4203-9445-044e3e954031.gif)


### After
![a](https://user-images.githubusercontent.com/1336821/130647635-b9cf1803-9ddc-4f1a-a7fc-fa00546a1aa2.gif)
