### PR TITLE
Update Mailslurp Test

### DIFF
--- a/cypress/integration/ete/reset_password.spec.js
+++ b/cypress/integration/ete/reset_password.spec.js
@@ -4,8 +4,8 @@ describe('Password reset flow', () => {
   context('Account exists', () => {
     // This test depends on this Mailslurp account already being registered
     const existing = {
-      email: '0298a96c-1028-4e3d-b943-a2b478c84dbd@mailslurp.com',
-      inbox: '0298a96c-1028-4e3d-b943-a2b478c84dbd',
+      email: 'a1ae9048-2823-45a0-a0e1-89e8f7a22420@mailslurp.com',
+      inbox: 'a1ae9048-2823-45a0-a0e1-89e8f7a22420',
     };
 
     it("changes the reader's password", () => {


### PR DESCRIPTION
## What does this change?
Sets the Mailslurp inbox to a new one created through an account registered under my name.

This is a temporary solution necessitated by the mail limit enforced by Mailslurp. This should be resolved once we have a paid team account in place.