### PR TITLE
Submit form when return key pressed on password field.

### DIFF
--- a/src/client/components/PasswordInput.tsx
+++ b/src/client/components/PasswordInput.tsx
@@ -98,6 +98,7 @@ const EyeSymbol = ({
 
   return (
     <button
+      type="button"
       css={buttonStyles}
       onClick={onClick}
       title="show or hide password text"
@@ -140,11 +141,9 @@ export const PasswordInput = ({
       {isEyeDisplayedOnBrowser ? (
         <EyeSymbol
           isOpen={!passwordVisible}
-          onClick={(event: React.MouseEvent<HTMLButtonElement>) => {
+          onClick={() => {
             // Toggle viewability of password
             setPasswordVisible((previousState) => !previousState);
-            // Prevent the form being submitted
-            event.preventDefault();
           }}
         />
       ) : null}


### PR DESCRIPTION
## What does this change
Behaviour right now: toggles the show password button when return is pressed and the input is focused.

New/desired behaviour:  set password field to submit the form when the return key is pressed and the input is focused. When show password button is focused and return key pressed, it should be toggled.