### PR TITLE
Update documentation with latest information

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@
 
 The (new) profile (dot) theguardian (dot) com
 
-Gateway is the new frontend to login and registration at the Guardian at [profile.theguardian.com](https://profile.theguardian.com).
+Gateway is the new frontend to sign-in and registration at the Guardian at [profile.theguardian.com](https://profile.theguardian.com).
 
 Need help? Contact the Identity team on [Digital/Identity](https://chat.google.com/room/AAAAFdv9gK8).
 
-## Architecture
+## Architecture/Overview
 
 See the [architecture](docs/architecture.md) doc.
 
@@ -25,13 +25,7 @@ The `.env` file should **never** be committed.
 
 #### 2. Running Locally
 
-3. Install dependencies:
-
-```sh
-$ yarn
-```
-
-4. Start development server:
+3. Install dependencies and start development server:
 
 ```sh
 $ make dev
@@ -63,11 +57,30 @@ Other documentation in the [docs](docs) folder.
 
 1. Branch off of `main`, name your branch related to the feature you're implementing, prefix with your initials (e.g. `mm/feature-name`)
 2. Do your thing
-3. Ensure CI passes by running `make ci` or `./ci.sh`
-   - This runs linting, type-check, unit tests, build check, and cypress tests
+3. Ensure tests pass:
+
+- `make ci` or `./ci.sh`
+  - This runs linting, type-check, unit tests, build checks
+- `make cypress-mocked` or `./cypress-mocked`
+  - This runs cypress integration tests against a mocked version of [Identity API](https://github.com/guardian/identity)
+- `make cypress-ete` or `./cypress-ete`
+  - This runs cypress end-to-end tests against the [Identity API](https://github.com/guardian/identity) defined in `.env`
+  - Be sure to use sparingly, this relies on [Mailosaur](https://mailosaur.com/) which has a limited number of emails we can test with it each day
+
 4. Make sure your branch is up to date with `main`
-   - By merging or (preferably, if possible) rebasing onto `main`
-   - This makes sure any conflicts are resolved prior to code review
+
+- By merging or (preferably, if possible) rebasing onto `main`
+- This makes sure any conflicts are resolved prior to code review
+- If possible, please clean up the commit history to make each commit a clean change to make it more readable
+  - e.g. for example when fixing things from a previous commit, or combining multiple commits into a single feature commit
+  - `git rebase -i <starting commit/branch name>` e.g. `git rebase -i origin/main`
+
 5. Open a pull request
+
+- The template can be used for guidance on how to structure the PR, but you don't have to follow it.
+- Draft pull requests, and open pull requests with further pushed commits will not run the `Chromatic` and `cypress-ete` on each push/by default.
+  - You have to manually opt into running these tests by either marking the draft PR as "Ready for review", or re-requesting a review (usually from "guardian/identity" or a previous reviewer)
+  - This change was made to limit the number of builds to Chromatic and emails with Mailosaur to reduce costs with those products
+
 6. Code will be reviewed and require a 👍 from a team member before it will be merged
-7. The merger is required to ensure the change is deployed to production.
+7. When a PR is merged with `main` branch, it will ensure that the change is deployed to production.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -16,7 +16,7 @@ Many other client side applications at the Guardian now are React app based, whi
 
 ## Technology
 
-Gateway is primarily a [TypeScript](https://www.typescriptlang.org/), [React](https://reactjs.org/), and [Express.js](https://expressjs.com/) application, utilising [the Guardian Source Design System](https://theguardian.design/) components, and [Emotion](https://emotion.sh) CSS-in-JS library for UI/design. We use [Jest](https://jestjs.io/) for unit testing, and [Cypress](https://www.cypress.io/) for integration tests (and hopefully E2E tests in the future).
+Gateway is primarily a [TypeScript](https://www.typescriptlang.org/), [React](https://reactjs.org/), and [Express.js](https://expressjs.com/) application, utilising [the Guardian Source Design System](https://theguardian.design/) components, and [Emotion](https://emotion.sh) CSS-in-JS library for UI/design. We use [Jest](https://jestjs.io/) for unit testing, and [Cypress](https://www.cypress.io/) for integration tests and E2E tests.
 
 ## Browser Support
 
@@ -25,6 +25,8 @@ Gateway is primarily a [TypeScript](https://www.typescriptlang.org/), [React](ht
 This has the added benefit that since we're only serving HTML, we can target a wider range of browsers compared to doing client side hydration, pretty much any browser thats supports [TLS 1.2](https://caniuse.com/#feat=tls1-2) will get functional support. As far as styling/css go, we target the recommended browsers from [guardian/dotcom-rendering](https://github.com/guardian/dotcom-rendering/blob/master/docs/principles/browser-support.md#recommended-browsers).
 
 However there will be some JavaScript code that needs to run client side, such as for analytics, consent etc. And hydration can be used to enhance functionality for the user.
+
+The no JavaScript principle has been violated since including reCAPTCHA on many of the forms to prevent bot attacks. However we still stick to this principle regardless for the reasons above, and in case we find a different solution to using reCAPTCHA in the future.
 
 Development principles can be found in [development.md](development.md).
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -389,34 +389,6 @@ This file also exposes an `addQueryParamsToPath` method which can be used to app
 
 #### Server
 
-To make sure the query params are parsed on the server, make sure to add the param to the [`parseExpressQueryParams`](../src/server/lib/queryParams.ts) and the [`unit tests`](../src/server/lib/__tests__/queryParams.test.ts) too.
-
-```ts
-// src/server/lib/queryParams.ts#
-export const parseExpressQueryParams = ({
-  returnUrl,
-  clientId,
-  testParam,
-}: {
-  returnUrl?: string;
-  clientId?: string;
-  testParam?: string;
-}): QueryParams => {
-  return {
-    returnUrl: validateReturnUrl(returnUrl),
-    clientId: validateClientId(clientId),
-    testParam: validateTestParam(testParams), // method to check if the parameter is valid, defined elsewhere
-  };
-};
-```
-
-Then simply include the [`queryParamsMiddleware`](../src/server/lib/middleware/queryParams.ts) on any routes that should parse the querystring.
-
-```ts
-// example on all reset password routes
-router.use(noCache, queryParamsMiddleware, reset);
-```
-
 You can access this server side on the `ResponseWithRequestState` object as `res.locals.queryParams`. For example you could get the `returnUrl` using:
 
 ```ts
@@ -555,21 +527,27 @@ Environment variables appear in a lot of places, so it's likely you'll need to u
    thisMethodNeedsTheKey(envKey);
    ```
 
-5. Github Actions (`.github/workflows/ci.yaml`)
+5. [Github Actions](../.github/workflows)
    - For GitHub Actions CI
    - Add development values to allow tests to pass
-   - For secret values, use a fake value
-   ```yml
-   env:
-     ENV_KEY: ENV_VALUE
-   ```
+   - For secret values depending on the use case either
+   - Use a fake value if not required in E2E testing
+     ```yml
+     env:
+       ENV_KEY: value
+     ```
+   - If required in E2E testing, store in [settings `"Secrets -> Actions"`](https://github.com/guardian/gateway/settings/secrets/actions) and use notation
+     ```yml
+     env:
+       ENV_KEY: ${{ secrets.ENV_KEY }}
+     ```
 6. S3 Config
    - If an environment variable has been changed/added/deleted, it might be useful to update the default S3 private DEV config for the project to help other developers
    - AWS `identity` account, in the `s3://identity-private-config/DEV/identity-gateway/` folder.
 
 ## Client Side Scripts
 
-The app itself is server side rendered for browsers not running JavaScript. We also hydrate the components with react, necessary for interactive components.
+The app itself is server side rendered. We also hydrate the components with react, necessary for interactive components, and for reCAPTCHA support where required.
 Also, there may need to be some scripts that fire on the client side, for example for analytics, or the consents management platform.
 
 To facilitate this, a client bundle is created at build time to the `build/static` folder. This corresponds to the script imported in the [`src/client/static/index.tsx`](../src/client/static/index.tsx) file, with a script tag pointing to the bundle delivered along with the rendered html.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -13,6 +13,7 @@ Make sure you have one or the other or both:
 
 - [Docker](https://www.docker.com/) - Make sure `docker` and `docker-compose` are available in your terminal.
   - Not required if running everything on your local machine using Node and Yarn.
+  - We generally don't recommend Docker due to it's low performance on macOS machines.
 
 ## Configuration
 
@@ -50,7 +51,7 @@ FetchError: request to https://idapi.thegulocal.com/auth?format=cookies failed, 
 
 You can get a preset `.env` file from the S3 private config. Be sure to have the `identity` Janus credentials.
 
-With dev-nginx (profile.thegulocal.com):
+Recommended: With nginx setup (profile.thegulocal.com):
 
 ```sh
 # IDAPI/Okta pointing to DEV environment (Recommended for development)
@@ -77,9 +78,38 @@ If using nginx, nginx will look for gateway on port `8861`, so be sure to use th
 
 If not using nginx, you can then access gateway on `http://localhost:8861`.
 
-### With Docker
+You can choose to run gateway locally, or using Docker.
 
-The easiest way to get developing is to use Docker. Development mode can be handled using `docker-compose` using the service name `gateway`.
+### Locally
+
+Firstly make sure your running the version of Node given by `.nvmrc`, if you have `nvm` installed, just run `nvm use`.
+
+Then to install dependencies and start the development server:
+
+```sh
+$ make dev
+```
+
+If you fancy running both dev commands in a tiled view you can run:
+
+```sh
+$ make dev-tile-v # vertical tiling
+$ make dev-tile-h # horizontal tiling
+```
+
+This adds the environment variables from the `.env` file and starts the development server.
+
+On the first run/ after removing the `build` folder, you may see errors in your console, this is because the `build` folder and project haven't finished compiling yet, just wait for a while for webpack to finish the bundling process.
+
+Once you see `{"level":"info","message":"server running on port 8861"}` in the console, the application is running.
+
+If your build folder is getting quite large, use `make clean-build` to remove the build folder. Then on the next `make dev` command, it will rebuild the application.
+
+You can see the [`makefile`](../makefile) for the full list of commands.
+
+### Docker
+
+Development mode can be handled using `docker-compose` using the service name `gateway` if you prefer this way.
 
 To start the development server, navigate to the root project folder with the `docker-compose.yml` file and run:
 
@@ -116,39 +146,6 @@ Finally, to directly access the container shell to run commands use
 ```sh
 $ docker-compose exec gateway /bin/sh
 ```
-
-### Without Docker
-
-It is also possible to run gateway without Docker.
-
-Firstly make sure your running the version of Node given by `.nvmrc`, if you have `nvm` installed, just run `nvm use`.
-
-Next install dependencies:
-
-```sh
-$ make install
-```
-
-Then to start the development server:
-
-```sh
-$ make dev
-```
-
-If you fancy running both dev commands in a tiled view you can run:
-
-```sh
-$ make dev-tile-v # vertical tiling
-$ make dev-tile-h # horizontal tiling
-```
-
-This adds the environment variables from the `.env` file and starts the development server.
-
-On the first run/ after removing the `build` folder, you may see errors in your console, this is because the `build` folder and project haven't finished compiling yet, just wait for a while for webpack to finish the bundling process.
-
-Once you see `{"level":"info","message":"server running on port 8861"}` in the console, the application is running.
-
-If your build folder is getting quite large, use `make clean-build` to remove the build folder. Then on the next `make dev` command, it will rebuild the application.
 
 ## Debugging
 
@@ -207,6 +204,8 @@ $ ./cypress-mocked.sh
 You can also open the end to end test runner using:
 
 ```sh
+$ make cypress-ete
+# or
 $ ./cypress-ete.sh
 ```
 

--- a/src/server/lib/getABTesting.ts
+++ b/src/server/lib/getABTesting.ts
@@ -16,9 +16,7 @@ export const getABTesting = (
 
   const runnableTests = abTestAPI.allRunnableTests(tests);
 
-  // Explicit notation needed due to TS Bug: https://github.com/microsoft/TypeScript/issues/36390
-  // Should be removable as of TS 4.2
-  const participations = (runnableTests as Runnable[]).map((test: Runnable) => {
+  const participations = runnableTests.map((test: Runnable) => {
     return [
       test.id,
       {


### PR DESCRIPTION
## What does this change?

- Update the documentation with up to date information 
- Remove explicit type notation in `src/server/lib/getABTesting.ts` since we've updated past Typescript 4.2