### PR TITLE
Revert: `http-errors` dependency upgrade

### DIFF
--- a/package.json
+++ b/package.json
@@ -132,7 +132,7 @@
     "express": "^4.17.2",
     "express-recaptcha": "^5.0.2",
     "helmet": "^4.6.0",
-    "http-errors": "^2.0.0",
+    "http-errors": "^1.8.1",
     "js-sha1": "^0.6.0",
     "jsonwebtoken": "^8.5.1",
     "mjml": "^4.11.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7097,11 +7097,6 @@ delegates@^1.0.0:
   resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
   integrity sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=
 
-depd@2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/depd/-/depd-2.0.0.tgz#b696163cc757560d09cf22cc8fad1571b79e76df"
-  integrity sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==
-
 depd@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.2.tgz#9bcd52e14c097763e749b274c4346ed2e560b5a9"
@@ -9523,7 +9518,7 @@ http-errors@1.7.2:
     statuses ">= 1.5.0 < 2"
     toidentifier "1.0.0"
 
-http-errors@1.8.1:
+http-errors@1.8.1, http-errors@^1.8.1:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-1.8.1.tgz#7c3f28577cbc8a207388455dbd62295ed07bd68c"
   integrity sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==
@@ -9532,17 +9527,6 @@ http-errors@1.8.1:
     inherits "2.0.4"
     setprototypeof "1.2.0"
     statuses ">= 1.5.0 < 2"
-    toidentifier "1.0.1"
-
-http-errors@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-2.0.0.tgz#b7774a1486ef73cf7667ac9ae0858c012c57b9d3"
-  integrity sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==
-  dependencies:
-    depd "2.0.0"
-    inherits "2.0.4"
-    setprototypeof "1.2.0"
-    statuses "2.0.1"
     toidentifier "1.0.1"
 
 http-errors@~1.7.2, http-errors@~1.7.3:
@@ -15363,11 +15347,6 @@ static-module@3.0.4:
     shallow-copy "~0.0.1"
     static-eval "^2.0.5"
     through2 "~2.0.3"
-
-statuses@2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/statuses/-/statuses-2.0.1.tgz#55cb000ccf1d48728bd23c685a063998cf1a1b63"
-  integrity sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==
 
 "statuses@>= 1.5.0 < 2", statuses@~1.5.0:
   version "1.5.0"


### PR DESCRIPTION
## What does this change?

- For some reason this upgrade causes an issue when launching the identity gateway service in EC2, which we didn't notice locally
- Reverting the version for now while we investigate

```sh
/etc/gu/node_modules/http-errors/node_modules/toidentifier/index.js:26
    .split(' ')
     ^

TypeError: Cannot read properties of undefined (reading 'split')
    at toIdentifier (/etc/gu/node_modules/http-errors/node_modules/toidentifier/index.js:26:6)
    at forEachCode (/etc/gu/node_modules/http-errors/index.js:267:16)
    at Array.forEach (<anonymous>)
    at populateConstructorExports (/etc/gu/node_modules/http-errors/index.js:265:9)
    at Object.<anonymous> (/etc/gu/node_modules/http-errors/index.js:31:1)
    at Module._compile (node:internal/modules/cjs/loader:1101:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1153:10)
    at Module.load (node:internal/modules/cjs/loader:981:32)
    at Function.Module._load (node:internal/modules/cjs/loader:822:12)
    at Module.require (node:internal/modules/cjs/loader:1005:19)
```