### PR TITLE
Tracking | Add form submit/input focus-blur/page load tracking/social button click

### DIFF
--- a/src/client/components/EmailInput.tsx
+++ b/src/client/components/EmailInput.tsx
@@ -67,6 +67,7 @@ export const EmailInput: React.FC<EmailInputProps> = ({
       label={label}
       name="email"
       type="email"
+      autoComplete="email"
       error={errorMessage}
       cssOverrides={disableAutofillBackground}
       onBlur={(e) => {

--- a/src/client/components/PasswordForm.tsx
+++ b/src/client/components/PasswordForm.tsx
@@ -18,12 +18,16 @@ import { CsrfFormField } from '@/client/components/CsrfFormField';
 import { css } from '@emotion/react';
 
 import sha1 from 'js-sha1';
-import { PasswordInput } from '@/client/components/PasswordInput';
+import {
+  PasswordAutoComplete,
+  PasswordInput,
+} from '@/client/components/PasswordInput';
 import { FieldError } from '@/shared/model/ClientState';
 import { ChangePasswordErrors } from '@/shared/model/Errors';
 import AwesomeDebouncePromise from 'awesome-debounce-promise';
 import { AutoRow, passwordFormSpanDef } from '@/client/styles/Grid';
 import { MainForm } from '@/client/components/MainForm';
+import { trackFormFocusBlur, trackFormSubmit } from '@/client/lib/ophan';
 
 type Props = {
   submitUrl: string;
@@ -35,6 +39,8 @@ type Props = {
   recaptchaSiteKey?: string;
   setRecaptchaErrorMessage?: React.Dispatch<React.SetStateAction<string>>;
   setRecaptchaErrorContext?: React.Dispatch<React.SetStateAction<ReactNode>>;
+  autoComplete?: PasswordAutoComplete;
+  formTrackingName?: string;
 };
 
 const baseIconStyles = css`
@@ -219,6 +225,8 @@ export const PasswordForm = ({
   submitButtonText,
   labelText,
   gridAutoRow,
+  autoComplete,
+  formTrackingName,
 }: Props) => {
   const [password, setPassword] = useState<string>('');
   const [error, setError] = useState<string | undefined>(
@@ -261,6 +269,9 @@ export const PasswordForm = ({
       method="post"
       action={submitUrl}
       onSubmit={(e) => {
+        if (formTrackingName) {
+          trackFormSubmit(formTrackingName);
+        }
         if (isTooShort) {
           setError(ChangePasswordErrors.AT_LEAST_8);
           e.preventDefault();
@@ -272,6 +283,12 @@ export const PasswordForm = ({
           e.preventDefault();
         }
       }}
+      onFocus={(e) =>
+        formTrackingName && trackFormFocusBlur(formTrackingName, e, 'focus')
+      }
+      onBlur={(e) =>
+        formTrackingName && trackFormFocusBlur(formTrackingName, e, 'blur')
+      }
     >
       <CsrfFormField />
       <div css={passwordInput}>
@@ -281,6 +298,7 @@ export const PasswordForm = ({
           onChange={(e) => {
             setPassword(e.target.value);
           }}
+          autoComplete={autoComplete}
         />
       </div>
       {!error && (
@@ -316,6 +334,8 @@ export const PasswordFormMainLayout = ({
   recaptchaSiteKey,
   setRecaptchaErrorMessage,
   setRecaptchaErrorContext,
+  autoComplete,
+  formTrackingName,
 }: Props) => {
   const [password, setPassword] = useState<string>('');
   const [error, setError] = useState<string | undefined>(
@@ -371,6 +391,7 @@ export const PasswordFormMainLayout = ({
       recaptchaSiteKey={recaptchaSiteKey}
       setRecaptchaErrorMessage={setRecaptchaErrorMessage}
       setRecaptchaErrorContext={setRecaptchaErrorContext}
+      formTrackingName={formTrackingName}
     >
       <div css={error ? undefined : passwordInput}>
         <PasswordInput
@@ -379,6 +400,7 @@ export const PasswordFormMainLayout = ({
           onChange={(e) => {
             setPassword(e.target.value);
           }}
+          autoComplete={autoComplete}
         />
       </div>
       {!error && (

--- a/src/client/components/PasswordInput.tsx
+++ b/src/client/components/PasswordInput.tsx
@@ -11,12 +11,15 @@ import { ClientState } from '@/shared/model/ClientState';
 import { ClientStateContext } from '@/client/components/ClientState';
 import { disableAutofillBackground } from '@/client/styles/Shared';
 
+export type PasswordAutoComplete = 'new-password' | 'current-password';
+
 export type PasswordInputProps = {
   label: string;
   error?: string;
   displayEye?: boolean;
   supporting?: string;
   onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  autoComplete?: PasswordAutoComplete;
 };
 
 export const isDisplayEyeOnBrowser = (browserName: string | undefined) => {
@@ -119,6 +122,7 @@ export const PasswordInput = ({
   supporting,
   onChange,
   displayEye = true,
+  autoComplete,
 }: PasswordInputProps) => {
   const [passwordVisible, setPasswordVisible] = useState(false);
   const { pageData: { browserName } = {} }: ClientState =
@@ -148,6 +152,7 @@ export const PasswordInput = ({
           name="password"
           supporting={supporting}
           type={passwordVisible ? 'text' : 'password'}
+          autoComplete={autoComplete}
           cssOverrides={[
             noBorder(isEyeDisplayedOnBrowser),
             paddingRight(isEyeDisplayedOnBrowser),

--- a/src/client/components/SocialButtons.tsx
+++ b/src/client/components/SocialButtons.tsx
@@ -84,6 +84,7 @@ export const SocialButtons = ({
         icon={<SvgGoogleBrand />}
         href={buildUrl(oauthBaseUrl, 'google', returnUrl)}
         data-cy="google-sign-in-button"
+        data-link-name="google-social-button"
       >
         Google
       </LinkButton>
@@ -94,6 +95,7 @@ export const SocialButtons = ({
         icon={<SvgFacebookBrand />}
         href={buildUrl(oauthBaseUrl, 'facebook', returnUrl)}
         data-cy="facebook-sign-in-button"
+        data-link-name="facebook-social-button"
       >
         Facebook
       </LinkButton>
@@ -104,6 +106,7 @@ export const SocialButtons = ({
         icon={<SvgAppleBrand />}
         href={buildUrl(oauthBaseUrl, 'apple', returnUrl)}
         data-cy="apple-sign-in-button"
+        data-link-name="apple-social-button"
       >
         Apple
       </LinkButton>

--- a/src/client/lib/hooks/usePageLoadOphanInteraction.ts
+++ b/src/client/lib/hooks/usePageLoadOphanInteraction.ts
@@ -1,0 +1,13 @@
+import { useEffect } from 'react';
+import { sendOphanInteractionEvent } from '@/client/lib/ophan';
+
+export const usePageLoadOphanInteraction = (page?: string): void => {
+  useEffect(() => {
+    if (page) {
+      sendOphanInteractionEvent({
+        component: `${page}-page`,
+        value: 'render',
+      });
+    }
+  }, [page]);
+};

--- a/src/client/lib/ophan.ts
+++ b/src/client/lib/ophan.ts
@@ -14,11 +14,7 @@ interface OphanBase {
 type OphanEvent = OphanBase | OphanInteraction;
 
 export const record = (event: OphanEvent) => {
-  if (
-    window.guardian &&
-    window.guardian.ophan &&
-    window.guardian.ophan.record
-  ) {
+  if (window.guardian?.ophan?.record) {
     window.guardian.ophan.record(event);
   }
 };
@@ -28,3 +24,24 @@ export const sendOphanInteractionEvent = ({
   atomId,
   value,
 }: OphanInteraction) => record({ component, atomId, value });
+
+export const trackFormSubmit = (formTrackingName: string): void => {
+  sendOphanInteractionEvent({
+    component: `${formTrackingName}-form`,
+    value: 'submit',
+  });
+};
+
+export const trackFormFocusBlur = (
+  formTrackingName: string,
+  event: React.FocusEvent<HTMLFormElement, Element>,
+  type: 'focus' | 'blur',
+): void => {
+  // we only want to track focus on input elements
+  if (event.target.tagName === 'INPUT') {
+    sendOphanInteractionEvent({
+      component: `${formTrackingName}-form`,
+      value: `${event.target.name}-input-${type}`,
+    });
+  }
+};

--- a/src/client/pages/ChangePassword.tsx
+++ b/src/client/pages/ChangePassword.tsx
@@ -28,6 +28,8 @@ export const ChangePassword = ({
       submitButtonText={buttonText}
       fieldErrors={fieldErrors}
       labelText="Password"
+      autoComplete="new-password"
+      formTrackingName="new-password"
     />
   </MainLayout>
 );

--- a/src/client/pages/EmailSent.tsx
+++ b/src/client/pages/EmailSent.tsx
@@ -21,6 +21,7 @@ type Props = {
   errorMessage?: string;
   noAccountInfo?: boolean;
   recaptchaSiteKey?: string;
+  formTrackingName?: string;
 };
 
 export const EmailSent = ({
@@ -32,6 +33,7 @@ export const EmailSent = ({
   errorMessage,
   noAccountInfo,
   recaptchaSiteKey,
+  formTrackingName,
 }: Props) => {
   const [recaptchaErrorMessage, setRecaptchaErrorMessage] = useState('');
   const [recaptchaErrorContext, setRecaptchaErrorContext] =
@@ -98,6 +100,7 @@ export const EmailSent = ({
             recaptchaSiteKey={recaptchaSiteKey}
             setRecaptchaErrorContext={setRecaptchaErrorContext}
             setRecaptchaErrorMessage={setRecaptchaErrorMessage}
+            formTrackingName={formTrackingName}
           >
             <EmailInput defaultValue={email} hidden hideLabel />
           </MainForm>

--- a/src/client/pages/EmailSentPage.tsx
+++ b/src/client/pages/EmailSentPage.tsx
@@ -6,9 +6,10 @@ import { buildQueryParamsString } from '@/shared/lib/queryParams';
 
 interface Props {
   noAccountInfo?: boolean;
+  formTrackingName?: string;
 }
 
-export const EmailSentPage = ({ noAccountInfo }: Props) => {
+export const EmailSentPage = ({ noAccountInfo, formTrackingName }: Props) => {
   const clientState: ClientState = useContext(ClientStateContext);
   const {
     pageData = {},
@@ -35,6 +36,7 @@ export const EmailSentPage = ({ noAccountInfo }: Props) => {
       errorMessage={error}
       noAccountInfo={noAccountInfo}
       recaptchaSiteKey={recaptchaSiteKey}
+      formTrackingName={formTrackingName}
     />
   );
 };

--- a/src/client/pages/Registration.tsx
+++ b/src/client/pages/Registration.tsx
@@ -22,6 +22,7 @@ import { buildUrlWithQueryParams } from '@/shared/lib/routeUtils';
 import { QueryParams } from '@/shared/model/QueryParams';
 import { GeoLocation } from '@/shared/model/Geolocation';
 import { RefTrackingFormFields } from '@/client/components/RefTrackingFormFields';
+import { trackFormFocusBlur, trackFormSubmit } from '@/client/lib/ophan';
 
 export type RegistrationProps = {
   returnUrl?: string;
@@ -66,6 +67,7 @@ export const Registration = ({
   queryParams,
   geolocation,
 }: RegistrationProps) => {
+  const formTrackingName = 'register';
   const registerFormRef = createRef<HTMLFormElement>();
   const recaptchaElementRef = useRef<HTMLDivElement>(null);
   const captchaElement = recaptchaElementRef.current ?? 'register-recaptcha';
@@ -97,6 +99,7 @@ export const Registration = ({
 
   const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
+    trackFormSubmit(formTrackingName);
     executeCaptcha();
   };
 
@@ -130,6 +133,8 @@ export const Registration = ({
           action={buildUrlWithQueryParams('/register', {}, queryParams)}
           ref={registerFormRef}
           onSubmit={handleSubmit}
+          onFocus={(e) => trackFormFocusBlur(formTrackingName, e, 'focus')}
+          onBlur={(e) => trackFormFocusBlur(formTrackingName, e, 'blur')}
         >
           <RecaptchaElement id="register-recaptcha" />
           <CsrfFormField />

--- a/src/client/pages/RegistrationEmailSentPage.tsx
+++ b/src/client/pages/RegistrationEmailSentPage.tsx
@@ -32,6 +32,7 @@ export const RegistrationEmailSentPage = () => {
       showSuccess={emailSentSuccess}
       errorMessage={error}
       recaptchaSiteKey={recaptchaSiteKey}
+      formTrackingName="register-resend"
     />
   );
 };

--- a/src/client/pages/ResendPasswordPage.tsx
+++ b/src/client/pages/ResendPasswordPage.tsx
@@ -23,6 +23,7 @@ export const ResendPasswordPage = () => {
       emailInputLabel="Email address"
       showRecentEmailSummary
       recaptchaSiteKey={recaptchaSiteKey}
+      formTrackingName="reset-password-link-expired"
     >
       <MainBodyText>This link has expired.</MainBodyText>
       <MainBodyText>

--- a/src/client/pages/ResendPasswordPage.tsx
+++ b/src/client/pages/ResendPasswordPage.tsx
@@ -23,7 +23,7 @@ export const ResendPasswordPage = () => {
       emailInputLabel="Email address"
       showRecentEmailSummary
       recaptchaSiteKey={recaptchaSiteKey}
-      formTrackingName="reset-password-link-expired"
+      formPageTrackingName="reset-password-link-expired"
     >
       <MainBodyText>This link has expired.</MainBodyText>
       <MainBodyText>

--- a/src/client/pages/ResetPassword.tsx
+++ b/src/client/pages/ResetPassword.tsx
@@ -24,6 +24,7 @@ interface ResetPasswordProps {
   showNoAccessEmail?: boolean;
   showRecentEmailSummary?: boolean;
   recaptchaSiteKey?: string;
+  formTrackingName?: string;
 }
 
 export const ResetPassword = ({
@@ -37,6 +38,7 @@ export const ResetPassword = ({
   showRecentEmailSummary,
   children,
   recaptchaSiteKey,
+  formTrackingName,
 }: PropsWithChildren<ResetPasswordProps>) => {
   const [recaptchaErrorMessage, setRecaptchaErrorMessage] = useState('');
   const [recaptchaErrorContext, setRecaptchaErrorContext] =
@@ -59,6 +61,7 @@ export const ResetPassword = ({
         recaptchaSiteKey={recaptchaSiteKey}
         setRecaptchaErrorMessage={setRecaptchaErrorMessage}
         setRecaptchaErrorContext={setRecaptchaErrorContext}
+        formTrackingName={formTrackingName}
       >
         <EmailInput label={emailInputLabel} defaultValue={email} />
       </MainForm>

--- a/src/client/pages/ResetPassword.tsx
+++ b/src/client/pages/ResetPassword.tsx
@@ -13,6 +13,7 @@ import { ExternalLink } from '@/client/components/ExternalLink';
 import { buildUrlWithQueryParams } from '@/shared/lib/routeUtils';
 import { QueryParams } from '@/shared/model/QueryParams';
 import { addQueryParamsToUntypedPath } from '@/shared/lib/queryParams';
+import { usePageLoadOphanInteraction } from '../lib/hooks/usePageLoadOphanInteraction';
 
 interface ResetPasswordProps {
   email?: string;
@@ -24,7 +25,7 @@ interface ResetPasswordProps {
   showNoAccessEmail?: boolean;
   showRecentEmailSummary?: boolean;
   recaptchaSiteKey?: string;
-  formTrackingName?: string;
+  formPageTrackingName?: string;
 }
 
 export const ResetPassword = ({
@@ -38,8 +39,11 @@ export const ResetPassword = ({
   showRecentEmailSummary,
   children,
   recaptchaSiteKey,
-  formTrackingName,
+  formPageTrackingName,
 }: PropsWithChildren<ResetPasswordProps>) => {
+  // track page/form load
+  usePageLoadOphanInteraction(formPageTrackingName);
+
   const [recaptchaErrorMessage, setRecaptchaErrorMessage] = useState('');
   const [recaptchaErrorContext, setRecaptchaErrorContext] =
     useState<ReactNode>(null);
@@ -61,7 +65,7 @@ export const ResetPassword = ({
         recaptchaSiteKey={recaptchaSiteKey}
         setRecaptchaErrorMessage={setRecaptchaErrorMessage}
         setRecaptchaErrorContext={setRecaptchaErrorContext}
-        formTrackingName={formTrackingName}
+        formTrackingName={formPageTrackingName}
       >
         <EmailInput label={emailInputLabel} defaultValue={email} />
       </MainForm>

--- a/src/client/pages/ResetPasswordPage.tsx
+++ b/src/client/pages/ResetPasswordPage.tsx
@@ -21,7 +21,7 @@ export const ResetPasswordPage = () => {
       queryString={queryParams}
       showNoAccessEmail
       recaptchaSiteKey={recaptchaSiteKey}
-      formTrackingName="forgot-password"
+      formPageTrackingName="forgot-password"
     >
       <MainBodyText>
         Forgot your password? Enter your email address and we’ll send you a link

--- a/src/client/pages/ResetPasswordPage.tsx
+++ b/src/client/pages/ResetPasswordPage.tsx
@@ -21,6 +21,7 @@ export const ResetPasswordPage = () => {
       queryString={queryParams}
       showNoAccessEmail
       recaptchaSiteKey={recaptchaSiteKey}
+      formTrackingName="forgot-password"
     >
       <MainBodyText>
         Forgot your password? Enter your email address and we’ll send you a link

--- a/src/client/pages/ResetPasswordSessionExpiredPage.tsx
+++ b/src/client/pages/ResetPasswordSessionExpiredPage.tsx
@@ -22,7 +22,7 @@ export const ResetPasswordSessionExpiredPage = () => {
       queryString={queryParams}
       emailInputLabel="Email address"
       recaptchaSiteKey={recaptchaSiteKey}
-      formTrackingName="reset-password-session-expired"
+      formPageTrackingName="reset-password-session-expired"
     >
       <MainBodyText>
         The link we sent you was valid for 30 minutes and it has now expired.

--- a/src/client/pages/ResetPasswordSessionExpiredPage.tsx
+++ b/src/client/pages/ResetPasswordSessionExpiredPage.tsx
@@ -22,6 +22,7 @@ export const ResetPasswordSessionExpiredPage = () => {
       queryString={queryParams}
       emailInputLabel="Email address"
       recaptchaSiteKey={recaptchaSiteKey}
+      formTrackingName="reset-password-session-expired"
     >
       <MainBodyText>
         The link we sent you was valid for 30 minutes and it has now expired.

--- a/src/client/pages/SetPasswordResendPage.tsx
+++ b/src/client/pages/SetPasswordResendPage.tsx
@@ -26,6 +26,7 @@ export const SetPasswordResendPage = () => {
       emailInputLabel="Email address"
       showRecentEmailSummary
       recaptchaSiteKey={recaptchaSiteKey}
+      formTrackingName="set-password-link-expired"
     >
       <MainBodyText>This link has expired.</MainBodyText>
       <MainBodyText>

--- a/src/client/pages/SetPasswordResendPage.tsx
+++ b/src/client/pages/SetPasswordResendPage.tsx
@@ -2,7 +2,6 @@ import React, { useContext } from 'react';
 import { ClientState } from '@/shared/model/ClientState';
 import { ClientStateContext } from '@/client/components/ClientState';
 import { ResetPassword } from '@/client/pages/ResetPassword';
-
 import { MainBodyText } from '@/client/components/MainBodyText';
 import { buildUrl } from '@/shared/lib/routeUtils';
 
@@ -26,7 +25,7 @@ export const SetPasswordResendPage = () => {
       emailInputLabel="Email address"
       showRecentEmailSummary
       recaptchaSiteKey={recaptchaSiteKey}
-      formTrackingName="set-password-link-expired"
+      formPageTrackingName="set-password-link-expired"
     >
       <MainBodyText>This link has expired.</MainBodyText>
       <MainBodyText>

--- a/src/client/pages/SetPasswordSessionExpiredPage.tsx
+++ b/src/client/pages/SetPasswordSessionExpiredPage.tsx
@@ -3,7 +3,6 @@ import { ClientState } from '@/shared/model/ClientState';
 import { ClientStateContext } from '@/client/components/ClientState';
 import { ResetPassword } from '@/client/pages/ResetPassword';
 import { MainBodyText } from '@/client/components/MainBodyText';
-
 import { buildUrl } from '@/shared/lib/routeUtils';
 
 export const SetPasswordSessionExpiredPage = () => {
@@ -25,7 +24,7 @@ export const SetPasswordSessionExpiredPage = () => {
       queryString={queryParams}
       emailInputLabel="Email address"
       recaptchaSiteKey={recaptchaSiteKey}
-      formTrackingName="set-password-session-expired"
+      formPageTrackingName="set-password-session-expired"
     >
       <MainBodyText>
         The link we sent you was valid for 30 minutes and it has now expired.

--- a/src/client/pages/SetPasswordSessionExpiredPage.tsx
+++ b/src/client/pages/SetPasswordSessionExpiredPage.tsx
@@ -25,6 +25,7 @@ export const SetPasswordSessionExpiredPage = () => {
       queryString={queryParams}
       emailInputLabel="Email address"
       recaptchaSiteKey={recaptchaSiteKey}
+      formTrackingName="set-password-session-expired"
     >
       <MainBodyText>
         The link we sent you was valid for 30 minutes and it has now expired.

--- a/src/client/pages/SignIn.tsx
+++ b/src/client/pages/SignIn.tsx
@@ -23,6 +23,7 @@ import useRecaptcha, {
 } from '@/client/lib/hooks/useRecaptcha';
 import locations from '@/shared/lib/locations';
 import { RefTrackingFormFields } from '@/client/components/RefTrackingFormFields';
+import { trackFormFocusBlur, trackFormSubmit } from '@/client/lib/ophan';
 
 export type SignInProps = {
   returnUrl?: string;
@@ -137,6 +138,7 @@ export const SignIn = ({
   geolocation,
   recaptchaSiteKey,
 }: SignInProps) => {
+  const formTrackingName = 'sign-in';
   const signInFormRef = createRef<HTMLFormElement>();
   const recaptchaElementRef = useRef<HTMLDivElement>(null);
   const captchaElement = recaptchaElementRef.current ?? 'signin-recaptcha';
@@ -171,6 +173,7 @@ export const SignIn = ({
 
   const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
+    trackFormSubmit(formTrackingName);
     executeCaptcha();
   };
 
@@ -210,13 +213,15 @@ export const SignIn = ({
           action={buildUrlWithQueryParams('/signin', {}, queryParams)}
           ref={signInFormRef}
           onSubmit={handleSubmit}
+          onFocus={(e) => trackFormFocusBlur(formTrackingName, e, 'focus')}
+          onBlur={(e) => trackFormFocusBlur(formTrackingName, e, 'blur')}
         >
           <RecaptchaElement id="signin-recaptcha" />
           <CsrfFormField />
           <RefTrackingFormFields />
           <EmailInput defaultValue={email} />
           <div css={passwordInput}>
-            <PasswordInput label="Password" />
+            <PasswordInput label="Password" autoComplete="current-password" />
           </div>
           <Links>
             <Link

--- a/src/client/pages/Welcome.tsx
+++ b/src/client/pages/Welcome.tsx
@@ -71,6 +71,8 @@ export const Welcome = ({
             labelText="Password"
             submitButtonText="Create password"
             gridAutoRow={autoRow}
+            autoComplete="new-password"
+            formTrackingName="welcome"
           />
         )}
       </ConsentsContent>

--- a/src/client/pages/WelcomeResendPage.tsx
+++ b/src/client/pages/WelcomeResendPage.tsx
@@ -26,6 +26,7 @@ export const WelcomeResendPage = () => {
       emailInputLabel="Email address"
       showRecentEmailSummary
       recaptchaSiteKey={recaptchaSiteKey}
+      formTrackingName="welcome-link-expired"
     >
       <MainBodyText>This link has expired.</MainBodyText>
       <MainBodyText>

--- a/src/client/pages/WelcomeResendPage.tsx
+++ b/src/client/pages/WelcomeResendPage.tsx
@@ -2,7 +2,6 @@ import React, { useContext } from 'react';
 import { ClientState } from '@/shared/model/ClientState';
 import { ClientStateContext } from '@/client/components/ClientState';
 import { ResetPassword } from '@/client/pages/ResetPassword';
-
 import { MainBodyText } from '@/client/components/MainBodyText';
 import { buildUrl } from '@/shared/lib/routeUtils';
 
@@ -26,7 +25,7 @@ export const WelcomeResendPage = () => {
       emailInputLabel="Email address"
       showRecentEmailSummary
       recaptchaSiteKey={recaptchaSiteKey}
-      formTrackingName="welcome-link-expired"
+      formPageTrackingName="welcome-link-expired"
     >
       <MainBodyText>This link has expired.</MainBodyText>
       <MainBodyText>

--- a/src/client/pages/WelcomeSessionExpiredPage.tsx
+++ b/src/client/pages/WelcomeSessionExpiredPage.tsx
@@ -25,6 +25,7 @@ export const WelcomeSessionExpiredPage = () => {
       queryString={queryParams}
       emailInputLabel="Email address"
       recaptchaSiteKey={recaptchaSiteKey}
+      formTrackingName="welcome-session-expired"
     >
       <MainBodyText>
         The link we sent you was valid for 30 minutes and it has now expired.

--- a/src/client/pages/WelcomeSessionExpiredPage.tsx
+++ b/src/client/pages/WelcomeSessionExpiredPage.tsx
@@ -25,7 +25,7 @@ export const WelcomeSessionExpiredPage = () => {
       queryString={queryParams}
       emailInputLabel="Email address"
       recaptchaSiteKey={recaptchaSiteKey}
-      formTrackingName="welcome-session-expired"
+      formPageTrackingName="welcome-session-expired"
     >
       <MainBodyText>
         The link we sent you was valid for 30 minutes and it has now expired.

--- a/src/client/routes.tsx
+++ b/src/client/routes.tsx
@@ -55,7 +55,9 @@ const routes: Array<{
   },
   {
     path: '/reset-password/email-sent',
-    element: <EmailSentPage noAccountInfo />,
+    element: (
+      <EmailSentPage formTrackingName="forgot-password-resend" noAccountInfo />
+    ),
   },
   {
     path: '/reset-password/complete',
@@ -87,7 +89,7 @@ const routes: Array<{
   },
   {
     path: '/set-password/email-sent',
-    element: <EmailSentPage />,
+    element: <EmailSentPage formTrackingName="set-password-resend" />,
   },
   {
     path: '/set-password/:token',
@@ -119,7 +121,7 @@ const routes: Array<{
   },
   {
     path: '/welcome/email-sent',
-    element: <EmailSentPage />,
+    element: <EmailSentPage formTrackingName="welcome-resend" />,
   },
   {
     path: '/welcome/complete',


### PR DESCRIPTION
## What does this change?
Adds additional tracking through the use of ophan interaction events to help us measure how specific parts of the MVP1 flow are being used.

There are 4 main parts we're tracking
- Form submit
  - Does a user submit and go to a new page?
  - Does the same page reload? Hinting at error. Does user drop off?
  - `trackFormSubmit` helper method which wraps the `sendOphanInteractionEvent` and fires on a form submission
- Input field focus and blur
  - Does a user interact with specific fields?
    - e.g. are there some fields they have more trouble with, for hypothetical example, the password input box
  - `trackFormFocusBlur` helper method which wraps the `sendOphanInteractionEvent` and fires on a form focus/blur event, and uses the `event.target.tagName` to filter for input elements.
- Page load tracking
  - Specifically for the `ResetPassword` component, which is used as a generic resend email page, e.g. for forgot password, link expired, and session expired pages.
  - Since the urls are often in the same format e.g. `/reset-password/:token`, for both a valid/invalid/expired token, we want to differentiate between the different types of pages that are rendered
  - Create a `usePageLoadOphanInteraction` hook, which only runs on first render/hydration to fire the ophan event
- Social button click event tracking using [`data-link-name`](https://github.com/guardian/ophan/blob/ccaa57bcee3f5f3f83ec28973074c9b3f98f1438/tracker-js/assets/coffee/ophan/click-path-capture.coffee#L23)

## Other changes
- Adds `autocomplete` attributes to help browsers filling out certain field values.

## Screenshots
### Form submit
![chrome_TWjLYQhYnr](https://user-images.githubusercontent.com/13315440/146947865-121b5937-acc8-44d3-8678-e5b3269ce5c2.png)
### Input field blur (loses focus)
![chrome_rQ5v4f3g81](https://user-images.githubusercontent.com/13315440/146947867-1f91f608-7b54-4d56-a6d1-99aefb53cd12.png)
### Input field focus
![chrome_RSSYJUHXYK](https://user-images.githubusercontent.com/13315440/146947871-2c42942d-c3ea-49bb-aab0-73b61312bc4e.png)
### Page load (render)
![chrome_0wNe04NB10](https://user-images.githubusercontent.com/13315440/146947873-d582cdda-af5f-4fb2-b505-0b8007de0e9a.png)
### Social button click
![chrome_d3g4iJ152f](https://user-images.githubusercontent.com/13315440/147107945-1d748c67-bdf2-45ae-9f97-d21661f7e1c4.png)
