### PR TITLE
Fix Storybook in IE11

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -1,4 +1,5 @@
 const path = require('path');
+const babelConfig = require('../babel.config');
 
 module.exports = {
   stories: ['../src/**/*.stories.mdx', '../src/**/*.stories.@(js|jsx|ts|tsx)'],
@@ -12,7 +13,39 @@ module.exports = {
       mjml: 'mjml-browser',
     };
 
+    // We need to transpile the Guardian and strip-ansi modules so that our vendors bundle will run in IE11.
+    const transpileGuardianModules = {
+      include: [/node_modules[\\\/]@guardian/, /node_modules[\\\/]strip-ansi/],
+      test: /\.(m?)(j|t)s(x?)/,
+      use: [
+        {
+          loader: 'babel-loader',
+          options: {
+            presets: [
+              [
+                '@babel/env',
+                {
+                  bugfixes: true,
+                  useBuiltIns: 'usage',
+                  corejs: '3.14',
+                  modules: 'amd',
+                },
+              ],
+              ...babelConfig.presets,
+            ],
+            plugins: [...babelConfig.plugins],
+          },
+        },
+      ],
+    };
+
     // Return the altered config
-    return config;
+    return {
+      ...config,
+      module: {
+        ...config.module,
+        rules: [...config.module.rules, transpileGuardianModules],
+      },
+    };
   },
 };


### PR DESCRIPTION
## What does this change?
Storybook wasn't working in IE11 because the `@guardian/*` and `strip-ansi` modules were not being transpiled into ES5.

This PR adds a rule to the Storybook webpack configuration which transpiles these files using the same rule that we use for our production build.

This change was made because the Chromatic IE11 build started to fail, presumably because of a change made on their side which failed the build if a render in IE11 couldn't be made (**this is a guess, needs a source to be sure**)
## Screenshots

### Before
<img width="1302" alt="Screenshot 2021-09-23 at 19 58 41" src="https://user-images.githubusercontent.com/1771189/134567474-5b5405f4-0eb7-4903-995e-9ac715e19ca9.png">

### After
<img width="1329" alt="Screenshot 2021-09-23 at 19 48 30" src="https://user-images.githubusercontent.com/1771189/134566126-689790ba-14bc-4f60-be0a-2d72cbf69b21.png">