### PR TITLE
Update `Container` padding

### DIFF
--- a/src/client/components/Container.tsx
+++ b/src/client/components/Container.tsx
@@ -3,7 +3,6 @@ import { css } from '@emotion/react';
 import { Container as SourceContainer } from '@guardian/src-layout';
 import { brandLine } from '@guardian/src-foundations/palette';
 import { from } from '@guardian/src-foundations/mq';
-import { space } from '@guardian/src-foundations';
 
 type Props = {
   children: React.ReactNode; // Children are inserted inside the nested div of the section
@@ -16,9 +15,9 @@ type Props = {
 
 const sidePaddingStyles = css`
   > div {
-    padding-left: ${space[3]}px;
-    padding-right: ${space[3]}px;
-    ${from.tablet} {
+    padding-left: 10px;
+    padding-right: 10px;
+    ${from.mobileLandscape} {
       padding-left: 20px;
       padding-right: 20px;
     }


### PR DESCRIPTION
`Container` should use 10px padding left and right until mobileLandscape where it switches to 20px

![chrome_rA1g0MSm8f](https://user-images.githubusercontent.com/13315440/135983692-cb7c3235-b92e-4768-acaa-be7de222f636.png)

`Container` is currently used by `Footer`, `Header`, `Nav`, `SubHeader` components. If we can move some of these components to use grid then we don't need the `Container` anymore. However this PR means that it will at least line up correctly with the grid implementation for those components in the meantime, and for those that cannot use the grid directly.