### PR TITLE
Add maintenance page

### DIFF
--- a/src/client/pages/MaintenancePage.stories.tsx
+++ b/src/client/pages/MaintenancePage.stories.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { Meta } from '@storybook/react';
+
+import { MaintenancePage } from './MaintenancePage';
+
+export default {
+  title: 'Pages/MaintenancePage',
+  component: MaintenancePage,
+  parameters: { layout: 'fullscreen' },
+} as Meta;
+
+export const Default = () => <MaintenancePage />;

--- a/src/client/pages/MaintenancePage.tsx
+++ b/src/client/pages/MaintenancePage.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { MainLayout } from '@/client/layouts/Main';
+import { MainBodyText } from '@/client/components/MainBodyText';
+
+export const MaintenancePage = () => (
+  <MainLayout pageHeader="We’ll be back soon">
+    <MainBodyText>
+      Sorry for the inconvenience. We are currently performing some essential
+      maintenance. Please try again later.
+    </MainBodyText>
+  </MainLayout>
+);

--- a/src/client/routes.tsx
+++ b/src/client/routes.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Route, Routes } from 'react-router-dom';
+import { RoutePaths } from '@/shared/model/Routes';
 import { RegistrationPage } from '@/client/pages/RegistrationPage';
 import { ResetPasswordPage } from '@/client/pages/ResetPasswordPage';
 import { EmailSentPage } from '@/client/pages/EmailSentPage';
@@ -26,7 +27,7 @@ import { SetPasswordPage } from '@/client/pages/SetPasswordPage';
 import { SetPasswordResendPage } from '@/client/pages/SetPasswordResendPage';
 import { SetPasswordSessionExpiredPage } from '@/client/pages/SetPasswordSessionExpiredPage';
 import { SetPasswordCompletePage } from '@/client/pages/SetPasswordCompletePage';
-import { RoutePaths } from '@/shared/model/Routes';
+import { MaintenancePage } from '@/client/pages/MaintenancePage';
 
 export type RoutingConfig = {
   clientState: ClientState;
@@ -150,6 +151,10 @@ const routes: Array<{
   {
     path: '/404',
     element: <NotFoundPage />,
+  },
+  {
+    path: '/maintenance',
+    element: <MaintenancePage />,
   },
 ];
 

--- a/src/server/routes/index.ts
+++ b/src/server/routes/index.ts
@@ -9,6 +9,7 @@ import { default as verifyEmail } from './verifyEmail';
 import { default as magicLink } from './magicLink';
 import { default as welcome } from './welcome';
 import { default as setPassword } from './setPassword';
+import { default as maintenance } from './maintenance';
 import { noCache } from '@/server/lib/middleware/cache';
 
 const router = Router();
@@ -20,6 +21,9 @@ router.use(core);
 // all routes should be uncached except for the core (static) routes
 // to avoid caching sensitive page state
 uncachedRoutes.use(noCache);
+
+// maintenance page
+uncachedRoutes.use(maintenance);
 
 // request sign in routes
 uncachedRoutes.use(signIn);
@@ -43,7 +47,7 @@ uncachedRoutes.use(verifyEmail);
 uncachedRoutes.use(magicLink);
 
 // welcome routes
-uncachedRoutes.use(noCache, welcome);
+uncachedRoutes.use(welcome);
 
 router.use(uncachedRoutes);
 

--- a/src/server/routes/maintenance.ts
+++ b/src/server/routes/maintenance.ts
@@ -1,0 +1,15 @@
+import { Router } from 'express';
+import { renderer } from '@/server/lib/renderer';
+import { ResponseWithRequestState } from '@/server/models/Express';
+
+const router = Router();
+
+router.use('/maintenance', (_, res: ResponseWithRequestState) => {
+  const html = renderer('/maintenance', {
+    pageTitle: 'Maintenance',
+    requestState: res.locals,
+  });
+  return res.type('html').status(503).send(html);
+});
+
+export default router;

--- a/src/shared/model/PageTitle.ts
+++ b/src/shared/model/PageTitle.ts
@@ -21,7 +21,8 @@ export type PageTitle =
   | 'Your data'
   | 'Stay in touch'
   | 'Newsletters'
-  | 'Review';
+  | 'Review'
+  | 'Maintenance';
 
 export type PasswordPageTitle = Extract<
   'Welcome' | 'Create Password' | 'Change Password',

--- a/src/shared/model/Routes.ts
+++ b/src/shared/model/Routes.ts
@@ -35,7 +35,8 @@ export type RoutePaths =
   | '/magic-link' //this is not being used until MVP4
   | '/magic-link/email-sent' //this is not being used until MVP4
   | '/error'
-  | '/404';
+  | '/404'
+  | '/maintenance';
 
 /**
  * These are all valid paths for the Identity API


### PR DESCRIPTION
## What does this change?

Add a maintenance page (`/maintenance`) to use for all of `profile.theguardian.com` while the identity database is being updated.

Returns page with 503 status as that's what MDN recommends: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/503
![chrome_i9AnyWKwk8](https://user-images.githubusercontent.com/13315440/148577893-2a45d927-9f20-42b4-9a21-1b01938c011b.png)

## TODO
- [x] Copy
- [x] Design
- [x] [Identity Platform PR](https://github.com/guardian/identity-platform/pull/479)
- [x] Testing on CODE

## Image

![60929d168594f80039336501-yzjpkbcecw chromatic com_iframe html_id=pages-maintenancepage--default args= viewMode=story(iPad Mini)](https://user-images.githubusercontent.com/13315440/148800306-9ada6cc1-9dfe-4958-aaaf-c98316f63c6b.png)

