### PR TITLE
Small CSS tweak to fix formatting on short pages

### DIFF
--- a/src/client/app.tsx
+++ b/src/client/app.tsx
@@ -36,7 +36,7 @@ export const App = (props: ClientState) => {
             height: 100%;
           }
           #app {
-            min-height: 100%;
+            height: 100%;
             display: flex;
             flex-direction: column;
           }


### PR DESCRIPTION
## What does this change?
On short pages (such as the new set password page on the onboarding flow), the vertical line does not go right to the bottom of the page. See screenshots below for the before/after

## Images
Before
<img width="1099" alt="Screenshot 2021-09-02 at 09 45 28" src="https://user-images.githubusercontent.com/33927854/131814052-89adf16b-5fbf-4852-94d0-083c1e99bfac.png">

After
<img width="1099" alt="Screenshot 2021-09-02 at 09 45 56" src="https://user-images.githubusercontent.com/33927854/131814112-edd84cae-8e81-43cf-a0de-c8f18116159f.png">

