### PR TITLE
Use encoded ref and return url for assertions

### DIFF
--- a/cypress/integration/ete/registration/register.spec.ts
+++ b/cypress/integration/ete/registration/register.spec.ts
@@ -78,10 +78,7 @@ describe('Registration flow', () => {
   it('successfully registers using an email with no existing account', () => {
     const encodedReturnUrl =
       'https%3A%2F%2Fm.code.dev-theguardian.com%2Ftravel%2F2019%2Fdec%2F18%2Ffood-culture-tour-bethlehem-palestine-east-jerusalem-photo-essay';
-    const decodedReturnUrl =
-      'https://m.code.dev-theguardian.com/travel/2019/dec/18/food-culture-tour-bethlehem-palestine-east-jerusalem-photo-essay';
     const encodedRef = 'https%3A%2F%2Fm.theguardian.com';
-    const decodedRef = 'https://m.theguardian.com/';
     const refViewId = 'testRefViewId';
 
     const unregisteredEmail = randomMailosaurEmail();
@@ -109,8 +106,8 @@ describe('Registration flow', () => {
       /welcome\/([^"]*)/,
     ).then(({ body, token }) => {
       expect(body).to.have.string('Complete registration');
-      expect(body).to.have.string('returnUrl=' + decodedReturnUrl);
-      expect(body).to.have.string('ref=' + decodedRef);
+      expect(body).to.have.string('returnUrl=' + encodedReturnUrl);
+      expect(body).to.have.string('ref=' + encodedRef);
       expect(body).to.have.string('refViewId=' + refViewId);
       cy.visit(`/welcome/${token}`);
       cy.contains('Create password');


### PR DESCRIPTION
## What does this change?
One of our registration tests made assertions checking for decoded parameter values in the email body content.

Following the change introduced in this PR: https://github.com/guardian/identity/pull/2022 the tests needed to be updated to check for the newly encoded parameters.