### PR TITLE
Update emails to use reworked guidelines from design

### DIFF
--- a/src/email/components/Button.tsx
+++ b/src/email/components/Button.tsx
@@ -10,7 +10,7 @@ import {
 type Props = { children: React.ReactNode; href: string };
 
 export const Button = ({ children, href }: Props) => (
-  <MjmlSection background-color={background.primary} padding="0 12px">
+  <MjmlSection background-color={background.primary} padding="0 24px">
     <MjmlColumn>
       <MjmlButton
         backgroundColor={brandBackground.primary}
@@ -18,7 +18,7 @@ export const Button = ({ children, href }: Props) => (
         borderRadius="24px"
         href={href}
         align="left"
-        padding="22px 0 48px 0"
+        padding="22px 0 32px 0"
         fontFamily="Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif"
         fontWeight={700}
         fontSize="17px"

--- a/src/email/components/Footer.tsx
+++ b/src/email/components/Footer.tsx
@@ -6,27 +6,34 @@ import { Link } from '@/email/components/Link';
 
 type Props = { mistakeParagraphComponent?: React.ReactNode };
 
-const FooterText = ({ children }: { children?: React.ReactNode }) => (
+const FooterText = ({
+  children,
+  noPaddingBottom = false,
+}: {
+  children?: React.ReactNode;
+  noPaddingBottom?: boolean;
+}) => (
   <MjmlText
     color={text.primary}
-    padding="0 0 10px 0"
+    padding={noPaddingBottom ? '0' : '0 0 10px 0'}
     fontSize="15px"
     fontFamily="Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif"
-    lineHeight="20.25px"
-    letterSpacing="-2%"
+    lineHeight="1.35"
+    letterSpacing="-0.02pt"
   >
     {children}
   </MjmlText>
 );
 
 export const Footer = ({ mistakeParagraphComponent }: Props) => (
-  <MjmlSection
-    background-color={background.secondary}
-    padding="16px 12px 56px 12px"
-    fullWidth
-  >
-    <MjmlColumn>
-      <FooterText>{mistakeParagraphComponent}</FooterText>
+  <MjmlSection padding="0 12px">
+    <MjmlColumn
+      padding="12px 12px 24px 12px"
+      background-color={background.secondary}
+    >
+      {mistakeParagraphComponent && (
+        <FooterText>{mistakeParagraphComponent}</FooterText>
+      )}
       <FooterText>
         If you have any queries about why you are receiving this email, please
         contact our customer service team at{' '}
@@ -35,7 +42,7 @@ export const Footer = ({ mistakeParagraphComponent }: Props) => (
         </Link>
         .
       </FooterText>
-      <FooterText>
+      <FooterText noPaddingBottom>
         Guardian News and Media Limited, Kings Place, 90 York Way, London, N1
         9GU, United Kingdom
       </FooterText>

--- a/src/email/components/Header.tsx
+++ b/src/email/components/Header.tsx
@@ -8,7 +8,7 @@ import { brandBackground } from '@guardian/source-foundations';
 export const Header = () => (
   <MjmlSection
     background-color={brandBackground.primary}
-    padding="0 12px"
+    padding="0 24px"
     fullWidth
   >
     <MjmlColumn>

--- a/src/email/components/Page.tsx
+++ b/src/email/components/Page.tsx
@@ -9,6 +9,6 @@ export const Page = ({ children, title }: Props) => (
     <MjmlHead>
       <MjmlTitle>{`${title} | The Guardian`}</MjmlTitle>
     </MjmlHead>
-    <MjmlBody width={660}>{children}</MjmlBody>
+    <MjmlBody width={600}>{children}</MjmlBody>
   </Mjml>
 );

--- a/src/email/components/SubHeader.tsx
+++ b/src/email/components/SubHeader.tsx
@@ -9,7 +9,7 @@ export const SubHeader = ({ children }: Props) => (
   <>
     <MjmlSection
       backgroundColor={background.primary}
-      padding="24px 12px 0 12px"
+      padding="24px 24px 0 24px"
     >
       <MjmlColumn>
         <MjmlDivider border-width="1px" border-color="#DCDCDC" padding="0" />
@@ -17,14 +17,14 @@ export const SubHeader = ({ children }: Props) => (
     </MjmlSection>
     <MjmlSection
       backgroundColor={background.primary}
-      padding="0px 12px 20px 12px"
+      padding="0px 24px 20px 24px"
     >
       <MjmlColumn>
         <MjmlText
           padding="4px 0px"
           fontSize="20px"
-          lineHeight="23px"
-          letterSpacing="-2%"
+          lineHeight="1.15"
+          letterSpacing="-0.02pt"
           fontWeight={700}
           fontFamily="Georgia, serif"
           color={text.primary}

--- a/src/email/components/Text.tsx
+++ b/src/email/components/Text.tsx
@@ -8,14 +8,14 @@ type Props = { children: React.ReactNode; noPaddingBottom?: boolean };
 export const Text = ({ children, noPaddingBottom = false }: Props) => (
   <MjmlSection
     background-color={background.primary}
-    padding={noPaddingBottom ? '0 12px' : '0 12px 12px 12px'}
+    padding={noPaddingBottom ? '0 24px' : '0 24px 12px 24px'}
   >
     <MjmlColumn>
       <MjmlText
         padding="0"
         fontSize="17px"
-        lineHeight="23px"
-        letterSpacing="-2%"
+        lineHeight="1.35"
+        letterSpacing="-0.02pt"
         fontFamily="Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif"
         color={text.primary}
       >


### PR DESCRIPTION
## What does this change?

Updates the MVP1 emails to use the following designs:

| Design | Typography |
| -- | -- |
| ![wavebox_1xb1J5cWYQ](https://user-images.githubusercontent.com/13315440/144084720-df1f7d69-72ae-4074-b3ec-b2fbb2aa0b67.png) | ![wavebox_DaffBiODhG](https://user-images.githubusercontent.com/13315440/144084780-d5e6f435-c6ed-4543-a8e2-af8c5a41365a.png) |

## Changes

- Reduce email with to 600px
- Increased margins to 24px
- Updated margins on footer/help box
- Tweaked vertical margins between button and the footer/helpbox
- Use correct line-height and letter-spacing values.

## Post-merge

- Raise PR in IDAPI to use the new designs

## Screenshots

Click on screenshot to see larger size.

| AccountExists | AccountExistsWithoutPassword | CreatePassword | ResetPassword | Verification |
| -- | -- | -- | -- | -- |
| ![60929d168594f80039336501-hmgqpygdmt chromatic com_iframe html_id=email-templates-accountexists--default args= viewMode=story(iPhone 6_7_8 Plus) (1)](https://user-images.githubusercontent.com/13315440/144088505-f1ab9afe-5925-48a1-af3a-688028270789.png) | ![60929d168594f80039336501-hmgqpygdmt chromatic com_iframe html_id=email-templates-accountwithoutpasswordexists--default args= viewMode=story(iPhone 6_7_8 Plus)](https://user-images.githubusercontent.com/13315440/144088544-cf37e696-6e7a-4399-9104-72c852b80624.png) | ![60929d168594f80039336501-hmgqpygdmt chromatic com_iframe html_id=email-templates-createpassword--default args= viewMode=story(iPhone 6_7_8 Plus)](https://user-images.githubusercontent.com/13315440/144088578-acf130f5-d379-4c88-a4c7-19a7ca6baf44.png) | ![60929d168594f80039336501-hmgqpygdmt chromatic com_iframe html_id=email-templates-resetpassword--default args= viewMode=story(iPhone 6_7_8 Plus)](https://user-images.githubusercontent.com/13315440/144088634-fb34073b-a3c5-441d-a0ba-7182d5972a84.png) |  ![60929d168594f80039336501-hmgqpygdmt chromatic com_iframe html_id=email-templates-verify--default args= viewMode=story(iPhone 6_7_8 Plus)](https://user-images.githubusercontent.com/13315440/144088659-c95b5cee-af11-4655-8663-3d331c36775e.png) |



## How to test/review this PR

- Open the [figma file](https://www.figma.com/file/ZDPonnBXbMhV2smf51Dylc/?node-id=4175%3A126191) on the `✅ - Sign in & register emails /Q3/21` page to see expected designs
- Open the [latest storybook](https://60929d168594f80039336501-hmgqpygdmt.chromatic.com/?path=/story/email-components-page--default) for this branch to see new designs, check the `Email` section in the left side bar.
- Open the [latest chromatic UI tests](https://www.chromatic.com/build?appId=60929d168594f80039336501&number=1494) to see what's changed