### PR TITLE
Fix Ophan referral on welcome/set password page

### DIFF
--- a/src/client/lib/ophan.ts
+++ b/src/client/lib/ophan.ts
@@ -7,7 +7,8 @@ export interface OphanInteraction {
 }
 
 interface OphanReferrer {
-  viewId?: string;
+  ref?: string;
+  refViewId?: string;
 }
 
 export interface OphanBase {
@@ -33,5 +34,5 @@ export const sendOphanInteractionEvent = ({
   value,
 }: OphanInteraction) => record({ component, atomId, value });
 
-export const sendOphanReferrerEvent = ({ viewId }: OphanReferrer) =>
-  record({ viewId });
+export const sendOphanReferrerEvent = ({ refViewId, ref }: OphanReferrer) =>
+  record({ refViewId, ref });

--- a/src/client/pages/Welcome.tsx
+++ b/src/client/pages/Welcome.tsx
@@ -13,19 +13,26 @@ import { sendOphanReferrerEvent } from '@/client/lib/ophan';
 type Props = {
   submitUrl: string;
   fieldErrors: FieldError[];
-  viewId?: string;
+  refViewId?: string;
+  refUrl?: string;
 };
 
-export const Welcome = ({ submitUrl, fieldErrors, viewId }: Props) => {
+export const Welcome = ({
+  submitUrl,
+  fieldErrors,
+  refViewId,
+  refUrl,
+}: Props) => {
   const autoRow = getAutoRow(1, gridItemColumnConsents);
 
   useEffect(() => {
-    if (viewId) {
+    if (refViewId && refUrl) {
       sendOphanReferrerEvent({
-        viewId,
+        refViewId,
+        ref: refUrl,
       });
     }
-  }, [viewId]);
+  }, [refViewId, refUrl]);
 
   return (
     <ConsentsLayout

--- a/src/client/pages/WelcomePage.tsx
+++ b/src/client/pages/WelcomePage.tsx
@@ -12,13 +12,15 @@ export const WelcomePage = () => {
   const { token } = useParams<{ token: string }>();
 
   const params = new URLSearchParams(search);
-  const viewId = params.get('viewId') || undefined;
+  const refViewId = params.get('refViewId') || undefined;
+  const ref = params.get('ref') || undefined;
 
   return (
     <Welcome
       submitUrl={`${Routes.WELCOME}/${token}${search}`}
       fieldErrors={fieldErrors}
-      viewId={viewId}
+      refViewId={refViewId}
+      refUrl={ref}
     />
   );
 };

--- a/src/server/lib/__tests__/validateUrl.test.ts
+++ b/src/server/lib/__tests__/validateUrl.test.ts
@@ -1,5 +1,5 @@
 import { getConfiguration } from '@/server/lib/getConfiguration';
-import { validateReturnUrl } from '@/server/lib/validateReturnUrl';
+import { validateReturnUrl, validateRefUrl } from '@/server/lib/validateUrl';
 
 // mock configuration to return a default uri
 jest.mock('@/server/lib/getConfiguration', () => ({
@@ -37,5 +37,37 @@ describe('validateReturnUrl', () => {
     const output = validateReturnUrl(input);
 
     expect(output).toEqual(defaultReturnUri);
+  });
+});
+
+describe('validateRefUrl', () => {
+  test('it should successfully validate refUrl', () => {
+    const input =
+      'https://www.theguardian.com/games/2020/mar/16/animal-crossing-new-horizons-review-nintendo-switch';
+
+    const output = validateRefUrl(input);
+
+    expect(output).toEqual(input);
+  });
+
+  test('it should successfully validate refUrl on profile path', () => {
+    const input = 'https://profile.theguardian.com/signin/register';
+
+    const output = validateRefUrl(input);
+
+    expect(output).toEqual(input);
+  });
+
+  test('it should return undefined if refUrl parameter is blank', () => {
+    expect(validateRefUrl()).toEqual(undefined);
+    expect(validateRefUrl('')).toEqual(undefined);
+  });
+
+  test('it should return undefined if the refUrl parameter includes an invalid hostname', () => {
+    const input = 'https://example.com/example/path';
+
+    const output = validateRefUrl(input);
+
+    expect(output).toEqual(undefined);
   });
 });

--- a/src/server/lib/queryParams.ts
+++ b/src/server/lib/queryParams.ts
@@ -1,5 +1,5 @@
 import { QueryParams } from '@/shared/model/QueryParams';
-import { validateReturnUrl } from '@/server/lib/validateReturnUrl';
+import { validateReturnUrl, validateRefUrl } from '@/server/lib/validateUrl';
 import { validateClientId } from '@/server/lib/validateClientId';
 
 const validateEmailVerified = (emailVerified?: string): boolean | undefined => {
@@ -33,11 +33,15 @@ export const parseExpressQueryParams = (
     clientId,
     emailVerified,
     csrfError,
+    refViewId,
+    ref,
   }: {
     returnUrl?: string;
     clientId?: string;
     emailVerified?: string;
     csrfError?: string;
+    refViewId?: string;
+    ref?: string;
   },
 ): QueryParams => {
   return {
@@ -45,6 +49,8 @@ export const parseExpressQueryParams = (
     clientId: validateClientId(clientId),
     emailVerified: validateEmailVerified(emailVerified),
     csrfError: validateCsrfError(method, csrfError),
+    refViewId,
+    ref: ref && validateRefUrl(ref),
   };
 };
 

--- a/src/server/lib/validateUrl.ts
+++ b/src/server/lib/validateUrl.ts
@@ -32,3 +32,21 @@ export const validateReturnUrl = (returnUrl = ''): string => {
     return defaultReturnUri;
   }
 };
+
+export const validateRefUrl = (ref = ''): string | undefined => {
+  try {
+    // we decode the returnUrl as we cant know for sure if it's been encoded or not
+    // so decode just to be safe
+    const url = new URL(decodeURIComponent(ref));
+
+    // check the hostname is valid
+    if (!validHostnames.some((hostname) => url.hostname.endsWith(hostname))) {
+      throw 'Invalid hostname';
+    }
+
+    return `https://${url.hostname}${url.pathname}`;
+  } catch (error) {
+    // error parsing url so return the default
+    return;
+  }
+};

--- a/src/shared/model/QueryParams.ts
+++ b/src/shared/model/QueryParams.ts
@@ -5,4 +5,11 @@ export interface QueryParams extends StringifiableRecord {
   clientId?: string;
   emailVerified?: boolean;
   csrfError?: boolean;
+  // this is the url of the referring page
+  // https://github.com/guardian/ophan/blob/70b658e785c490c411670bbd3c7fde62ae0224fc/the-slab/app/extractors/ReferrerExtractor.scala#L171
+  ref?: string;
+  // this refViewId refers to the referral page view id
+  // that the user was on to use for tracking referrals
+  // https://github.com/guardian/ophan/blob/70b658e785c490c411670bbd3c7fde62ae0224fc/the-slab/app/extractors/ReferrerExtractor.scala#L129
+  refViewId?: string;
 }


### PR DESCRIPTION
## What does this change?

When investigating why the `referrer_page_view_id` was not being populated in the data late, we found that the way we were sending this parameter to ophan was incorrect. Instead of sending just the `viewId` as a parameter using ophan's `record` method, this should actually be called `refViewId` according to the Ophan source files:

https://github.com/guardian/ophan/blob/70b658e785c490c411670bbd3c7fde62ae0224fc/the-slab/app/extractors/ReferrerExtractor.scala#L129

We also realised that we needed to pass a second parameter to Ophan too. This is the `ref` parameter, which is the url of the referrer page.

https://github.com/guardian/ophan/blob/70b658e785c490c411670bbd3c7fde62ae0224fc/the-slab/app/extractors/ReferrerExtractor.scala#L171

This PR renames `viewId` to `refViewId` and adds the `ref` parameter. We then make sure that we're sending these parameters as expected by Ophan.

This PR also adds a method to validate the `ref` url parameter to make sure that it's from a Guardian domain. Which is why `validateReturnUrl.ts` was renamed to `validateUrl.ts` as this now exports multiple methods.