### PR TITLE
Safari 10/11: Use only legacy bundle to fix JS issues

### DIFF
--- a/src/server/lib/middleware/requestState.ts
+++ b/src/server/lib/middleware/requestState.ts
@@ -8,6 +8,7 @@ import { getConfiguration } from '@/server/lib/getConfiguration';
 import { tests } from '@/shared/model/experiments/abTests';
 import { getABTesting } from '@/server/lib/getABTesting';
 import { RequestState, RequestWithTypedQuery } from '@/server/models/Express';
+import Bowser from 'bowser';
 
 const {
   idapiBaseUrl,
@@ -28,6 +29,8 @@ const getRequestState = (req: RequestWithTypedQuery): RequestState => {
     ref,
     refViewId,
   });
+
+  const browser = Bowser.getParser(req.header('user-agent') || 'unknown');
 
   return {
     queryParams,
@@ -56,6 +59,7 @@ const getRequestState = (req: RequestWithTypedQuery): RequestState => {
       stage,
       dsn: sentryDsn,
     },
+    browser: browser.getBrowser(),
   };
 };
 

--- a/src/server/models/Express.ts
+++ b/src/server/models/Express.ts
@@ -9,6 +9,7 @@ import {
 } from '@/shared/model/ClientState';
 import { Participations, ABTestAPI } from '@guardian/ab-core';
 import { OphanConfig } from '@/server/lib/ophan';
+import Bowser from 'bowser';
 
 export interface ABTesting {
   mvtId: number;
@@ -30,6 +31,7 @@ export interface RequestState {
   recaptchaConfig: RecaptchaConfig;
   ophanConfig: OphanConfig;
   sentryConfig: SentryConfig;
+  browser: Bowser.Parser.Details;
 }
 
 export interface ResponseWithRequestState extends Response {


### PR DESCRIPTION
## What does this change?

Safari 10/11 both support the `module` tag, but has bugs in the implementation of some modern features, causing JavaScript issues and making anything that relied on these features unusable.

In this case there was an issue with the use of promises and the breached password check form:
![Screenshot 2022-01-19 at 08 19 20](https://user-images.githubusercontent.com/13315440/150098387-f434dfc8-d530-412a-acb9-647c2ecfd2a6.png)


We decided it was best to exclude the modern bundle from safari 10 and 11 and only rely on the legacy bundle. To do this we parse the user agent and add the browser information on the request state. In the renderer we check the browser version and include the relevant script tags in the response.

## Testes
- [x] CODE