### PR TITLE
Emails: use px instead of pt

### DIFF
--- a/src/email/components/Footer.tsx
+++ b/src/email/components/Footer.tsx
@@ -19,7 +19,7 @@ const FooterText = ({
     fontSize="15px"
     fontFamily="Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif"
     lineHeight="1.35"
-    letterSpacing="-0.02pt"
+    letterSpacing="-0.02px"
   >
     {children}
   </MjmlText>

--- a/src/email/components/SubHeader.tsx
+++ b/src/email/components/SubHeader.tsx
@@ -24,7 +24,7 @@ export const SubHeader = ({ children }: Props) => (
           padding="4px 0px"
           fontSize="20px"
           lineHeight="1.15"
-          letterSpacing="-0.02pt"
+          letterSpacing="-0.02px"
           fontWeight={700}
           fontFamily="Georgia, serif"
           color={text.primary}

--- a/src/email/components/Text.tsx
+++ b/src/email/components/Text.tsx
@@ -15,7 +15,7 @@ export const Text = ({ children, noPaddingBottom = false }: Props) => (
         padding="0"
         fontSize="17px"
         lineHeight="1.35"
-        letterSpacing="-0.02pt"
+        letterSpacing="-0.02px"
         fontFamily="Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif"
         color={text.primary}
       >


### PR DESCRIPTION
## What does this change?

- Fixes a validation issue where `pt` is not valid as a unit for `letter-spacing` in mjml, so using `px` after speaking to design
  - Design said that in this case they are equivalent enough
  - `Attribute letter-spacing has invalid value: -0.02pt for type Unit, only accepts (px, em) units and 1 value(s)`
