### PR TITLE
Add `ref` and `refViewId` tracking parameters to gateway flows

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "husky": "^7.0.4",
     "image-webpack-loader": "^8.0.1",
     "jest": "^27.4.4",
+    "jest-mock": "^27.4.2",
     "nodemon": "^2.0.15",
     "prettier": "^2.5.1",
     "react-test-renderer": "^17.0.2",

--- a/src/client/components/MainForm.tsx
+++ b/src/client/components/MainForm.tsx
@@ -17,7 +17,8 @@ import {
   UseRecaptchaReturnValue,
 } from '@/client/lib/hooks/useRecaptcha';
 import { CaptchaErrors } from '@/shared/model/Errors';
-import { DetailedRecaptchaError } from './DetailedRecaptchaError';
+import { DetailedRecaptchaError } from '@/client/components/DetailedRecaptchaError';
+import { RefTrackingFormFields } from '@/client/components/RefTrackingFormFields';
 
 export interface MainFormProps {
   formAction: string;
@@ -156,6 +157,7 @@ export const MainForm = ({
         />
       )}
       <CsrfFormField />
+      <RefTrackingFormFields />
       <div css={inputStyles(hasTerms)}>{children}</div>
       {hasGuardianTerms && <GuardianTerms />}
       {recaptchaEnabled && <RecaptchaTerms />}

--- a/src/client/components/RefTrackingFormFields.tsx
+++ b/src/client/components/RefTrackingFormFields.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { useRefTracking } from '../lib/hooks/useRefTracking';
+
+export const RefTrackingFormFields = () => {
+  const { ref, refViewId } = useRefTracking();
+
+  return (
+    <>
+      <input type="hidden" name="ref" value={ref} />
+      <input type="hidden" name="refViewId" value={refViewId} />
+    </>
+  );
+};

--- a/src/client/lib/hooks/useRefTracking.ts
+++ b/src/client/lib/hooks/useRefTracking.ts
@@ -1,0 +1,12 @@
+// react hook for getting the `ref` and `refViewId` for tracking
+// `ref` is the current url of the page we want to track
+// `refViewId` is the current ophan page view id we want to track
+export const useRefTracking = (): { ref?: string; refViewId?: string } => {
+  if (typeof window !== 'undefined') {
+    return {
+      ref: `${window.location.origin}${window.location.pathname}`,
+      refViewId: window.guardian.ophan?.viewId,
+    };
+  }
+  return {};
+};

--- a/src/client/lib/hooks/useRefTracking.ts
+++ b/src/client/lib/hooks/useRefTracking.ts
@@ -1,7 +1,9 @@
+import { TrackingQueryParams } from '@/shared/model/QueryParams';
+
 // react hook for getting the `ref` and `refViewId` for tracking
 // `ref` is the current url of the page we want to track
 // `refViewId` is the current ophan page view id we want to track
-export const useRefTracking = (): { ref?: string; refViewId?: string } => {
+export const useRefTracking = (): TrackingQueryParams => {
   if (typeof window !== 'undefined') {
     return {
       ref: `${window.location.origin}${window.location.pathname}`,

--- a/src/client/pages/Registration.tsx
+++ b/src/client/pages/Registration.tsx
@@ -22,6 +22,7 @@ import { EmailInput } from '@/client/components/EmailInput';
 import { buildUrlWithQueryParams } from '@/shared/lib/routeUtils';
 import { QueryParams } from '@/shared/model/QueryParams';
 import { GeoLocation } from '@/shared/model/Geolocation';
+import { RefTrackingFormFields } from '@/client/components/RefTrackingFormFields';
 
 export type RegistrationProps = {
   returnUrl?: string;
@@ -130,6 +131,7 @@ export const Registration = ({
         >
           <RecaptchaElement id="register-recaptcha" />
           <CsrfFormField />
+          <RefTrackingFormFields />
           <EmailInput defaultValue={email} />
           <Terms />
           <Button css={registerButton} type="submit" data-cy="register-button">

--- a/src/client/pages/SignIn.tsx
+++ b/src/client/pages/SignIn.tsx
@@ -24,6 +24,7 @@ import useRecaptcha, {
   RecaptchaElement,
 } from '@/client/lib/hooks/useRecaptcha';
 import locations from '@/shared/lib/locations';
+import { RefTrackingFormFields } from '@/client/components/RefTrackingFormFields';
 
 export type SignInProps = {
   returnUrl?: string;
@@ -211,6 +212,7 @@ export const SignIn = ({
         >
           <RecaptchaElement id="signin-recaptcha" />
           <CsrfFormField />
+          <RefTrackingFormFields />
           <EmailInput defaultValue={email} />
           <div css={passwordInput}>
             <PasswordInput label="Password" />

--- a/src/server/lib/__tests__/crypto.test.ts
+++ b/src/server/lib/__tests__/crypto.test.ts
@@ -1,5 +1,5 @@
 import crypto from 'crypto';
-import { mocked } from 'ts-jest/utils';
+import { mocked } from 'jest-mock';
 import { Configuration } from '@/server/models/Configuration';
 import { decrypt, encrypt } from '../crypto';
 import { getConfiguration } from '../getConfiguration';

--- a/src/server/lib/getABTesting.ts
+++ b/src/server/lib/getABTesting.ts
@@ -1,5 +1,4 @@
 import { ABTesting } from '@/server/models/Express';
-import { Configuration } from '@/server/models/Configuration';
 import { getMvtId } from './getMvtId';
 import { Request } from 'express';
 import { getABForcedVariants } from './getABForcedVariants';
@@ -8,10 +7,9 @@ import { ABTest, ABTestAPI, Runnable } from '@guardian/ab-core';
 
 export const getABTesting = (
   req: Request,
-  config: Configuration,
   tests: ABTest[],
 ): [ABTesting, ABTestAPI] => {
-  const mvtId = getMvtId(req, config);
+  const mvtId = getMvtId(req);
   const forcedTestVariants = getABForcedVariants(req);
 
   const abTestAPI = abTestApiForMvtId(mvtId, forcedTestVariants);

--- a/src/server/lib/getMvtId.ts
+++ b/src/server/lib/getMvtId.ts
@@ -1,13 +1,9 @@
 import { Request } from 'express';
-import { Configuration } from '@/server/models/Configuration';
+import { getConfiguration } from '@/server/lib/getConfiguration';
 
-export const getMvtId = (
-  request: Request,
-  configuration: Configuration,
-): number => {
+export const getMvtId = (request: Request): number => {
   const { cookies } = request;
-  const { stage } = configuration;
-  if (cookies['GU_mvt_id_local'] && stage === 'DEV') {
+  if (cookies['GU_mvt_id_local'] && getConfiguration().stage === 'DEV') {
     return Number(cookies['GU_mvt_id_local']) || 0;
   }
 

--- a/src/server/lib/idapi/resetPassword.ts
+++ b/src/server/lib/idapi/resetPassword.ts
@@ -28,7 +28,13 @@ const handleError = ({ error, status = 500 }: IDAPIError) => {
   throw new IdapiError({ message: ResetPasswordErrors.GENERIC, status });
 };
 
-export async function create(email: string, ip: string, returnUrl: string) {
+export async function create(
+  email: string,
+  ip: string,
+  returnUrl: string,
+  ref?: string,
+  refViewId?: string,
+) {
   const options = APIPostOptions({
     'email-address': email,
     returnUrl,
@@ -37,6 +43,6 @@ export async function create(email: string, ip: string, returnUrl: string) {
   return idapiFetch({
     path: '/pwd-reset/send-password-reset-email',
     options: APIAddClientAccessToken(options, ip),
-    queryParams: { returnUrl },
+    queryParams: { returnUrl, ref, refViewId },
   }).catch(handleError);
 }

--- a/src/server/lib/idapi/user.ts
+++ b/src/server/lib/idapi/user.ts
@@ -130,6 +130,8 @@ export const sendAccountVerificationEmail = async (
   email: string,
   ip: string,
   returnUrl: string,
+  ref?: string,
+  refViewId?: string,
 ) => {
   const options = APIPostOptions({
     'email-address': email,
@@ -138,7 +140,7 @@ export const sendAccountVerificationEmail = async (
     await idapiFetch({
       path: '/user/send-account-verification-email',
       options: APIAddClientAccessToken(options, ip),
-      queryParams: { returnUrl },
+      queryParams: { returnUrl, ref, refViewId },
     });
     trackMetric(emailSendMetric('AccountVerification', 'Success'));
   } catch (error) {
@@ -155,6 +157,8 @@ export const sendAccountExistsEmail = async (
   email: string,
   ip: string,
   returnUrl: string,
+  ref?: string,
+  refViewId?: string,
 ) => {
   const options = APIPostOptions({
     'email-address': email,
@@ -163,7 +167,7 @@ export const sendAccountExistsEmail = async (
     await idapiFetch({
       path: '/user/send-account-exists-email',
       options: APIAddClientAccessToken(options, ip),
-      queryParams: { returnUrl },
+      queryParams: { returnUrl, ref, refViewId },
     });
     trackMetric(emailSendMetric('AccountExists', 'Success'));
   } catch (error) {
@@ -180,6 +184,8 @@ export const sendAccountWithoutPasswordExistsEmail = async (
   email: string,
   ip: string,
   returnUrl: string,
+  ref?: string,
+  refViewId?: string,
 ) => {
   const options = APIPostOptions({
     'email-address': email,
@@ -188,7 +194,7 @@ export const sendAccountWithoutPasswordExistsEmail = async (
     await idapiFetch({
       path: '/user/send-account-without-password-exists-email',
       options: APIAddClientAccessToken(options, ip),
-      queryParams: { returnUrl },
+      queryParams: { returnUrl, ref, refViewId },
     });
     trackMetric(emailSendMetric('AccountExistsWithoutPassword', 'Success'));
   } catch (error) {
@@ -205,6 +211,8 @@ export const sendCreatePasswordEmail = async (
   email: string,
   ip: string,
   returnUrl: string,
+  ref?: string,
+  refViewId?: string,
 ) => {
   const options = APIPostOptions({
     'email-address': email,
@@ -213,7 +221,7 @@ export const sendCreatePasswordEmail = async (
     await idapiFetch({
       path: '/user/send-create-password-account-exists-email',
       options: APIAddClientAccessToken(options, ip),
-      queryParams: { returnUrl },
+      queryParams: { returnUrl, ref, refViewId },
     });
     trackMetric(emailSendMetric('CreatePassword', 'Success'));
   } catch (error) {

--- a/src/server/lib/middleware/login.ts
+++ b/src/server/lib/middleware/login.ts
@@ -18,8 +18,7 @@ export const loginMiddleware = async (
   res: ResponseWithRequestState,
   next: NextFunction,
 ) => {
-  const config = getConfiguration();
-  const LOGIN_REDIRECT_URL = config.signInPageUrl;
+  const { signInPageUrl: LOGIN_REDIRECT_URL } = getConfiguration();
 
   const redirectAuth = (auth: IDAPIAuthRedirect) => {
     if (auth.redirect) {

--- a/src/server/lib/middleware/requestState.ts
+++ b/src/server/lib/middleware/requestState.ts
@@ -3,19 +3,24 @@
 // Requires: csurf middlware
 import { getGeolocationRegion } from '@/server/lib/getGeolocationRegion';
 import { parseExpressQueryParams } from '@/server/lib/queryParams';
-import { NextFunction, Request, Response } from 'express';
+import { NextFunction, Response } from 'express';
 import { getConfiguration } from '@/server/lib/getConfiguration';
 import { tests } from '@/shared/model/experiments/abTests';
 import { getABTesting } from '@/server/lib/getABTesting';
-import { RequestState } from '@/server/models/Express';
+import { RequestState, RequestWithTypedQuery } from '@/server/models/Express';
 
-const config = getConfiguration();
+const { idapiBaseUrl, oauthBaseUrl, googleRecaptcha } = getConfiguration();
 
-const { idapiBaseUrl, oauthBaseUrl, googleRecaptcha } = config;
+const getRequestState = (req: RequestWithTypedQuery): RequestState => {
+  const [abTesting, abTestAPI] = getABTesting(req, tests);
 
-const getRequestState = (req: Request): RequestState => {
-  const [abTesting, abTestAPI] = getABTesting(req, config, tests);
-  const queryParams = parseExpressQueryParams(req.method, req.query);
+  // tracking parameters might be from body too
+  const { ref, refViewId } = req.body;
+
+  const queryParams = parseExpressQueryParams(req.method, req.query, {
+    ref,
+    refViewId,
+  });
   return {
     queryParams,
     pageData: {
@@ -37,7 +42,7 @@ const getRequestState = (req: Request): RequestState => {
 };
 
 export const requestStateMiddleware = (
-  req: Request,
+  req: RequestWithTypedQuery,
   res: Response,
   next: NextFunction,
 ) => {

--- a/src/server/lib/queryParams.ts
+++ b/src/server/lib/queryParams.ts
@@ -45,18 +45,8 @@ export const parseExpressQueryParams = (
     ref,
     encryptedEmail,
     error,
-  }: {
-    returnUrl?: string;
-    clientId?: string;
-    emailVerified?: string;
-    emailSentSuccess?: string;
-    csrfError?: string;
-    recaptchaError?: string;
-    refViewId?: string;
-    ref?: string;
-    encryptedEmail?: string;
-    error?: string;
-  },
+  }: Record<keyof QueryParams, string | undefined>, // parameters from req.query
+  bodyParams: Pick<QueryParams, 'ref' | 'refViewId'> = {}, // some parameters may be manually passed in req.body too
 ): QueryParams => {
   return {
     returnUrl: validateReturnUrl(returnUrl),
@@ -65,8 +55,8 @@ export const parseExpressQueryParams = (
     emailSentSuccess: isStringBoolean(emailSentSuccess),
     csrfError: validateGetOnlyError(method, csrfError),
     recaptchaError: validateGetOnlyError(method, recaptchaError),
-    refViewId,
-    ref: ref && validateRefUrl(ref),
+    refViewId: refViewId || bodyParams.refViewId,
+    ref: (ref || bodyParams.ref) && validateRefUrl(ref || bodyParams.ref),
     encryptedEmail,
     error: validateError(error),
   };

--- a/src/server/lib/queryParams.ts
+++ b/src/server/lib/queryParams.ts
@@ -1,4 +1,4 @@
-import { QueryParams } from '@/shared/model/QueryParams';
+import { QueryParams, TrackingQueryParams } from '@/shared/model/QueryParams';
 import { validateReturnUrl, validateRefUrl } from '@/server/lib/validateUrl';
 import { validateClientId } from '@/server/lib/validateClientId';
 import { FederationErrors } from '@/shared/model/Errors';
@@ -46,7 +46,9 @@ export const parseExpressQueryParams = (
     encryptedEmail,
     error,
   }: Record<keyof QueryParams, string | undefined>, // parameters from req.query
-  bodyParams: Pick<QueryParams, 'ref' | 'refViewId'> = {}, // some parameters may be manually passed in req.body too
+  // some parameters may be manually passed in req.body too,
+  // generally for tracking purposes
+  bodyParams: TrackingQueryParams = {},
 ): QueryParams => {
   return {
     returnUrl: validateReturnUrl(returnUrl),

--- a/src/server/models/Express.ts
+++ b/src/server/models/Express.ts
@@ -1,4 +1,4 @@
-import { Response } from 'express';
+import { Request, Response } from 'express';
 import { QueryParams } from '@/shared/model/QueryParams';
 import {
   ClientHosts,
@@ -30,4 +30,8 @@ export interface RequestState {
 
 export interface ResponseWithRequestState extends Response {
   locals: RequestState;
+}
+
+export interface RequestWithTypedQuery extends Request {
+  query: Record<keyof QueryParams, string | undefined>;
 }

--- a/src/server/routes/register.ts
+++ b/src/server/routes/register.ts
@@ -61,7 +61,8 @@ router.post(
   '/register/email-sent/resend',
   handleRecaptcha,
   handleAsyncErrors(async (req: Request, res: ResponseWithRequestState) => {
-    const { returnUrl, emailSentSuccess } = res.locals.queryParams;
+    const { returnUrl, emailSentSuccess, ref, refViewId } =
+      res.locals.queryParams;
 
     try {
       // read and parse the encrypted state cookie
@@ -86,11 +87,23 @@ router.post(
         switch (emailType) {
           // they were a newly registered user, so resend the AccountVerification Email
           case EmailType.ACCOUNT_VERIFICATION:
-            await sendAccountVerificationEmail(email, req.ip, returnUrl);
+            await sendAccountVerificationEmail(
+              email,
+              req.ip,
+              returnUrl,
+              ref,
+              refViewId,
+            );
             break;
           // they were an already registered user, so resend the AccountExists Email
           case EmailType.ACCOUNT_EXISTS:
-            await sendAccountExistsEmail(email, req.ip, returnUrl);
+            await sendAccountExistsEmail(
+              email,
+              req.ip,
+              returnUrl,
+              ref,
+              refViewId,
+            );
             break;
           // they were an already registered user without password
           // so resend the AccountWithoutPasswordExists Email
@@ -99,6 +112,8 @@ router.post(
               email,
               req.ip,
               returnUrl,
+              ref,
+              refViewId,
             );
             break;
           default:
@@ -169,7 +184,13 @@ router.post(
         // user exists with password
         // so we want to send them the account exists email
         case UserType.CURRENT:
-          await sendAccountExistsEmail(email, req.ip, returnUrl);
+          await sendAccountExistsEmail(
+            email,
+            req.ip,
+            returnUrl,
+            ref,
+            refViewId,
+          );
           setEncryptedStateCookie(res, {
             email,
             emailType: EmailType.ACCOUNT_EXISTS,
@@ -178,7 +199,13 @@ router.post(
         // user exists without password
         // so we send them the account exists without password email to set a password
         case UserType.GUEST:
-          await sendAccountWithoutPasswordExistsEmail(email, req.ip, returnUrl);
+          await sendAccountWithoutPasswordExistsEmail(
+            email,
+            req.ip,
+            returnUrl,
+            ref,
+            refViewId,
+          );
           setEncryptedStateCookie(res, {
             email,
             emailType: EmailType.ACCOUNT_WITHOUT_PASSWORD_EXISTS,

--- a/src/server/routes/reset.ts
+++ b/src/server/routes/reset.ts
@@ -44,10 +44,11 @@ router.post(
 
     const { email = '' } = req.body;
 
-    const { returnUrl, emailSentSuccess } = res.locals.queryParams;
+    const { returnUrl, emailSentSuccess, ref, refViewId } =
+      res.locals.queryParams;
 
     try {
-      await resetPassword(email, req.ip, returnUrl);
+      await resetPassword(email, req.ip, returnUrl, ref, refViewId);
 
       setEncryptedStateCookie(res, { email });
     } catch (error) {

--- a/src/server/routes/setPassword.ts
+++ b/src/server/routes/setPassword.ts
@@ -68,10 +68,11 @@ router.post(
   handleRecaptcha,
   handleAsyncErrors(async (req: Request, res: ResponseWithRequestState) => {
     const { email } = req.body;
-    const { returnUrl, emailSentSuccess } = res.locals.queryParams;
+    const { returnUrl, emailSentSuccess, ref, refViewId } =
+      res.locals.queryParams;
 
     try {
-      await sendCreatePasswordEmail(email, req.ip, returnUrl);
+      await sendCreatePasswordEmail(email, req.ip, returnUrl, ref, refViewId);
 
       setEncryptedStateCookie(res, {
         email,

--- a/src/server/routes/welcome.ts
+++ b/src/server/routes/welcome.ts
@@ -43,10 +43,17 @@ router.post(
   handleRecaptcha,
   handleAsyncErrors(async (req: Request, res: ResponseWithRequestState) => {
     const { email } = req.body;
-    const { returnUrl, emailSentSuccess } = res.locals.queryParams;
+    const { returnUrl, emailSentSuccess, ref, refViewId } =
+      res.locals.queryParams;
 
     try {
-      await sendAccountVerificationEmail(email, req.ip, returnUrl);
+      await sendAccountVerificationEmail(
+        email,
+        req.ip,
+        returnUrl,
+        ref,
+        refViewId,
+      );
 
       setEncryptedStateCookie(res, { email });
 

--- a/src/shared/model/QueryParams.ts
+++ b/src/shared/model/QueryParams.ts
@@ -1,14 +1,6 @@
 import { StringifiableRecord } from 'query-string';
 
-/**
- * PersistableQueryParams are query parameters
- * that are safe to persist between requests
- * for example query parameters that should be passed
- * from page to page in a flow e.g. returnUrl
- */
-export interface PersistableQueryParams extends StringifiableRecord {
-  returnUrl: string;
-  clientId?: string;
+export interface TrackingQueryParams {
   // this is the url of the referring page
   // https://github.com/guardian/ophan/blob/70b658e785c490c411670bbd3c7fde62ae0224fc/the-slab/app/extractors/ReferrerExtractor.scala#L171
   ref?: string;
@@ -16,6 +8,19 @@ export interface PersistableQueryParams extends StringifiableRecord {
   // that the user was on to use for tracking referrals
   // https://github.com/guardian/ophan/blob/70b658e785c490c411670bbd3c7fde62ae0224fc/the-slab/app/extractors/ReferrerExtractor.scala#L129
   refViewId?: string;
+}
+
+/**
+ * PersistableQueryParams are query parameters
+ * that are safe to persist between requests
+ * for example query parameters that should be passed
+ * from page to page in a flow e.g. returnUrl
+ */
+export interface PersistableQueryParams
+  extends TrackingQueryParams,
+    StringifiableRecord {
+  returnUrl: string;
+  clientId?: string;
 }
 
 /**


### PR DESCRIPTION
## What does this change?

- Adds the `ref` and `refViewId` tracking parameters to endpoints in gateway where we want to track the users journey through email.
- The first commit adds it to the client side
  - We use a custom hook (`useRefTracking`) to get the `ref` and `refViewId` parameters if they are defined.
  - This is consumed by a custom component (`RefTrackingFormFields`) which are hidden input fields which can be added to forms. This means that on a form submit these parameters will also be included in the request body
  - We then append it to any form which could rely on this: `MainForm`, `Registration`, and `SignIn`
- The second commit modifies the server to be able to consume these parameters from the body
  - The `parseExpressQueryParams` method is modified to be able to read parameters from `req.query` and `req.body`
    - We also improve the way we type this method by using utility types
  - The `requestStateMiddleware` is then modified to consume this new way of parsing query params
    - As we're using utility types to type the query parameters now, we introduce a `RequestWithTypedQuery` type to expand the express `Request` type with exactly which query parameters we're expecting at compile time.
  - We can then read these query parameters on the `ResponseWithRequestState`, so the `res.locals.requestState` object, and then use them in the relevant IDAPI controllers.
  - This commit also refactors usage of `getConfiguration` and makes sure that it is destructed where its used rather than a config object being passed around.
    - This is to avoid any consuming methods that were using the `config` object to read any variables that it shouldn't have access to
- Also use `jest-mock` instead of `ts-jest/utils` as the functionality of mocks has moved from the latter (where it's been deprecated) to the former. 

## Related
[Identity API PR](https://github.com/guardian/identity/pull/2037) which should be reviewed and go in before this PR.