### PR TITLE
Stack social buttons

### DIFF
--- a/src/client/components/SocialButtons.stories.tsx
+++ b/src/client/components/SocialButtons.stories.tsx
@@ -16,6 +16,7 @@ Desktop.parameters = {
   viewport: {
     defaultViewport: 'DESKTOP',
   },
+  chromatic: { viewports: [1300] },
 };
 
 export const Mobile = () => (
@@ -26,4 +27,5 @@ Mobile.parameters = {
   viewport: {
     defaultViewport: 'MOBILE_320',
   },
+  chromatic: { viewports: [320] },
 };

--- a/src/client/components/SocialButtons.stories.tsx
+++ b/src/client/components/SocialButtons.stories.tsx
@@ -8,7 +8,22 @@ export default {
   component: SocialButtons,
 } as Meta;
 
-export const Default = () => (
+export const Desktop = () => (
   <SocialButtons returnUrl="https://www.theguardian.com/uk/" />
 );
-Default.storyName = 'with defaults';
+Desktop.storyName = 'At desktop';
+Desktop.parameters = {
+  viewport: {
+    defaultViewport: 'DESKTOP',
+  },
+};
+
+export const Mobile = () => (
+  <SocialButtons returnUrl="https://www.theguardian.com/uk/" />
+);
+Mobile.storyName = 'At mobile 320';
+Mobile.parameters = {
+  viewport: {
+    defaultViewport: 'MOBILE_320',
+  },
+};

--- a/src/client/components/SocialButtons.tsx
+++ b/src/client/components/SocialButtons.tsx
@@ -5,6 +5,7 @@ import { LinkButton } from '@guardian/src-button';
 import { SvgGoogleBrand } from '@guardian/src-icons';
 import { SvgAppleBrand } from '@guardian/src-icons';
 import { SvgFacebookBrand } from '@guardian/src-icons';
+import { from } from '@guardian/src-foundations/mq';
 
 type Props = {
   returnUrl: string;
@@ -12,16 +13,22 @@ type Props = {
 
 const containerStyles = css`
   display: flex;
-  flex-direction: row;
+  flex-direction: column;
+  ${from.mobileLandscape} {
+    flex-direction: row;
+  }
   justify-content: center;
+  margin-top: ${space[12]}px;
+  margin-bottom: ${space[12]}px;
   width: 100%;
-  margin: ${space[9]}px 0;
 `;
 
 const buttonOverrides = css`
   border-color: ${brand[400]};
   justify-content: flex-end;
-  min-width: 145px;
+  ${from.mobileLandscape} {
+    min-width: 145px;
+  }
 `;
 
 // TODO: If the issue below is fixed and a new version of Source published with that fix in it, then
@@ -36,7 +43,12 @@ const iconOverrides = css`
 const Gap = () => (
   <span
     css={css`
-      width: ${space[2]}px;
+      width: 0;
+      height: ${space[3]}px;
+      ${from.mobileLandscape} {
+        width: ${space[2]}px;
+        height: 0;
+      }
     `}
   ></span>
 );


### PR DESCRIPTION
## What does this change?
We now respect the [rules laid out in the design system](https://theguardian.design/2a1e5182b/p/435225-button/b/86f344/t/053f03) and stack groups of buttons on mobile

### Before
<img width="341" alt="Screenshot 2021-08-31 at 13 58 29" src="https://user-images.githubusercontent.com/1336821/131508944-4ca3a143-bd2e-4384-966d-45df25ac26ab.png">

### After
<img width="341" alt="Screenshot 2021-08-31 at 13 56 44" src="https://user-images.githubusercontent.com/1336821/131508943-908ee682-1833-44b3-be95-6063ad1d3934.png">

