### PR TITLE
Warn if `CYPRESS_MAILSLURP_KEY` is missing

### DIFF
--- a/cypress-ete.sh
+++ b/cypress-ete.sh
@@ -6,9 +6,17 @@ set -ae
 trap 'kill $(jobs -p)' INT TERM EXIT
 
 source .env
-CI_ENV=$(cat .env | tr '\n' ',')
-CI_ENV=${CI_ENV%?}
-yarn build
-yarn start &
-yarn wait-on:server
-yarn cypress open --env $CI_ENV
+
+if [[ -z "${CYPRESS_MAILSLURP_KEY}" ]]; then
+  echo "You don't have the CYPRESS_MAILSLURP_KEY environment variable set!"
+  echo
+  echo "This key is required to run these ete Cypress tests. You can find your api key here: https://app.mailslurp.com/settings/" 
+  echo
+else
+  CI_ENV=$(cat .env | tr '\n' ',')
+  CI_ENV=${CI_ENV%?}
+  yarn build
+  yarn start &
+  yarn wait-on:server
+  yarn cypress open --env $CI_ENV
+fi


### PR DESCRIPTION
## What does this change?
Adds a check for the `CYPRESS_MAILSLURP_KEY` environment variable and fails the `make cypress-ete` command if it is

## Why?
Because the error message you get from Cypress when this key isn't present isn't very helpful

### Before
<img width="381" alt="Screenshot 2021-08-26 at 10 01 44" src="https://user-images.githubusercontent.com/1336821/130934365-2274ffc7-e58a-4722-8ab8-1248f0b03e53.png">


### After
<img width="851" alt="Screenshot 2021-08-26 at 09 58 58" src="https://user-images.githubusercontent.com/1336821/130933932-27833371-6aad-4da5-8e40-f75845ef8490.png">
