### PR TITLE
Fix border lines on consents pages

### DIFF
--- a/src/client/components/ConsentsBlueBackground.tsx
+++ b/src/client/components/ConsentsBlueBackground.tsx
@@ -28,6 +28,10 @@ const height100 = css`
 `;
 
 const flex = css`
+  /* Allow this element to act as flex container,
+   so that children can flex */
+  display: flex;
+  /* Allow this element to grow to the parent flex container */
   flex: 1 1 auto;
 `;
 


### PR DESCRIPTION
## What does this change?

On short pages using the ConsentsLayout and the ConsentsBlueBackground component, the border lines
would not strech to the bottom of the page.

To fix this we allow the ConsentsBlueBackground to act as a flex container, which means that children become flex items allowing them to grow to fill the remaining space.

See also #880 (initial fix) and #964 (which broke #880)

## Images

| Before  | After |
| - | - |
| ![profile thegulocal com_welcome_7031f93f-2401-4b66-8124-c121401f5266_returnUrl=https___m code dev-theguardian com_](https://user-images.githubusercontent.com/13315440/136369689-1711b531-d8e9-4743-95a0-e83383a01232.png) | ![profile thegulocal com_welcome_7031f93f-2401-4b66-8124-c121401f5266_returnUrl=https___m code dev-theguardian com_ (1)](https://user-images.githubusercontent.com/13315440/136369719-36cba851-a8e7-4e54-bb67-23093207267d.png) |
