### PR TITLE
Removed market research opt out from onboarding flow

### DIFF
--- a/cypress/integration/mocked/onboarding_flow.spec.ts
+++ b/cypress/integration/mocked/onboarding_flow.spec.ts
@@ -94,17 +94,13 @@ describe('Onboarding flow', () => {
 
       CommunicationsPage.backButton().should('not.exist');
       CommunicationsPage.allCheckboxes().should('not.be.checked');
-      CommunicationsPage.marketingOptoutClickableSection().click();
 
       // mock form save success
       cy.mockNext(200);
 
       CommunicationsPage.saveAndContinueButton().click();
 
-      cy.lastPayloadIs([
-        { id: 'market_research_optout', consented: true },
-        { id: 'supporter', consented: false },
-      ]);
+      cy.lastPayloadIs([{ id: 'supporter', consented: false }]);
 
       cy.url().should('include', NewslettersPage.URL);
       cy.url().should('include', `returnUrl=${returnUrl}`);
@@ -171,7 +167,6 @@ describe('Onboarding flow', () => {
         cy.contains(newsletter),
       );
 
-      ReviewPage.marketingResearchChoice().contains('Yes');
       ReviewPage.marketingAnalysisChoice().contains('Yes');
 
       ReviewPage.returnButton()
@@ -206,10 +201,7 @@ describe('Onboarding flow', () => {
 
       CommunicationsPage.saveAndContinueButton().click();
 
-      cy.lastPayloadIs([
-        { id: 'market_research_optout', consented: false },
-        { id: 'supporter', consented: true },
-      ]);
+      cy.lastPayloadIs([{ id: 'supporter', consented: true }]);
 
       cy.url().should('include', NewslettersPage.URL);
       cy.url().should('include', `returnUrl=${returnUrl}`);
@@ -250,7 +242,6 @@ describe('Onboarding flow', () => {
       ReviewPage.newslettersSection().contains('N/A');
       ReviewPage.consentsSection().contains('N/A');
 
-      ReviewPage.marketingResearchChoice().contains('No');
       ReviewPage.marketingAnalysisChoice().contains('No');
 
       ReviewPage.returnButton()

--- a/cypress/support/pages/onboarding/communications_page.ts
+++ b/cypress/support/pages/onboarding/communications_page.ts
@@ -8,10 +8,6 @@ class CommunicationsPage extends OnboardingPage {
       'I do NOT wish to be contacted by the Guardian for market research purposes.',
   };
 
-  static marketingOptoutClickableSection() {
-    return cy.contains(CommunicationsPage.CONTENT.OPT_OUT_MESSAGE).parent();
-  }
-
   static consentCheckboxWithTitle(title: string) {
     return cy
       .contains(title)

--- a/cypress/support/pages/onboarding/review_page.ts
+++ b/cypress/support/pages/onboarding/review_page.ts
@@ -14,7 +14,6 @@ class ReviewPage extends OnboardingPage {
       SUBSCRIPTIONS: 'Subscriptions, membership and contributions',
     },
     CONSENT_OPTOUT: {
-      RESEARCH: 'Marketing research',
       ANALYSIS: 'Marketing analysis',
     },
     NEWSLETTER_SECTION_TITLE: 'Newsletters',
@@ -38,14 +37,6 @@ class ReviewPage extends OnboardingPage {
       .contains(ReviewPage.CONTENT.NEWSLETTER_SECTION_TITLE)
       .parent()
       .siblings();
-  }
-
-  static marketingResearchChoice() {
-    return cy
-      .contains(ReviewPage.CONTENT.CONSENT_OPTOUT.RESEARCH)
-      .parent()
-      .siblings()
-      .children();
   }
 
   static marketingAnalysisChoice() {

--- a/src/client/pages/ConsentsCommunication.stories.tsx
+++ b/src/client/pages/ConsentsCommunication.stories.tsx
@@ -9,31 +9,14 @@ export default {
   parameters: { layout: 'fullscreen' },
 } as Meta;
 
-export const NoConsent = () => (
-  <ConsentsCommunication consentsWithoutOptout={[]} />
-);
+export const NoConsent = () => <ConsentsCommunication consents={[]} />;
 NoConsent.story = {
   name: 'with no consents',
 };
 
-export const MarketResearch = () => (
-  <ConsentsCommunication
-    marketResearchOptout={{
-      id: '0',
-      name: 'mr-name',
-      description:
-        'I do NOT wish to be contacted by the Guardian for market research purposes.',
-    }}
-    consentsWithoutOptout={[]}
-  />
-);
-MarketResearch.story = {
-  name: 'with market research consent',
-};
-
 export const WithoutOptout = () => (
   <ConsentsCommunication
-    consentsWithoutOptout={[
+    consents={[
       {
         id: '0',
         name: 'My Consent Name',
@@ -48,7 +31,7 @@ WithoutOptout.story = {
 
 export const MultipleConsents = () => (
   <ConsentsCommunication
-    consentsWithoutOptout={[
+    consents={[
       {
         id: '0',
         name: 'My Consent Name',
@@ -64,30 +47,4 @@ export const MultipleConsents = () => (
 );
 MultipleConsents.story = {
   name: 'with multiple consents',
-};
-
-export const MultipleConsentsAndMarketing = () => (
-  <ConsentsCommunication
-    marketResearchOptout={{
-      id: '0',
-      name: 'mr-name',
-      description:
-        'I do NOT wish to be contacted by the Guardian for market research purposes.',
-    }}
-    consentsWithoutOptout={[
-      {
-        id: '0',
-        name: 'My Consent Name',
-        description: 'Consent description',
-      },
-      {
-        id: '1',
-        name: 'My Other Consent Name',
-        description: 'Other consent description',
-      },
-    ]}
-  />
-);
-MultipleConsentsAndMarketing.story = {
-  name: 'with multiple consents and marketing',
 };

--- a/src/client/pages/ConsentsCommunication.tsx
+++ b/src/client/pages/ConsentsCommunication.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { css } from '@emotion/react';
-import { from, space, neutral, textSans } from '@guardian/source-foundations';
+import { from, space } from '@guardian/source-foundations';
 import {
   getAutoRow,
   gridItemColumnConsents,
@@ -10,7 +10,6 @@ import { CommunicationCard } from '@/client/components/CommunicationCard';
 import { CONSENTS_PAGES } from '@/client/models/ConsentsPages';
 import { heading, text } from '@/client/styles/Consents';
 import { Consent } from '@/shared/model/Consent';
-import { Checkbox, CheckboxGroup } from '@guardian/source-react-components';
 import { ConsentsLayout } from '@/client/layouts/ConsentsLayout';
 import {
   ConsentsContent,
@@ -18,20 +17,8 @@ import {
 } from '@/client/layouts/shared/Consents';
 
 type ConsentsCommunicationProps = {
-  marketResearchOptout?: Consent;
-  consentsWithoutOptout: Consent[];
+  consents: Consent[];
 };
-
-const fieldset = css`
-  border: 0;
-  padding: 0;
-  margin: 14px 0 ${space[1]}px 0;
-  ${textSans.medium()}
-`;
-
-const checkboxLabel = css`
-  color: ${neutral[46]};
-`;
 
 const communicationCardContainer = css`
   display: flex;
@@ -59,14 +46,9 @@ const communicationCardSpanDef = {
 };
 
 export const ConsentsCommunication = ({
-  marketResearchOptout,
-  consentsWithoutOptout,
+  consents,
 }: ConsentsCommunicationProps) => {
   const autoRow = getAutoRow(1, gridItemColumnConsents);
-
-  const label = (
-    <span css={checkboxLabel}>{marketResearchOptout?.description}</span>
-  );
 
   return (
     <ConsentsLayout
@@ -83,7 +65,7 @@ export const ConsentsCommunication = ({
         <div
           css={[communicationCardContainer, autoRow(communicationCardSpanDef)]}
         >
-          {consentsWithoutOptout.map((consent) => (
+          {consents.map((consent) => (
             <CommunicationCard
               key={consent.id}
               title={consent.name}
@@ -93,28 +75,6 @@ export const ConsentsCommunication = ({
             />
           ))}
         </div>
-        {marketResearchOptout && (
-          <>
-            <h2 css={[heading, autoRow()]}>
-              Using your data for market research
-            </h2>
-            <p css={[text, autoRow()]}>
-              From time to time we may contact you for market research purposes
-              inviting you to complete a survey, or take part in a group
-              discussion. Normally, this invitation would be sent via email, but
-              we may also contact you by phone.
-            </p>
-            <fieldset css={[fieldset, autoRow()]}>
-              <CheckboxGroup name={marketResearchOptout.id}>
-                <Checkbox
-                  value="consent-option"
-                  label={label}
-                  defaultChecked={marketResearchOptout.consented}
-                />
-              </CheckboxGroup>
-            </fieldset>
-          </>
-        )}
       </ConsentsContent>
     </ConsentsLayout>
   );

--- a/src/client/pages/ConsentsCommunicationPage.tsx
+++ b/src/client/pages/ConsentsCommunicationPage.tsx
@@ -1,7 +1,6 @@
 import React, { useContext } from 'react';
 import { ClientState } from '@/shared/model/ClientState';
 import { ClientStateContext } from '@/client/components/ClientState';
-import { Consents } from '@/shared/model/Consent';
 import { ConsentsCommunication } from '@/client/pages/ConsentsCommunication';
 
 export const ConsentsCommunicationPage = () => {
@@ -10,18 +9,5 @@ export const ConsentsCommunicationPage = () => {
   const { pageData = {} } = clientState;
   const { consents = [] } = pageData;
 
-  const marketResearchOptout = consents.find(
-    (consent) => consent.id === Consents.MARKET_RESEARCH,
-  );
-
-  const consentsWithoutOptout = consents.filter(
-    (consent) => !consent.id.includes('_optout'),
-  );
-
-  return (
-    <ConsentsCommunication
-      marketResearchOptout={marketResearchOptout}
-      consentsWithoutOptout={consentsWithoutOptout}
-    />
-  );
+  return <ConsentsCommunication consents={consents} />;
 };

--- a/src/client/pages/ConsentsConfirmation.stories.tsx
+++ b/src/client/pages/ConsentsConfirmation.stories.tsx
@@ -9,23 +9,9 @@ export default {
   parameters: { layout: 'fullscreen' },
 } as Meta;
 
-export const NoConsent = () => (
-  <ConsentsConfirmation
-    returnUrl=""
-    optedOutOfMarketResearch={true}
-    optedOutOfProfiling={true}
-    productConsents={[]}
-    subscribedNewsletters={[]}
-  />
-);
-NoConsent.story = {
-  name: 'with no consent given',
-};
-
 export const Profiling = () => (
   <ConsentsConfirmation
     returnUrl=""
-    optedOutOfMarketResearch={true}
     optedOutOfProfiling={false}
     productConsents={[]}
     subscribedNewsletters={[]}
@@ -35,23 +21,9 @@ Profiling.story = {
   name: 'with consent given to profilling',
 };
 
-export const ProfilingMarketing = () => (
-  <ConsentsConfirmation
-    returnUrl=""
-    optedOutOfMarketResearch={false}
-    optedOutOfProfiling={false}
-    productConsents={[]}
-    subscribedNewsletters={[]}
-  />
-);
-ProfilingMarketing.story = {
-  name: 'with consent given to profilling and marketing',
-};
-
 export const Newsletters = () => (
   <ConsentsConfirmation
     returnUrl=""
-    optedOutOfMarketResearch={true}
     optedOutOfProfiling={true}
     productConsents={[]}
     subscribedNewsletters={[
@@ -79,7 +51,6 @@ Newsletters.story = {
 export const Products = () => (
   <ConsentsConfirmation
     returnUrl=""
-    optedOutOfMarketResearch={true}
     optedOutOfProfiling={true}
     productConsents={[
       {

--- a/src/client/pages/ConsentsConfirmation.tsx
+++ b/src/client/pages/ConsentsConfirmation.tsx
@@ -31,7 +31,6 @@ type ConsentsConfirmationProps = {
   success?: string;
   returnUrl: string;
   optedOutOfProfiling: boolean;
-  optedOutOfMarketResearch: boolean;
   productConsents: Consent[];
   subscribedNewsletters: NewsLetter[];
   geolocation?: GeoLocation;
@@ -153,7 +152,6 @@ export const ConsentsConfirmation = ({
   success,
   returnUrl,
   optedOutOfProfiling,
-  optedOutOfMarketResearch,
   productConsents,
   subscribedNewsletters,
   geolocation,
@@ -206,9 +204,6 @@ export const ConsentsConfirmation = ({
                 ) : (
                   <p css={text}>N/A</p>
                 )}
-              </ReviewTableRow>
-              <ReviewTableRow title="Marketing research">
-                <p css={text}>{optedOutOfMarketResearch ? 'No' : 'Yes'}</p>
               </ReviewTableRow>
               <ReviewTableRow title="Marketing analysis">
                 <p css={text}>{optedOutOfProfiling ? 'No' : 'Yes'}</p>

--- a/src/client/pages/ConsentsConfirmationPage.tsx
+++ b/src/client/pages/ConsentsConfirmationPage.tsx
@@ -20,10 +20,6 @@ export const ConsentsConfirmationPage = () => {
     (consent) => consent.id === Consents.PROFILING && consent.consented,
   );
 
-  const optedOutOfMarketResearch = !!consents.find(
-    (consent) => consent.id === Consents.MARKET_RESEARCH && consent.consented,
-  );
-
   const productConsents = consents.filter(
     (c) => !c.id.includes('_optout') && c.consented,
   );
@@ -36,7 +32,6 @@ export const ConsentsConfirmationPage = () => {
       success={success}
       returnUrl={returnUrl}
       optedOutOfProfiling={optedOutOfProfiling}
-      optedOutOfMarketResearch={optedOutOfMarketResearch}
       productConsents={productConsents}
       subscribedNewsletters={subscribedNewsletters}
     />

--- a/src/shared/model/Consent.ts
+++ b/src/shared/model/Consent.ts
@@ -7,7 +7,6 @@ export interface Consent {
 
 export enum Consents {
   PROFILING = 'profiling_optout',
-  MARKET_RESEARCH = 'market_research_optout',
   SUPPORTER = 'supporter',
   JOBS = 'jobs',
   HOLIDAYS = 'holidays',
@@ -17,7 +16,4 @@ export enum Consents {
 
 export const CONSENTS_DATA_PAGE: string[] = [Consents.PROFILING];
 
-export const CONSENTS_COMMUNICATION_PAGE: string[] = [
-  Consents.MARKET_RESEARCH,
-  Consents.SUPPORTER,
-];
+export const CONSENTS_COMMUNICATION_PAGE: string[] = [Consents.SUPPORTER];


### PR DESCRIPTION
## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

The removes the marketing research opt out from the onboarding flow, and also any related code.

## How to test

- Go to `/register` and enter an email address,
- Visit the sign in link sent to that address (locally, I have been logging the URL to the terminal from the running IDAPI process)
- Enter a password
- Observe that the market research opt out is no longer visible on the `/consents/communication` page
- Continue through the onboarding flow
- Observe that no information relating to market research consent is visible on the final `/consents/review` page

## How can we measure success?

This change has already been tested previously.

## Have we considered potential risks?

No major risks anticipated.

## Images

### Before

![Screenshot_2021-12-08_at_12 14 28](https://user-images.githubusercontent.com/3338808/145841476-0519e1b6-ef1f-4c0a-965b-9c7809d34684.png)

### After

![image](https://user-images.githubusercontent.com/3338808/145842538-4f58d139-dc99-4a6a-9f3e-07e8e2dc0487.png)

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

- [ ] [Tested with screen reader](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#screen-readers)
- [ ] [Navigable with keyboard](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#keyboard-navigation)
- [ ] [Colour contrast passed](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#colour-contrast)
- [ ] [The change doesn't use only colour to convey meaning](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#use-of-colour)
