### PR TITLE
MVP1: Geolocated logo in header

### DIFF
--- a/src/client/components/ConsentsHeader.tsx
+++ b/src/client/components/ConsentsHeader.tsx
@@ -3,15 +3,17 @@ import { GlobalError } from '@/client/components/GlobalError';
 import { GlobalSuccess } from '@/client/components/GlobalSuccess';
 import { Header } from '@/client/components/Header';
 import { getErrorLink } from '@/client/lib/ErrorLink';
+import { GeoLocation } from '@/shared/model/Geolocation';
 
 type Props = {
   error?: string;
   success?: string;
+  geolocation?: GeoLocation;
 };
 
-export const ConsentsHeader = ({ error, success }: Props) => (
+export const ConsentsHeader = ({ error, success, geolocation }: Props) => (
   <>
-    <Header />
+    <Header geolocation={geolocation} />
     {error && <GlobalError error={error} link={getErrorLink(error)} left />}
     {success && <GlobalSuccess success={success} />}
   </>

--- a/src/client/components/Header.stories.tsx
+++ b/src/client/components/Header.stories.tsx
@@ -32,3 +32,9 @@ Mobile.parameters = {
     defaultViewport: 'MOBILE',
   },
 };
+
+export const GeoGB = () => <Header geolocation="GB" />;
+GeoGB.storyName = 'with geolocation GB';
+
+export const GeoNotGB = () => <Header geolocation="ROW" />;
+GeoNotGB.storyName = 'with geolocation not GB';

--- a/src/client/components/Header.tsx
+++ b/src/client/components/Header.tsx
@@ -4,6 +4,11 @@ import { brand, space } from '@guardian/src-foundations';
 import { from } from '@guardian/src-foundations/mq';
 import { Logo } from '@guardian/source-react-components-development-kitchen';
 import { gridRow, manualRow, SpanDefinition } from '@/client/styles/Grid';
+import { GeoLocation } from '@/shared/model/Geolocation';
+
+interface HeaderProps {
+  geolocation?: GeoLocation;
+}
 
 const marginStyles = css`
   margin-top: ${space[5]}px;
@@ -48,11 +53,11 @@ const headerSpanDefinition: SpanDefinition = {
   },
 };
 
-export const Header = () => (
+export const Header = ({ geolocation }: HeaderProps) => (
   <header id="top" css={backgroundColor}>
     <div css={[gridRow, marginStyles]}>
       <div css={[manualRow(1, headerSpanDefinition), headerGridRightToLeft]}>
-        <Logo logoType="bestWebsite" />
+        <Logo logoType={geolocation === 'GB' ? 'bestWebsite' : 'anniversary'} />
       </div>
     </div>
   </header>

--- a/src/client/layouts/ConsentsLayout.tsx
+++ b/src/client/layouts/ConsentsLayout.tsx
@@ -86,7 +86,7 @@ export const ConsentsLayout: FunctionComponent<ConsentsLayoutProps> = ({
     globalMessage: { error, success } = {},
     queryParams,
   } = clientState;
-  const { page = '', previousPage } = pageData;
+  const { page = '', previousPage, geolocation } = pageData;
   const queryString = addQueryParamsToPath('', queryParams);
 
   const optionalBgColor =
@@ -99,7 +99,11 @@ export const ConsentsLayout: FunctionComponent<ConsentsLayoutProps> = ({
     `;
   return (
     <>
-      <ConsentsHeader error={error} success={success} />
+      <ConsentsHeader
+        error={error}
+        success={success}
+        geolocation={geolocation}
+      />
       <main css={mainStyles}>
         <ConsentsSubHeader autoRow={autoRow} title={title} current={current} />
         <form

--- a/src/client/layouts/Main.tsx
+++ b/src/client/layouts/Main.tsx
@@ -125,7 +125,10 @@ export const MainLayout = ({
   errorOverride,
 }: PropsWithChildren<MainLayoutProps>) => {
   const clientState: ClientState = useContext(ClientStateContext);
-  const { globalMessage: { error, success } = {} } = clientState;
+  const {
+    globalMessage: { error, success } = {},
+    pageData: { geolocation } = {},
+  } = clientState;
 
   const successMessage = successOverride || success;
   const errorMessage = errorOverride || error;
@@ -135,7 +138,7 @@ export const MainLayout = ({
 
   return (
     <>
-      <Header />
+      <Header geolocation={geolocation} />
       <main css={[mainStyles, gridRow]}>
         <section css={gridItem(gridSpanDefinition)}>
           {errorMessage && (

--- a/src/client/pages/ConsentsConfirmation.tsx
+++ b/src/client/pages/ConsentsConfirmation.tsx
@@ -25,6 +25,7 @@ import {
   ExternalLink,
   ExternalLinkButton,
 } from '@/client/components/ExternalLink';
+import { GeoLocation } from '@/shared/model/Geolocation';
 
 type ConsentsConfirmationProps = {
   error?: string;
@@ -34,7 +35,9 @@ type ConsentsConfirmationProps = {
   optedOutOfMarketResearch: boolean;
   productConsents: Consent[];
   subscribedNewsletters: NewsLetter[];
+  geolocation?: GeoLocation;
 };
+
 const reviewTableContainer = css`
   display: flex;
   flex-flow: column;
@@ -154,11 +157,16 @@ export const ConsentsConfirmation = ({
   optedOutOfMarketResearch,
   productConsents,
   subscribedNewsletters,
+  geolocation,
 }: ConsentsConfirmationProps) => {
   const autoRow = getAutoRow(1, confirmationSpanDefinition);
   return (
     <>
-      <ConsentsHeader error={error} success={success} />
+      <ConsentsHeader
+        error={error}
+        success={success}
+        geolocation={geolocation}
+      />
       <main>
         <ConsentsSubHeader
           autoRow={autoRow}

--- a/src/client/pages/Registration.tsx
+++ b/src/client/pages/Registration.tsx
@@ -21,6 +21,7 @@ import useRecaptcha, {
 import { DetailedRecaptchaError } from '@/client/components/DetailedRecaptchaError';
 import locations from '@/client/lib/locations';
 import { EmailInput } from '@/client/components/EmailInput';
+import { GeoLocation } from '@/shared/model/Geolocation';
 
 export type RegistrationProps = {
   returnUrl?: string;
@@ -28,6 +29,7 @@ export type RegistrationProps = {
   recaptchaSiteKey: string;
   oauthBaseUrl: string;
   queryString?: string;
+  geolocation?: GeoLocation;
 };
 
 const registerButton = css`
@@ -61,6 +63,7 @@ export const Registration = ({
   recaptchaSiteKey,
   oauthBaseUrl,
   queryString,
+  geolocation,
 }: RegistrationProps) => {
   const registerFormRef = createRef<HTMLFormElement>();
   const recaptchaElementRef = useRef<HTMLDivElement>(null);
@@ -97,7 +100,7 @@ export const Registration = ({
 
   return (
     <>
-      <Header />
+      <Header geolocation={geolocation} />
       <Nav
         tabs={[
           {

--- a/src/client/pages/RegistrationPage.tsx
+++ b/src/client/pages/RegistrationPage.tsx
@@ -12,7 +12,7 @@ export const RegistrationPage = () => {
     clientHosts,
     queryParams,
   } = clientState;
-  const { returnUrl, email } = pageData;
+  const { returnUrl, email, geolocation } = pageData;
   const { oauthBaseUrl } = clientHosts;
   const { recaptchaSiteKey } = recaptchaConfig;
   const queryString = addQueryParamsToPath('', queryParams);
@@ -24,6 +24,7 @@ export const RegistrationPage = () => {
       recaptchaSiteKey={recaptchaSiteKey}
       oauthBaseUrl={oauthBaseUrl}
       queryString={queryString}
+      geolocation={geolocation}
     />
   );
 };

--- a/src/client/pages/SignIn.tsx
+++ b/src/client/pages/SignIn.tsx
@@ -19,6 +19,7 @@ import { from } from '@guardian/src-foundations/mq';
 import { Divider } from '@guardian/source-react-components-development-kitchen';
 import { SignInErrors } from '@/shared/model/Errors';
 import { EmailInput } from '@/client/components/EmailInput';
+import { GeoLocation } from '@/shared/model/Geolocation';
 
 export type SignInProps = {
   returnUrl?: string;
@@ -26,6 +27,7 @@ export type SignInProps = {
   email?: string;
   error?: string;
   oauthBaseUrl: string;
+  geolocation?: GeoLocation;
 };
 
 const passwordInput = css`
@@ -127,9 +129,10 @@ export const SignIn = ({
   error,
   oauthBaseUrl,
   queryString,
+  geolocation,
 }: SignInProps) => (
   <>
-    <Header />
+    <Header geolocation={geolocation} />
     <Nav
       tabs={[
         {

--- a/src/client/pages/SignInPage.tsx
+++ b/src/client/pages/SignInPage.tsx
@@ -13,7 +13,7 @@ export const SignInPage = () => {
     clientHosts,
     queryParams,
   } = clientState;
-  const { returnUrl, email } = pageData;
+  const { returnUrl, email, geolocation } = pageData;
   const { error } = globalMessage;
   const { oauthBaseUrl } = clientHosts;
   const queryString = addQueryParamsToPath('', queryParams);
@@ -26,6 +26,7 @@ export const SignInPage = () => {
       error={error}
       oauthBaseUrl={oauthBaseUrl}
       queryString={queryString}
+      geolocation={geolocation}
     />
   );
 };


### PR DESCRIPTION
## What does this change?
- When a user is geolocated to the `GB`, show the `bestWebsite` logo in the header, if coming from anywhere else show the `anniversary` logo
  - We reuse the existing `geolocation` property from the `clientState` `pageData` object, in turn provided by the `x-gu-geolocation` header from fastly.

## Images

### GB
![chrome_8DSnFKkTkD](https://user-images.githubusercontent.com/13315440/142888527-c6b97b28-fddd-4317-b353-e4eb0c1402bf.png)

### Not GB
![chrome_ceM6OJ0lxZ](https://user-images.githubusercontent.com/13315440/142888556-af04e8e7-8506-4fd2-ac74-a2934d08d35c.png)

