### PR TITLE
Space footer items equally

### DIFF
--- a/src/client/components/Footer.stories.tsx
+++ b/src/client/components/Footer.stories.tsx
@@ -32,3 +32,11 @@ Tablet.parameters = {
     defaultViewport: 'TABLET',
   },
 };
+
+export const Mobile320 = () => <Footer />;
+Mobile320.storyName = 'At mobile 320';
+Mobile320.parameters = {
+  viewport: {
+    defaultViewport: 'MOBILE_320',
+  },
+};

--- a/src/client/components/Footer.tsx
+++ b/src/client/components/Footer.tsx
@@ -47,7 +47,7 @@ const ulStyles = css`
 const columnStyles = css`
   display: flex;
   flex-direction: column;
-  flex-grow: 1;
+  flex-basis: 100%;
   padding-top: ${space[3]}px;
   padding-right: 0;
   padding-bottom: 0;

--- a/src/client/components/Footer.tsx
+++ b/src/client/components/Footer.tsx
@@ -47,7 +47,8 @@ const ulStyles = css`
 const columnStyles = css`
   display: flex;
   flex-direction: column;
-  flex-basis: 100%;
+  flex-basis: 0;
+  flex-grow: 1;
   padding-top: ${space[3]}px;
   padding-right: 0;
   padding-bottom: 0;

--- a/src/client/components/Footer.tsx
+++ b/src/client/components/Footer.tsx
@@ -47,8 +47,7 @@ const ulStyles = css`
 const columnStyles = css`
   display: flex;
   flex-direction: column;
-  flex-basis: 0;
-  flex-grow: 1;
+  flex: 1;
   padding-top: ${space[3]}px;
   padding-right: 0;
   padding-bottom: 0;


### PR DESCRIPTION
## What does this change?
Replaces

```css
flex-basis: auto; /* this was the default previously so wasn't explicitly present */
flex-grow: 1;
```

 with

```css
flex: 1;
```

which is shorthand for

```css
flex-basis: 0;
flex-grow: 1;
```


## Why?
To ensure that all footer groups are evenly spaced.

Some [interesting reading](https://stackoverflow.com/questions/25066214/flexbox-not-giving-equal-width-to-elements/25066844#25066844) on why this change works


### Before
<img width="344" alt="Screenshot 2021-08-26 at 10 58 03" src="https://user-images.githubusercontent.com/1336821/130943117-121ffa0d-433c-4b1b-b82a-67363e9e0129.png">


### After
<img width="344" alt="Screenshot 2021-08-26 at 10 57 36" src="https://user-images.githubusercontent.com/1336821/130943046-3109898f-39ad-408f-a3ae-87cfc020aff2.png">
