### PR TITLE
Fix mocked test returnUrl timeout issue

### DIFF
--- a/cypress/integration/mocked/sign_in.spec.js
+++ b/cypress/integration/mocked/sign_in.spec.js
@@ -58,7 +58,7 @@ describe('Sign in flow', () => {
     });
 
     it('loads the returnUrl upon successful authentication', function () {
-      const returnUrl = 'https://www.theguardian.com/about';
+      const returnUrl = 'https://www.theguardian.com/about.json';
       cy.visit(`/signin?returnUrl=${encodeURIComponent(returnUrl)}`);
       cy.get('input[name="email"]').type('example@example.com');
       cy.get('input[name="password"]').type('password');


### PR DESCRIPTION
## What does this change?
Redirecting to the /about page caused this test to intermittently time out, it's very likely to be the same issue as #1033 where the fix was to redirect to a simple CAPI JSON response for the page. This takes a similar approach, rendering the CAPI JSON output for the about page.

## Example of the timeout
![Screenshot 2021-10-27 at 19 08 38](https://user-images.githubusercontent.com/1771189/139122357-0744d08e-868f-40b8-ab2e-ecd004ae7ae8.png)
