### PR TITLE
Add `ExternalLink` and `ExternalLinkButton` components

### DIFF
--- a/src/client/components/ExternalLink.tsx
+++ b/src/client/components/ExternalLink.tsx
@@ -1,0 +1,11 @@
+import { LinkButton, LinkButtonProps } from '@guardian/src-button';
+import { Link, LinkProps } from '@guardian/src-link';
+import React from 'react';
+
+export const ExternalLink = (props: LinkProps) => (
+  <Link {...props} rel="noopener noreferrer" />
+);
+
+export const ExternalLinkButton = (props: LinkButtonProps) => (
+  <LinkButton {...props} rel="noopener noreferrer" />
+);

--- a/src/client/components/Footer.tsx
+++ b/src/client/components/Footer.tsx
@@ -9,11 +9,11 @@ import {
 import { space } from '@guardian/src-foundations';
 import { textSans } from '@guardian/src-foundations/typography';
 import { from } from '@guardian/src-foundations/mq';
-import { Link } from '@guardian/src-link';
 import { Hide } from '@guardian/src-layout';
 import locations from '@/client/lib/locations';
 import { BackToTop } from '@/client/components/BackToTop';
 import { Container } from '@/client/components/Container';
+import { ExternalLink } from '@/client/components/ExternalLink';
 
 const footer = css`
   background-color: ${brandBackground.primary};
@@ -146,42 +146,29 @@ export const Footer = () => (
         <div css={ulWrapperStyles}>
           <ul css={[ulStyles, columnStyles]}>
             <li>
-              <Link
-                cssOverrides={linkStyles}
-                href={locations.PRIVACY}
-                rel="noreferrer"
-              >
+              <ExternalLink cssOverrides={linkStyles} href={locations.PRIVACY}>
                 Privacy policy
-              </Link>
+              </ExternalLink>
             </li>
             <li>
-              <Link
+              <ExternalLink
                 cssOverrides={linkStyles}
                 href={locations.CONTACT_US}
-                rel="noreferrer"
               >
                 Contact us
-              </Link>
+              </ExternalLink>
             </li>
           </ul>
           <ul css={[ulStyles, columnStyles, leftBorderStyles]}>
             <li>
-              <Link
-                cssOverrides={linkStyles}
-                href={locations.HELP}
-                rel="noreferrer"
-              >
+              <ExternalLink cssOverrides={linkStyles} href={locations.HELP}>
                 Help
-              </Link>
+              </ExternalLink>
             </li>
             <li>
-              <Link
-                cssOverrides={linkStyles}
-                href={locations.TERMS}
-                rel="noreferrer"
-              >
+              <ExternalLink cssOverrides={linkStyles} href={locations.TERMS}>
                 Terms &amp; conditions
-              </Link>
+              </ExternalLink>
             </li>
           </ul>
           <div css={backToTopStyles}>
@@ -196,46 +183,33 @@ export const Footer = () => (
         <div css={ulWrapperStyles}>
           <ul css={[ulStyles, columnStyles]}>
             <li>
-              <Link
-                cssOverrides={linkStyles}
-                href={locations.PRIVACY}
-                rel="noreferrer"
-              >
+              <ExternalLink cssOverrides={linkStyles} href={locations.PRIVACY}>
                 Privacy policy
-              </Link>
+              </ExternalLink>
             </li>
           </ul>
           <ul css={[ulStyles, columnStyles, leftBorderStyles]}>
             <li>
-              <Link
+              <ExternalLink
                 cssOverrides={linkStyles}
                 href={locations.CONTACT_US}
-                rel="noreferrer"
               >
                 Contact us
-              </Link>
+              </ExternalLink>
             </li>
           </ul>
           <ul css={[ulStyles, columnStyles, leftBorderStyles]}>
             <li>
-              <Link
-                cssOverrides={linkStyles}
-                href={locations.HELP}
-                rel="noreferrer"
-              >
+              <ExternalLink cssOverrides={linkStyles} href={locations.HELP}>
                 Help
-              </Link>
+              </ExternalLink>
             </li>
           </ul>
           <ul css={[ulStyles, columnStyles, leftBorderStyles]}>
             <li>
-              <Link
-                cssOverrides={linkStyles}
-                href={locations.TERMS}
-                rel="noreferrer"
-              >
+              <ExternalLink cssOverrides={linkStyles} href={locations.TERMS}>
                 Terms &amp; conditions
-              </Link>
+              </ExternalLink>
             </li>
           </ul>
           <div css={backToTopStyles}>

--- a/src/client/components/GlobalError.tsx
+++ b/src/client/components/GlobalError.tsx
@@ -10,7 +10,7 @@ import {
   gridRow,
   COLUMNS,
 } from '@/client/styles/Grid';
-import { Link } from '@guardian/src-link';
+import { ExternalLink } from '@/client/components/ExternalLink';
 
 interface GlobalErrorProps {
   error: string;
@@ -76,14 +76,9 @@ export const GlobalError = ({ error, link, left }: GlobalErrorProps) => {
           <div>
             {error}
             &nbsp;
-            <Link
-              href={link.link}
-              css={errorLink}
-              subdued={true}
-              rel="noreferrer"
-            >
+            <ExternalLink href={link.link} css={errorLink} subdued={true}>
               {link.linkText}
-            </Link>
+            </ExternalLink>
           </div>
         </div>
       </div>

--- a/src/client/components/Terms.tsx
+++ b/src/client/components/Terms.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { css } from '@emotion/react';
-import { Link } from '@guardian/src-link';
 import { textSans } from '@guardian/src-foundations/typography';
 import { from } from '@guardian/src-foundations/mq';
 import { space } from '@guardian/src-foundations';
+import { ExternalLink } from '@/client/components/ExternalLink';
 
 const Text = ({ children }: { children: React.ReactNode }) => (
   <p
@@ -27,16 +27,15 @@ const TermsLink = ({
   children: React.ReactNode;
   href: string;
 }) => (
-  <Link
+  <ExternalLink
     subdued={true}
     cssOverrides={css`
       ${textSans.xxsmall()}
     `}
     href={href}
-    rel="noreferrer"
   >
     {children}
-  </Link>
+  </ExternalLink>
 );
 
 const terms = css`

--- a/src/client/pages/ChangePasswordComplete.tsx
+++ b/src/client/pages/ChangePasswordComplete.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { LinkButton } from '@guardian/src-button';
 import { PageBox } from '@/client/components/PageBox';
 import { PageHeader } from '@/client/components/PageHeader';
 import { PageBodyText } from '@/client/components/PageBodyText';
@@ -9,6 +8,7 @@ import { Main } from '@/client/layouts/Main';
 import { Header } from '@/client/components/Header';
 import { Footer } from '@/client/components/Footer';
 import { SvgArrowRightStraight } from '@guardian/src-icons';
+import { ExternalLinkButton } from '@/client/components/ExternalLink';
 
 type ChangePasswordCompleteProps = {
   headerText: string;
@@ -38,16 +38,15 @@ export const ChangePasswordComplete = ({
               </PageBodyText>
             )}
           </PageBody>
-          <LinkButton
+          <ExternalLinkButton
             css={linkButton}
             iconSide="right"
             nudgeIcon={true}
             icon={<SvgArrowRightStraight />}
             href={returnUrl}
-            rel="noreferrer"
           >
             Continue to the Guardian
-          </LinkButton>
+          </ExternalLinkButton>
         </PageBox>
       </Main>
       <Footer />

--- a/src/client/pages/ConsentsConfirmation.tsx
+++ b/src/client/pages/ConsentsConfirmation.tsx
@@ -18,11 +18,13 @@ import { ConsentsBlueBackground } from '@/client/components/ConsentsBlueBackgrou
 import { ConsentsHeader } from '@/client/components/ConsentsHeader';
 import { Footer } from '@/client/components/Footer';
 import { headingWithMq, text } from '@/client/styles/Consents';
-import { Link } from '@guardian/src-link';
-import { LinkButton } from '@guardian/src-button';
 import { SvgArrowRightStraight } from '@guardian/src-icons';
 import { Consent } from '@/shared/model/Consent';
 import { NewsLetter } from '@/shared/model/Newsletter';
+import {
+  ExternalLink,
+  ExternalLinkButton,
+} from '@/client/components/ExternalLink';
 
 type ConsentsConfirmationProps = {
   error?: string;
@@ -169,13 +171,12 @@ export const ConsentsConfirmation = ({
             <h2 css={[headingWithMq, autoRow()]}>Your selections</h2>
             <p css={[text, autoRow()]}>
               You can change these setting anytime by going to{' '}
-              <Link
+              <ExternalLink
                 href="https://manage.theguardian.com/email-prefs"
                 subdued={true}
-                rel="noreferrer"
               >
                 My Preferences
-              </Link>
+              </ExternalLink>
               .
             </p>
             <div css={[reviewTableContainer, autoRow()]}>
@@ -213,15 +214,14 @@ export const ConsentsConfirmation = ({
           </ConsentsContent>
           <ConsentsBlueBackground cssOverrides={continueBoxFlex}>
             <div css={[gridItem(gridItemColumnConsents), controls]}>
-              <LinkButton
+              <ExternalLinkButton
                 iconSide="right"
                 nudgeIcon={true}
                 icon={<SvgArrowRightStraight />}
                 href={returnUrl}
-                rel="noreferrer"
               >
                 Return to the Guardian
-              </LinkButton>
+              </ExternalLinkButton>
             </div>
           </ConsentsBlueBackground>
           <ConsentsContent cssOverrides={newslettersBox}>
@@ -232,13 +232,12 @@ export const ConsentsConfirmation = ({
               We have over 40 different emails that focus on a range of diverse
               topics - from politics and the latest tech to documentaries, sport
               and scientific breakthroughs. Sign up to more in{' '}
-              <Link
+              <ExternalLink
                 href="https://manage.theguardian.com/email-prefs"
                 subdued={true}
-                rel="noreferrer"
               >
                 Guardian newsletters
-              </Link>
+              </ExternalLink>
               .
             </p>
           </ConsentsContent>

--- a/src/client/pages/ConsentsData.tsx
+++ b/src/client/pages/ConsentsData.tsx
@@ -10,7 +10,6 @@ import {
 } from '@/client/styles/Grid';
 import { CONSENTS_PAGES } from '@/client/models/ConsentsPages';
 import { heading, text, headingMarginSpace6 } from '@/client/styles/Consents';
-import { Link } from '@guardian/src-link';
 import { Checkbox, CheckboxGroup } from '@guardian/src-checkbox';
 import { ConsentsLayout } from '@/client/layouts/ConsentsLayout';
 import {
@@ -18,6 +17,7 @@ import {
   CONSENTS_MAIN_COLOR,
 } from '@/client/layouts/shared/Consents';
 import { Consents } from '@/shared/model/Consent';
+import { ExternalLink } from '@/client/components/ExternalLink';
 
 type ConsentsDataProps = {
   consented?: boolean;
@@ -55,14 +55,13 @@ export const ConsentsData = ({ consented, description }: ConsentsDataProps) => {
             team who are dedicated to keeping any data we collect safe and
             secure. You can find out more about how the Guardian aims to
             safeguard users data by going to the{' '}
-            <Link
+            <ExternalLink
               href={Locations.PRIVACY}
               subdued={true}
               target="_blank"
-              rel="noopener noreferrer"
             >
               Privacy
-            </Link>{' '}
+            </ExternalLink>{' '}
             section of the website.
           </p>
           <h2 css={[heading, headingMarginSpace6, autoRow()]}>

--- a/src/client/pages/MagicLink.tsx
+++ b/src/client/pages/MagicLink.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { css } from '@emotion/react';
-import { Link } from '@guardian/src-link';
 import { textSans } from '@guardian/src-foundations/typography';
 import { TextInput } from '@guardian/src-text-input';
 import { Button } from '@guardian/src-button';
@@ -12,7 +11,8 @@ import { Header } from '@/client/components/Header';
 import { Footer } from '@/client/components/Footer';
 import { Routes } from '@/shared/model/Routes';
 import { button, form, textInput } from '@/client/styles/Shared';
-import { CsrfFormField } from '../components/CsrfFormField';
+import { CsrfFormField } from '@/client/components/CsrfFormField';
+import { ExternalLink } from '@/client/components/ExternalLink';
 
 type Props = {
   email?: string;
@@ -52,9 +52,9 @@ export const MagicLink = ({ email }: Props) => {
                 `}
               >
                 If you no longer have access to this email account please{' '}
-                <Link subdued={true} href="/help/contact-us" rel="noreferrer">
+                <ExternalLink subdued={true} href="/help/contact-us">
                   contact our help department
-                </Link>
+                </ExternalLink>
               </p>
             </form>
           </PageBody>

--- a/src/client/pages/NotFoundPage.tsx
+++ b/src/client/pages/NotFoundPage.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { css } from '@emotion/react';
 import locations from '@/client/lib/locations';
-import { Link } from '@guardian/src-link';
 import { PageBox } from '@/client/components/PageBox';
 import { PageHeader } from '@/client/components/PageHeader';
 import { PageBody } from '@/client/components/PageBody';
@@ -9,6 +8,7 @@ import { PageBodyText } from '@/client/components/PageBodyText';
 import { Main } from '@/client/layouts/Main';
 import { Header } from '@/client/components/Header';
 import { Footer } from '@/client/components/Footer';
+import { ExternalLink } from '@/client/components/ExternalLink';
 
 const link = css`
   display: inline-block;
@@ -24,14 +24,13 @@ export const NotFoundPage = () => (
           <PageBodyText>
             You may have followed an outdated link, or have mistyped a URL. If
             you believe this to be an error, please{' '}
-            <Link
+            <ExternalLink
               css={link}
               href={locations.REPORT_ISSUE}
               subdued={true}
-              rel="noreferrer"
             >
               report it
-            </Link>
+            </ExternalLink>
             .
           </PageBodyText>
         </PageBody>

--- a/src/client/pages/UnexpectedErrorPage.tsx
+++ b/src/client/pages/UnexpectedErrorPage.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { css } from '@emotion/react';
 import locations from '@/client/lib/locations';
-import { Link } from '@guardian/src-link';
 import { PageBox } from '@/client/components/PageBox';
 import { PageHeader } from '@/client/components/PageHeader';
 import { PageBody } from '@/client/components/PageBody';
@@ -9,6 +8,7 @@ import { PageBodyText } from '@/client/components/PageBodyText';
 import { Main } from '@/client/layouts/Main';
 import { Header } from '@/client/components/Header';
 import { Footer } from '@/client/components/Footer';
+import { ExternalLink } from '@/client/components/ExternalLink';
 
 const link = css`
   display: inline-block;
@@ -23,14 +23,13 @@ export const UnexpectedErrorPage = () => (
         <PageBody>
           <PageBodyText>
             An error occurred, please try again or{' '}
-            <Link
+            <ExternalLink
               css={link}
               href={locations.REPORT_ISSUE}
               subdued={true}
-              rel="noreferrer"
             >
               report it
-            </Link>
+            </ExternalLink>
             .
           </PageBodyText>
         </PageBody>


### PR DESCRIPTION
We want to apply `noreferrer` and `noopener` on external links for security reasons.

We could easily apply these to the `rel` attribute on the source `Link`/`LinkButton` component, but to be more explicit that the link is pointing externally, we create the `ExternalLink` and `ExternalLinkButton` components that extends the link component with the attribute already applied.
