### PR TITLE
Fix e2e email token retrieval

### DIFF
--- a/cypress/integration/ete/register.spec.js
+++ b/cypress/integration/ete/register.spec.js
@@ -211,7 +211,9 @@ describe('Registration flow', () => {
       const passwordResetUrl = new URL(passwordResetLink.href);
 
       // extract the reset token (so we can reset this reader's password)
-      const match = passwordResetUrl.pathname.match(/\/c\/([^"]*)/);
+      const match = passwordResetUrl.pathname.match(
+        /\/reset-password\/([^"]*)/,
+      );
       const token = match[1];
 
       cy.visit(`/reset-password/${token}`);
@@ -261,10 +263,10 @@ describe('Registration flow', () => {
 
       expect(createPasswordLink).not.to.be.undefined;
 
-      const passwordResetUrl = new URL(createPasswordLink.href);
+      const createPasswordUrl = new URL(createPasswordLink.href);
 
       // extract the reset token (so we can reset this reader's password)
-      const match = passwordResetUrl.pathname.match(/\/c\/([^"]*)/);
+      const match = createPasswordUrl.pathname.match(/\/set-password\/([^"]*)/);
       const token = match[1];
 
       cy.visit(`/reset-password/${token}`);

--- a/cypress/integration/ete/reset_password.spec.js
+++ b/cypress/integration/ete/reset_password.spec.js
@@ -34,7 +34,9 @@ describe('Password reset flow', () => {
         },
       ).then((email) => {
         // extract the reset token (so we can reset this reader's password)
-        const match = email.html.body.match(/theguardian.com\/c\/([^"]*)/);
+        const match = email.html.body.match(
+          /theguardian.com\/reset-password\/([^"]*)/,
+        );
         const token = match[1];
         cy.visit(`/reset-password/${token}`);
         cy.get('input[name=password]').type('0298a96c-1028!@#');


### PR DESCRIPTION
## What does this change?
Changes reset password and registration tests after the path was changed in the reset password email from `c` to `reset-password` or `create-password` where necessary so that our e2e tests can fetch the token from the email body correctly.

[![cypress-ete](https://github.com/guardian/gateway/actions/workflows/cypress-ete.yml/badge.svg?branch=ob%2Ffix-reset-password-test)](https://github.com/guardian/gateway/actions/workflows/cypress-ete.yml)
