### PR TITLE
Fix scroll issues by setting min-height on the app

### DIFF
--- a/src/client/app.tsx
+++ b/src/client/app.tsx
@@ -36,7 +36,7 @@ export const App = (props: ClientState) => {
             height: 100%;
           }
           #app {
-            height: 100%;
+            min-height: 100%;
             display: flex;
             flex-direction: column;
           }


### PR DESCRIPTION
## What does this change?
Change the height to a min-height on the `#app` so that on smaller screens there is a scroll.

## Screenshots
#### Before
![IMG_3386](https://user-images.githubusercontent.com/13315440/136214941-09909eed-6f1b-409a-ad78-4839d574f0a4.PNG)

#### After 
![Screenshot 2021-10-06 at 14 46 06](https://user-images.githubusercontent.com/13315440/136215082-5d1cb18d-6369-462c-a59e-274021113b7a.png)
