### PR TITLE
Use test user endpoint in Cypress

### DIFF
--- a/.github/workflows/cypress-ete.yml
+++ b/.github/workflows/cypress-ete.yml
@@ -22,6 +22,7 @@ jobs:
           BASE_URI: localhost:8861
           IDAPI_CLIENT_ACCESS_TOKEN: ${{ secrets.IDAPI_CLIENT_ACCESS_TOKEN }}
           IDAPI_BASE_URL: https://idapi.code.dev-theguardian.com
+          CYPRESS_IDAPI_BASE_URL: https://idapi.code.dev-theguardian.com
           PLAY_SESSION_COOKIE_SECRET: ${{ secrets.PLAY_SESSION_COOKIE_SECRET }}
           DEFAULT_RETURN_URI: https://m.code.dev-theguardian.com
           CYPRESS_DEFAULT_RETURN_URI: https://m.code.dev-theguardian.com

--- a/.github/workflows/cypress-ete.yml
+++ b/.github/workflows/cypress-ete.yml
@@ -21,6 +21,7 @@ jobs:
           STAGE: CODE
           BASE_URI: localhost:8861
           IDAPI_CLIENT_ACCESS_TOKEN: ${{ secrets.IDAPI_CLIENT_ACCESS_TOKEN }}
+          CYPRESS_IDAPI_CLIENT_ACCESS_TOKEN: ${{ secrets.IDAPI_CLIENT_ACCESS_TOKEN }}
           IDAPI_BASE_URL: https://idapi.code.dev-theguardian.com
           CYPRESS_IDAPI_BASE_URL: https://idapi.code.dev-theguardian.com
           PLAY_SESSION_COOKIE_SECRET: ${{ secrets.PLAY_SESSION_COOKIE_SECRET }}

--- a/cypress/integration/ete/registration/register.spec.ts
+++ b/cypress/integration/ete/registration/register.spec.ts
@@ -119,7 +119,6 @@ describe('Registration flow', () => {
 
   it('sends user an account exists email for user with existing account with password trying to register, clicks sign in, taken to /signin', () => {
     cy.createTestUser({
-      password: 'test_password',
       isUserEmailValidated: true,
     })?.then(({ emailAddress }) => {
       cy.visit('/register');
@@ -157,7 +156,6 @@ describe('Registration flow', () => {
 
   it('sends user an account exists email for user with existing account with password trying to register, clicks reset password on email', () => {
     cy.createTestUser({
-      password: 'test_password',
       isUserEmailValidated: true,
     })?.then(({ emailAddress }) => {
       cy.visit('/register');

--- a/cypress/integration/ete/registration/register.spec.ts
+++ b/cypress/integration/ete/registration/register.spec.ts
@@ -198,6 +198,7 @@ describe('Registration flow', () => {
   it('sends user an account exists without password email for user with existing account without password trying to register, clicks create password on email', () => {
     cy.createTestUser({
       isUserEmailValidated: false,
+      isGuestUser: true,
     })?.then(({ emailAddress }) => {
       cy.visit('/register');
       const timeRequestWasMade = new Date();

--- a/cypress/integration/ete/registration/register.spec.ts
+++ b/cypress/integration/ete/registration/register.spec.ts
@@ -1,31 +1,4 @@
-import { v4 as uuidv4 } from 'uuid';
-
-const unregisteredAccount = {
-  serverId: Cypress.env('MAILOSAUR_SERVER_ID'),
-  serverDomain: Cypress.env('MAILOSAUR_SERVER_ID') + '.mailosaur.net',
-  email:
-    'registrationTest+' +
-    uuidv4() +
-    '@' +
-    Cypress.env('MAILOSAUR_SERVER_ID') +
-    '.mailosaur.net',
-};
-
-// This test depends on this Mailosaur account already being registered
-const existingWithPassword = {
-  serverId: Cypress.env('MAILOSAUR_SERVER_ID'),
-  serverDomain: Cypress.env('MAILOSAUR_SERVER_ID') + '.mailosaur.net',
-  email: 'signIn@' + Cypress.env('MAILOSAUR_SERVER_ID') + '.mailosaur.net',
-};
-
-const existingWithoutPassword = {
-  serverId: Cypress.env('MAILOSAUR_SERVER_ID'),
-  serverDomain: Cypress.env('MAILOSAUR_SERVER_ID') + '.mailosaur.net',
-  email:
-    'registrationEmailSentPage@' +
-    Cypress.env('MAILOSAUR_SERVER_ID') +
-    '.mailosaur.net',
-};
+import { randomMailosaurEmail } from '../../../support/commands/testUser';
 
 describe('Registration flow', () => {
   context('Terms and Conditions links', () => {
@@ -110,6 +83,9 @@ describe('Registration flow', () => {
     const encodedRef = 'https%3A%2F%2Fm.theguardian.com';
     const decodedRef = 'https://m.theguardian.com/';
     const refViewId = 'testRefViewId';
+
+    const unregisteredEmail = randomMailosaurEmail();
+
     cy.visit(
       '/register?returnUrl=' +
         encodedReturnUrl +
@@ -119,182 +95,155 @@ describe('Registration flow', () => {
         refViewId,
     );
     const timeRequestWasMade = new Date();
-    cy.get('input[name=email]').type(unregisteredAccount.email);
+    cy.get('input[name=email]').type(unregisteredEmail);
     cy.get('[data-cy="register-button"]').click();
 
     cy.contains('Email sent');
-    cy.contains(unregisteredAccount.email);
+    cy.contains(unregisteredEmail);
     cy.contains('Resend email');
     cy.contains('Change email address');
 
-    cy.mailosaurGetMessage(
-      unregisteredAccount.serverId,
-      {
-        sentTo: unregisteredAccount.email,
-      },
-      {
-        receivedAfter: timeRequestWasMade,
-      },
-    ).then((email) => {
-      cy.getEmailDetails(email, /theguardian.com\/welcome\/([^"]*)/).then(
-        ({ id, body, token }) => {
-          expect(body).to.have.string('Complete registration');
-          expect(body).to.have.string('returnUrl=' + decodedReturnUrl);
-          expect(body).to.have.string('ref=' + decodedRef);
-          expect(body).to.have.string('refViewId=' + refViewId);
-          cy.visit(`/welcome/${token}`);
-          cy.contains('Create password');
-          cy.mailosaurDeleteMessage(id);
-        },
-      );
+    cy.checkForEmailAndGetDetails(
+      unregisteredEmail,
+      timeRequestWasMade,
+      /welcome\/([^"]*)/,
+    ).then(({ body, token }) => {
+      expect(body).to.have.string('Complete registration');
+      expect(body).to.have.string('returnUrl=' + decodedReturnUrl);
+      expect(body).to.have.string('ref=' + decodedRef);
+      expect(body).to.have.string('refViewId=' + refViewId);
+      cy.visit(`/welcome/${token}`);
+      cy.contains('Create password');
     });
   });
 
   it('sends user an account exists email for user with existing account with password trying to register, clicks sign in, taken to /signin', () => {
-    cy.visit('/register');
-    const timeRequestWasMade = new Date();
+    cy.createTestUser({
+      password: 'test_password',
+      isUserEmailValidated: true,
+    })?.then(({ emailAddress }) => {
+      cy.visit('/register');
+      const timeRequestWasMade = new Date();
 
-    cy.get('input[name=email]').type(existingWithPassword.email);
-    cy.get('[data-cy="register-button"]').click();
+      cy.get('input[name=email]').type(emailAddress);
+      cy.get('[data-cy="register-button"]').click();
 
-    cy.contains('Email sent');
-    cy.contains(existingWithPassword.email);
-    cy.contains('Resend email');
-    cy.contains('Change email address');
+      cy.contains('Email sent');
+      cy.contains(emailAddress);
+      cy.contains('Resend email');
+      cy.contains('Change email address');
 
-    cy.mailosaurGetMessage(
-      unregisteredAccount.serverId,
-      {
-        sentTo: existingWithPassword.email,
-      },
-      {
-        receivedAfter: timeRequestWasMade,
-      },
-    ).then((email) => {
-      cy.getEmailDetails(email).then(({ links, body, id }) => {
-        expect(body).to.have.string('This account already exists');
-        expect(body).to.have.string('Sign in');
-        expect(body).to.have.string('Reset password');
+      cy.checkForEmailAndGetDetails(emailAddress, timeRequestWasMade).then(
+        ({ links, body }) => {
+          expect(body).to.have.string('This account already exists');
+          expect(body).to.have.string('Sign in');
+          expect(body).to.have.string('Reset password');
 
-        expect(links.length).to.eq(3);
+          expect(links.length).to.eq(3);
 
-        const signInLink = links.find((link) => link.text === 'Sign in');
+          const signInLink = links.find((link) => link.text === 'Sign in');
 
-        expect(signInLink).not.to.be.undefined;
-        expect(signInLink?.href ?? '').to.include('/signin');
+          expect(signInLink).not.to.be.undefined;
+          expect(signInLink?.href ?? '').to.include('/signin');
 
-        const signInUrl = new URL(signInLink?.href ?? '');
+          const signInUrl = new URL(signInLink?.href ?? '');
 
-        cy.visit(signInUrl.pathname);
-        cy.url().should('include', '/signin');
-
-        cy.mailosaurDeleteMessage(id);
-      });
+          cy.visit(signInUrl.pathname);
+          cy.url().should('include', '/signin');
+        },
+      );
     });
   });
 
   it('sends user an account exists email for user with existing account with password trying to register, clicks reset password on email', () => {
-    cy.visit('/register');
-    const timeRequestWasMade = new Date();
+    cy.createTestUser({
+      password: 'test_password',
+      isUserEmailValidated: true,
+    })?.then(({ emailAddress }) => {
+      cy.visit('/register');
+      const timeRequestWasMade = new Date();
 
-    cy.get('input[name=email]').type(existingWithPassword.email);
-    cy.get('[data-cy="register-button"]').click();
+      cy.get('input[name=email]').type(emailAddress);
+      cy.get('[data-cy="register-button"]').click();
 
-    cy.contains('Email sent');
-    cy.contains(existingWithPassword.email);
-    cy.contains('Resend email');
-    cy.contains('Change email address');
+      cy.contains('Email sent');
+      cy.contains(emailAddress);
+      cy.contains('Resend email');
+      cy.contains('Change email address');
 
-    cy.mailosaurGetMessage(
-      unregisteredAccount.serverId,
-      {
-        sentTo: existingWithPassword.email,
-      },
-      {
-        receivedAfter: timeRequestWasMade,
-      },
-    ).then((email) => {
-      cy.getEmailDetails(email, /\/reset-password\/([^"]*)/).then(
-        ({ links, body, id, token }) => {
-          expect(body).to.have.string('This account already exists');
-          expect(body).to.have.string('Sign in');
-          expect(body).to.have.string('Reset password');
-          expect(body).to.have.string(
-            'This link is only valid for 30 minutes.',
-          );
+      cy.checkForEmailAndGetDetails(
+        emailAddress,
+        timeRequestWasMade,
+        /\/reset-password\/([^"]*)/,
+      ).then(({ links, body, token }) => {
+        expect(body).to.have.string('This account already exists');
+        expect(body).to.have.string('Sign in');
+        expect(body).to.have.string('Reset password');
+        expect(body).to.have.string('This link is only valid for 30 minutes.');
 
-          expect(links.length).to.eq(3);
+        expect(links.length).to.eq(3);
 
-          const passwordResetLink = links.find(
-            (link) => link.text === 'Reset password',
-          );
+        const passwordResetLink = links.find(
+          (link) => link.text === 'Reset password',
+        );
 
-          expect(passwordResetLink).not.to.be.undefined;
+        expect(passwordResetLink).not.to.be.undefined;
 
-          cy.visit(`/reset-password/${token}`);
-          cy.contains('Reset password');
-
-          cy.mailosaurDeleteMessage(id);
-        },
-      );
+        cy.visit(`/reset-password/${token}`);
+        cy.contains('Reset password');
+      });
     });
   });
 
   it('sends user an account exists without password email for user with existing account without password trying to register, clicks create password on email', () => {
-    cy.visit('/register');
-    const timeRequestWasMade = new Date();
+    cy.createTestUser({
+      isUserEmailValidated: false,
+    })?.then(({ emailAddress }) => {
+      cy.visit('/register');
+      const timeRequestWasMade = new Date();
 
-    cy.get('input[name=email]').type(existingWithoutPassword.email);
-    cy.get('[data-cy="register-button"]').click();
+      cy.get('input[name=email]').type(emailAddress);
+      cy.get('[data-cy="register-button"]').click();
 
-    cy.contains('Email sent');
-    cy.contains(existingWithoutPassword.email);
-    cy.contains('Resend email');
-    cy.contains('Change email address');
+      cy.contains('Email sent');
+      cy.contains(emailAddress);
+      cy.contains('Resend email');
+      cy.contains('Change email address');
 
-    cy.mailosaurGetMessage(
-      unregisteredAccount.serverId,
-      {
-        sentTo: existingWithoutPassword.email,
-      },
-      {
-        receivedAfter: timeRequestWasMade,
-      },
-    ).then((email) => {
-      cy.getEmailDetails(email, /\/set-password\/([^"]*)/).then(
-        ({ links, body, id, token }) => {
-          expect(body).to.have.string('This account already exists');
-          expect(body).to.have.string(
-            'To continue to your account please click below to create a password.',
-          );
-          expect(body).to.have.string(
-            'This link is only valid for 30 minutes.',
-          );
-          expect(body).to.have.string('Create password');
+      cy.checkForEmailAndGetDetails(
+        emailAddress,
+        timeRequestWasMade,
+        /\/set-password\/([^"]*)/,
+      ).then(({ links, body, token }) => {
+        expect(body).to.have.string('This account already exists');
+        expect(body).to.have.string(
+          'To continue to your account please click below to create a password.',
+        );
+        expect(body).to.have.string('This link is only valid for 30 minutes.');
+        expect(body).to.have.string('Create password');
 
-          expect(links.length).to.eq(2);
+        expect(links.length).to.eq(2);
 
-          const createPasswordLink = links.find(
-            (link) => link.text === 'Create password',
-          );
+        const createPasswordLink = links.find(
+          (link) => link.text === 'Create password',
+        );
 
-          expect(createPasswordLink).not.to.be.undefined;
+        expect(createPasswordLink).not.to.be.undefined;
 
-          cy.visit(`/set-password/${token}`);
-          cy.contains('Create password');
-
-          cy.mailosaurDeleteMessage(id);
-        },
-      );
+        cy.visit(`/set-password/${token}`);
+        cy.contains('Create password');
+      });
     });
   });
 
   it('errors when the user tries to register offline and allows registration when back online', () => {
+    const unregisteredEmail = randomMailosaurEmail();
+
     cy.visit('/register');
 
     cy.network({ offline: true });
 
-    cy.get('input[name=email').type(unregisteredAccount.email);
+    cy.get('input[name=email').type(unregisteredEmail);
     cy.get('[data-cy="register-button"]').click();
     cy.contains('Google reCAPTCHA verification failed. Please try again.');
 
@@ -317,20 +266,12 @@ describe('Registration flow', () => {
     ).should('not.exist');
 
     cy.contains('Email sent');
-    cy.contains(unregisteredAccount.email);
+    cy.contains(unregisteredEmail);
 
-    cy.mailosaurGetMessage(
-      unregisteredAccount.serverId,
-      {
-        sentTo: unregisteredAccount.email,
+    cy.checkForEmailAndGetDetails(unregisteredEmail, timeRequestWasMade).then(
+      ({ body }) => {
+        expect(body).to.have.string('Complete registration');
       },
-      {
-        receivedAfter: timeRequestWasMade,
-      },
-    ).then((email) => {
-      cy.getEmailDetails(email).then(({ id }) => {
-        cy.mailosaurDeleteMessage(id);
-      });
-    });
+    );
   });
 });

--- a/cypress/integration/ete/registration/register_email_sent.spec.ts
+++ b/cypress/integration/ete/registration/register_email_sent.spec.ts
@@ -98,6 +98,7 @@ describe('Registration email sent page', () => {
   it('should resend account exists without password email when an existing user without password registers which is same as initial email sent', () => {
     cy.createTestUser({
       isUserEmailValidated: false,
+      isGuestUser: true,
     })?.then(({ emailAddress }) => {
       cy.visit('/register');
       cy.get('input[name=email]').type(emailAddress);

--- a/cypress/integration/ete/registration/register_email_sent.spec.ts
+++ b/cypress/integration/ete/registration/register_email_sent.spec.ts
@@ -1,29 +1,13 @@
 import { injectAndCheckAxe } from '../../../support/cypress-axe';
-import { v4 as uuidv4 } from 'uuid';
+import { randomMailosaurEmail } from '../../../support/commands/testUser';
 
 describe('Registration email sent page', () => {
+  // This needs to remain static for now, because we can't generate a PLAY_SESSION_2 encrypted email.
   const existingWithoutPassword = {
     serverId: Cypress.env('MAILOSAUR_SERVER_ID'),
     serverDomain: Cypress.env('MAILOSAUR_SERVER_ID') + '.mailosaur.net',
     email:
       'registrationEmailSentPage@' +
-      Cypress.env('MAILOSAUR_SERVER_ID') +
-      '.mailosaur.net',
-  };
-
-  const existingWithPassword = {
-    serverId: Cypress.env('MAILOSAUR_SERVER_ID'),
-    serverDomain: Cypress.env('MAILOSAUR_SERVER_ID') + '.mailosaur.net',
-    email: 'signIn@' + Cypress.env('MAILOSAUR_SERVER_ID') + '.mailosaur.net',
-  };
-
-  const unregisteredAccount = {
-    serverId: Cypress.env('MAILOSAUR_SERVER_ID'),
-    serverDomain: Cypress.env('MAILOSAUR_SERVER_ID') + '.mailosaur.net',
-    email:
-      'registrationTest+' +
-      uuidv4() +
-      '@' +
       Cypress.env('MAILOSAUR_SERVER_ID') +
       '.mailosaur.net',
   };
@@ -43,7 +27,7 @@ describe('Registration email sent page', () => {
     });
   });
 
-  it('should load the page with a success banner given a valid encrypted email cookie', () => {
+  it('should load the page with a success banner given a valid PLAY_SESSION_2 encrypted email cookie', () => {
     cy.setCookie('PLAY_SESSION_2', encryptedEmail, {
       log: true,
     });
@@ -55,7 +39,7 @@ describe('Registration email sent page', () => {
   });
 
   // Depends on a Guest account already created using this email.
-  it('should resend the email when the resend button is clicked', () => {
+  it('should resend the email when the resend button is clicked given a valid PLAY_SESSION_2 encrypted email cookie', () => {
     cy.setCookie('PLAY_SESSION_2', encryptedEmail, {
       log: true,
     });
@@ -84,21 +68,23 @@ describe('Registration email sent page', () => {
   });
 
   it('should resend "Complete Registration" email when a new user registers which is same as initial email sent', () => {
+    const unregisteredEmail = randomMailosaurEmail();
+
     cy.visit('/register');
-    cy.get('input[name=email]').type(unregisteredAccount.email);
+    cy.get('input[name=email]').type(unregisteredEmail);
     const timeRequestWasMadeInitialEmail = new Date();
     cy.get('[data-cy="register-button"]').click();
 
     cy.contains('Email sent');
-    cy.contains(unregisteredAccount.email);
+    cy.contains(unregisteredEmail);
     cy.contains('Resend email');
     cy.contains('Change email address');
 
     // test and delete initial email
     cy.mailosaurGetMessage(
-      unregisteredAccount.serverId,
+      Cypress.env('MAILOSAUR_SERVER_ID'),
       {
-        sentTo: unregisteredAccount.email,
+        sentTo: unregisteredEmail,
       },
       {
         receivedAfter: timeRequestWasMadeInitialEmail,
@@ -113,12 +99,12 @@ describe('Registration email sent page', () => {
     const timeRequestWasMade = new Date();
     cy.contains('Resend email').click();
     cy.contains('Email sent');
-    cy.contains(unregisteredAccount.email);
+    cy.contains(unregisteredEmail);
     // test and delete resent email
     cy.mailosaurGetMessage(
-      unregisteredAccount.serverId,
+      Cypress.env('MAILOSAUR_SERVER_ID'),
       {
-        sentTo: unregisteredAccount.email,
+        sentTo: unregisteredEmail,
       },
       {
         receivedAfter: timeRequestWasMade,
@@ -132,112 +118,108 @@ describe('Registration email sent page', () => {
   });
 
   it('should resend account exists without password email when an existing user without password registers which is same as initial email sent', () => {
-    cy.visit('/register');
-    cy.get('input[name=email]').type(existingWithoutPassword.email);
-    const timeRequestWasMadeInitialEmail = new Date();
-    cy.get('[data-cy="register-button"]').click();
+    cy.createTestUser({
+      isUserEmailValidated: false,
+    })?.then(({ emailAddress }) => {
+      cy.visit('/register');
+      cy.get('input[name=email]').type(emailAddress);
+      const timeRequestWasMadeInitialEmail = new Date();
+      cy.get('[data-cy="register-button"]').click();
 
-    cy.contains('Email sent');
-    cy.contains(existingWithoutPassword.email);
-    cy.contains('Resend email');
-    cy.contains('Change email address');
+      cy.contains('Email sent');
+      cy.contains(emailAddress);
+      cy.contains('Resend email');
+      cy.contains('Change email address');
 
-    // test and delete initial email
-    cy.mailosaurGetMessage(
-      existingWithoutPassword.serverId,
-      {
-        sentTo: existingWithoutPassword.email,
-      },
-      {
-        receivedAfter: timeRequestWasMadeInitialEmail,
-      },
-    ).then((email) => {
-      cy.getEmailDetails(email).then(({ id, body }) => {
-        expect(body).to.have.string('This account already exists');
-        expect(body).to.have.string(
-          'To continue to your account please click below to create a password.',
-        );
-        expect(body).to.have.string('This link is only valid for 30 minutes.');
-        expect(body).to.have.string('Create password');
-        cy.mailosaurDeleteMessage(id);
+      // test and delete initial email
+      cy.mailosaurGetMessage(
+        Cypress.env('MAILOSAUR_SERVER_ID'),
+        {
+          sentTo: emailAddress,
+        },
+        {
+          receivedAfter: timeRequestWasMadeInitialEmail,
+        },
+      ).then((email) => {
+        cy.getEmailDetails(email).then(({ id, body }) => {
+          expect(body).to.have.string('This account already exists');
+          expect(body).to.have.string(
+            'To continue to your account please click below to create a password.',
+          );
+          expect(body).to.have.string(
+            'This link is only valid for 30 minutes.',
+          );
+          expect(body).to.have.string('Create password');
+          cy.mailosaurDeleteMessage(id);
+        });
       });
-    });
 
-    const timeRequestWasMade = new Date();
-    cy.contains('Resend email').click();
-    cy.contains('Email sent');
-    cy.contains(existingWithoutPassword.email);
-    // test and delete resent email
-    cy.mailosaurGetMessage(
-      existingWithoutPassword.serverId,
-      {
-        sentTo: existingWithoutPassword.email,
-      },
-      {
-        receivedAfter: timeRequestWasMade,
-      },
-    ).then((email) => {
-      cy.getEmailDetails(email).then(({ id, body }) => {
-        expect(body).to.have.string('This account already exists');
-        expect(body).to.have.string(
-          'To continue to your account please click below to create a password.',
-        );
-        expect(body).to.have.string('This link is only valid for 30 minutes.');
-        expect(body).to.have.string('Create password');
-        cy.mailosaurDeleteMessage(id);
+      const timeRequestWasMade = new Date();
+      cy.contains('Resend email').click();
+      cy.contains('Email sent');
+      cy.contains(emailAddress);
+      // test and delete resent email
+      cy.mailosaurGetMessage(
+        Cypress.env('MAILOSAUR_SERVER_ID'),
+        {
+          sentTo: emailAddress,
+        },
+        {
+          receivedAfter: timeRequestWasMade,
+        },
+      ).then((email) => {
+        cy.getEmailDetails(email).then(({ id, body }) => {
+          expect(body).to.have.string('This account already exists');
+          expect(body).to.have.string(
+            'To continue to your account please click below to create a password.',
+          );
+          expect(body).to.have.string(
+            'This link is only valid for 30 minutes.',
+          );
+          expect(body).to.have.string('Create password');
+          cy.mailosaurDeleteMessage(id);
+        });
       });
     });
   });
 
-  it('should resend "Account Exists" email when an existing user with password registers which is same as initial email sent', () => {
-    cy.visit('/register');
-    cy.get('input[name=email]').type(existingWithPassword.email);
-    const timeRequestWasMadeInitialEmail = new Date();
-    cy.get('[data-cy="register-button"]').click();
+  it.only('should resend "Account Exists" email when an existing user with password registers which is same as initial email sent', () => {
+    cy.createTestUser({
+      isUserEmailValidated: false,
+      password: 'test_password',
+    })?.then(({ emailAddress }) => {
+      cy.visit('/register');
+      cy.get('input[name=email]').type(emailAddress);
+      const timeRequestWasMadeInitialEmail = new Date();
+      cy.get('[data-cy="register-button"]').click();
 
-    cy.contains('Email sent');
-    cy.contains(existingWithPassword.email);
-    cy.contains('Resend email');
-    cy.contains('Change email address');
+      cy.contains('Email sent');
+      cy.contains(emailAddress);
+      cy.contains('Resend email');
+      cy.contains('Change email address');
 
-    // test and delete initial email
-    cy.mailosaurGetMessage(
-      existingWithPassword.serverId,
-      {
-        sentTo: existingWithPassword.email,
-      },
-      {
-        receivedAfter: timeRequestWasMadeInitialEmail,
-      },
-    ).then((email) => {
-      cy.getEmailDetails(email).then(({ id, body }) => {
+      cy.checkForEmailAndGetDetails(
+        emailAddress,
+        timeRequestWasMadeInitialEmail,
+      ).then(({ body }) => {
         expect(body).to.have.string(
           'You are already registered with the Guardian.',
         );
-        cy.mailosaurDeleteMessage(id);
       });
-    });
 
-    const timeRequestWasMade = new Date();
-    cy.contains('Resend email').click();
-    cy.contains('Email sent');
-    cy.contains(existingWithPassword.email);
-    // test and delete resent email
-    cy.mailosaurGetMessage(
-      existingWithPassword.serverId,
-      {
-        sentTo: existingWithPassword.email,
-      },
-      {
-        receivedAfter: timeRequestWasMade,
-      },
-    ).then((email) => {
-      cy.getEmailDetails(email).then(({ id, body }) => {
-        expect(body).to.have.string(
-          'You are already registered with the Guardian.',
-        );
-        cy.mailosaurDeleteMessage(id);
-      });
+      const timeRequestWasMade = new Date();
+      cy.contains('Resend email').click();
+      cy.contains('Email sent');
+      cy.contains(emailAddress);
+
+      // test and delete resent email
+      cy.checkForEmailAndGetDetails(emailAddress, timeRequestWasMade).then(
+        ({ body }) => {
+          expect(body).to.have.string(
+            'You are already registered with the Guardian.',
+          );
+        },
+      );
     });
   });
 

--- a/cypress/integration/ete/registration/register_email_sent.spec.ts
+++ b/cypress/integration/ete/registration/register_email_sent.spec.ts
@@ -147,7 +147,6 @@ describe('Registration email sent page', () => {
   it('should resend "Account Exists" email when an existing user with password registers which is same as initial email sent', () => {
     cy.createTestUser({
       isUserEmailValidated: false,
-      password: 'test_password',
     })?.then(({ emailAddress }) => {
       cy.visit('/register');
       cy.get('input[name=email]').type(emailAddress);

--- a/cypress/integration/ete/registration/register_email_sent.spec.ts
+++ b/cypress/integration/ete/registration/register_email_sent.spec.ts
@@ -39,7 +39,7 @@ describe('Registration email sent page', () => {
   });
 
   // Depends on a Guest account already created using this email.
-  it.only('should resend the email when the resend button is clicked given a valid PLAY_SESSION_2 encrypted email cookie', () => {
+  it('should resend the email when the resend button is clicked given a valid PLAY_SESSION_2 encrypted email cookie', () => {
     cy.setCookie('PLAY_SESSION_2', encryptedEmail, {
       log: true,
     });

--- a/cypress/integration/ete/reset_password.spec.ts
+++ b/cypress/integration/ete/reset_password.spec.ts
@@ -8,7 +8,6 @@ describe('Password reset flow', () => {
 
       cy.createTestUser({
         isUserEmailValidated: true,
-        password: 'test_user',
       })?.then(({ emailAddress }) => {
         cy.visit('/signin');
         const timeRequestWasMade = new Date();

--- a/cypress/integration/ete/reset_password.spec.ts
+++ b/cypress/integration/ete/reset_password.spec.ts
@@ -1,47 +1,33 @@
 describe('Password reset flow', () => {
   context('Account exists', () => {
-    // This test depends on this Mailosaur account already being registered
-    const existing = {
-      serverId: Cypress.env('MAILOSAUR_SERVER_ID'),
-      serverDomain: Cypress.env('MAILOSAUR_SERVER_ID') + '.mailosaur.net',
-      email:
-        'passwordResetFlow@' +
-        Cypress.env('MAILOSAUR_SERVER_ID') +
-        '.mailosaur.net',
-    };
-
     it("changes the reader's password", () => {
       cy.intercept({
         method: 'GET',
         url: 'https://api.pwnedpasswords.com/range/*',
       }).as('breachCheck');
-      cy.visit('/signin');
-      const timeRequestWasMade = new Date();
-      cy.contains('Reset password').click();
-      cy.contains('Forgotten password');
-      cy.get('input[name=email]').type(existing.email);
-      cy.get('[data-cy="reset-password-button"]').click();
-      cy.contains('Check your email inbox');
-      cy.mailosaurGetMessage(
-        existing.serverId,
-        {
-          sentTo: existing.email,
-        },
-        {
-          receivedAfter: timeRequestWasMade,
-        },
-      ).then((email) => {
-        cy.getEmailDetails(
-          email,
-          /theguardian.com\/reset-password\/([^"]*)/,
-        ).then(({ token, id }) => {
+
+      cy.createTestUser({
+        isUserEmailValidated: true,
+        password: 'test_user',
+      })?.then(({ emailAddress }) => {
+        cy.visit('/signin');
+        const timeRequestWasMade = new Date();
+        cy.contains('Reset password').click();
+        cy.contains('Forgotten password');
+        cy.get('input[name=email]').type(emailAddress);
+        cy.get('[data-cy="reset-password-button"]').click();
+        cy.contains('Check your email inbox');
+        cy.checkForEmailAndGetDetails(
+          emailAddress,
+          timeRequestWasMade,
+          /reset-password\/([^"]*)/,
+        ).then(({ token }) => {
           cy.visit(`/reset-password/${token}`);
           cy.get('input[name=password]').type('0298a96c-1028!@#');
           cy.wait('@breachCheck');
           cy.get('[data-cy="change-password-button"]').click();
           cy.contains('Password updated');
-          cy.contains(existing.email.toLowerCase());
-          cy.mailosaurDeleteMessage(id);
+          cy.contains(emailAddress.toLowerCase());
         });
       });
     });
@@ -50,36 +36,24 @@ describe('Password reset flow', () => {
 
 describe('Password set flow', () => {
   context('Account without password exists', () => {
-    const existingWithoutPassword = {
-      serverId: Cypress.env('MAILOSAUR_SERVER_ID'),
-      serverDomain: Cypress.env('MAILOSAUR_SERVER_ID') + '.mailosaur.net',
-      email:
-        'registrationEmailSentPage@' +
-        Cypress.env('MAILOSAUR_SERVER_ID') +
-        '.mailosaur.net',
-    };
-
     it('from the set passsword link expired page, successfully send and reset the create password email, and get taken to the set password page from the email', () => {
-      cy.visit('/set-password/expired');
+      cy.createTestUser({
+        isUserEmailValidated: false,
+      })?.then(({ emailAddress }) => {
+        cy.visit('/set-password/expired');
 
-      // link expired
-      const timeRequestWasMadeLinkExpired = new Date();
-      cy.get('input[name=email]').type(existingWithoutPassword.email);
-      cy.get('[data-cy="reset-password-button"]').click();
-      cy.contains('Email sent');
-      cy.contains(existingWithoutPassword.email);
-      cy.contains('Resend email');
-      cy.contains('Change email address');
-      cy.mailosaurGetMessage(
-        existingWithoutPassword.serverId,
-        {
-          sentTo: existingWithoutPassword.email,
-        },
-        {
-          receivedAfter: timeRequestWasMadeLinkExpired,
-        },
-      ).then((email) => {
-        cy.getEmailDetails(email).then(({ body, id }) => {
+        // link expired
+        const timeRequestWasMadeLinkExpired = new Date();
+        cy.get('input[name=email]').type(emailAddress);
+        cy.get('[data-cy="reset-password-button"]').click();
+        cy.contains('Email sent');
+        cy.contains(emailAddress);
+        cy.contains('Resend email');
+        cy.contains('Change email address');
+        cy.checkForEmailAndGetDetails(
+          emailAddress,
+          timeRequestWasMadeLinkExpired,
+        ).then(({ body }) => {
           expect(body).to.have.string('Welcome back');
           expect(body).to.have.string(
             'Please click below to create a password for your account.',
@@ -88,49 +62,38 @@ describe('Password set flow', () => {
             'This link is only valid for 30 minutes.',
           );
           expect(body).to.have.string('Create password');
-          cy.mailosaurDeleteMessage(id);
         });
-      });
 
-      // resend email
-      const timeRequestWasMadeResend = new Date();
-      cy.contains('Resend email').click();
-      cy.contains('Email sent');
-      cy.contains(existingWithoutPassword.email);
-      cy.mailosaurGetMessage(
-        existingWithoutPassword.serverId,
-        {
-          sentTo: existingWithoutPassword.email,
-        },
-        {
-          receivedAfter: timeRequestWasMadeResend,
-        },
-      ).then((email) => {
-        cy.getEmailDetails(email, /\/set-password\/([^"]*)/).then(
-          ({ body, id, links, token }) => {
-            expect(body).to.have.string('Welcome back');
-            expect(body).to.have.string(
-              'Please click below to create a password for your account.',
-            );
-            expect(body).to.have.string(
-              'This link is only valid for 30 minutes.',
-            );
-            expect(body).to.have.string('Create password');
+        // resend email
+        const timeRequestWasMadeResend = new Date();
+        cy.contains('Resend email').click();
+        cy.contains('Email sent');
+        cy.contains(emailAddress);
+        cy.checkForEmailAndGetDetails(
+          emailAddress,
+          timeRequestWasMadeResend,
+          /\/set-password\/([^"]*)/,
+        ).then(({ body, links, token }) => {
+          expect(body).to.have.string('Welcome back');
+          expect(body).to.have.string(
+            'Please click below to create a password for your account.',
+          );
+          expect(body).to.have.string(
+            'This link is only valid for 30 minutes.',
+          );
+          expect(body).to.have.string('Create password');
 
-            expect(links.length).to.eq(2);
+          expect(links.length).to.eq(2);
 
-            const createPasswordLink = links.find(
-              (link) => link.text === 'Create password',
-            );
+          const createPasswordLink = links.find(
+            (link) => link.text === 'Create password',
+          );
 
-            expect(createPasswordLink).not.to.be.undefined;
+          expect(createPasswordLink).not.to.be.undefined;
 
-            cy.visit(`/set-password/${token}`);
-            cy.contains('Create password');
-
-            cy.mailosaurDeleteMessage(id);
-          },
-        );
+          cy.visit(`/set-password/${token}`);
+          cy.contains('Create password');
+        });
       });
     });
   });

--- a/cypress/integration/ete/reset_password.spec.ts
+++ b/cypress/integration/ete/reset_password.spec.ts
@@ -39,6 +39,7 @@ describe('Password set flow', () => {
     it('from the set passsword link expired page, successfully send and reset the create password email, and get taken to the set password page from the email', () => {
       cy.createTestUser({
         isUserEmailValidated: false,
+        isGuestUser: true,
       })?.then(({ emailAddress }) => {
         cy.visit('/set-password/expired');
 

--- a/cypress/integration/ete/sign_in.spec.ts
+++ b/cypress/integration/ete/sign_in.spec.ts
@@ -1,10 +1,3 @@
-// This test depends on this Mailosaur account already being registered
-const existing = {
-  serverId: Cypress.env('MAILOSAUR_SERVER_ID'),
-  serverDomain: Cypress.env('MAILOSAUR_SERVER_ID') + '.mailosaur.net',
-  email: 'signIn@' + Cypress.env('MAILOSAUR_SERVER_ID') + '.mailosaur.net',
-  password: 'existing_password',
-};
 const oauthBaseUrl = 'https://oauth.code.dev-theguardian.com';
 describe('Sign in flow', () => {
   const returnUrl =
@@ -50,12 +43,16 @@ describe('Sign in flow', () => {
     cy.intercept('GET', 'https://m.code.dev-theguardian.com/', (req) => {
       req.reply(200);
     });
-
-    cy.visit('/signin');
-    cy.get('input[name=email]').type(existing.email);
-    cy.get('input[name=password]').type(existing.password);
-    cy.get('[data-cy="sign-in-button"]').click();
-    cy.url().should('include', 'https://m.code.dev-theguardian.com/');
+    cy.createTestUser({
+      isUserEmailValidated: true,
+      password: 'test_user',
+    })?.then(({ emailAddress }) => {
+      cy.visit('/signin');
+      cy.get('input[name=email]').type(emailAddress);
+      cy.get('input[name=password]').type('test_user');
+      cy.get('[data-cy="sign-in-button"]').click();
+      cy.url().should('include', 'https://m.code.dev-theguardian.com/');
+    });
   });
 
   it('navigates to reset password', () => {
@@ -76,11 +73,16 @@ describe('Sign in flow', () => {
     cy.intercept('GET', returnUrl, (req) => {
       req.reply(200);
     });
-    cy.visit(`/signin?returnUrl=${encodeURIComponent(returnUrl)}`);
-    cy.get('input[name=email]').type(existing.email);
-    cy.get('input[name=password]').type(existing.password);
-    cy.get('[data-cy="sign-in-button"]').click();
-    cy.url().should('eq', returnUrl);
+    cy.createTestUser({
+      isUserEmailValidated: true,
+      password: 'test_user',
+    })?.then(({ emailAddress }) => {
+      cy.visit(`/signin?returnUrl=${encodeURIComponent(returnUrl)}`);
+      cy.get('input[name=email]').type(emailAddress);
+      cy.get('input[name=password]').type('test_user');
+      cy.get('[data-cy="sign-in-button"]').click();
+      cy.url().should('eq', returnUrl);
+    });
   });
 
   it('redirects correctly for social sign in', () => {

--- a/cypress/integration/ete/sign_in.spec.ts
+++ b/cypress/integration/ete/sign_in.spec.ts
@@ -45,11 +45,10 @@ describe('Sign in flow', () => {
     });
     cy.createTestUser({
       isUserEmailValidated: true,
-      password: 'test_user',
-    })?.then(({ emailAddress }) => {
+    })?.then(({ emailAddress, finalPassword }) => {
       cy.visit('/signin');
       cy.get('input[name=email]').type(emailAddress);
-      cy.get('input[name=password]').type('test_user');
+      cy.get('input[name=password]').type(finalPassword);
       cy.get('[data-cy="sign-in-button"]').click();
       cy.url().should('include', 'https://m.code.dev-theguardian.com/');
     });
@@ -75,11 +74,10 @@ describe('Sign in flow', () => {
     });
     cy.createTestUser({
       isUserEmailValidated: true,
-      password: 'test_user',
-    })?.then(({ emailAddress }) => {
+    })?.then(({ emailAddress, finalPassword }) => {
       cy.visit(`/signin?returnUrl=${encodeURIComponent(returnUrl)}`);
       cy.get('input[name=email]').type(emailAddress);
-      cy.get('input[name=password]').type('test_user');
+      cy.get('input[name=password]').type(finalPassword);
       cy.get('[data-cy="sign-in-button"]').click();
       cy.url().should('eq', returnUrl);
     });

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -5,10 +5,7 @@ import { setMvtId } from './commands/setMvtId';
 import { network } from './commands/network';
 import { mockPattern } from './commands/mockPattern';
 import { lastPayloadIs } from './commands/lastPayloadIs';
-import {
-  getEmailDetails,
-  checkForEmailAndGetDetails,
-} from './commands/getEmailDetails';
+import { checkForEmailAndGetDetails } from './commands/getEmailDetails';
 import { createTestUser } from './commands/testUser';
 
 Cypress.Commands.add('mockNext', mockNext);
@@ -18,6 +15,5 @@ Cypress.Commands.add('mockPurge', mockPurge);
 Cypress.Commands.add('mockAll', mockAll);
 Cypress.Commands.add('setMvtId', setMvtId);
 Cypress.Commands.add('lastPayloadIs', lastPayloadIs);
-Cypress.Commands.add('getEmailDetails', getEmailDetails);
 Cypress.Commands.add('checkForEmailAndGetDetails', checkForEmailAndGetDetails);
 Cypress.Commands.add('createTestUser', createTestUser);

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -5,7 +5,11 @@ import { setMvtId } from './commands/setMvtId';
 import { network } from './commands/network';
 import { mockPattern } from './commands/mockPattern';
 import { lastPayloadIs } from './commands/lastPayloadIs';
-import { getEmailDetails } from './commands/getEmailDetails';
+import {
+  getEmailDetails,
+  checkForEmailAndGetDetails,
+} from './commands/getEmailDetails';
+import { createTestUser } from './commands/testUser';
 
 Cypress.Commands.add('mockNext', mockNext);
 Cypress.Commands.add('mockPattern', mockPattern); // unused, candidate for removal
@@ -15,3 +19,5 @@ Cypress.Commands.add('mockAll', mockAll);
 Cypress.Commands.add('setMvtId', setMvtId);
 Cypress.Commands.add('lastPayloadIs', lastPayloadIs);
 Cypress.Commands.add('getEmailDetails', getEmailDetails);
+Cypress.Commands.add('checkForEmailAndGetDetails', checkForEmailAndGetDetails);
+Cypress.Commands.add('createTestUser', createTestUser);

--- a/cypress/support/commands/getEmailDetails.ts
+++ b/cypress/support/commands/getEmailDetails.ts
@@ -1,14 +1,22 @@
-import { Message } from 'cypress-mailosaur';
+import { Link, Message } from 'cypress-mailosaur';
 declare global {
   // eslint-disable-next-line @typescript-eslint/no-namespace
   namespace Cypress {
     interface Chainable {
-      getEmailDetails: typeof getEmailDetails;
       checkForEmailAndGetDetails: typeof checkForEmailAndGetDetails;
     }
   }
 }
 
+/**
+ * Checks that a Mailosaur email has been sent and returns the details of the email.
+ *
+ * @param sentTo The email address to check for.
+ * @param receivedAfter The date to check for emails received after.
+ * @param tokenMatcher A regular expression to extract the token from the email body.
+ * @param deleteAfter Whether to delete the email after it has been checked (optional).
+ * @returns The email details.
+ */
 export const checkForEmailAndGetDetails = (
   sentTo: string,
   receivedAfter?: Date,
@@ -33,20 +41,36 @@ export const checkForEmailAndGetDetails = (
     });
 };
 
-export const getEmailDetails = (email: Message, tokenMatcher?: RegExp) => {
+type EmailDetails = {
+  id: string;
+  body: string;
+  token?: string;
+  links: Link[];
+};
+
+/**
+ * Extracts information from a Mailosaur email.
+ *
+ * @param email The email to extract information from.
+ * @param tokenMatcher A regular expression to extract the token from the email body.
+ * @returns The email details.
+ */
+const getEmailDetails = (email: Message, tokenMatcher?: RegExp) => {
   const { id, html } = email;
   const { body, links } = html || {};
   if (id === undefined || body === undefined || links === undefined) {
     throw new Error('Email details not found');
   }
-  let token = null;
+  let token = undefined;
   if (tokenMatcher) {
     const match = body.match(tokenMatcher);
     if (match === null) {
-      throw new Error('Unable to find token');
+      throw new Error(
+        'Unable to find token in the email body with the given regex',
+      );
     }
     token = match[1];
   }
 
-  return cy.wrap({ id, body, token, links });
+  return cy.wrap<EmailDetails>({ id, body, token, links });
 };

--- a/cypress/support/commands/getEmailDetails.ts
+++ b/cypress/support/commands/getEmailDetails.ts
@@ -4,9 +4,34 @@ declare global {
   namespace Cypress {
     interface Chainable {
       getEmailDetails: typeof getEmailDetails;
+      checkForEmailAndGetDetails: typeof checkForEmailAndGetDetails;
     }
   }
 }
+
+export const checkForEmailAndGetDetails = (
+  sentTo: string,
+  receivedAfter?: Date,
+  tokenMatcher?: RegExp,
+  deleteAfter = true,
+) => {
+  return cy
+    .mailosaurGetMessage(
+      Cypress.env('MAILOSAUR_SERVER_ID'),
+      { sentTo },
+      {
+        receivedAfter,
+      },
+    )
+    .then((message: Message) => {
+      return getEmailDetails(message, tokenMatcher).then((details) => {
+        if (deleteAfter) {
+          cy.mailosaurDeleteMessage(details.id);
+        }
+        return cy.wrap(details);
+      });
+    });
+};
 
 export const getEmailDetails = (email: Message, tokenMatcher?: RegExp) => {
   const { id, html } = email;

--- a/cypress/support/commands/testUser.ts
+++ b/cypress/support/commands/testUser.ts
@@ -21,7 +21,24 @@ type IDAPITestUserOptions = {
   isUserEmailValidated?: boolean;
   socialLinks?: SocialLink[];
   password?: string;
+  deleteAfterMinute?: boolean;
 };
+
+type IDAPITestUserResponse = [
+  {
+    key: 'GU_U';
+    value: string;
+  },
+  {
+    key: 'SC_GU_LA';
+    sessionCookie: boolean;
+    value: string;
+  },
+  {
+    key: 'SC_GU_U';
+    value: string;
+  },
+];
 
 export const randomMailosaurEmail = () => {
   return uuidv4() + '@' + Cypress.env('MAILOSAUR_SERVER_ID') + '.mailosaur.net';
@@ -29,10 +46,12 @@ export const randomMailosaurEmail = () => {
 
 export const createTestUser = ({
   primaryEmailAddress,
-  socialLinks,
-  isUserEmailValidated,
   password,
+  socialLinks = [],
+  isUserEmailValidated = false,
+  deleteAfterMinute = true,
 }: IDAPITestUserOptions) => {
+  // Generate a random email address if none is provided.
   const finalEmail = primaryEmailAddress || randomMailosaurEmail();
   try {
     return cy
@@ -49,15 +68,17 @@ export const createTestUser = ({
           isUserEmailValidated,
           socialLinks,
           password,
+          deleteAfterMinute,
         } as IDAPITestUserOptions,
       })
       .then((res) => {
+        console.log(res.body.values);
         return cy.wrap({
           emailAddress: finalEmail,
-          cookies: res.body.values,
+          cookies: res.body.values as IDAPITestUserResponse,
         });
       });
   } catch (error) {
-    console.error(error);
+    throw new Error('Failed to create IDAPI test user: ' + error);
   }
 };

--- a/cypress/support/commands/testUser.ts
+++ b/cypress/support/commands/testUser.ts
@@ -22,6 +22,7 @@ type IDAPITestUserOptions = {
   socialLinks?: SocialLink[];
   password?: string;
   deleteAfterMinute?: boolean;
+  isGuestUser?: boolean;
 };
 
 type IDAPITestUserResponse = [
@@ -50,6 +51,7 @@ export const createTestUser = ({
   socialLinks = [],
   isUserEmailValidated = false,
   deleteAfterMinute = true,
+  isGuestUser = false,
 }: IDAPITestUserOptions) => {
   // Generate a random email address if none is provided.
   const finalEmail = primaryEmailAddress || randomMailosaurEmail();
@@ -69,6 +71,7 @@ export const createTestUser = ({
           socialLinks,
           password,
           deleteAfterMinute,
+          isGuestUser,
         } as IDAPITestUserOptions,
       })
       .then((res) => {

--- a/cypress/support/commands/testUser.ts
+++ b/cypress/support/commands/testUser.ts
@@ -55,6 +55,8 @@ export const createTestUser = ({
 }: IDAPITestUserOptions) => {
   // Generate a random email address if none is provided.
   const finalEmail = primaryEmailAddress || randomMailosaurEmail();
+  // Generate a random password if none is provided.
+  const finalPassword = password || uuidv4();
   try {
     return cy
       .request({
@@ -69,7 +71,7 @@ export const createTestUser = ({
           primaryEmailAddress: finalEmail,
           isUserEmailValidated,
           socialLinks,
-          password,
+          password: finalPassword,
           deleteAfterMinute,
           isGuestUser,
         } as IDAPITestUserOptions,
@@ -79,6 +81,7 @@ export const createTestUser = ({
         return cy.wrap({
           emailAddress: finalEmail,
           cookies: res.body.values as IDAPITestUserResponse,
+          finalPassword,
         });
       });
   } catch (error) {

--- a/cypress/support/commands/testUser.ts
+++ b/cypress/support/commands/testUser.ts
@@ -1,0 +1,63 @@
+import { v4 as uuidv4 } from 'uuid';
+
+declare global {
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace Cypress {
+    interface Chainable {
+      createTestUser: typeof createTestUser;
+    }
+  }
+}
+
+type Networks = 'facebook' | 'apple' | 'google';
+
+type SocialLink = {
+  socialId: number;
+  network: Networks;
+};
+
+type IDAPITestUserOptions = {
+  primaryEmailAddress?: `${string}@${string}.mailosaur.net`;
+  isUserEmailValidated?: boolean;
+  socialLinks?: SocialLink[];
+  password?: string;
+};
+
+export const randomMailosaurEmail = () => {
+  return uuidv4() + '@' + Cypress.env('MAILOSAUR_SERVER_ID') + '.mailosaur.net';
+};
+
+export const createTestUser = ({
+  primaryEmailAddress,
+  socialLinks,
+  isUserEmailValidated,
+  password,
+}: IDAPITestUserOptions) => {
+  const finalEmail = primaryEmailAddress || randomMailosaurEmail();
+  try {
+    return cy
+      .request({
+        url: Cypress.env('IDAPI_BASE_URL') + '/user/test',
+        method: 'POST',
+        headers: {
+          'X-GU-ID-Client-Access-Token': `Bearer ${Cypress.env(
+            'IDAPI_CLIENT_ACCESS_TOKEN',
+          )}`,
+        },
+        body: {
+          primaryEmailAddress: finalEmail,
+          isUserEmailValidated,
+          socialLinks,
+          password,
+        } as IDAPITestUserOptions,
+      })
+      .then((res) => {
+        return cy.wrap({
+          emailAddress: finalEmail,
+          cookies: res.body.values,
+        });
+      });
+  } catch (error) {
+    console.error(error);
+  }
+};


### PR DESCRIPTION
## What does this change?
Uses an improved `/user/test` endpoint to generate test users at runtime during our e2e tests.

To do this, a new `createTestUser` command was implemented [^1]. This command accepts the following options:

```
type IDAPITestUserOptions = {
  primaryEmailAddress?: `${string}@${string}.mailosaur.net`;
  isUserEmailValidated?: boolean;
  socialLinks?: SocialLink[];
  password?: string;
  deleteAfterMinute?: boolean;
};
```

__Note: These tests will not pass until a companion PR in IDAPI (https://github.com/guardian/identity/pull/2011) which extends the `user/test` endpoint is released.__

The e2e test suite was then transitioned to use `createTestUser` where appropriate at the beginning of each test. By default, if nothing is passed for an email, a random email is created.

In order to clean up test users following each test run, an option was added to the IDAPI endpoint: `deleteAfterMinute`, if this is set to `true`, the IDAPI server will schedule a task for 60 seconds time which will delete the user.

It was implemented this way because it seemed more resilient than calling a delete endpoint from the cypress test itself, because our Cypress tests are often stopped midway through (during development for example), or if a runtime error happens.

A new helper command: `checkForEmailAndGetDetails` [^2] was also implemented. This wraps the `cypress.mailosaurGetMessage` method. This reduces some code repetition that developed after a while, as our use case was largely the same across each test.

[^1]: https://github.com/guardian/gateway/pull/1111/files#diff-ee6b852a30c06f7bab0b2ba2e9ba15fab814c5642b99ae33ddbb41d8904fe616R47
[^2]: https://github.com/guardian/gateway/pull/1111/files#diff-f07a49b8a432bd055c3eb8928bd6014232513e85953308603d9da7d21849d9c5R12
