### PR TITLE
feat: track referral event in Ophan

### DIFF
--- a/src/client/lib/ophan.ts
+++ b/src/client/lib/ophan.ts
@@ -6,12 +6,16 @@ export interface OphanInteraction {
   atomId?: string;
 }
 
+interface OphanReferrer {
+  viewId?: string;
+}
+
 export interface OphanBase {
   experiences?: string;
   abTestRegister?: { [testId: string]: OphanABEvent };
 }
 
-export type OphanEvent = OphanBase | OphanInteraction;
+export type OphanEvent = OphanBase | OphanInteraction | OphanReferrer;
 
 export const record = (event: OphanEvent) => {
   if (
@@ -28,3 +32,6 @@ export const sendOphanInteractionEvent = ({
   atomId,
   value,
 }: OphanInteraction) => record({ component, atomId, value });
+
+export const sendOphanReferrerEvent = ({ viewId }: OphanReferrer) =>
+  record({ viewId });

--- a/src/client/pages/Welcome.tsx
+++ b/src/client/pages/Welcome.tsx
@@ -9,26 +9,23 @@ import {
 import { getAutoRow, gridItemColumnConsents } from '@/client/styles/Grid';
 import { CONSENTS_PAGES } from '@/client/models/ConsentsPages';
 import { sendOphanReferrerEvent } from '../lib/ophan';
-import { useLocation } from 'react-router-dom';
+
 type Props = {
   submitUrl: string;
   fieldErrors: FieldError[];
+  viewId?: string;
 };
 
-export const Welcome = ({ submitUrl, fieldErrors }: Props) => {
+export const Welcome = ({ submitUrl, fieldErrors, viewId }: Props) => {
   const autoRow = getAutoRow(1, gridItemColumnConsents);
-  const { search } = useLocation();
 
   useEffect(() => {
-    const params = new URLSearchParams(search);
-    const viewId = params.get('viewId');
-
     if (viewId) {
       sendOphanReferrerEvent({
         viewId,
       });
     }
-  }, []);
+  }, [viewId]);
 
   return (
     <ConsentsLayout

--- a/src/client/pages/Welcome.tsx
+++ b/src/client/pages/Welcome.tsx
@@ -8,7 +8,7 @@ import {
 } from '@/client/layouts/shared/Consents';
 import { getAutoRow, gridItemColumnConsents } from '@/client/styles/Grid';
 import { CONSENTS_PAGES } from '@/client/models/ConsentsPages';
-import { sendOphanReferrerEvent } from '../lib/ophan';
+import { sendOphanReferrerEvent } from '@/client/lib/ophan';
 
 type Props = {
   submitUrl: string;

--- a/src/client/pages/Welcome.tsx
+++ b/src/client/pages/Welcome.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { PasswordForm } from '@/client/components/PasswordForm';
 import { FieldError } from '@/shared/model/ClientState';
 import { ConsentsLayout } from '@/client/layouts/ConsentsLayout';
@@ -8,7 +8,8 @@ import {
 } from '@/client/layouts/shared/Consents';
 import { getAutoRow, gridItemColumnConsents } from '@/client/styles/Grid';
 import { CONSENTS_PAGES } from '@/client/models/ConsentsPages';
-
+import { sendOphanReferrerEvent } from '../lib/ophan';
+import { useLocation } from 'react-router-dom';
 type Props = {
   submitUrl: string;
   fieldErrors: FieldError[];
@@ -16,6 +17,19 @@ type Props = {
 
 export const Welcome = ({ submitUrl, fieldErrors }: Props) => {
   const autoRow = getAutoRow(1, gridItemColumnConsents);
+  const { search } = useLocation();
+
+  useEffect(() => {
+    const params = new URLSearchParams(search);
+    const viewId = params.get('viewId');
+
+    if (viewId) {
+      sendOphanReferrerEvent({
+        viewId,
+      });
+    }
+  }, []);
+
   return (
     <ConsentsLayout
       title="Welcome to the Guardian"

--- a/src/client/pages/WelcomePage.tsx
+++ b/src/client/pages/WelcomePage.tsx
@@ -11,10 +11,14 @@ export const WelcomePage = () => {
   const { pageData: { fieldErrors = [] } = {} } = clientState;
   const { token } = useParams<{ token: string }>();
 
+  const params = new URLSearchParams(search);
+  const viewId = params.get('viewId') || undefined;
+
   return (
     <Welcome
       submitUrl={`${Routes.WELCOME}/${token}${search}`}
       fieldErrors={fieldErrors}
+      viewId={viewId}
     />
   );
 };


### PR DESCRIPTION
## What changed?
We use the `viewId` passed in from the account verification email to execute the Ophan referral event once on first render of the `/welcome` flow.