### PR TITLE
Return and pre-fill the email on sign in error

### DIFF
--- a/cypress/integration/mocked/sign_in.spec.ts
+++ b/cypress/integration/mocked/sign_in.spec.ts
@@ -38,6 +38,7 @@ describe('Sign in flow', () => {
       });
       cy.get('[data-cy=sign-in-button]').click();
       cy.contains("Email and password don't match");
+      cy.get('input[name="email"]').should('have.value', 'example@example.com');
     });
 
     it('shows a generic error message when the api error response is not known', function () {


### PR DESCRIPTION
## What does this change?

- When there is an error on the sign in page, now return the email address so that the user does not have to fill it out again.
  - This is in accordance with the UX designs
  - Updates the mocked test to check for the email input field value
- We also update the sign in page to use the email from the `EncryptedState` or `playSessionCookie` alongside the `encryptedEmail` parameter if it exists

| Before | After |
| --- | ----------- |
| ![Screen Recording 2021-11-25 at 11 37 20](https://user-images.githubusercontent.com/13315440/143462239-983e18eb-297c-42ae-86f0-0ac167f8be48.gif) | ![Screen Recording 2021-11-25 at 14 55 03](https://user-images.githubusercontent.com/13315440/143463238-80124a66-be60-4c6f-8541-5c5fda85f833.gif) |


