### PR TITLE
Fix Safari 10 `SyntaxError: Cannot declare a let variable twice: 'n'`

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
     "react-test-renderer": "^17.0.2",
     "snyk": "^1.821.0",
     "stmux": "^1.8.3",
+    "terser-webpack-plugin": "^5.3.0",
     "ts-jest": "^27.1.2",
     "ts-prune": "^0.10.3",
     "typescript": "^4.5.4",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,6 +6,7 @@ const AssetsPlugin = require('assets-webpack-plugin');
 const { merge } = require('webpack-merge');
 const nodeExternals = require('webpack-node-externals');
 const Dotenv = require('dotenv-webpack');
+const TerserPlugin = require("terser-webpack-plugin");
 
 const mode =
   process.env.ENVIRONMENT === 'production' ? 'production' : 'development';
@@ -209,6 +210,15 @@ const browser = ({ isLegacy }) => {
       ]
     },
     optimization: {
+      minimizer: [
+        new TerserPlugin({
+          terserOptions: {
+            mangle: {
+              safari10: true,
+            }
+          }
+        }),
+      ],
       splitChunks: {
         cacheGroups: {
           commons: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -11190,7 +11190,7 @@ jest-worker@^27.0.6:
     merge-stream "^2.0.0"
     supports-color "^8.0.0"
 
-jest-worker@^27.4.6:
+jest-worker@^27.4.1, jest-worker@^27.4.6:
   version "27.4.6"
   resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-27.4.6.tgz#5d2d93db419566cb680752ca0792780e71b3273e"
   integrity sha512-gHWJF/6Xi5CTG5QCvROr6GcmpIqNYpDJyc8A1h/DyXqH1tD6SnRCM0d3U5msV31D2LB/U+E0M+W4oyvKV44oNw==
@@ -16106,6 +16106,17 @@ terser-webpack-plugin@^5.1.3:
   integrity sha512-3luOVHku5l0QBeYS8r4CdHYWEGMmIj3H1U64jgkdZzECcSOJAyJ9TjuqcQZvw1Y+4AOBN9SeYJPJmFn2cM4/2g==
   dependencies:
     jest-worker "^27.0.6"
+    schema-utils "^3.1.1"
+    serialize-javascript "^6.0.0"
+    source-map "^0.6.1"
+    terser "^5.7.2"
+
+terser-webpack-plugin@^5.3.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/terser-webpack-plugin/-/terser-webpack-plugin-5.3.0.tgz#21641326486ecf91d8054161c816e464435bae9f"
+  integrity sha512-LPIisi3Ol4chwAaPP8toUJ3L4qCM1G0wao7L3qNv57Drezxj6+VEyySpPw4B1HSO2Eg/hDY/MNF5XihCAoqnsQ==
+  dependencies:
+    jest-worker "^27.4.1"
     schema-utils "^3.1.1"
     serialize-javascript "^6.0.0"
     source-map "^0.6.1"


### PR DESCRIPTION
## What does this change?
Safari 10 users seeing: `SyntaxError: Cannot declare a let variable twice: 'n'`

User the `terser-webpack-plugin` with the `mangle.safari10` option to work around the Safari 10 loop iterator bug "Cannot declare a let variable twice"

See: https://github.com/terser/terser#mangle-options

Tested using browserstack iphone 7 on safari 10 and CODE