### PR TITLE
Improved reCAPTCHA error messaging

### DIFF
--- a/cypress/integration/ete/register.spec.js
+++ b/cypress/integration/ete/register.spec.js
@@ -300,8 +300,6 @@ describe('Registration flow', () => {
   });
 
   it('errors when the user tries to register offline and allows registration when back online', () => {
-    const reportErrorLink = 'https://www.theguardian.com/info/tech-feedback';
-
     cy.visit('/register');
 
     cy.network({ offline: true });
@@ -317,7 +315,7 @@ describe('Registration flow', () => {
     cy.contains('Report this error').should(
       'have.attr',
       'href',
-      reportErrorLink,
+      'https://manage.theguardian.com/help-centre/contact-us',
     );
     cy.contains('If the problem persists please try the following:');
 

--- a/cypress/integration/ete/register.spec.js
+++ b/cypress/integration/ete/register.spec.js
@@ -300,21 +300,32 @@ describe('Registration flow', () => {
   });
 
   it('errors when the user tries to register offline and allows registration when back online', () => {
+    const reportErrorLink = 'https://www.theguardian.com/info/tech-feedback';
+
     cy.visit('/register');
 
     cy.network({ offline: true });
 
     cy.get('input[name=email').type(unregisteredAccount.email);
     cy.get('[data-cy="register-button"]').click();
-    cy.contains(
-      'There was a problem with the captcha process. You may find disabling your browser plugins, ensuring JavaScript is enabled or updating your browser will resolve this issue.',
+    cy.contains('Google reCAPTCHA verification failed. Please try again.');
+
+    // On second click, an expanded error is shown.
+    cy.get('[data-cy="register-button"]').click();
+
+    cy.contains('Google reCAPTCHA verification failed.');
+    cy.contains('Report this error').should(
+      'have.attr',
+      'href',
+      reportErrorLink,
     );
+    cy.contains('If the problem persists please try the following:');
 
     cy.network({ offline: false });
     const timeRequestWasMade = new Date();
     cy.get('[data-cy="register-button"]').click();
     cy.contains(
-      'There was a problem with the captcha process. You may find disabling your browser plugins, ensuring JavaScript is enabled or updating your browser will resolve this issue.',
+      'Google reCAPTCHA verification failed. Please try again.',
     ).should('not.exist');
 
     cy.contains('Email sent');

--- a/cypress/integration/mocked/register.spec.js
+++ b/cypress/integration/mocked/register.spec.js
@@ -61,9 +61,27 @@ describe('Registration flow', () => {
         statusCode: 500,
       });
       cy.get('[data-cy=register-button]').click();
-      cy.contains(
-        'here was a problem with the captcha process. You may find disabling your browser plugins, ensuring JavaScript is enabled or updating your browser will resolve this issue.',
-      );
+      cy.contains('Google reCAPTCHA verification failed. Please try again.');
+    });
+
+    it('shows detailed recaptcha error message when reCAPTCHA token request fails two times', () => {
+      // Intercept "Report this error" link because we just check it is linked to.
+      const reportErrorLink = 'https://www.theguardian.com/info/tech-feedback';
+      cy.intercept('GET', reportErrorLink, {
+        statusCode: 200,
+      });
+      cy.visit('/register?returnUrl=https%3A%2F%2Fwww.theguardian.com%2Fabout');
+      cy.get('input[name="email"]').type('placeholder@example.com');
+      cy.intercept('POST', 'https://www.google.com/recaptcha/api2/**', {
+        statusCode: 500,
+      });
+      cy.get('[data-cy=register-button]').click();
+      cy.contains('Google reCAPTCHA verification failed. Please try again.');
+      cy.get('[data-cy=register-button]').click();
+      cy.contains('Google reCAPTCHA verification failed.');
+      cy.contains('If the problem persists please try the following:');
+      cy.contains('Report this error').click();
+      cy.url().should('eq', reportErrorLink);
     });
 
     it('redirects to email sent page upon successful guest registration', () => {

--- a/cypress/integration/mocked/register.spec.js
+++ b/cypress/integration/mocked/register.spec.js
@@ -66,10 +66,13 @@ describe('Registration flow', () => {
 
     it('shows detailed recaptcha error message when reCAPTCHA token request fails two times', () => {
       // Intercept "Report this error" link because we just check it is linked to.
-      const reportErrorLink = 'https://www.theguardian.com/info/tech-feedback';
-      cy.intercept('GET', reportErrorLink, {
-        statusCode: 200,
-      });
+      cy.intercept(
+        'GET',
+        'https://manage.theguardian.com/help-centre/contact-us',
+        {
+          statusCode: 200,
+        },
+      );
       cy.visit('/register?returnUrl=https%3A%2F%2Fwww.theguardian.com%2Fabout');
       cy.get('input[name="email"]').type('placeholder@example.com');
       cy.intercept('POST', 'https://www.google.com/recaptcha/api2/**', {
@@ -81,7 +84,10 @@ describe('Registration flow', () => {
       cy.contains('Google reCAPTCHA verification failed.');
       cy.contains('If the problem persists please try the following:');
       cy.contains('Report this error').click();
-      cy.url().should('eq', reportErrorLink);
+      cy.url().should(
+        'eq',
+        'https://manage.theguardian.com/help-centre/contact-us',
+      );
     });
 
     it('redirects to email sent page upon successful guest registration', () => {

--- a/cypress/integration/mocked/welcome.spec.js
+++ b/cypress/integration/mocked/welcome.spec.js
@@ -190,7 +190,7 @@ describe('Welcome and set password page', () => {
       cy.contains('Resend email');
     });
 
-    it.only('shows the session time out page if the token expires while on the set password page', () => {
+    it('shows the session time out page if the token expires while on the set password page', () => {
       cy.mockNext(200, checkTokenSuccessResponse(Date.now() + 1000));
       cy.visit(`/welcome/fake_token`);
       cy.contains('Session timed out');

--- a/src/client/components/DetailedRecaptchaError.stories.tsx
+++ b/src/client/components/DetailedRecaptchaError.stories.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { Meta } from '@storybook/react';
+
+import { DetailedRecaptchaError } from './DetailedRecaptchaError';
+
+export default {
+  title: 'Components/DetailedRecaptchaError',
+  component: DetailedRecaptchaError,
+} as Meta;
+
+export const Default = () => <DetailedRecaptchaError />;
+Default.storyName = 'default';

--- a/src/client/components/DetailedRecaptchaError.tsx
+++ b/src/client/components/DetailedRecaptchaError.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { space } from '@guardian/src-foundations';
+import { css } from '@emotion/react';
+
+const errorContextSpacing = css`
+  margin: 0;
+  margin-top: ${space[2]}px;
+`;
+
+export const DetailedRecaptchaError = () => (
+  <>
+    <p css={errorContextSpacing}>
+      If the problem persists please try the following:
+    </p>
+    <ul css={errorContextSpacing}>
+      <li>Disable your browser plugins</li>
+      <li>Ensure that JavaScript is enabled</li>
+      <li>Update your browser</li>
+    </ul>
+    <p css={[errorContextSpacing, { marginBottom: `${space[3]}px` }]}>
+      For further help please contact our customer service team at{' '}
+      <a href="email:userhelp@theguardian.com">userhelp@theguardian.com</a>
+    </p>
+  </>
+);

--- a/src/client/layouts/MainGrid.tsx
+++ b/src/client/layouts/MainGrid.tsx
@@ -14,6 +14,8 @@ type Props = {
   subTitle?: string;
   successOverride?: string;
   errorOverride?: string;
+  errorContext?: React.ReactNode | string;
+  errorReportUrl?: string;
   children: React.ReactNode;
   gridSpanDefinition?: SpanDefinition;
 };
@@ -49,6 +51,8 @@ export const MainGrid = ({
   subTitle,
   successOverride,
   errorOverride,
+  errorContext,
+  errorReportUrl,
   children,
   gridSpanDefinition,
 }: Props) => {
@@ -68,6 +72,8 @@ export const MainGrid = ({
             <ErrorSummary
               error={errorMessage}
               cssOverrides={errorSummaryMargin}
+              errorReportUrl={errorReportUrl}
+              context={errorContext}
             />
           )}
           {children}

--- a/src/client/lib/hooks/useRecaptcha.tsx
+++ b/src/client/lib/hooks/useRecaptcha.tsx
@@ -86,6 +86,9 @@ type UseRecaptchaReturnValue = {
   // If successful, `token` is set and `error` + `expired` are reset to false.
   // Returns a bool to indicate whether `grecaptcha.execute` was called successfully.
   executeCaptcha: () => void;
+  // Keeps track of the number of times the `executeRecaptcha` has been called.
+  // Initial value: 0.
+  requestCount: number;
 };
 
 /**
@@ -99,7 +102,7 @@ type UseRecaptchaReturnValue = {
  * @param renderElement Element on the page to bind reCAPTCHA to.
  * @param size optional - How the reCAPTCHA check should display on the page.
  * @param src optional - The Google recaptcha script URI.
- * @returns reCAPTCHA check state.
+ * @returns reCAPTCHA check state: UseRecaptchaReturnValue.
  */
 const useRecaptcha: UseRecaptcha = (
   siteKey,
@@ -111,6 +114,7 @@ const useRecaptcha: UseRecaptcha = (
   const [error, setError] = React.useState(false);
   const [expired, setExpired] = React.useState(false);
   const [widgetId, setWidgetId] = React.useState(0);
+  const [requestCount, setRequestCount] = React.useState(0);
 
   // We can't initialise recaptcha if no site key or render element is provided.
   if (siteKey === '' || renderElement === '') {
@@ -120,6 +124,7 @@ const useRecaptcha: UseRecaptcha = (
       expired,
       widgetId,
       executeCaptcha: () => null,
+      requestCount,
     };
   }
 
@@ -158,8 +163,10 @@ const useRecaptcha: UseRecaptcha = (
     window.grecaptcha.reset(widgetId);
     window.grecaptcha.execute(widgetId);
 
+    setRequestCount(requestCount + 1);
+
     return true;
-  }, [widgetId]);
+  }, [widgetId, requestCount]);
 
   return {
     token,
@@ -167,6 +174,7 @@ const useRecaptcha: UseRecaptcha = (
     expired,
     widgetId,
     executeCaptcha,
+    requestCount,
   };
 };
 

--- a/src/client/lib/locations.ts
+++ b/src/client/lib/locations.ts
@@ -3,6 +3,6 @@ export default {
   TERMS: 'https://www.theguardian.com/help/terms-of-service',
   CONTACT_US: 'https://www.theguardian.com/help/contact-us',
   PRIVACY: 'https://www.theguardian.com/info/privacy',
-  REPORT_ISSUE: 'https://www.theguardian.com/info/tech-feedback',
+  REPORT_ISSUE: 'https://manage.theguardian.com/help-centre/contact-us',
   COOKIE_POLICY: 'https://www.theguardian.com/info/cookies',
 };

--- a/src/shared/model/Errors.ts
+++ b/src/shared/model/Errors.ts
@@ -76,5 +76,6 @@ export enum CsrfErrors {
 }
 
 export enum CaptchaErrors {
-  GENERIC = 'There was a problem with the captcha process. You may find disabling your browser plugins, ensuring JavaScript is enabled or updating your browser will resolve this issue.',
+  GENERIC = 'Google reCAPTCHA verification failed. Please try again.',
+  RETRY = 'Google reCAPTCHA verification failed.',
 }


### PR DESCRIPTION
## What does this change?
This PR introduces an expanded error message for the reCAPTCHA check which has extra context.

Adding this expanded error message involved opening two PRs to Source.
* The first was to allow a ReactNode to be passed as the error message context: guardian/source#1107.
* The second was to allow a 'Report this error' link to be passed to the ErrorSummary component: guardian/source#1111.
 
The extended error message (`DetailedRecaptchaError`) is displayed once two or more unsuccessful reCAPTCHA attempts have been made. A link to _**Report this error**_ is added too if this condition has been reached.

## Behaviour on first reCAPTCHA failure
![Screenshot 2021-10-28 at 16 48 30](https://user-images.githubusercontent.com/1771189/139291063-27f3bd26-ec03-403f-9b93-ca554d330cbc.png)

## Behaviour on second and all subsequent reCAPTCHA failures
![Screenshot 2021-10-28 at 16 48 36](https://user-images.githubusercontent.com/1771189/139291081-0a1ffded-b0e1-4a7e-a5a4-603a61c88240.png)

## Reference Figma Designs

### First failure
![Screenshot 2021-10-28 at 17 01 44](https://user-images.githubusercontent.com/1771189/139293072-bf63fec1-d2d6-43a3-977a-98eb043ba62b.png)


### Second + subsequent failures
![Screenshot 2021-10-28 at 17 01 39](https://user-images.githubusercontent.com/1771189/139293087-ae411b24-4790-442a-ac2f-5a2b87d750d8.png)
