### PR TITLE
Test potential returnUrl timeout fix

### DIFF
--- a/cypress/integration/ete/sign_in.spec.js
+++ b/cypress/integration/ete/sign_in.spec.js
@@ -7,8 +7,10 @@ const existing = {
   password: 'existing_password',
 };
 describe('Sign in flow', () => {
+  // We specify the CAPI json version of the article to reduce page load time waiting for ads.
+  // This change was added because our test was timing out occasionally.
   const returnUrl =
-    'https://www.theguardian.com/world/2013/jun/09/edward-snowden-nsa-whistleblower-surveillance';
+    'https://www.theguardian.com/world/2013/jun/09/edward-snowden-nsa-whistleblower-surveillance.json';
 
   it('links to the correct places', () => {
     cy.visit('/signin');


### PR DESCRIPTION
## What does this change?
This tests a theory that one of our cypress tests was having to wait too long for ad scripts to load before checking the URL of the page when a user signs in and is redirected to a `returnUrl`. Here is the test in question: https://github.com/guardian/gateway/blob/main/cypress/integration/ete/sign_in.spec.js#L60

I've tested this locally and it does seem to take a few seconds before `cypress.url()` is evaluated.

The PR changes the `returnUrl` to point to https://www.theguardian.com/world/2013/jun/09/edward-snowden-nsa-whistleblower-surveillance.json which should take a lot less time to load than the full article.

Hopefully this will stop the timeouts.. or alternatively help us to narrow down the problem.

## Illustration of the number of requests that happen before cypress.url() is checked
![Screenshot 2021-10-20 at 17 56 16](https://user-images.githubusercontent.com/1771189/138137580-34626624-58de-4d9e-8b3e-8648c2a2efba.png)


