### PR TITLE
Fix: IE11 polyfill and transpilation issues

### DIFF
--- a/src/server/lib/renderer.tsx
+++ b/src/server/lib/renderer.tsx
@@ -50,6 +50,8 @@ const getScriptTags = (isSafari10Or11: boolean): string => {
     `;
   }
   return `
+    <script type="module" src="https://assets.guim.co.uk/polyfill.io/v3/polyfill.min.js?features=es2015%2Ces2016%2Ces2017%2Ces2018%2Ces2019%2Ces2020%2Ces2021%2Cfetch" defer></script>
+  
     <script type="module" src="/${assets.runtime}" defer></script>
     <script type="module" src="/${assets.vendors}" defer></script>
     <script type="module" src="/${assets.main}" defer></script>
@@ -163,8 +165,6 @@ export const renderer: <P extends RoutePaths>(
         <link rel="icon" href="https://static.guim.co.uk/images/${favicon}">
         <title>${pageTitle} | The Guardian</title>
         <script>window.gaUID = "${gaUID.id}"</script>
-
-        <script src="https://assets.guim.co.uk/polyfill.io/v3/polyfill.min.js?features=Object.fromEntries" defer></script>
 
         ${scriptTags}
 


### PR DESCRIPTION
## What does this change?

This PR fixes two issues with IE11 introduced after the safari fixes in #1403 and #1406 :

### 1.
We were mixing polyfills provided by polyfill.io and corejs causing an uncaught error to be thrown in IE11. Ideally we want to move all polyfills to using polyfill.io rather than corejs as we can target only features that the users browser does not support rather than providing polyfills for all features using corejs.

![chrome_JId4TGVBOk](https://user-images.githubusercontent.com/13315440/150310147-c7c14325-6d48-41f7-b9d6-c8f9a0b14530.png)

As a temp migration measure we set the `type="module"` attribute on the polyfill.io script tag so that it is not executed by legacy browsers such as IE11. We'll migrate fully to using polyfill.io for all browsers after this PR as it's a bit more work to implement.

We also add all supported features we transpile with to polyfill.io namely: `es2015` through `es2021` and `fetch`. This includes polyfills for `Object.fromEntries` and `Promise.prototype.finally`.

### 2.
Although we provide a polyfill for `Promise.finally`, our usage of it causes a `Object doesn't support property or method 'finally'` only in the case of the `PasswordForm.tsx`, after investigation it seems that the transpilation is behaving in a strange way for this promise in legacy browsers, where as in other cases `.finally` behaves as expected.

![chrome_AhOAJsvWQH](https://user-images.githubusercontent.com/13315440/150310228-b52abaee-5c8c-4f62-a73a-40a3586a415d.png)

We solve this issue by refactoring the breached check to use async/await avoiding the need for the `.finally` in this scenario.

We also add sentry logging for checking when the breached password check fails for any reason.

## Tested
- [x] CODE
  - [x] Browserstack IE11 Win 10
  - [x] Browserstack Safari 10
  - [x] Browserstack Safari 11
  - [x] Modern browser