### PR TITLE
Fixing routing on register/email-sent page

### DIFF
--- a/src/client/pages/RegistrationEmailSentPage.tsx
+++ b/src/client/pages/RegistrationEmailSentPage.tsx
@@ -21,7 +21,7 @@ export const RegistrationEmailSentPage = () => {
       email={email}
       queryString={queryString}
       previousPage={`${Routes.SIGN_IN}`}
-      resendEmailAction={`${Routes.REGISTRATION}${Routes.RESEND}`}
+      resendEmailAction={`${Routes.REGISTRATION}${Routes.EMAIL_SENT}${Routes.RESEND}`}
       showSuccess={emailSentSuccess}
       errorMessage={error}
       helpInfoBox

--- a/src/server/routes/register.ts
+++ b/src/server/routes/register.ts
@@ -69,7 +69,7 @@ router.get(
 );
 
 router.post(
-  `${Routes.REGISTRATION}${Routes.RESEND}`,
+  `${Routes.REGISTRATION}${Routes.EMAIL_SENT}${Routes.RESEND}`,
   handleAsyncErrors(async (req: Request, res: ResponseWithRequestState) => {
     const { returnUrl, emailSentSuccess } = res.locals.queryParams;
 


### PR DESCRIPTION
## What does this change?
Fixes the routing on the `/register/email-sent` page to resend the email and show the 'email sent' success message. Currently if you click on the `Resend email` button it redirects to the `/signin` page.