### PR TITLE
Add GitHub Action for Snyk

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -1,0 +1,14 @@
+name: Snyk
+on: push
+jobs:
+  security:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Run Snyk to check for vulnerabilities
+        uses: snyk/actions/node@master
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        with:
+          command: monitor
+          args: --org=${{ secrets.SNYK_ORG_NAME }} --project-name=${{ secrets.SNYK_PROJECT_NAME }}


### PR DESCRIPTION
## What does this change?

In TeamCity the last build step was to run `synk monitor` to check and report any security issues in Snyk. When setting up [CI in GitHub Actions](https://github.com/guardian/gateway/pull/1349) we forgot to include the snyk step.

This adds in a GitHub action to run `snyk monitor` on every push in a similar way to TeamCity was doing it.

## How to test

The gateway project in snyk should take snapshots on every push.