### PR TITLE
Email copy changes from UX

### DIFF
--- a/src/email/components/Footer.tsx
+++ b/src/email/components/Footer.tsx
@@ -18,33 +18,10 @@ export const Footer = ({ mistakeParagraphComponent }: Props) => (
       >
         {mistakeParagraphComponent}
         <p>
-          If you have any queries about this email please contact our customer
-          services team at{' '}
+          If you have any queries about why you are receiving this email, please
+          contact our customer services team at{' '}
           <Link href="mailto:userhelp@theguardian.com">
             userhelp@theguardian.com
-          </Link>
-          .
-        </p>
-        <p>
-          <strong>Your Data</strong>{' '}
-        </p>
-        <p>
-          To find out what personal data we collect and how we use it, please
-          visit our{' '}
-          <Link href="https://www.theguardian.com/help/privacy-policy">
-            privacy policy
-          </Link>
-          .
-        </p>
-        <p>
-          <strong>Terms & Conditions</strong>
-        </p>
-        <p>
-          By registering with{' '}
-          <Link href="https://www.theguardian.com/">theguardian.com</Link> you
-          agreed to abide by our terms of service, as described at{' '}
-          <Link href="https://www.theguardian.com/help/terms-of-service">
-            https://www.theguardian.com/help/terms-of-service
           </Link>
           .
         </p>

--- a/src/email/templates/Verify/Verify.tsx
+++ b/src/email/templates/Verify/Verify.tsx
@@ -19,9 +19,9 @@ export const Verify = () => {
       <Footer
         mistakeParagraphComponent={
           <p>
-            If you received this email by mistake, simply delete it. You
-            won&apos;t be registered if you don&apos;t click the confirmation
-            button above.
+            If you received this email by mistake, please delete it. You
+            won&apos;t be registered if you don&apos;t click the &ldquo;Complete
+            registration&rdquo; button above.
           </p>
         }
       />

--- a/src/email/templates/Verify/sendVerifyEmail.ts
+++ b/src/email/templates/Verify/sendVerifyEmail.ts
@@ -14,7 +14,7 @@ const { html } = render(Verify());
 
 export const sendVerifyEmail = ({
   to,
-  subject = 'Welcome to the Guardian',
+  subject = 'Please complete your registration',
 }: Props) => {
   return send({
     html,


### PR DESCRIPTION
## What does this change?
- Changes the email copy based on feedback from UX

From the card:

```
Subject "Please complete your registration"
Title "Welcome to the Guardian"
Copy "Please click below to complete your registration"
CTA "Complete registration"
Footer:
"If you received this email by mistake, please delete it. You won’t be registered if you don’t click the ‘Complete registration’ button above.
If you have any queries about why you are receiving this email, please contact our customer service team at userhelp@theguardian.com.

Guardian News and Media Limited, Kings Place, 90 York Way London N1 9GU, United Kingdom"
```