### PR TITLE
Github action changes

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -1,7 +1,12 @@
 name: 'Chromatic'
 
 # Event for the workflow
-on: push
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types: ['review_requested']
 
 # List of jobs
 jobs:

--- a/.github/workflows/cypress-ete.yml
+++ b/.github/workflows/cypress-ete.yml
@@ -1,5 +1,10 @@
 name: cypress-ete
-on: push
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types: ['review_requested']
 jobs:
   cypress-ete:
     name: Cypress (ete)

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -4,6 +4,6 @@
     "dbaeumer.vscode-eslint",
     "esbenp.prettier-vscode",
     "visualstudioexptteam.vscodeintellicode",
-    "ms-vsliveshare.vsliveshare",
+    "ms-vsliveshare.vsliveshare"
   ]
 }


### PR DESCRIPTION
## What does this change?
- Change `cypress-ete` and `chromatic` action
  - run on `push` to `main` branch
  - run on `pull_request` `review_requested` in all other cases
- Update formatting in `.vscode/extensions.json`

We update when we run these actions as they are super expensive to run, i.e in the number of total calls we can make to each application.

Within the `cypress-ete` tests, we have a limited number of emails per day that we can send to mailosaur. By limiting it to only when a review is requested from someone, those tests won't run on every commit/push, which should hopefully mean fewer calls overall to mailosaur so that we don't hit our limit. We also do want this to run on every push to the main branch, so we can catch any production problems which may filter through.

This is the same for the `chromatic` action, every number of month there are a limited number of regression tests that we can run at an organization level, by limiting it to review request, we can limit the number of ui tests that we need to run.

Once a review is requested it will only run one, to rerun an action, you can manually go into the action and run it again from there.
 