### PR TITLE
Actually fix lines not extending to bottom on consents page

### DIFF
--- a/src/client/components/ConsentsBlueBackground.tsx
+++ b/src/client/components/ConsentsBlueBackground.tsx
@@ -23,10 +23,6 @@ const blueBorder = css`
   }
 `;
 
-const height100 = css`
-  height: 100%;
-`;
-
 const flex = css`
   /* Allow this element to act as flex container,
    so that children can flex */
@@ -37,6 +33,6 @@ const flex = css`
 
 export const ConsentsBlueBackground = ({ children, cssOverrides }: Props) => (
   <div css={[consentsBackground, flex, cssOverrides]}>
-    <div css={[gridRow, blueBorder, height100]}>{children}</div>
+    <div css={[gridRow, blueBorder]}>{children}</div>
   </div>
 );


### PR DESCRIPTION
## What does this change?
- Turns out we also needed to remove the height too (alongside adding the display flex in #966) , so that an height is automatically set, to properly resolve this issue 😅

## Screenshots

| Before  | After |
| - | - |
| ![profile thegulocal com_welcome_8e10f074-0bc8-45db-bb65-c847b76ebf72_returnUrl=https___m code dev-theguardian com_](https://user-images.githubusercontent.com/13315440/136522190-237d5fb4-3dcd-44f9-b476-f405e6ef5e06.png) |![profile thegulocal com_welcome_8e10f074-0bc8-45db-bb65-c847b76ebf72_returnUrl=https___m code dev-theguardian com_ (1)](https://user-images.githubusercontent.com/13315440/136522232-5a5d255f-479b-495f-8ecb-a428aca1c30c.png) |




