### PR TITLE
Migrate from `@guardian/types` to `@guardian/libs`

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "@babel/runtime": "^7.15.4",
     "@emotion/babel-preset-css-prop": "^11.2.0",
     "@guardian/node-riffraff-artifact": "^0.2.2",
-    "@guardian/types": "^8.1.0",
     "@storybook/addon-actions": "^6.3.8",
     "@storybook/addon-essentials": "^6.3.8",
     "@storybook/addon-links": "^6.3.8",

--- a/src/client/lib/ophan.ts
+++ b/src/client/lib/ophan.ts
@@ -1,4 +1,4 @@
-import { OphanABEvent } from '@guardian/types/dist/ophan';
+import { OphanABEvent } from '@guardian/libs';
 
 export interface OphanInteraction {
   component: string;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3167,11 +3167,6 @@
     "@guardian/src-helpers" "^3.9.0"
     "@guardian/src-icons" "^3.9.0"
 
-"@guardian/types@^8.1.0":
-  version "8.1.0"
-  resolved "https://registry.yarnpkg.com/@guardian/types/-/types-8.1.0.tgz#520e16d93c1a8f2bf36c8f4faff5bea81fb9346d"
-  integrity sha512-6qpQxHW+DwvJqc4aPrWIN0GoErTN8R+WlQ4Cq/NJKiIWROvgOytC4P/2hiLNxoEpla93cT56293Fd1cYRUhnPA==
-
 "@hapi/hoek@^9.0.0":
   version "9.0.4"
   resolved "https://registry.yarnpkg.com/@hapi/hoek/-/hoek-9.0.4.tgz#e80ad4e8e8d2adc6c77d985f698447e8628b6010"


### PR DESCRIPTION
## What does this change?

This PR migrates from the [`@guardian/types`](https://github.com/guardian/types) library to [`@guardian/libs`](https://github.com/guardian/libs) as [`@guardian/types` is now deprecated](https://github.com/guardian/types/pull/140).

## How to test

Run all validation and ensure that everything still runs as expected.