### PR TITLE
Refactor logging: Remove logstash, use Kinesis

### DIFF
--- a/.github/workflows/cypress-ete.yml
+++ b/.github/workflows/cypress-ete.yml
@@ -41,6 +41,8 @@ jobs:
           ENCRYPTION_SECRET_KEY: ${{ secrets.ENCRYPTION_SECRET_KEY }}
           OKTA_ORG_URL: oktaorgurl
           OKTA_API_TOKEN: oktatoken
+          LOGGING_KINESIS_STREAM: ''
+          EC2_INSTANCE_ID: ''
         with:
           build: yarn build
           start: yarn start

--- a/.github/workflows/cypress-mocked.yml
+++ b/.github/workflows/cypress-mocked.yml
@@ -34,6 +34,8 @@ jobs:
           ENCRYPTION_SECRET_KEY: f3d87b231ddd6f50d99e227c5bc9b7cbb649387b321008df412fd73805ac2e32
           OKTA_ORG_URL: oktaorgurl
           OKTA_API_TOKEN: oktatoken
+          LOGGING_KINESIS_STREAM: ''
+          EC2_INSTANCE_ID: ''
         with:
           build: yarn build
           start: yarn start, yarn mock-server

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -234,53 +234,13 @@ Resources:
             Environment=ENCRYPTION_SECRET_KEY=$ENCRYPTION_SECRET_KEY
             Environment=OKTA_ORG_URL=${OktaOrgUrl}
             Environment=OKTA_API_TOKEN=$OKTA_API_TOKEN
+            Environment=LOGGING_KINESIS_STREAM=${KinesisStream}
+            Environment=EC2_INSTANCE_ID=$(curl -s http://169.254.169.254/latest/meta-data/instance-id)
 
             [Install]
             WantedBy=multi-user.target
             EOL
 
-            # logstash setup
-            sed -i 's/-Xms.*/-Xms512m/g' /etc/logstash/jvm.options
-            sed -i 's/-Xmx.*/-Xmx512m/g' /etc/logstash/jvm.options
-
-            instanceid=$(curl -s http://169.254.169.254/latest/meta-data/instance-id)
-
-            cat > /etc/logstash/conf.d/logstash.conf <<__END__
-            input {
-              stdin {}
-              file {
-                add_field => {
-                  'app' => '${App}'
-                  'stage' => '${Stage}'
-                  'stack' => '${Stack}'
-                  'ec2_instance' => '$instanceid'
-                }
-                path => "/var/log/identity-gateway.log"
-                type => "app"
-                start_position => "beginning"
-              }
-            }
-            output {
-              kinesis {
-                stream_name => "${KinesisStream}"
-                region => "${AWS::Region}"
-              }
-            }
-            filter {
-                if [type] == "app" {
-                    multiline {
-                        pattern => "^\s"
-                        what => "previous"
-                      }
-                }
-                date {
-                    match => [ "timestamp" , "yyyy-MM-dd HH:mm:ss,SSS" ]
-                }
-            }
-            __END__
-
-            # Run
-            # systemctl start logstash
             systemctl enable identity-gateway
             systemctl start identity-gateway
 

--- a/package.json
+++ b/package.json
@@ -144,6 +144,7 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-router-dom": "^6.1.1",
-    "winston": "^3.3.3"
+    "winston": "^3.3.3",
+    "winston-transport": "^4.4.1"
   }
 }

--- a/src/server/lib/__tests__/getConfiguration.test.ts
+++ b/src/server/lib/__tests__/getConfiguration.test.ts
@@ -69,6 +69,10 @@ describe('getConfiguration', () => {
         orgUrl: 'oktaorgurl',
         token: 'oktatoken',
       },
+      aws: {
+        kinesisStreamName: '',
+        instanceId: '',
+      },
     };
     expect(output).toEqual(expected);
   });

--- a/src/server/lib/awsConfig.ts
+++ b/src/server/lib/awsConfig.ts
@@ -8,7 +8,12 @@ const CREDENTIAL_PROVIDER = new AWS.CredentialProviderChain([
   ...AWS.CredentialProviderChain.defaultProviders,
 ]);
 
-export const awsConfig = {
+export const awsConfig: AWS.ConfigurationOptions = {
   region: AWS_REGION,
   credentialProvider: CREDENTIAL_PROVIDER,
+  maxRetries: 0,
+  httpOptions: {
+    connectTimeout: 500,
+    timeout: 250,
+  },
 };

--- a/src/server/lib/getConfiguration.ts
+++ b/src/server/lib/getConfiguration.ts
@@ -9,8 +9,12 @@ import {
 } from '@/server/models/Configuration';
 import { featureSwitches } from '@/shared/lib/featureSwitches';
 
-const getOrThrow = (value: string | undefined, errorMessage: string) => {
-  if (!value) {
+const getOrThrow = (
+  value: string | undefined,
+  errorMessage: string,
+  strictCheck = true,
+) => {
+  if (typeof value === 'undefined' || (strictCheck && value === '')) {
     throw Error(errorMessage);
   }
   return value;
@@ -145,11 +149,16 @@ export const getConfiguration = (): Configuration => {
         : getOrThrow(
             process.env.LOGGING_KINESIS_STREAM,
             'LOGGING_KINESIS_STREAM missing',
+            false,
           ),
     instanceId:
       stage === 'DEV'
         ? ''
-        : getOrThrow(process.env.EC2_INSTANCE_ID, 'EC2_INSTANCE_ID missing'),
+        : getOrThrow(
+            process.env.EC2_INSTANCE_ID,
+            'EC2_INSTANCE_ID missing',
+            false,
+          ),
   };
 
   return {

--- a/src/server/lib/logger.ts
+++ b/src/server/lib/logger.ts
@@ -47,11 +47,9 @@ class KinesisTransport extends Transport {
           .promise()
           .catch((error: AWSError) => {
             if (error.code === 'ExpiredToken' && stage === 'DEV') {
-              logger.warn(
+              console.warn(
                 'AWS Credentials Expired. Have you added `Identity` Janus credentials?',
               );
-            } else {
-              logger.error('Kinesis Logging Error', error);
             }
           });
       }

--- a/src/server/lib/logger.ts
+++ b/src/server/lib/logger.ts
@@ -1,9 +1,68 @@
+import { AWSError, Kinesis } from 'aws-sdk';
 import { Logger, LogLevel } from '@/server/models/Logger';
 import { createLogger, transports } from 'winston';
+import Transport, { TransportStreamOptions } from 'winston-transport';
 import { formatWithOptions, InspectOptions } from 'util';
+import { awsConfig } from './awsConfig';
+import { getConfiguration } from './getConfiguration';
+
+const {
+  stage,
+  aws: { instanceId, kinesisStreamName },
+} = getConfiguration();
+
+// custom "Winston Transport" to send logs to the AWS kinesis stream
+// see https://github.com/winstonjs/winston-transport#usage
+class KinesisTransport extends Transport {
+  private kinesis: Kinesis;
+
+  constructor(opts?: TransportStreamOptions) {
+    super(opts);
+
+    this.kinesis = new Kinesis(awsConfig);
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  public log(info: any, callback: () => void) {
+    const { level, message } = info;
+
+    setImmediate(() => {
+      this.emit('logger', level);
+      if (kinesisStreamName) {
+        this.kinesis
+          .putRecord({
+            StreamName: kinesisStreamName,
+            PartitionKey: stage,
+            Data: JSON.stringify({
+              type: 'app',
+              app: 'identity-gateway',
+              stack: 'identity',
+              path: '/var/log/identity-gateway.log',
+              instance_id: instanceId,
+              stage,
+              level,
+              message,
+            }),
+          })
+          .promise()
+          .catch((error: AWSError) => {
+            if (error.code === 'ExpiredToken' && stage === 'DEV') {
+              logger.warn(
+                'AWS Credentials Expired. Have you added `Identity` Janus credentials?',
+              );
+            } else {
+              logger.error('Kinesis Logging Error', error);
+            }
+          });
+      }
+    });
+
+    callback();
+  }
+}
 
 const winstonLogger = createLogger({
-  transports: [new transports.Console()],
+  transports: [new transports.Console(), new KinesisTransport()],
 });
 
 const loggingOptions: InspectOptions = {
@@ -13,7 +72,7 @@ const loggingOptions: InspectOptions = {
   compact: true,
 };
 
-// eslint-disable-next-line
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 const formatLogParam = (message?: any) =>
   formatWithOptions(loggingOptions, message);
 

--- a/src/server/lib/logger.ts
+++ b/src/server/lib/logger.ts
@@ -46,10 +46,13 @@ class KinesisTransport extends Transport {
           })
           .promise()
           .catch((error: AWSError) => {
-            if (error.code === 'ExpiredToken' && stage === 'DEV') {
+            if (error.code.includes('ExpiredToken') && stage === 'DEV') {
               console.warn(
                 'AWS Credentials Expired. Have you added `Identity` Janus credentials?',
               );
+            }
+            if (error.code.includes('TimeoutError')) {
+              console.warn('Timeout when attempting to log to kinesis stream.');
             }
           });
       }

--- a/src/server/lib/trackMetric.ts
+++ b/src/server/lib/trackMetric.ts
@@ -46,12 +46,12 @@ export const trackMetric = (
   })
     .promise()
     .catch((error: AWSError) => {
-      if (error.code === 'ExpiredToken' && Stage === 'DEV') {
+      if (error.code.includes('ExpiredToken') && Stage === 'DEV') {
         logger.warn(
           'AWS Credentials Expired. Have you added `Identity` Janus credentials?',
         );
       } else {
-        logger.error('Track Metric Error', error);
+        logger.warn('Track Metric Error', error);
       }
     });
 };

--- a/src/server/models/Configuration.ts
+++ b/src/server/models/Configuration.ts
@@ -1,3 +1,4 @@
+export type Stage = 'DEV' | 'CODE' | 'PROD';
 export interface Configuration {
   port: number;
   idapiClientAccessToken: string;
@@ -6,7 +7,7 @@ export interface Configuration {
   signInPageUrl: string;
   baseUri: string;
   defaultReturnUri: string;
-  stage: string;
+  stage: Stage;
   gaUID: {
     id: string;
     hash: string;
@@ -22,6 +23,12 @@ export interface Configuration {
   encryptionSecretKey: string;
   oauthBaseUrl: string;
   okta: Okta;
+  aws: AWSConfiguration;
+}
+
+export interface AWSConfiguration {
+  kinesisStreamName: string;
+  instanceId: string;
 }
 
 export interface Okta {

--- a/yarn.lock
+++ b/yarn.lock
@@ -16271,6 +16271,15 @@ winston-transport@^4.4.0:
     readable-stream "^2.3.7"
     triple-beam "^1.2.0"
 
+winston-transport@^4.4.1:
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/winston-transport/-/winston-transport-4.4.1.tgz#42a830e07363719c13c12bd2fb87a226f692dc75"
+  integrity sha512-ciZRlU4CSjHqHe8RQG1iPxKMRVwv6ZJ0RC7DxStKWd0KjpAhPDy5gVYSCpIUq+5CUsP+IyNOTZy1X0tO2QZqjg==
+  dependencies:
+    logform "^2.2.0"
+    readable-stream "^3.4.0"
+    triple-beam "^1.2.0"
+
 winston@^3.3.3:
   version "3.3.3"
   resolved "https://registry.yarnpkg.com/winston/-/winston-3.3.3.tgz#ae6172042cafb29786afa3d09c8ff833ab7c9170"


### PR DESCRIPTION
## What does this change?
Use AWS Kinesis directly in gateway for logging, replacing logstash to resolve the log4j vulnerability. Example of logs coming through in Kibana: https://logs.gutools.co.uk/s/identity/goto/5718bb0ff3699215b6bd453bec4b5662

- Remove logstash configuration from the cloudformation.
- Add environment variables (only for `CODE`/`PROD`) for the `LOGGING_KINESIS_STREAM` and `EC2_INSTANCE_ID`
- Set up new ["winston transport"](https://github.com/winstonjs/winston-transport#usage) to pipe logs directly to aws kinesis through our logging solution "winston"
  - We have to use `any` in typescript as the shape of the `info` object can change.
- Type the `stage` variable so it has to be one of `DEV | CODE | PROD`
- Update `getOrThrow` to add another parameter to do strict checking
  - strict checking checks for both `undefined` and empty string `""`
  - disabling strict checking only checks for `undefined`
  - strict checking enabled by default
  - this option is needed as in CI the kinesis stream variable should be an empty string, but was previously failing as `getOrThrow` was doing a simple falsey check
- Update the aws configuration options so that the following happens to help prevent promises from leaking:
  - `maxRetries = 0` - Set retries to 0 so that aws doesn't attempt to retry the request
  - `httpOptions.connectTimeout = 500` - The maximum time in milliseconds that the connection phase of the request should be allowed to take.
  - `httpOptions.timeout = 250` - Sets the socket to timeout after timeout milliseconds of inactivity on the socket. Defaulted previously two minutes (120000).
  - This also affects `trackMetric` too
  - Use `includes` for certain error codes as some errors don't exactly match
 
## Post-merge
- [ ] Update the AMI to remove logstash