### PR TITLE
Update Error spacing and copy

### DIFF
--- a/cypress/integration/ete/sign_in.spec.js
+++ b/cypress/integration/ete/sign_in.spec.js
@@ -42,7 +42,7 @@ describe('Sign in flow', () => {
     cy.get('input[name=email]').type('invalid@doesnotexist.com');
     cy.get('input[name=password]').type('password');
     cy.get('[data-cy="sign-in-button"]').click();
-    cy.contains('This email and password combination is not valid');
+    cy.contains("Email and password don't match");
   });
 
   it('correctly signs in an existing user', () => {

--- a/cypress/integration/mocked/sign_in.spec.js
+++ b/cypress/integration/mocked/sign_in.spec.js
@@ -39,7 +39,7 @@ describe('Sign in flow', () => {
         ],
       });
       cy.get('[data-cy=sign-in-button]').click();
-      cy.contains('This email and password combination is not valid');
+      cy.contains("Email and password don't match");
     });
 
     it('shows a generic error message when the api error response is not known', function () {

--- a/src/client/layouts/MainGrid.tsx
+++ b/src/client/layouts/MainGrid.tsx
@@ -7,7 +7,7 @@ import { SubHeader } from '@/client/components/SubHeader';
 import { GlobalSuccess } from '@/client/components/GlobalSuccess';
 import { ErrorSummary } from '@guardian/source-react-components-development-kitchen';
 import { from } from '@guardian/src-foundations/mq';
-import { topMargin } from '../styles/Shared';
+import { topMargin } from '@/client/styles/Shared';
 import { space } from '@guardian/src-foundations';
 
 type Props = {
@@ -59,7 +59,7 @@ export const MainGrid = ({
   const errorMessage = errorOverride || error;
 
   return (
-    <main css={[mainStyle]}>
+    <main css={mainStyle}>
       <div css={[gridRow, gridStyle]}>
         {subTitle && <SubHeader title={subTitle} />}
         {successMessage && <GlobalSuccess success={successMessage} />}

--- a/src/client/layouts/MainGrid.tsx
+++ b/src/client/layouts/MainGrid.tsx
@@ -6,8 +6,9 @@ import { ClientStateContext } from '@/client/components/ClientState';
 import { SubHeader } from '@/client/components/SubHeader';
 import { GlobalSuccess } from '@/client/components/GlobalSuccess';
 import { ErrorSummary } from '@guardian/source-react-components-development-kitchen';
-import { topMargin } from '@/client/styles/Shared';
 import { from } from '@guardian/src-foundations/mq';
+import { topMargin } from '../styles/Shared';
+import { space } from '@guardian/src-foundations';
 
 type Props = {
   subTitle?: string;
@@ -30,6 +31,20 @@ const gridStyle = css`
   }
 `;
 
+// This extra margin is added to keep the error
+// margin-top 24px above tablet and 20px below
+// the margin-bottom is consistently 12px.
+const errorSummaryMargin = css`
+  margin-bottom: ${space[3]}px;
+  margin-top: ${space[3]}px;
+  ${from.mobileMedium} {
+    margin-top: ${space[1]}px;
+  }
+  ${from.tablet} {
+    margin-top: 0;
+  }
+`;
+
 export const MainGrid = ({
   subTitle,
   successOverride,
@@ -44,13 +59,16 @@ export const MainGrid = ({
   const errorMessage = errorOverride || error;
 
   return (
-    <main css={mainStyle}>
+    <main css={[mainStyle]}>
       <div css={[gridRow, gridStyle]}>
         {subTitle && <SubHeader title={subTitle} />}
         {successMessage && <GlobalSuccess success={successMessage} />}
-        <section css={gridItem(gridSpanDefinition)}>
+        <section css={[gridItem(gridSpanDefinition), topMargin]}>
           {errorMessage && (
-            <ErrorSummary error={errorMessage} cssOverrides={topMargin} />
+            <ErrorSummary
+              error={errorMessage}
+              cssOverrides={errorSummaryMargin}
+            />
           )}
           {children}
         </section>

--- a/src/client/pages/Registration.tsx
+++ b/src/client/pages/Registration.tsx
@@ -9,7 +9,6 @@ import { Footer } from '@/client/components/Footer';
 import { CsrfFormField } from '@/client/components/CsrfFormField';
 import { Terms } from '@/client/components/Terms';
 import { SocialButtons } from '@/client/components/SocialButtons';
-import { topMargin } from '@/client/styles/Shared';
 import { border, space } from '@guardian/src-foundations';
 import { css } from '@emotion/react';
 import { from } from '@guardian/src-foundations/mq';
@@ -126,14 +125,12 @@ export const Registration = ({
         >
           <RecaptchaElement id="register-recaptcha" />
           <CsrfFormField />
-          <div css={topMargin}>
-            <TextInput
-              label="Email"
-              name="email"
-              type="email"
-              defaultValue={email}
-            />
-          </div>
+          <TextInput
+            label="Email"
+            name="email"
+            type="email"
+            defaultValue={email}
+          />
           <Terms />
           <Button css={registerButton} type="submit" data-cy="register-button">
             Register

--- a/src/client/pages/SignIn.tsx
+++ b/src/client/pages/SignIn.tsx
@@ -17,7 +17,6 @@ import { textSans } from '@guardian/src-foundations/typography';
 import { gridItemSignInAndRegistration } from '@/client/styles/Grid';
 import { border, space } from '@guardian/src-foundations';
 import { from } from '@guardian/src-foundations/mq';
-import { topMargin } from '@/client/styles/Shared';
 import { Divider } from '@guardian/source-react-components-development-kitchen';
 import { SignInErrors } from '@/shared/model/Errors';
 
@@ -117,14 +116,12 @@ export const SignIn = ({
         )}
         <form method="post" action={`${Routes.SIGN_IN}${returnUrlQuery}`}>
           <CsrfFormField />
-          <div css={topMargin}>
-            <TextInput
-              label="Email"
-              name="email"
-              type="email"
-              defaultValue={email}
-            />
-          </div>
+          <TextInput
+            label="Email"
+            name="email"
+            type="email"
+            defaultValue={email}
+          />
           <div css={passwordInput}>
             <PasswordInput label="Password" />
           </div>

--- a/src/shared/model/Errors.ts
+++ b/src/shared/model/Errors.ts
@@ -27,7 +27,7 @@ export enum ResetPasswordErrors {
 
 export enum SignInErrors {
   GENERIC = 'There was a problem signing in, please try again.',
-  AUTHENTICATION_FAILED = 'This email and password combination is not valid.',
+  AUTHENTICATION_FAILED = "Email and password don't match",
   ACCOUNT_ALREADY_EXISTS = 'Account already exists',
 }
 


### PR DESCRIPTION
## What does this change?
This sets the spacing between the bottom of the global error message and the form to always be 12px.

The spacing between the top of the error message and the header is set to be 20px until the viewport width hits the `tablet` size when it becomes 24px.

_**Note:** to achieve this, the standard spacing for the form was moved up from the individual SignIn/Registration pages to the MainGrid, so that different `margin-top` spacing could be achieved for the page with/without the error message_

Also makes a small change to the copy for invalid credentials from: **"This email and password combination is not valid"** to **"Email and password don't match."**

## Mobile
### Figma
![Screenshot 2021-10-28 at 17 35 32](https://user-images.githubusercontent.com/1771189/139302525-e1653002-e264-4237-a434-bb1e687acc83.png)

### Implementation
![image](https://user-images.githubusercontent.com/1771189/139305400-bc4ea9e2-75ea-424e-8021-07c36567b9c1.png)

## Desktop
### Figma
![Screenshot 2021-10-28 at 18 12 30](https://user-images.githubusercontent.com/1771189/139303232-f2f4238d-7821-4ae8-9deb-d137c1c7fff8.png)

### Implementation
![image](https://user-images.githubusercontent.com/1771189/139305320-95cadda5-6bc0-471f-85bf-07f46993359d.png)


