### PR TITLE
Fix emails missing in storybook by passing `profileUrl` as a prop

### DIFF
--- a/src/email/templates/AccountExists/AccountExists.stories.tsx
+++ b/src/email/templates/AccountExists/AccountExists.stories.tsx
@@ -11,6 +11,8 @@ export default {
 } as Meta;
 
 export const Default = () => {
-  return renderMJML(<AccountExists />);
+  return renderMJML(
+    <AccountExists profileUrl="https://profile.theguardian.com" />,
+  );
 };
 Default.storyName = 'with defaults';

--- a/src/email/templates/AccountExists/AccountExists.tsx
+++ b/src/email/templates/AccountExists/AccountExists.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 
-import { getProfileUrl } from '@/server/lib/getProfileUrl';
 import { Routes } from '@/shared/model/Routes';
 import { Page } from '@/email/components/Page';
 import { Button } from '@/email/components/Button';
@@ -10,9 +9,11 @@ import { Text } from '@/email/components/Text';
 import { Link } from '@/email/components/Link';
 import { Footer } from '@/email/components/Footer';
 
-const profileUrl = getProfileUrl();
+interface Props {
+  profileUrl: string;
+}
 
-export const AccountExists = () => {
+export const AccountExists = ({ profileUrl }: Props) => {
   return (
     <Page>
       <Header />

--- a/src/email/templates/AccountExists/sendAccountExistsEmail.ts
+++ b/src/email/templates/AccountExists/sendAccountExistsEmail.ts
@@ -1,5 +1,6 @@
 import { render } from 'mjml-react';
 import { send } from '@/email/lib/send';
+import { getProfileUrl } from '@/server/lib/getProfileUrl';
 
 import { AccountExists } from './AccountExists';
 import { AccountExistsText } from './AccountExistsText';
@@ -11,7 +12,11 @@ type Props = {
 };
 
 const plainText = AccountExistsText();
-const { html } = render(AccountExists());
+const { html } = render(
+  AccountExists({
+    profileUrl: getProfileUrl(),
+  }),
+);
 
 export const sendAccountExistsEmail = ({
   token,

--- a/src/email/templates/NoAccount/NoAccount.stories.tsx
+++ b/src/email/templates/NoAccount/NoAccount.stories.tsx
@@ -11,6 +11,6 @@ export default {
 } as Meta;
 
 export const Default = () => {
-  return renderMJML(<NoAccount />);
+  return renderMJML(<NoAccount profileUrl="https://profile.theguardian.com" />);
 };
 Default.storyName = 'with defaults';

--- a/src/email/templates/NoAccount/NoAccount.tsx
+++ b/src/email/templates/NoAccount/NoAccount.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 
-import { getProfileUrl } from '@/server/lib/getProfileUrl';
 import { Routes } from '@/shared/model/Routes';
 import { Page } from '@/email/components/Page';
 import { Button } from '@/email/components/Button';
@@ -9,9 +8,11 @@ import { SubHeader } from '@/email/components/SubHeader';
 import { Text } from '@/email/components/Text';
 import { Footer } from '@/email/components/Footer';
 
-const profileUrl = getProfileUrl();
+interface Props {
+  profileUrl: string;
+}
 
-export const NoAccount = () => {
+export const NoAccount = ({ profileUrl }: Props) => {
   return (
     <Page>
       <Header />

--- a/src/email/templates/NoAccount/sendNoAccountEmail.ts
+++ b/src/email/templates/NoAccount/sendNoAccountEmail.ts
@@ -1,5 +1,6 @@
 import { render } from 'mjml-react';
 import { send } from '@/email/lib/send';
+import { getProfileUrl } from '@/server/lib/getProfileUrl';
 
 import { NoAccount } from './NoAccount';
 import { NoAccountText } from './NoAccountText';
@@ -10,7 +11,11 @@ type Props = {
 };
 
 const plainText = NoAccountText();
-const { html } = render(NoAccount());
+const { html } = render(
+  NoAccount({
+    profileUrl: getProfileUrl(),
+  }),
+);
 
 export const sendNoAccountEmail = ({
   to,

--- a/src/email/templates/ResetPassword/ResetPassword.stories.tsx
+++ b/src/email/templates/ResetPassword/ResetPassword.stories.tsx
@@ -11,6 +11,8 @@ export default {
 } as Meta;
 
 export const Default = () => {
-  return renderMJML(<ResetPassword />);
+  return renderMJML(
+    <ResetPassword profileUrl="https://profile.theguardian.com" />,
+  );
 };
 Default.storyName = 'with defaults';

--- a/src/email/templates/ResetPassword/ResetPassword.tsx
+++ b/src/email/templates/ResetPassword/ResetPassword.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 
-import { getProfileUrl } from '@/server/lib/getProfileUrl';
 import { Routes } from '@/shared/model/Routes';
 import { Page } from '@/email/components/Page';
 import { Button } from '@/email/components/Button';
@@ -9,9 +8,11 @@ import { SubHeader } from '@/email/components/SubHeader';
 import { Text } from '@/email/components/Text';
 import { Footer } from '@/email/components/Footer';
 
-const profileUrl = getProfileUrl();
+interface Props {
+  profileUrl: string;
+}
 
-export const ResetPassword = () => {
+export const ResetPassword = ({ profileUrl }: Props) => {
   return (
     <Page>
       <Header />

--- a/src/email/templates/ResetPassword/sendResetPasswordEmail.ts
+++ b/src/email/templates/ResetPassword/sendResetPasswordEmail.ts
@@ -1,5 +1,6 @@
 import { render } from 'mjml-react';
 import { send } from '@/email/lib/send';
+import { getProfileUrl } from '@/server/lib/getProfileUrl';
 
 import { ResetPassword } from './ResetPassword';
 import { ResetPasswordText } from './ResetPasswordText';
@@ -11,7 +12,11 @@ type Props = {
 };
 
 const plainText = ResetPasswordText();
-const { html } = render(ResetPassword());
+const { html } = render(
+  ResetPassword({
+    profileUrl: getProfileUrl(),
+  }),
+);
 
 export const sendResetPasswordEmail = ({
   token,


### PR DESCRIPTION
This is because the remote storybook/remote ui tests wasn't generating the stories for these emails as the `profileUrl` was unable to be derived due to missing environment variables on the github action, but was rendering them locally in storybook as those environment variables were available.

The template of the emails should not rely on calling external methods/environment variables, so we should pass in any values as a prop so that we can render the emails independently.
