### PR TITLE
Support Jobs user registration in Gateway

### DIFF
--- a/cypress/integration/ete/registration/register.spec.ts
+++ b/cypress/integration/ete/registration/register.spec.ts
@@ -112,7 +112,7 @@ describe('Registration flow', () => {
       'https%3A%2F%2Fm.code.dev-theguardian.com%2Ftravel%2F2019%2Fdec%2F18%2Ffood-culture-tour-bethlehem-palestine-east-jerusalem-photo-essay';
     const encodedRef = 'https%3A%2F%2Fm.theguardian.com';
     const refViewId = 'testRefViewId';
-
+    const clientId = 'jobs';
     const unregisteredEmail = randomMailosaurEmail();
 
     cy.visit(
@@ -121,7 +121,9 @@ describe('Registration flow', () => {
         '&ref=' +
         encodedRef +
         '&refViewId=' +
-        refViewId,
+        refViewId +
+        '&clientId=' +
+        clientId,
     );
     const timeRequestWasMade = new Date();
     cy.get('input[name=email]').type(unregisteredEmail);
@@ -141,6 +143,7 @@ describe('Registration flow', () => {
       expect(body).to.have.string('returnUrl=' + encodedReturnUrl);
       expect(body).to.have.string('ref=' + encodedRef);
       expect(body).to.have.string('refViewId=' + refViewId);
+      expect(body).to.have.string('clientId=' + clientId);
       cy.visit(`/welcome/${token}`);
       cy.contains('Create password');
     });

--- a/cypress/integration/ete/registration/register_email_sent.spec.ts
+++ b/cypress/integration/ete/registration/register_email_sent.spec.ts
@@ -61,7 +61,7 @@ describe('Registration email sent page', () => {
     });
   });
 
-  it.only('should resend "Complete Registration" email when a new user registers which is same as initial email sent', () => {
+  it('should resend "Complete Registration" email when a new user registers which is same as initial email sent', () => {
     const unregisteredEmail = randomMailosaurEmail();
 
     const clientId = 'jobs';

--- a/cypress/integration/ete/registration/register_email_sent.spec.ts
+++ b/cypress/integration/ete/registration/register_email_sent.spec.ts
@@ -61,10 +61,11 @@ describe('Registration email sent page', () => {
     });
   });
 
-  it('should resend "Complete Registration" email when a new user registers which is same as initial email sent', () => {
+  it.only('should resend "Complete Registration" email when a new user registers which is same as initial email sent', () => {
     const unregisteredEmail = randomMailosaurEmail();
 
-    cy.visit('/register');
+    const clientId = 'jobs';
+    cy.visit('/register?clientId=' + clientId);
     cy.get('input[name=email]').type(unregisteredEmail);
     const timeRequestWasMadeInitialEmail = new Date();
     cy.get('[data-cy="register-button"]').click();
@@ -91,6 +92,7 @@ describe('Registration email sent page', () => {
     cy.checkForEmailAndGetDetails(unregisteredEmail, timeRequestWasMade).then(
       ({ body }) => {
         expect(body).to.have.string('Complete registration');
+        expect(body).to.have.string('clientId=' + clientId);
       },
     );
   });

--- a/src/server/controllers/changePassword.ts
+++ b/src/server/controllers/changePassword.ts
@@ -93,7 +93,7 @@ export const setPasswordController = (
 
       // When a jobs user is registering, we'd like to add them to the GRS group.
       //
-      // We'd like to do this so they aren't shown a confirmation page when-
+      // Once they belong to this group, they aren't shown a confirmation page when-
       // they first visit the jobs site.
       //
       // If the SC_GU_U cookie exists, we try to add the user to the group.

--- a/src/server/controllers/changePassword.ts
+++ b/src/server/controllers/changePassword.ts
@@ -81,24 +81,15 @@ export const setPasswordController = (
         });
       }
 
-      // we need to track both of these cloudwatch metrics as two
-      // separate metrics at this point as the changePassword endpoint
-      // does two things
-      // a) account verification
-      // b) change password
-      // since these could happen at different points in time, it's best
-      // to keep them as two seperate metrics
-      trackMetric('AccountVerification::Success');
-      trackMetric('UpdatePassword::Success');
-
       // When a jobs user is registering, we'd like to add them to the GRS group.
+      // We only do this for users going through the welcome flow.
       //
       // Once they belong to this group, they aren't shown a confirmation page when-
       // they first visit the jobs site.
       //
       // If the SC_GU_U cookie exists, we try to add the user to the group.
-      // If the cookie doesn't exist we log the incident.
-      if (clientId === 'jobs') {
+      // If the cookie doesn't exist for some reason, we log the incident.
+      if (clientId === 'jobs' && path === '/welcome') {
         const SC_GU_U = cookies?.values.find(({ key }) => key === 'SC_GU_U');
         if (SC_GU_U) {
           addToGroup(GroupCode.GRS, req.ip, SC_GU_U.value);
@@ -108,6 +99,16 @@ export const setPasswordController = (
           );
         }
       }
+
+      // we need to track both of these cloudwatch metrics as two
+      // separate metrics at this point as the changePassword endpoint
+      // does two things
+      // a) account verification
+      // b) change password
+      // since these could happen at different points in time, it's best
+      // to keep them as two seperate metrics
+      trackMetric('AccountVerification::Success');
+      trackMetric('UpdatePassword::Success');
 
       return res.redirect(
         303,

--- a/src/server/controllers/changePassword.ts
+++ b/src/server/controllers/changePassword.ts
@@ -92,7 +92,7 @@ export const setPasswordController = (
       if (clientId === 'jobs' && path === '/welcome') {
         const SC_GU_U = cookies?.values.find(({ key }) => key === 'SC_GU_U');
         if (SC_GU_U) {
-          addToGroup(GroupCode.GRS, req.ip, SC_GU_U.value);
+          await addToGroup(GroupCode.GRS, req.ip, SC_GU_U.value);
         } else {
           logger.error(
             'Failed to add the user to the GRS group because the SC_GU_U cookie is not set.',

--- a/src/server/lib/idapi/changePassword.ts
+++ b/src/server/lib/idapi/changePassword.ts
@@ -11,6 +11,7 @@ import {
 } from '@/shared/model/Errors';
 import { logger } from '@/server/lib/logger';
 import { IdapiError } from '@/server/models/Error';
+import { IdapiCookies } from '../setIDAPICookies';
 
 const handleError = ({ error, status = 500 }: IDAPIError) => {
   if (error.status === 'error' && error.errors?.length) {
@@ -75,7 +76,11 @@ export async function validate(
   }
 }
 
-export async function change(password: string, token: string, ip: string) {
+export async function change(
+  password: string,
+  token: string,
+  ip: string,
+): Promise<IdapiCookies | undefined> {
   const options = APIPostOptions({
     password,
     token,

--- a/src/server/lib/idapi/guest.ts
+++ b/src/server/lib/idapi/guest.ts
@@ -43,6 +43,7 @@ export const guest = async (
   returnUrl?: string,
   refViewId?: string,
   ref?: string,
+  clientId?: string,
   ophanTrackingConfig?: OphanConfig,
 ): Promise<EmailType> => {
   const options = APIPostOptions({
@@ -58,6 +59,7 @@ export const guest = async (
         returnUrl: returnUrl || defaultReturnUri,
         ref,
         refViewId,
+        clientId,
       },
     });
     sendOphanInteractionEventServer(

--- a/src/server/lib/idapi/user.ts
+++ b/src/server/lib/idapi/user.ts
@@ -203,7 +203,6 @@ export const sendAccountExistsEmail = async (
   returnUrl: string,
   ref?: string,
   refViewId?: string,
-  clientId?: string,
   ophanTrackingConfig?: OphanConfig,
 ) => {
   const options = APIPostOptions({
@@ -213,7 +212,7 @@ export const sendAccountExistsEmail = async (
     await idapiFetch({
       path: '/user/send-account-exists-email',
       options: APIAddClientAccessToken(options, ip),
-      queryParams: { returnUrl, ref, refViewId, clientId },
+      queryParams: { returnUrl, ref, refViewId },
     });
     sendOphanInteractionEventServer(
       {
@@ -239,7 +238,6 @@ export const sendAccountWithoutPasswordExistsEmail = async (
   returnUrl: string,
   ref?: string,
   refViewId?: string,
-  clientId?: string,
   ophanTrackingConfig?: OphanConfig,
 ) => {
   const options = APIPostOptions({
@@ -249,7 +247,7 @@ export const sendAccountWithoutPasswordExistsEmail = async (
     await idapiFetch({
       path: '/user/send-account-without-password-exists-email',
       options: APIAddClientAccessToken(options, ip),
-      queryParams: { returnUrl, ref, refViewId, clientId },
+      queryParams: { returnUrl, ref, refViewId },
     });
     sendOphanInteractionEventServer(
       {

--- a/src/server/lib/idapi/user.ts
+++ b/src/server/lib/idapi/user.ts
@@ -167,6 +167,7 @@ export const sendAccountVerificationEmail = async (
   returnUrl: string,
   ref?: string,
   refViewId?: string,
+  clientId?: string,
   ophanTrackingConfig?: OphanConfig,
 ) => {
   const options = APIPostOptions({
@@ -176,7 +177,7 @@ export const sendAccountVerificationEmail = async (
     await idapiFetch({
       path: '/user/send-account-verification-email',
       options: APIAddClientAccessToken(options, ip),
-      queryParams: { returnUrl, ref, refViewId },
+      queryParams: { returnUrl, ref, refViewId, clientId },
     });
     sendOphanInteractionEventServer(
       {
@@ -202,6 +203,7 @@ export const sendAccountExistsEmail = async (
   returnUrl: string,
   ref?: string,
   refViewId?: string,
+  clientId?: string,
   ophanTrackingConfig?: OphanConfig,
 ) => {
   const options = APIPostOptions({
@@ -211,7 +213,7 @@ export const sendAccountExistsEmail = async (
     await idapiFetch({
       path: '/user/send-account-exists-email',
       options: APIAddClientAccessToken(options, ip),
-      queryParams: { returnUrl, ref, refViewId },
+      queryParams: { returnUrl, ref, refViewId, clientId },
     });
     sendOphanInteractionEventServer(
       {
@@ -237,6 +239,7 @@ export const sendAccountWithoutPasswordExistsEmail = async (
   returnUrl: string,
   ref?: string,
   refViewId?: string,
+  clientId?: string,
   ophanTrackingConfig?: OphanConfig,
 ) => {
   const options = APIPostOptions({
@@ -246,7 +249,7 @@ export const sendAccountWithoutPasswordExistsEmail = async (
     await idapiFetch({
       path: '/user/send-account-without-password-exists-email',
       options: APIAddClientAccessToken(options, ip),
-      queryParams: { returnUrl, ref, refViewId },
+      queryParams: { returnUrl, ref, refViewId, clientId },
     });
     sendOphanInteractionEventServer(
       {

--- a/src/server/lib/idapi/user.ts
+++ b/src/server/lib/idapi/user.ts
@@ -26,6 +26,11 @@ interface APIResponse {
   user: User;
 }
 
+interface APIGroupResponse {
+  status: string;
+  groupCode: string;
+}
+
 /**
  * This enum maps to the type of user as defined in,
  * and returned by Identity API.
@@ -40,6 +45,10 @@ export enum UserType {
   NEW = 'new',
   CURRENT = 'current',
   GUEST = 'guest',
+}
+
+export enum GroupCode {
+  GRS = 'GRS',
 }
 
 const handleError = ({ error, status = 500 }: IDAPIError) => {
@@ -92,6 +101,28 @@ export const read = async (ip: string, sc_gu_u: string): Promise<User> => {
     return responseToEntity(response);
   } catch (error) {
     logger.error(`IDAPI Error user read '/user/me'`, error);
+    return handleError(error as IDAPIError);
+  }
+};
+
+export const addToGroup = async (
+  groupCode: GroupCode,
+  ip: string,
+  sc_gu_u: string,
+) => {
+  const options = APIForwardSessionIdentifier(
+    APIAddClientAccessToken(APIPostOptions(), ip),
+    sc_gu_u,
+  );
+  try {
+    const response = (await idapiFetch({
+      path: '/user/me/group/:groupCode',
+      options,
+      tokenisationParam: { groupCode },
+    })) as APIGroupResponse;
+    return response;
+  } catch (error) {
+    logger.error(`IDAPI error assigning user to group: ${groupCode}`, error);
     return handleError(error as IDAPIError);
   }
 };

--- a/src/server/lib/setIDAPICookies.ts
+++ b/src/server/lib/setIDAPICookies.ts
@@ -7,7 +7,7 @@ interface IdapiCookie {
   sessionCookie?: boolean;
 }
 
-interface IdapiCookies {
+export interface IdapiCookies {
   values: Array<IdapiCookie>;
   expiresAt: string;
 }

--- a/src/server/routes/register.ts
+++ b/src/server/routes/register.ts
@@ -61,7 +61,8 @@ router.post(
   handleAsyncErrors(async (req: Request, res: ResponseWithRequestState) => {
     const state = res.locals;
 
-    const { returnUrl, emailSentSuccess, ref, refViewId } = state.queryParams;
+    const { returnUrl, emailSentSuccess, ref, refViewId, clientId } =
+      state.queryParams;
 
     try {
       // read and parse the encrypted state cookie
@@ -92,6 +93,7 @@ router.post(
               returnUrl,
               ref,
               refViewId,
+              clientId,
               state.ophanConfig,
             );
             break;
@@ -103,6 +105,7 @@ router.post(
               returnUrl,
               ref,
               refViewId,
+              clientId,
               state.ophanConfig,
             );
             break;
@@ -115,6 +118,7 @@ router.post(
               returnUrl,
               ref,
               refViewId,
+              clientId,
               state.ophanConfig,
             );
             break;
@@ -159,7 +163,7 @@ router.post(
     let state = res.locals;
 
     const { email = '' } = req.body;
-    const { returnUrl, ref, refViewId } = state.queryParams;
+    const { returnUrl, ref, refViewId, clientId } = state.queryParams;
 
     try {
       // use idapi user type endpoint to determine user type
@@ -179,6 +183,7 @@ router.post(
               returnUrl,
               refViewId,
               ref,
+              clientId,
               state.ophanConfig,
             );
           }
@@ -199,6 +204,7 @@ router.post(
             returnUrl,
             ref,
             refViewId,
+            clientId,
             state.ophanConfig,
           );
           setEncryptedStateCookie(res, {
@@ -215,6 +221,7 @@ router.post(
             returnUrl,
             ref,
             refViewId,
+            clientId,
             state.ophanConfig,
           );
           setEncryptedStateCookie(res, {

--- a/src/server/routes/register.ts
+++ b/src/server/routes/register.ts
@@ -105,7 +105,6 @@ router.post(
               returnUrl,
               ref,
               refViewId,
-              clientId,
               state.ophanConfig,
             );
             break;
@@ -118,7 +117,6 @@ router.post(
               returnUrl,
               ref,
               refViewId,
-              clientId,
               state.ophanConfig,
             );
             break;
@@ -204,7 +202,6 @@ router.post(
             returnUrl,
             ref,
             refViewId,
-            clientId,
             state.ophanConfig,
           );
           setEncryptedStateCookie(res, {
@@ -221,7 +218,6 @@ router.post(
             returnUrl,
             ref,
             refViewId,
-            clientId,
             state.ophanConfig,
           );
           setEncryptedStateCookie(res, {

--- a/src/server/routes/welcome.ts
+++ b/src/server/routes/welcome.ts
@@ -41,7 +41,8 @@ router.post(
   handleAsyncErrors(async (req: Request, res: ResponseWithRequestState) => {
     const { email } = req.body;
     const state = res.locals;
-    const { returnUrl, emailSentSuccess, ref, refViewId } = state.queryParams;
+    const { returnUrl, emailSentSuccess, ref, refViewId, clientId } =
+      state.queryParams;
 
     try {
       await sendAccountVerificationEmail(
@@ -50,6 +51,7 @@ router.post(
         returnUrl,
         ref,
         refViewId,
+        clientId,
         state.ophanConfig,
       );
 

--- a/src/shared/model/QueryParams.ts
+++ b/src/shared/model/QueryParams.ts
@@ -1,5 +1,5 @@
 import { StringifiableRecord } from 'query-string';
-import { validClientId } from '../lib/clientId';
+import { ValidClientId } from '../lib/clientId';
 
 export interface TrackingQueryParams {
   // this is the url of the referring page
@@ -21,7 +21,7 @@ export interface PersistableQueryParams
   extends TrackingQueryParams,
     StringifiableRecord {
   returnUrl: string;
-  clientId?: typeof validClientId[number];
+  clientId?: ValidClientId;
 }
 
 /**

--- a/src/shared/model/Routes.ts
+++ b/src/shared/model/Routes.ts
@@ -56,6 +56,7 @@ export type ApiRoutePaths =
   | '/users/me/consents'
   | '/users/me/newsletters'
   | '/user/me'
+  | '/user/me/group/:groupCode'
   | '/user/type/:email'
   | '/guest'
   | '/newsletters'


### PR DESCRIPTION
## Background
A Jobs account is a user account that has been added to the GRS user group. Users who are signed in have to join the GRS group or sign out before they can access Guardian Jobs.

Users are currently added to the GRS group (in identity-frontend) under these conditions:

* When a logged in user not belonging to the GRS group navigates to the Jobs site and gives consent.
* When a user originating from Jobs registers an account.

In both cases, the user is added to the GRS group through a POST request made on the client side to the /agree/GRS endpoint in IDAPI.

Following this process, when the user who now belongs to GRS next visits jobs.theguardian.com, their madgex account is created and the welcome email is sent.

## What does this change?
This PR introduces support for adding users to the `GRS` group if the `clientId` query parameter is set to `jobs`.

It builds upon the prior work in #1273 to persist the `clientId` query parameter across the different pages on Gateway.

To add the users to the GRS group, the `/user/me/group/:groupCode` endpoint in IDAPI is called when the password is set by users originating from the welcome flow using the `SC_GU_U` cookie they are granted

Two changes were made in IDAPI (https://github.com/guardian/identity/pull/2045) to support passing the `clientId` through as a query param to the `/guest` endpoint and the `/user/send-account-verification-email` endpoints.

This ensures that on the registration confirmation email and any subsequent resend requests, the `clientId` will be included in the generated link.

## How to test
A separate PR has been raised against identity-platform: https://github.com/guardian/identity-platform/pull/482, this will let us test with `clientId=jobs` in PROD, by setting `gateway=true` as an extra query param in the request.

## How can we measure success?
Users should be added to the GRS group when originating from jobs.theguardian.com and be redirected without having to go through the full confirmation flow.
