### PR TITLE
Update the Grid styles

### DIFF
--- a/src/client/models/Style.ts
+++ b/src/client/models/Style.ts
@@ -2,6 +2,7 @@
 
 export enum Breakpoints {
   WIDE = 1300,
+  LEFT_COL = 1140,
   DESKTOP = 980,
   TABLET = 740,
   // mobile breakpoints differ

--- a/src/client/pages/ConsentsConfirmation.tsx
+++ b/src/client/pages/ConsentsConfirmation.tsx
@@ -122,6 +122,10 @@ const confirmationSpanDefinition: SpanDefinition = {
     start: 2,
     span: 8,
   },
+  LEFT_COL: {
+    start: 2,
+    span: 8,
+  },
   WIDE: {
     start: 3,
     span: 10,

--- a/src/client/pages/ConsentsNewsletters.tsx
+++ b/src/client/pages/ConsentsNewsletters.tsx
@@ -6,6 +6,7 @@ import {
   gridItemColumnConsents,
   getAutoRow,
   consentsParagraphSpanDef,
+  SpanDefinition,
 } from '@/client/styles/Grid';
 import { CONSENTS_PAGES } from '@/client/models/ConsentsPages';
 import { NewsletterCard } from '@/client/components/NewsletterCard';
@@ -30,9 +31,10 @@ const getNewsletterCardCss = (index: number) => {
   const row = Math.trunc(index / ITEMS_PER_ROW) + OFFSET;
   const column = index % ITEMS_PER_ROW;
 
-  const gridDef = {
+  const gridDef: SpanDefinition = {
     TABLET: { start: 2 + column * 5, span: 5 },
     DESKTOP: { start: 2 + column * 5, span: 5 },
+    LEFT_COL: { start: 2 + column * 6, span: 6 },
     WIDE: { start: 3 + column * 6, span: 6 },
   };
 
@@ -51,9 +53,10 @@ const getNewsletterCardCss = (index: number) => {
 };
 
 const getNewsletterCardCssAB = () => {
-  const gridDef = {
+  const gridDef: SpanDefinition = {
     TABLET: { start: 2, span: 10 },
     DESKTOP: { start: 2, span: 10 },
+    LEFT_COL: { start: 2, span: 12 },
     WIDE: { start: 3, span: 12 },
   };
 

--- a/src/client/styles/Grid.stories.tsx
+++ b/src/client/styles/Grid.stories.tsx
@@ -1,0 +1,86 @@
+import React from 'react';
+import { Meta } from '@storybook/react';
+import { getAutoRow, gridRow, manualRow, SpanDefinition } from './Grid';
+
+export default {
+  title: 'Styles/Grid',
+  parameters: { layout: 'fullscreen' },
+} as Meta;
+
+export const Basic = () => {
+  const autoRow = getAutoRow();
+
+  return (
+    <div css={gridRow}>
+      <div css={[autoRow(), { backgroundColor: 'lightseagreen' }]}>
+        This is an item in a grid
+      </div>
+      <div css={[autoRow(), { backgroundColor: 'lightsteelblue' }]}>
+        This is another item in a grid, in another row
+      </div>
+    </div>
+  );
+};
+Basic.storyName = 'Basic layout using autoRow';
+
+export const CustomSpanDefinition = () => {
+  const customSpanDefinition: SpanDefinition = {
+    TABLET: { start: 2, span: 4 },
+    DESKTOP: { start: 3, span: 6 },
+    LEFT_COL: { start: 4, span: 8 },
+    WIDE: { start: 5, span: 10 },
+  };
+
+  const manualSpanDefinition: SpanDefinition = {
+    TABLET: { start: 2, span: 3 },
+    DESKTOP: { start: 3, span: 5 },
+    LEFT_COL: { start: 4, span: 7 },
+    WIDE: { start: 5, span: 9 },
+  };
+
+  const autoRow = getAutoRow(0, customSpanDefinition);
+
+  return (
+    <div css={gridRow}>
+      <div css={[autoRow(), { backgroundColor: 'lightseagreen' }]}>
+        this is using a customSpanDefinition in getAutoRow
+      </div>
+      <div
+        css={[
+          autoRow(manualSpanDefinition),
+          { backgroundColor: 'lightsteelblue' },
+        ]}
+      >
+        this is using a different manualSpanDefinition for this item in autoRow
+      </div>
+    </div>
+  );
+};
+CustomSpanDefinition.storyName = 'CustomSpanDefinition layout using autoRow';
+
+export const Manual = () => {
+  const customSpanDefinition: SpanDefinition = {
+    TABLET: { start: 2, span: 4 },
+    DESKTOP: { start: 3, span: 6 },
+    LEFT_COL: { start: 4, span: 8 },
+    WIDE: { start: 5, span: 10 },
+  };
+
+  return (
+    <div css={gridRow}>
+      <div css={[manualRow(2), { backgroundColor: 'lightseagreen' }]}>
+        This is an item in a grid row, manually set to row 2
+      </div>
+      <div
+        css={[
+          manualRow(1, customSpanDefinition),
+          { backgroundColor: 'lightsteelblue' },
+        ]}
+      >
+        This is another item in a grid, manually set to row 1 with a
+        customSpanDefinition
+      </div>
+    </div>
+  );
+};
+Manual.storyName = 'Manualrow layout using';

--- a/src/client/styles/Grid.ts
+++ b/src/client/styles/Grid.ts
@@ -5,60 +5,94 @@ import { from } from '@guardian/src-foundations/mq';
 
 export enum COLUMNS {
   MOBILE = 4,
+  MOBILE_MEDIUM = 4,
+  MOBILE_LANDSCAPE = 4,
   TABLET = 12,
   DESKTOP = 12,
+  LEFT_COL = 14,
   WIDE = 16,
 }
 
 enum COLUMN_WIDTH {
   MOBILE = 'minmax(0, 1fr)',
+  MOBILE_MEDIUM = 'minmax(0, 1fr)',
+  MOBILE_LANDSCAPE = 'minmax(0, 1fr)',
   TABLET = '40px',
   DESKTOP = '60px',
+  LEFT_COL = '60px',
   WIDE = '60px',
 }
 
 enum SPACING {
-  MOBILE = space[3],
+  MOBILE = 10,
+  MOBILE_MEDIUM = 10,
+  MOBILE_LANDSCAPE = space[5],
   TABLET = space[5],
   DESKTOP = space[5],
+  LEFT_COL = space[5],
   WIDE = space[5],
-}
-
-interface SpanDefinitionStartSpan {
-  start: number;
-  span: number;
-}
-
-export interface SpanDefinition {
-  MOBILE?: SpanDefinitionStartSpan;
-  TABLET?: SpanDefinitionStartSpan;
-  DESKTOP?: SpanDefinitionStartSpan;
-  WIDE?: SpanDefinitionStartSpan;
 }
 
 export type AutoRow = (
   customSpanDefinition?: SpanDefinition | undefined,
 ) => SerializedStyles;
 
+interface SpanDefinitionStartSpan {
+  start: number;
+  span: number;
+}
+
+// the SpanDefinition defines for each breakpoint
+// on which column the item should start
+// and how many columns it should span
+// if a breakpoint isn't provided, it will use the
+// defaultSpanDefinition
+export interface SpanDefinition {
+  MOBILE?: SpanDefinitionStartSpan;
+  MOBILE_MEDIUM?: SpanDefinitionStartSpan;
+  MOBILE_LANDSCAPE?: SpanDefinitionStartSpan;
+  TABLET?: SpanDefinitionStartSpan;
+  DESKTOP?: SpanDefinitionStartSpan;
+  LEFT_COL?: SpanDefinitionStartSpan;
+  WIDE?: SpanDefinitionStartSpan;
+}
+
+// the default span definition spans the whole row
+// for each breakpoint
 const defaultSpanDefinition: Required<SpanDefinition> = {
   MOBILE: {
     start: 1,
     span: COLUMNS.MOBILE,
   },
+  MOBILE_MEDIUM: {
+    start: 1,
+    span: COLUMNS.MOBILE_MEDIUM,
+  },
+  MOBILE_LANDSCAPE: {
+    start: 1,
+    span: COLUMNS.MOBILE_LANDSCAPE,
+  },
   TABLET: { start: 1, span: COLUMNS.TABLET },
   DESKTOP: { start: 1, span: COLUMNS.DESKTOP },
+  LEFT_COL: { start: 1, span: COLUMNS.LEFT_COL },
   WIDE: { start: 1, span: COLUMNS.WIDE },
 };
 
 const px = (num: number) => `${num}px`;
 
-const mw = (c: number, cw: number, gw: number, pw: number): number =>
-  cw * c + (c - 1) * gw + 2 * pw;
+const maxWidth = (
+  numColumns: number,
+  columnWidth: number,
+  gapSize: number,
+  paddingSize: number,
+): number =>
+  columnWidth * numColumns + (numColumns - 1) * gapSize + 2 * paddingSize;
 
 export enum MAX_WIDTH {
-  TABLET = mw(COLUMNS.TABLET, 40, space[5], space[5]),
-  DESKTOP = mw(COLUMNS.DESKTOP, 60, space[5], space[5]),
-  WIDE = mw(COLUMNS.WIDE, 60, space[5], space[5]),
+  TABLET = maxWidth(COLUMNS.TABLET, 40, space[5], space[5]),
+  DESKTOP = maxWidth(COLUMNS.DESKTOP, 60, space[5], space[5]),
+  LEFT_COL = maxWidth(COLUMNS.LEFT_COL, 60, space[5], space[5]),
+  WIDE = maxWidth(COLUMNS.WIDE, 60, space[5], space[5]),
 }
 
 const generateGridRowCss = (
@@ -76,18 +110,36 @@ const generateGridRowCss = (
     max-width: ${maxWidth ? px(maxWidth) : '100%'};
 `;
 
+// this styles should be applied to an element to make it behave as
+// the grid container, it defines the css on how all the breakpoints
+// should behave
+// anything items should be added inside this container, and use
+// either the autoRow/getAutoRow or manualRow functionality to layout the items
 export const gridRow = css`
   display: -ms-grid;
   display: grid;
   width: 100%;
+
+  /* column-gap is always 20px on all breakpoints */
   column-gap: ${px(space[5])};
 
-  -ms-grid-columns: \(${COLUMN_WIDTH.MOBILE}\)\[${COLUMNS.MOBILE}\];
-  grid-template-columns: repeat(${COLUMNS.MOBILE}, ${COLUMN_WIDTH.MOBILE});
-  padding-left: ${px(SPACING.MOBILE)};
-  padding-right: ${px(SPACING.MOBILE)};
-
   ${generateGridRowCss(SPACING.MOBILE, COLUMN_WIDTH.MOBILE, COLUMNS.MOBILE)}
+
+  ${from.mobileMedium} {
+    ${generateGridRowCss(
+      SPACING.MOBILE_MEDIUM,
+      COLUMN_WIDTH.MOBILE_MEDIUM,
+      COLUMNS.MOBILE_MEDIUM,
+    )}
+  }
+
+  ${from.mobileLandscape} {
+    ${generateGridRowCss(
+      SPACING.MOBILE_LANDSCAPE,
+      COLUMN_WIDTH.MOBILE_LANDSCAPE,
+      COLUMNS.MOBILE_LANDSCAPE,
+    )}
+  }
 
   ${from.tablet} {
     ${generateGridRowCss(
@@ -104,6 +156,15 @@ export const gridRow = css`
       COLUMN_WIDTH.DESKTOP,
       COLUMNS.DESKTOP,
       MAX_WIDTH.DESKTOP,
+    )}
+  }
+
+  ${from.leftCol} {
+    ${generateGridRowCss(
+      SPACING.LEFT_COL,
+      COLUMN_WIDTH.LEFT_COL,
+      COLUMNS.LEFT_COL,
+      MAX_WIDTH.LEFT_COL,
     )}
   }
 
@@ -124,7 +185,15 @@ const generateGridItemCss = (columnStart: number, columnSpan: number) => `
 `;
 
 export const gridItem = (spanDefinition?: SpanDefinition) => {
-  const { MOBILE, TABLET, DESKTOP, WIDE } = {
+  const {
+    MOBILE,
+    MOBILE_MEDIUM,
+    MOBILE_LANDSCAPE,
+    TABLET,
+    DESKTOP,
+    LEFT_COL,
+    WIDE,
+  } = {
     ...defaultSpanDefinition,
     ...spanDefinition,
   };
@@ -132,12 +201,24 @@ export const gridItem = (spanDefinition?: SpanDefinition) => {
   return css`
     ${generateGridItemCss(MOBILE.start, MOBILE.span)}
 
+    ${from.mobileMedium} {
+      ${generateGridItemCss(MOBILE_MEDIUM.start, MOBILE_MEDIUM.span)}
+    }
+
+    ${from.mobileLandscape} {
+      ${generateGridItemCss(MOBILE_LANDSCAPE.start, MOBILE_LANDSCAPE.span)}
+    }
+
     ${from.tablet} {
       ${generateGridItemCss(TABLET.start, TABLET.span)}
     }
 
     ${from.desktop} {
       ${generateGridItemCss(DESKTOP.start, DESKTOP.span)}
+    }
+
+    ${from.leftCol} {
+      ${generateGridItemCss(LEFT_COL.start, LEFT_COL.span)}
     }
 
     ${from.wide} {
@@ -149,18 +230,21 @@ export const gridItem = (spanDefinition?: SpanDefinition) => {
 export const gridItemColumnConsents: SpanDefinition = {
   TABLET: { start: 2, span: 10 },
   DESKTOP: { start: 2, span: 10 },
+  LEFT_COL: { start: 2, span: 10 },
   WIDE: { start: 3, span: 12 },
 };
 
 export const consentsParagraphSpanDef: SpanDefinition = {
   TABLET: { start: 2, span: 10 },
   DESKTOP: { start: 2, span: 9 },
+  LEFT_COL: { start: 2, span: 9 },
   WIDE: { start: 3, span: 9 },
 };
 
 export const passwordFormSpanDef: SpanDefinition = {
   TABLET: { start: 2, span: 6 },
   DESKTOP: { start: 2, span: 6 },
+  LEFT_COL: { start: 2, span: 6 },
   WIDE: { start: 3, span: 6 },
 };
 


### PR DESCRIPTION
## What does this change?
Updating the grid styles currently used in Gateway to that defined in our Figma file. The template of which is shown here:

<img width="1198" alt="Screenshot_2021-09-27_at_11 55 09" src="https://user-images.githubusercontent.com/13315440/135288986-74028a61-c049-477c-bf62-597da16548bb.png">

I've also added some storybook files with examples on how to use the grid styles.

Following on from this PR, we will be updating the pages not currently using the grid to use it.