### PR TITLE
Adds an eslint plugin for rules of hooks

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -6,7 +6,8 @@
     "plugin:react/recommended",
     "prettier",
     "plugin:jsx-a11y/recommended",
-    "plugin:functional/no-mutations"
+    "plugin:functional/no-mutations",
+    "plugin:react-hooks/recommended"
   ],
   "parserOptions": {
     "ecmaFeatures": {

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "eslint-plugin-jsx-a11y": "^6.5.1",
     "eslint-plugin-prettier": "^4.0.0",
     "eslint-plugin-react": "^7.27.1",
+    "eslint-plugin-react-hooks": "^4.3.0",
     "file-loader": "^6.2.0",
     "fork-ts-checker-notifier-webpack-plugin": "^4.0.0",
     "fork-ts-checker-webpack-plugin": "^6.4.0",

--- a/src/client/lib/hooks/useRecaptcha.test.tsx
+++ b/src/client/lib/hooks/useRecaptcha.test.tsx
@@ -331,17 +331,23 @@ test('should expect an error state when the Google reCAPTCHA script fails to loa
 });
 
 test('should expect an error state when no siteToken is provided', async () => {
-  const { result } = renderHook(() => useRecaptcha('', 'element-id'));
-
-  expect(result.current.token).toBe('');
-  expect(result.current.error).toBe(true);
+  renderHook(() =>
+    expect(() =>
+      useRecaptcha('', 'element-id'),
+    ).toThrowErrorMatchingInlineSnapshot(
+      '"No site key or render element passed"',
+    ),
+  );
 });
 
 test('should expect an error state when no renderElement is provided', async () => {
-  const { result } = renderHook(() => useRecaptcha('valid-site-key', ''));
-
-  expect(result.current.token).toBe('');
-  expect(result.current.error).toBe(true);
+  renderHook(() =>
+    expect(() =>
+      useRecaptcha('valid-site-key', ''),
+    ).toThrowErrorMatchingInlineSnapshot(
+      '"No site key or render element passed"',
+    ),
+  );
 });
 
 test('should try again successfully after an unsuccessful reCAPTCHA check and receive a valid token on the second attempt', async () => {

--- a/src/client/lib/hooks/useRecaptcha.tsx
+++ b/src/client/lib/hooks/useRecaptcha.tsx
@@ -50,7 +50,7 @@ const useRecaptchaScript = (src: string) => {
     recaptchaScriptLoadPromise
       .then(initialiseRecaptcha)
       .catch(() => setError(true));
-  }, []);
+  }, [src]);
 
   return {
     loaded,
@@ -118,14 +118,7 @@ const useRecaptcha: UseRecaptcha = (
 
   // We can't initialise recaptcha if no site key or render element is provided.
   if (siteKey === '' || renderElement === '') {
-    return {
-      token,
-      error: true,
-      expired,
-      widgetId,
-      executeCaptcha: () => null,
-      requestCount,
-    };
+    throw new Error('No site key or render element passed');
   }
 
   const { loaded, error: scriptLoadError } = useRecaptchaScript(src);
@@ -154,7 +147,7 @@ const useRecaptcha: UseRecaptcha = (
       });
       setWidgetId(widgetId);
     }
-  }, [loaded]);
+  }, [loaded, renderElement, siteKey, size]);
 
   const executeCaptcha = React.useCallback(() => {
     if (!recaptchaReady()) {

--- a/src/client/lib/hooks/useRemoveEncryptedEmailParam.tsx
+++ b/src/client/lib/hooks/useRemoveEncryptedEmailParam.tsx
@@ -14,5 +14,5 @@ export const useRemoveEncryptedEmailParam = () => {
       const qs = removeEncryptedParam(search);
       window.history.replaceState(null, '', `${pathname}?${qs}`);
     }
-  }, []);
+  }, [pathname, search]);
 };

--- a/src/client/pages/ChangePasswordPage.tsx
+++ b/src/client/pages/ChangePasswordPage.tsx
@@ -24,7 +24,7 @@ export const ChangePasswordPage = () => {
         window.location.replace(`${Routes.RESET}${Routes.EXPIRED}`);
       }, tokenExpiryTimestamp - Date.now());
     }
-  }, []);
+  }, [tokenExpiryTimestamp]);
 
   return (
     <ChangePassword

--- a/src/client/pages/Registration.stories.tsx
+++ b/src/client/pages/Registration.stories.tsx
@@ -33,7 +33,7 @@ Email.story = {
 };
 
 export const InvalidRecaptcha = (args: RegistrationProps) => (
-  <Registration {...args} recaptchaSiteKey="" />
+  <Registration {...args} recaptchaSiteKey="invalid-key" />
 );
 InvalidRecaptcha.story = {
   name: 'with invalid reCAPTCHA',

--- a/src/client/pages/Registration.tsx
+++ b/src/client/pages/Registration.tsx
@@ -88,7 +88,7 @@ export const Registration = ({
     if (token) {
       registerFormElement?.submit();
     }
-  }, [token]);
+  }, [registerFormRef, token]);
 
   const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();

--- a/src/client/pages/SetPasswordPage.tsx
+++ b/src/client/pages/SetPasswordPage.tsx
@@ -24,7 +24,7 @@ export const SetPasswordPage = () => {
         window.location.replace(`${Routes.SET_PASSWORD}${Routes.EXPIRED}`);
       }, tokenExpiryTimestamp - Date.now());
     }
-  }, []);
+  }, [tokenExpiryTimestamp]);
 
   return (
     <ChangePassword

--- a/src/client/pages/WelcomePage.tsx
+++ b/src/client/pages/WelcomePage.tsx
@@ -23,7 +23,7 @@ export const WelcomePage = () => {
         window.location.replace(`${Routes.WELCOME}${Routes.EXPIRED}`);
       }, tokenExpiryTimestamp - Date.now());
     }
-  }, []);
+  }, [tokenExpiryTimestamp]);
 
   return (
     <Welcome

--- a/yarn.lock
+++ b/yarn.lock
@@ -7387,6 +7387,11 @@ eslint-plugin-prettier@^4.0.0:
   dependencies:
     prettier-linter-helpers "^1.0.0"
 
+eslint-plugin-react-hooks@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.3.0.tgz#318dbf312e06fab1c835a4abef00121751ac1172"
+  integrity sha512-XslZy0LnMn+84NEG9jSGR6eGqaZB3133L8xewQo3fQagbQuGt7a63gf+P1NGKZavEYEC3UXaWEAA/AqDkuN6xA==
+
 eslint-plugin-react@^7.27.1:
   version "7.27.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.27.1.tgz#469202442506616f77a854d91babaae1ec174b45"


### PR DESCRIPTION
## What does this change?
Adds an eslint plugin [^1] that ensures we are following the official React "rules of hooks" as defined here: https://reactjs.org/docs/hooks-rules.html 

It adds a helpful set of intellisense suggestions to vscode for when we make hooks that go against these rules. For example, we need to add a dependency here it shows us in a hint:

![Screenshot 2021-11-18 at 17 17 01](https://user-images.githubusercontent.com/1771189/142464388-44f6b81b-729e-410f-8519-a8dcb847f1c9.png)

Fixes all warnings/errors that the plugin throws up. Includes a small change to the test for going online/offline during the reCAPTCHA test.

[^1]: https://www.npmjs.com/package/eslint-plugin-react-hooks