### PR TITLE
Add E2E tests for some reset password cases

### DIFF
--- a/cypress/integration/ete/reset_password.spec.ts
+++ b/cypress/integration/ete/reset_password.spec.ts
@@ -1,3 +1,5 @@
+import { randomPassword } from '../../support/commands/testUser';
+
 describe('Password reset flow', () => {
   context('Account exists', () => {
     it("changes the reader's password", () => {
@@ -24,15 +26,15 @@ describe('Password reset flow', () => {
         cy.get('input[name=email]').type(emailAddress);
 
         // Check that both reCAPTCHA errors are shown.
-        cy.contains('Reset password').click();
+        cy.get('[data-cy="main-form-submit-button"]').click();
         cy.contains('Google reCAPTCHA verification failed. Please try again.');
-        cy.contains('Reset password').click();
+        cy.get('[data-cy="main-form-submit-button"]').click();
         cy.contains('Google reCAPTCHA verification failed.');
         cy.contains('If the problem persists please try the following:');
         cy.contains('userhelp@');
 
         // Continue checking the password reset flow after reCAPTCHA assertions above.
-        cy.contains('Reset password').click();
+        cy.get('[data-cy="main-form-submit-button"]').click();
         cy.contains('Check your email inbox');
         cy.checkForEmailAndGetDetails(
           emailAddress,
@@ -40,13 +42,75 @@ describe('Password reset flow', () => {
           /reset-password\/([^"]*)/,
         ).then(({ token }) => {
           cy.visit(`/reset-password/${token}`);
-          cy.get('input[name=password]').type('0298a96c-1028!@#');
+          cy.get('input[name=password]').type(randomPassword());
           cy.wait('@breachCheck');
           cy.get('[data-cy="main-form-submit-button"]').click();
           cy.contains('Password updated');
           cy.contains(emailAddress.toLowerCase());
         });
       });
+    });
+  });
+
+  context('Account without password exists', () => {
+    it('changes the users password', () => {
+      cy.intercept({
+        method: 'GET',
+        url: 'https://api.pwnedpasswords.com/range/*',
+      }).as('breachCheck');
+
+      cy.createTestUser({
+        isUserEmailValidated: true,
+      })?.then(({ emailAddress }) => {
+        cy.visit('/signin');
+        const timeRequestWasMade = new Date();
+        cy.contains('Reset password').click();
+
+        // Simulate going offline by failing the reCAPTCHA POST request.
+        cy.intercept({
+          method: 'POST',
+          url: 'https://www.google.com/recaptcha/api2/**',
+          times: 1,
+        });
+
+        cy.contains('Forgot password');
+        cy.get('input[name=email]').type(emailAddress);
+
+        // Check that both reCAPTCHA errors are shown.
+        cy.get('[data-cy="main-form-submit-button"]').click();
+        cy.contains('Google reCAPTCHA verification failed. Please try again.');
+        cy.get('[data-cy="main-form-submit-button"]').click();
+        cy.contains('Google reCAPTCHA verification failed.');
+        cy.contains('If the problem persists please try the following:');
+        cy.contains('userhelp@');
+
+        // Continue checking the password reset flow after reCAPTCHA assertions above.
+        cy.get('[data-cy="main-form-submit-button"]').click();
+        cy.contains('Check your email inbox');
+        cy.checkForEmailAndGetDetails(
+          emailAddress,
+          timeRequestWasMade,
+          /reset-password\/([^"]*)/,
+        ).then(({ token }) => {
+          cy.visit(`/reset-password/${token}`);
+          cy.get('input[name=password]').type(randomPassword());
+          cy.wait('@breachCheck');
+          cy.get('[data-cy="main-form-submit-button"]').click();
+          cy.contains('Password updated');
+          cy.contains(emailAddress.toLowerCase());
+        });
+      });
+    });
+  });
+
+  context('No Account', () => {
+    it('shows the email sent page with link to register when attempting to reset password', () => {
+      cy.visit('/reset');
+      cy.contains('Forgot password');
+      cy.get('input[name=email]').type('invalid@doesnotexist.com');
+      cy.get('[data-cy="main-form-submit-button"]').click();
+      cy.contains('Check your email inbox');
+      cy.contains('Register for free');
     });
   });
 });

--- a/cypress/support/commands/testUser.ts
+++ b/cypress/support/commands/testUser.ts
@@ -45,6 +45,8 @@ export const randomMailosaurEmail = () => {
   return uuidv4() + '@' + Cypress.env('MAILOSAUR_SERVER_ID') + '.mailosaur.net';
 };
 
+export const randomPassword = () => uuidv4();
+
 export const createTestUser = ({
   primaryEmailAddress,
   password,


### PR DESCRIPTION
## What does this change?

- Add test for "account without password exists"
  - Same as "account with password exists flow", user should get reset password email
  - https://www.figma.com/file/ZDPonnBXbMhV2smf51Dylc/Sign-in-Journeys?node-id=3428%3A148115
- Add test for "no account"
  - Shown the email sent page, however no email is sent, email sent page should have link to `/register`
  - https://www.figma.com/file/ZDPonnBXbMhV2smf51Dylc/Sign-in-Journeys?node-id=2930%3A200646
- Use random password in tests
  - We shouldn't be exposing passwords, even for temporary/test users

This PR is dependent on https://github.com/guardian/identity/pull/2028 being merged first.