### PR TITLE
Fixing X-Forwarded-For header in IDAPI requests

### DIFF
--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -10,4 +10,5 @@ const server: Express = express();
 applyMiddleware(server);
 
 server.listen(port);
+server.set('trust proxy', true);
 logger.info(`server running on port ${port}`);

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -10,5 +10,5 @@ const server: Express = express();
 applyMiddleware(server);
 
 server.listen(port);
-server.set('trust proxy', true);
+// server.set('trust proxy', true);
 logger.info(`server running on port ${port}`);

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -10,5 +10,5 @@ const server: Express = express();
 applyMiddleware(server);
 
 server.listen(port);
-// server.set('trust proxy', true);
+server.set('trust proxy', true);
 logger.info(`server running on port ${port}`);

--- a/src/server/routes/reset.ts
+++ b/src/server/routes/reset.ts
@@ -42,10 +42,6 @@ router.post(
 
     const { returnUrl } = res.locals.queryParams;
 
-    logger.info(
-      `Debugging IP addresses: req.ip = ${req.ip}, req.ips = ${req.ips}`,
-    );
-
     try {
       await resetPassword(email, req.ip, returnUrl);
 

--- a/src/server/routes/reset.ts
+++ b/src/server/routes/reset.ts
@@ -42,6 +42,10 @@ router.post(
 
     const { returnUrl } = res.locals.queryParams;
 
+    logger.info(
+      `Debugging IP addresses: req.ip = ${req.ip}, req.ips = ${req.ips}`,
+    );
+
     try {
       await resetPassword(email, req.ip, returnUrl);
 


### PR DESCRIPTION
## What does this change?
We are currently sending the IP address of the EC2 instance in the `X-Forwarded-For` header to IDAPI, which is then being used for rate limiting. This configures the Express server to be able to pass in the client's IP address. This is required when the server is sitting behind a reverse proxy (https://expressjs.com/en/guide/behind-proxies.html).

## How to test
This was tested by running gateway `CODE` with and without changing the setting and seeing the different IP addresses being logged and passed through to IDAPI.