### PR TITLE
Fix deploy problems by using frozen lockfile in CI

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -2,7 +2,7 @@
 
 set -ae
 
-yarn
+yarn install --frozen-lockfile
 yarn lint
 yarn test
 yarn build


### PR DESCRIPTION
## What does this change?

- Attempt to fix deployment issues by using a frozen lockfile in CI.
  - `yarn install --frozen-lockfile` -> Makes reproducible dependencies, which is usually the case with the continuous integration system. Also doesn’t generate a yarn.lock lockfile and fail if an update is needed. https://classic.yarnpkg.com/en/docs/cli/install