### PR TITLE
EmailSentPage: Update designs and copy to latest versions

### DIFF
--- a/src/client/pages/EmailSent.stories.tsx
+++ b/src/client/pages/EmailSent.stories.tsx
@@ -27,6 +27,7 @@ export const WithEmailResend = () => (
     previousPage="/reset"
     email="example@theguardian.com"
     resendEmailAction="#"
+    recaptchaSiteKey="6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI"
   />
 );
 WithEmailResend.story = {
@@ -38,23 +39,12 @@ export const WithEmailResendNoAccount = () => (
     previousPage="/reset"
     email="example@theguardian.com"
     resendEmailAction="#"
-    noAccountInfoBox
+    noAccountInfo
+    recaptchaSiteKey="6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI"
   />
 );
 WithEmailResendNoAccount.story = {
-  name: 'with email, resend, and no account box',
-};
-
-export const WithEmailResendHelp = () => (
-  <EmailSent
-    previousPage="/reset"
-    email="example@theguardian.com"
-    resendEmailAction="#"
-    helpInfoBox
-  />
-);
-WithEmailResendHelp.story = {
-  name: 'with email, resend, and help box',
+  name: 'with email, resend, and no account text',
 };
 
 export const WithRecaptchaError = () => (
@@ -62,7 +52,6 @@ export const WithRecaptchaError = () => (
     previousPage="/reset"
     email="example@theguardian.com"
     resendEmailAction="#"
-    helpInfoBox
     recaptchaSiteKey="invalid-key"
   />
 );

--- a/src/client/pages/EmailSent.tsx
+++ b/src/client/pages/EmailSent.tsx
@@ -19,8 +19,7 @@ type Props = {
   queryString?: string;
   showSuccess?: boolean;
   errorMessage?: string;
-  noAccountInfoBox?: boolean;
-  helpInfoBox?: boolean;
+  noAccountInfo?: boolean;
   recaptchaSiteKey?: string;
 };
 
@@ -31,8 +30,7 @@ export const EmailSent = ({
   queryString,
   showSuccess,
   errorMessage,
-  noAccountInfoBox,
-  helpInfoBox,
+  noAccountInfo,
   recaptchaSiteKey,
 }: Props) => {
   const [recaptchaErrorMessage, setRecaptchaErrorMessage] = useState('');
@@ -54,12 +52,9 @@ export const EmailSent = ({
       ) : (
         <MainBodyText>We’ve sent you an email.</MainBodyText>
       )}
+      <MainBodyText>Please follow the instructions in this email.</MainBodyText>
       <MainBodyText>
-        Please follow the instructions in this email. If you can’t find it, it
-        may be in your spam folder.
-      </MainBodyText>
-      <MainBodyText>
-        <b>This link is only valid for 30 minutes.</b>
+        <b>The link is only valid for 30 minutes.</b>
       </MainBodyText>
       {previousPage && (
         <MainBodyText>
@@ -67,13 +62,33 @@ export const EmailSent = ({
           <Link subdued href={previousPage}>
             Change email address
           </Link>
+          .
         </MainBodyText>
       )}
       {email && resendEmailAction && (
         <>
           <InfoSummary
             message="Didn’t receive an email?"
-            context="If you can’t find the email in your inbox or spam folder, please click below and we will send you a new one."
+            context={
+              <>
+                If you can’t find the email in your inbox or spam folder, please
+                click below and we will send you a new one.
+                {noAccountInfo && (
+                  <>
+                    <br />
+                    <b>
+                      If you don’t receive an email within 2 minutes you may not
+                      have an account.
+                    </b>
+                    <br />
+                    Don’t have an account?{' '}
+                    <Link subdued href={Routes.REGISTRATION}>
+                      Register for free
+                    </Link>
+                  </>
+                )}
+              </>
+            }
           />
           <MainForm
             formAction={`${resendEmailAction}${queryString}`}
@@ -86,46 +101,20 @@ export const EmailSent = ({
           >
             <EmailInput defaultValue={email} hidden hideLabel />
           </MainForm>
-          {noAccountInfoBox && (
-            <InfoSummary
-              cssOverrides={belowFormMarginTopSpacingStyle}
-              message="If you don’t receive an email within 2 minutes you may not have an account."
-              context={
-                <>
-                  Don’t have an account?{' '}
-                  <Link subdued href={Routes.REGISTRATION}>
-                    Register for free
-                  </Link>
-                  <br />
-                  If you are having trouble, please contact our customer service
-                  team at{' '}
-                  <ExternalLink subdued href="mailto:userhelp@theguardian.com">
-                    userhelp@guardian.com
-                  </ExternalLink>
-                </>
-              }
-            />
-          )}
-          {helpInfoBox && (
-            <InfoSummary
-              cssOverrides={belowFormMarginTopSpacingStyle}
-              message={
-                <>
-                  If you are still having trouble contact our customer service
-                  team at{' '}
-                  <ExternalLink
-                    cssOverrides={css`
-                      font-weight: 700;
-                    `}
-                    subdued
-                    href="mailto:userhelp@theguardian.com"
-                  >
-                    userhelp@guardian.com
-                  </ExternalLink>
-                </>
-              }
-            />
-          )}
+          <MainBodyText cssOverrides={belowFormMarginTopSpacingStyle}>
+            If you are still having trouble, contact our customer service team
+            at{' '}
+            <ExternalLink
+              cssOverrides={css`
+                font-weight: 700;
+              `}
+              subdued
+              href="mailto:userhelp@theguardian.com"
+            >
+              userhelp@guardian.com
+            </ExternalLink>
+            .
+          </MainBodyText>
         </>
       )}
     </MainLayout>

--- a/src/client/pages/EmailSentPage.tsx
+++ b/src/client/pages/EmailSentPage.tsx
@@ -5,11 +5,10 @@ import { EmailSent } from '@/client/pages/EmailSent';
 import { addQueryParamsToPath } from '@/shared/lib/queryParams';
 
 interface Props {
-  noAccountInfoBox?: boolean;
-  helpInfoBox?: boolean;
+  noAccountInfo?: boolean;
 }
 
-export const EmailSentPage = ({ noAccountInfoBox, helpInfoBox }: Props) => {
+export const EmailSentPage = ({ noAccountInfo }: Props) => {
   const clientState: ClientState = useContext(ClientStateContext);
   const {
     pageData = {},
@@ -34,8 +33,7 @@ export const EmailSentPage = ({ noAccountInfoBox, helpInfoBox }: Props) => {
       queryString={queryString}
       showSuccess={emailSentSuccess}
       errorMessage={error}
-      noAccountInfoBox={noAccountInfoBox}
-      helpInfoBox={helpInfoBox}
+      noAccountInfo={noAccountInfo}
       recaptchaSiteKey={recaptchaSiteKey}
     />
   );

--- a/src/client/pages/RegistrationEmailSentPage.tsx
+++ b/src/client/pages/RegistrationEmailSentPage.tsx
@@ -30,7 +30,6 @@ export const RegistrationEmailSentPage = () => {
       resendEmailAction={`${Routes.REGISTRATION}${Routes.EMAIL_SENT}${Routes.RESEND}`}
       showSuccess={emailSentSuccess}
       errorMessage={error}
-      helpInfoBox
       recaptchaSiteKey={recaptchaSiteKey}
     />
   );

--- a/src/client/routes.tsx
+++ b/src/client/routes.tsx
@@ -48,7 +48,7 @@ export const GatewayRoutes = () => (
       <ResetPasswordPage />
     </Route>
     <Route exact path={`${Routes.RESET}${Routes.EMAIL_SENT}`}>
-      <EmailSentPage noAccountInfoBox />
+      <EmailSentPage noAccountInfo />
     </Route>
     <Route exact path={`${Routes.CHANGE_PASSWORD}${Routes.TOKEN_PARAM}`}>
       <ChangePasswordPage />
@@ -72,7 +72,7 @@ export const GatewayRoutes = () => (
       <SetPasswordCompletePage />
     </Route>
     <Route path={`${Routes.SET_PASSWORD}${Routes.EMAIL_SENT}`}>
-      <EmailSentPage helpInfoBox />
+      <EmailSentPage />
     </Route>
     <Route exact path={`${Routes.SET_PASSWORD}${Routes.TOKEN_PARAM}`}>
       <SetPasswordPage />
@@ -96,7 +96,7 @@ export const GatewayRoutes = () => (
       <WelcomeSessionExpiredPage />
     </Route>
     <Route exact path={`${Routes.WELCOME}${Routes.EMAIL_SENT}`}>
-      <EmailSentPage helpInfoBox />
+      <EmailSentPage />
     </Route>
     <Route exact path={`${Routes.WELCOME}${Routes.COMPLETE}`}>
       <WelcomePasswordAlreadySetPage />
@@ -111,7 +111,7 @@ export const GatewayRoutes = () => (
       <MagicLinkPage />
     </Route>
     <Route exact path={`${Routes.MAGIC_LINK}${Routes.EMAIL_SENT}`}>
-      <EmailSentPage noAccountInfoBox />
+      <EmailSentPage noAccountInfo />
     </Route>
     <Route exact path={Routes.UNEXPECTED_ERROR}>
       <UnexpectedErrorPage />


### PR DESCRIPTION
## What does this change?

- Updates the UX copy and design to show only one `InfoSummary` box on the EmailSent page.
  - The "don't have an account" text only appears on the reset password flow through the `noAccountInfo` prop
- Rename `noAccountInfoBox` prop to `noAccountInfo`
- Removes the `helpInfoBox` as it's no longer relevant
- Updates the stories in storybook to show recaptcha message

## Images

Click images for larger sizes

### `noAccountInfo`
| Mobile Design | Mobile Screenshot | Desktop Design | Desktop Screenshot |
| -- | -- | -- | -- |
| ![image](https://user-images.githubusercontent.com/13315440/144445535-fae9b2c6-29b8-4080-bb17-5ef78464f899.png) | ![localhost_6006_iframe html_id=pages-emailsent--with-email-resend-no-account args= viewMode=story](https://user-images.githubusercontent.com/13315440/144445898-56b76d2d-b54e-4200-9185-ee1a881a21b7.png) | ![image](https://user-images.githubusercontent.com/13315440/144445584-176e4cba-385f-4075-9a5b-cd040fff4fb9.png) | ![localhost_6006_iframe html_id=pages-emailsent--with-email-resend-no-account args= viewMode=story (1)](https://user-images.githubusercontent.com/13315440/144446024-0d900bbc-a9d6-4150-ae6a-7ce41705dffd.png) |

### Generic

| Mobile Design | Mobile Screenshot | Desktop Design | Desktop Screenshot |
| -- | -- | -- | -- |
| ![image](https://user-images.githubusercontent.com/13315440/144445675-ca28ee08-8baf-45f4-8d21-8e93e0b3e299.png) | ![localhost_6006_iframe html_id=pages-emailsent--with-email-resend args= viewMode=story (1)](https://user-images.githubusercontent.com/13315440/144446262-5acae2ec-f40c-4281-9f04-d10fb26028a0.png) | ![image](https://user-images.githubusercontent.com/13315440/144445714-0faceee3-efca-4c00-babe-64eadc70f950.png) | ![localhost_6006_iframe html_id=pages-emailsent--with-email-resend args= viewMode=story](https://user-images.githubusercontent.com/13315440/144446150-763cb98c-bb76-471a-b225-4d1f2352f2c3.png) |

## Links
- [Figma](https://www.figma.com/file/ZDPonnBXbMhV2smf51Dylc/Sign-in-Journeys?node-id=3628%3A102723)
- [Storybook](https://60929d168594f80039336501-wbcnqvgvrz.chromatic.com/?path=/story/pages-emailsent--with-email-resend-no-account)
- [UI Tests](https://www.chromatic.com/build?appId=60929d168594f80039336501&number=1520)