### PR TITLE
Remove "orta.vscode-jest" as a recommended ext

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -5,6 +5,5 @@
     "esbenp.prettier-vscode",
     "visualstudioexptteam.vscodeintellicode",
     "ms-vsliveshare.vsliveshare",
-    "christian-kohler.npm-intellisense"
   ]
 }

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -238,5 +238,3 @@ Here's a list of recommended extensions and why we include them:
 - [Live Share](https://marketplace.visualstudio.com/items?itemName=ms-vsliveshare.vsliveshare)
   - Visual Studio Live Share enables you to collaboratively edit and debug with others in real time.
   - **_THE_** pairing tool.
-- [npm Intellisense](https://marketplace.visualstudio.com/items?itemName=christian-kohler.npm-intellisense)
-  - Visual Studio Code plugin that provides autocompletion npm modules in import statements.


### PR DESCRIPTION
### `orta.vscode-jest`
This extension was causing high memory usage in vscode, so recommend to uninstall it and removing it from the recommended extension list.

Jest unit tests can still be run using `make test`/`yarn test`, and I'll keep an eye out for other extensions which provide instant feedback in VSCode

### `npm-intellisense`

This isn't required anymore as VSCode by default autofills imports now. 