### PR TITLE
Track server side reCAPTCHA middleware error and success as metric

### DIFF
--- a/src/server/lib/middleware/errorHandler.ts
+++ b/src/server/lib/middleware/errorHandler.ts
@@ -7,6 +7,7 @@ import { PageTitle } from '@/shared/model/PageTitle';
 import { logger } from '@/server/lib/logger';
 import { addQueryParamsToUntypedPath } from '@/shared/lib/queryParams';
 import { getConfiguration } from '@/server/lib/getConfiguration';
+import { trackMetric } from '@/server/lib/trackMetric';
 
 const { defaultReturnUri } = getConfiguration();
 
@@ -34,6 +35,7 @@ export const routeErrorHandler = (
     );
     return next(err);
   } else if (err.code === 'EBADRECAPTCHA') {
+    trackMetric('RecaptchaMiddleware::Failure');
     res.redirect(
       303,
       addQueryParamsToUntypedPath(

--- a/src/server/lib/recaptcha.ts
+++ b/src/server/lib/recaptcha.ts
@@ -3,7 +3,8 @@ import { NextFunction, Request, Response } from 'express';
 import { RecaptchaV2 } from 'express-recaptcha';
 import { getConfiguration } from './getConfiguration';
 import createError from 'http-errors';
-import { logger } from './logger';
+import { logger } from '@/server/lib/logger';
+import { trackMetric } from '@/server/lib/trackMetric';
 
 const {
   googleRecaptcha: { secretKey, siteKey },
@@ -15,11 +16,7 @@ const recaptcha = new RecaptchaV2(siteKey, secretKey);
  * Throws a generic error if the recaptcha check has failed.
  * @param recaptchaResponse
  */
-const checkRecaptchaError = (
-  req: Request,
-  res: Response,
-  next: NextFunction,
-) => {
+const checkRecaptchaError = (req: Request, _: Response, next: NextFunction) => {
   const recaptchaError = createError(400, CaptchaErrors.GENERIC, {
     code: 'EBADRECAPTCHA',
   });
@@ -33,6 +30,8 @@ const checkRecaptchaError = (
     logger.error('Problem verifying recaptcha, error response: ', error);
     return next(recaptchaError);
   }
+
+  trackMetric('RecaptchaMiddleware::Success');
   next();
 };
 

--- a/src/server/models/Metrics.ts
+++ b/src/server/models/Metrics.ts
@@ -20,7 +20,8 @@ type ConditionalMetrics =
   | 'EmailValidated'
   | 'AccountVerification'
   | `${EmailMetrics}EmailSend`
-  | `${'Get' | 'Post'}ConsentsPage-${string}`;
+  | `${'Get' | 'Post'}ConsentsPage-${string}`
+  | `RecaptchaMiddleware`;
 
 // Unconditional metrics that we want to track directly
 type UnconditionalMetrics =


### PR DESCRIPTION
## What does this change?
Adds a metric to track the frequency of successful vs failed reCAPTCHA verification requests: `RecaptchaMiddleware::Success`, `RecaptchaMiddleware::Failure`.

This could be useful if we are experiencing an extended bot attack for example and would like to track how many requests are failing the reCAPTCHA validation middleware.