### PR TITLE
Show prompt to opt into supporter marketing after sign in

### DIFF
--- a/cypress/integration/mocked/post_sign_in_prompt.ts
+++ b/cypress/integration/mocked/post_sign_in_prompt.ts
@@ -1,0 +1,83 @@
+import {
+  authRedirectSignInRecentlyEmailValidated,
+  AUTH_REDIRECT_ENDPOINT,
+} from '../../support/idapi/auth';
+import { allConsents, CONSENTS_ENDPOINT } from '../../support/idapi/consent';
+import {
+  verifiedUserWithNoConsent,
+  createUser,
+  USER_ENDPOINT,
+} from '../../support/idapi/user';
+import { setAuthCookies } from '../../support/idapi/cookie';
+import { injectAndCheckAxe } from '../../support/cypress-axe';
+
+describe('Post sign-in prompt', () => {
+  const defaultReturnUrl = 'https://m.code.dev-theguardian.com';
+  const returnUrl = 'https://www.theguardian.com/about';
+
+  beforeEach(() => {
+    cy.mockPurge();
+    setAuthCookies();
+    cy.mockAll(
+      200,
+      authRedirectSignInRecentlyEmailValidated,
+      AUTH_REDIRECT_ENDPOINT,
+    );
+    cy.mockAll(200, allConsents, CONSENTS_ENDPOINT);
+    cy.mockAll(200, verifiedUserWithNoConsent, USER_ENDPOINT);
+    cy.intercept('GET', defaultReturnUrl, (req) => {
+      req.reply(200);
+    });
+    cy.intercept('GET', returnUrl, (req) => {
+      req.reply(200);
+    });
+  });
+
+  it('Has no detectable a11y violations on prompt page', () => {
+    cy.visit('/signin/success');
+    injectAndCheckAxe();
+  });
+
+  it('Allows user to opt in and continue', () => {
+    cy.visit('/signin/success');
+    const checkbox = cy.findByLabelText('Yes, sign me up');
+    checkbox.should('not.be.checked');
+    checkbox.click();
+
+    // mock form save success
+    cy.mockNext(200);
+
+    cy.findByText('Continue to The Guardian').click();
+    cy.lastPayloadIs([{ id: 'supporter', consented: true }]);
+    cy.url().should('include', defaultReturnUrl);
+  });
+
+  it('Allows user to opt out and continue', () => {
+    const supporterConsent = allConsents.find(({ id }) => id === 'supporter');
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const consentData = [{ ...supporterConsent!, consented: true }];
+    cy.mockAll(200, createUser(consentData), USER_ENDPOINT);
+    cy.visit('/signin/success');
+    const checkbox = cy.findByLabelText('Yes, sign me up');
+    checkbox.should('be.checked');
+    checkbox.click();
+
+    // mock form save success
+    cy.mockNext(200);
+
+    cy.findByText('Continue to The Guardian').click();
+    cy.lastPayloadIs([{ id: 'supporter', consented: false }]);
+    cy.url().should('include', defaultReturnUrl);
+  });
+
+  it('Allows user to continue to different returnUrl', () => {
+    cy.visit(`/signin/success?returnUrl=${encodeURIComponent(returnUrl)}`);
+
+    // mock form save success
+    cy.mockNext(200);
+
+    cy.findByText('Continue to The Guardian').click();
+    cy.lastPayloadIs([{ id: 'supporter', consented: false }]);
+    cy.url().should('include', returnUrl);
+  });
+});

--- a/cypress/integration/mocked/post_sign_in_prompt.ts
+++ b/cypress/integration/mocked/post_sign_in_prompt.ts
@@ -47,7 +47,7 @@ describe('Post sign-in prompt', () => {
     // mock form save success
     cy.mockNext(200);
 
-    cy.findByText('Continue to The Guardian').click();
+    cy.findByText('Continue to the Guardian').click();
     cy.lastPayloadIs([{ id: 'supporter', consented: true }]);
     cy.url().should('include', defaultReturnUrl);
   });
@@ -65,7 +65,7 @@ describe('Post sign-in prompt', () => {
     // mock form save success
     cy.mockNext(200);
 
-    cy.findByText('Continue to The Guardian').click();
+    cy.findByText('Continue to the Guardian').click();
     cy.lastPayloadIs([{ id: 'supporter', consented: false }]);
     cy.url().should('include', defaultReturnUrl);
   });
@@ -76,7 +76,7 @@ describe('Post sign-in prompt', () => {
     // mock form save success
     cy.mockNext(200);
 
-    cy.findByText('Continue to The Guardian').click();
+    cy.findByText('Continue to the Guardian').click();
     cy.lastPayloadIs([{ id: 'supporter', consented: false }]);
     cy.url().should('include', returnUrl);
   });

--- a/cypress/integration/mocked/sign_in.spec.ts
+++ b/cypress/integration/mocked/sign_in.spec.ts
@@ -1,4 +1,12 @@
+import { stringify } from 'query-string';
+
 import { injectAndCheckAxe } from '../../support/cypress-axe';
+import { allConsents, CONSENTS_ENDPOINT } from '../../support/idapi/consent';
+import {
+  verifiedUserWithNoConsent,
+  createUser,
+  USER_ENDPOINT,
+} from '../../support/idapi/user';
 
 describe('Sign in flow', () => {
   beforeEach(() => {
@@ -290,6 +298,93 @@ describe('Sign in flow', () => {
       cy.get('input[name="password"]').type('password');
       cy.get('[data-cy=sign-in-button]').click();
       cy.contains('There was a problem signing in, please try again');
+    });
+  });
+
+  context('Redirect to post sign-in prompt', () => {
+    const defaultReturnUrl = 'https://m.code.dev-theguardian.com';
+    const returnUrl = 'https://www.theguardian.com/about';
+
+    beforeEach(() => {
+      cy.mockAll(200, allConsents, CONSENTS_ENDPOINT);
+      cy.mockAll(200, verifiedUserWithNoConsent, USER_ENDPOINT);
+      cy.setCookie('GU_mvt_id', '1');
+      // Intercept the pages that we would redirect to.
+      // We just want to check that the redirect happens, not that the page loads.
+      cy.intercept('GET', '/signin/success*', (req) => {
+        req.reply(200);
+      });
+      cy.intercept('GET', defaultReturnUrl, (req) => {
+        req.reply(200);
+      });
+      cy.intercept('GET', returnUrl, (req) => {
+        req.reply(200);
+      });
+    });
+
+    const signIn = (returnUrl = defaultReturnUrl) => {
+      cy.visit(`/signin?returnUrl=${encodeURIComponent(returnUrl)}`);
+      cy.get('input[name="email"]').type('example@example.com');
+      cy.get('input[name="password"]').type('password');
+      cy.mockNext(200, {
+        cookies: {
+          values: [{ key: 'SC_GU_U', value: 'something' }],
+          expiresAt: 'tomorrow',
+        },
+      });
+      cy.get('[data-cy=sign-in-button]').click();
+    };
+
+    it('if all conditions met', () => {
+      signIn();
+      cy.url().should(
+        'include',
+        `/signin/success?returnUrl=${encodeURIComponent(defaultReturnUrl)}`,
+      );
+    });
+
+    it('unless mvt id not in a / b test', () => {
+      cy.setCookie('GU_mvt_id', '100001');
+      signIn();
+      cy.url().should('include', defaultReturnUrl);
+    });
+
+    it('unless no mvt id', () => {
+      cy.clearCookie('GU_mvt_id');
+      signIn();
+      cy.url().should('include', defaultReturnUrl);
+    });
+
+    it('unless returnUrl is not default', () => {
+      signIn(returnUrl);
+      cy.url().should('include', returnUrl);
+    });
+
+    it('unless experiment already viewed', () => {
+      cy.setCookie(
+        'GU_ran_experiments',
+        stringify({ OptInPromptPostSignIn: Date.now() }),
+      );
+      signIn();
+      cy.url().should('include', defaultReturnUrl);
+    });
+
+    it('if no consent information for user', () => {
+      cy.mockAll(200, createUser([]), USER_ENDPOINT);
+      signIn();
+      cy.url().should(
+        'include',
+        `/signin/success?returnUrl=${encodeURIComponent(defaultReturnUrl)}`,
+      );
+    });
+
+    it('unless user has already consented', () => {
+      const supporterConsent = allConsents.find(({ id }) => id === 'supporter');
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      const consentData = [{ ...supporterConsent!, consented: true }];
+      cy.mockAll(200, createUser(consentData), USER_ENDPOINT);
+      signIn();
+      cy.url().should('include', defaultReturnUrl);
     });
   });
 });

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -1,3 +1,5 @@
+import '@testing-library/cypress/add-commands';
+
 import { mockNext } from './commands/mockNext';
 import { mockAll } from './commands/mockAll';
 import { mockPurge } from './commands/mockPurge';

--- a/cypress/tsconfig.json
+++ b/cypress/tsconfig.json
@@ -6,7 +6,7 @@
     "noEmit": true,
     // be explicit about types included
     // to avoid clashing with Jest types
-    "types": ["node", "cypress"],
+    "types": ["node", "cypress", "@testing-library/cypress"],
     "esModuleInterop": true,
     "strict": true,
     "skipLibCheck": true,

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "@storybook/builder-webpack5": "^6.5.0-alpha.34",
     "@storybook/manager-webpack5": "^6.5.0-alpha.34",
     "@storybook/react": "^6.5.0-alpha.34",
+    "@testing-library/cypress": "^8.0.2",
     "@testing-library/jest-dom": "^5.16.2",
     "@testing-library/react": "^12.1.3",
     "@testing-library/react-hooks": "^7.0.2",

--- a/src/client/components/CommunicationCard.tsx
+++ b/src/client/components/CommunicationCard.tsx
@@ -17,6 +17,7 @@ import { greyBorderBottom, greyBorderTop } from '../styles/Consents';
 
 interface CommunicationCardProps {
   title: string;
+  titleLevel?: 1 | 2 | 3 | 4 | 5;
   body: string;
   value: string;
   checked: boolean;
@@ -116,17 +117,20 @@ const ieFlexOverflowFix = css`
 
 export const CommunicationCard: FunctionComponent<CommunicationCardProps> = ({
   title,
+  titleLevel = 3,
   body,
   value,
   image,
   checked,
 }) => {
+  const HeadingTag = `h${titleLevel}` as const;
+
   return (
     <div css={[greyBorderTop, blueBorderBottom, ieFlexOverflowFix]}>
       <div css={[communicationCardInfoContainer]}>
         <img css={img} src={image} alt={title} />
         <div css={ieFlexOverflowFix}>
-          <h3 css={communicationCardHeadingText}>{title}</h3>
+          <HeadingTag css={communicationCardHeadingText}>{title}</HeadingTag>
           <div css={communicationCardBodyContainer}>
             <p css={communicationCardBodyText}>{body}</p>
           </div>

--- a/src/client/lib/consentsTracking.ts
+++ b/src/client/lib/consentsTracking.ts
@@ -77,6 +77,7 @@ export const onboardingFormSubmitOphanTracking = (
   switch (`/${page}`) {
     case '/communication':
     case '/data':
+    case '/signin/success':
       return consentsFormSubmitOphanTracking(inputElems, pageData);
     case '/newsletters':
       return newslettersFormSubmitOphanTracking(inputElems, pageData);

--- a/src/client/pages/ConsentsCommunication.tsx
+++ b/src/client/pages/ConsentsCommunication.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { css } from '@emotion/react';
-import { from, space } from '@guardian/source-foundations';
+import { space } from '@guardian/source-foundations';
 import { getAutoRow, gridItemColumnConsents } from '@/client/styles/Grid';
 import { Consent } from '@/shared/model/Consent';
 import { CONSENTS_PAGES } from '@/client/models/ConsentsPages';
@@ -13,17 +13,6 @@ import { CONSENT_IMAGES } from '@/client/models/ConsentImages';
 type ConsentsCommunicationProps = {
   consents: Consent[];
 };
-
-const communicationCardContainer = css`
-  display: flex;
-  flex-flow: row wrap;
-  ${from.desktop} {
-    grid-column: 2 / span 9;
-  }
-  ${from.wide} {
-    grid-column: 3 / span 9;
-  }
-`;
 
 const p = css`
   margin-bottom: ${space[6]}px;
@@ -44,7 +33,7 @@ export const ConsentsCommunication = ({
           Would you like to join our mailing list to stay informed and up to
           date with all that the Guardian has to offer?
         </p>
-        <div css={[communicationCardContainer, autoRow()]}>
+        <div css={autoRow()}>
           {consents.map((consent) => (
             <CommunicationCard
               key={consent.id}

--- a/src/client/pages/SignInSuccess.tsx
+++ b/src/client/pages/SignInSuccess.tsx
@@ -1,18 +1,174 @@
 import React, { useContext } from 'react';
-import { Checkbox } from '@guardian/source-react-components';
+import { css } from '@emotion/react';
+import {
+  body,
+  brand,
+  from,
+  headline,
+  neutral,
+  space,
+  titlepiece,
+  until,
+} from '@guardian/source-foundations';
+import { Button, Checkbox } from '@guardian/source-react-components';
+
 import { Header } from '@/client/components/Header';
 import { Footer } from '@/client/components/Footer';
 import { GeoLocation } from '@/shared/model/Geolocation';
 import { Consent } from '@/shared/model/Consent';
-import { QueryParams } from '@/shared/model/QueryParams';
 import { buildUrlWithQueryParams } from '@/shared/lib/routeUtils';
 import { CsrfFormField } from '@/client/components/CsrfFormField';
 import { onboardingFormSubmitOphanTracking } from '@/client/lib/consentsTracking';
 import { ClientState } from '@/shared/model/ClientState';
 import { ClientStateContext } from '@/client/components/ClientState';
+import {
+  gridItem,
+  gridRow,
+  gridRowPadding,
+  innerGridRow,
+} from '@/client/styles/Grid';
+import { EnvelopeImage } from '@/client/components/EnvelopeImage';
 
-export type SignInSuccessProps = {
-  queryParams: QueryParams;
+const titleSpanDefinition = {
+  DESKTOP: { start: 2, span: 10 },
+  LEFT_COL: { start: 2, span: 11 },
+  WIDE: { start: 2, span: 11 },
+};
+
+const envelopeSpanDefinition = {
+  DESKTOP: { start: 9, span: 3 },
+  LEFT_COL: { start: 11, span: 3 },
+  WIDE: { start: 13, span: 3 },
+};
+
+const formSpanDefinition = {
+  DESKTOP: { start: 2, span: 6 },
+  LEFT_COL: { start: 2, span: 6 },
+  WIDE: { start: 2, span: 6 },
+};
+
+const titleWrapper = css`
+  background: ${brand[400]};
+  border-top: 1px solid ${brand[600]};
+
+  ${from.desktop} {
+    border-top: none;
+    margin-top: 1px;
+  }
+`;
+
+const autoMargin = css`
+  margin: 0 auto;
+`;
+
+const title = css`
+  ${titlepiece.small()}
+  ${gridItem(titleSpanDefinition)}
+  font-size: 36px;
+  color: ${neutral[100]};
+  margin: 60px 0 70px;
+
+  ${from.desktop} {
+    ${titlepiece.large()}
+    margin: 60px 0 130px;
+  }
+`;
+
+const formStyles = css`
+  ${gridItem(formSpanDefinition)}
+
+  ${until.desktop} {
+    padding: 0 ${space[5]}px;
+  }
+`;
+
+const formBackground = css`
+  background: ${neutral[97]};
+  flex-grow: 1;
+`;
+
+const formWrapper = css`
+  background: ${neutral[100]};
+  border: 1px solid ${neutral[86]};
+  position: relative;
+  top: -${space[12]}px;
+
+  ${from.desktop} {
+    top: -72px;
+  }
+`;
+
+const formGridRow = css`
+  padding-bottom: 30px;
+
+  ${until.desktop} {
+    display: block;
+  }
+`;
+
+const consentTitle = css`
+  ${headline.xsmall({ fontWeight: 'bold' })}
+  margin: ${space[1]}px 0 ${space[9]}px;
+
+  ${from.desktop} {
+    ${headline.medium({ fontWeight: 'bold' })}
+  }
+`;
+
+const consentDescription = css`
+  ${body.medium()}
+  position: relative;
+
+  &::before {
+    display: block;
+    content: '';
+    width: 100%;
+    height: 1px;
+    background: ${neutral[86]};
+  }
+
+  ${from.desktop} {
+    font-size: 20px;
+
+    &::after {
+      display: block;
+      content: '';
+      position: absolute;
+      top: 0;
+      right: 100%;
+      width: 60px;
+      height: 1px;
+      background: ${neutral[86]};
+    }
+  }
+`;
+
+const envelopeImageWrapper = css`
+  ${gridItem(envelopeSpanDefinition)}
+  display: flex;
+  justify-content: center;
+
+  ${until.desktop} {
+    padding-top: 52px;
+    border-bottom: 1px solid ${neutral[86]};
+    overflow: hidden;
+  }
+
+  ${from.desktop} {
+    order: 2;
+  }
+`;
+
+const envelopeImage = css`
+  width: 220px;
+  margin-bottom: -26px;
+`;
+
+const button = css`
+  margin-top: ${space[4]}px;
+`;
+
+type SignInSuccessProps = {
   geolocation?: GeoLocation;
   consents: Consent[];
 };
@@ -22,33 +178,55 @@ export const SignInSuccess = ({ consents }: SignInSuccessProps) => {
   const clientState: ClientState = useContext(ClientStateContext);
   const { pageData = {}, queryParams } = clientState;
   const { page = '', geolocation } = pageData;
+  const renderForm = () => (
+    <form
+      css={formStyles}
+      action={buildUrlWithQueryParams('/signin/success', {}, queryParams)}
+      method="post"
+      onSubmit={({ target: form }) => {
+        onboardingFormSubmitOphanTracking(
+          page,
+          pageData,
+          // have to explicitly type as HTMLFormElement as typescript can't infer type of the event.target
+          form as HTMLFormElement,
+        );
+      }}
+    >
+      <CsrfFormField />
+      <h2 css={consentTitle}>{name}</h2>
+      <p css={consentDescription}>{description}</p>
+      <Checkbox
+        name={id}
+        value={id}
+        label="Yes, sign me up"
+        defaultChecked={!!consented}
+      />
+      <Button type="submit" cssOverrides={button}>
+        Continue to The Guardian
+      </Button>
+    </form>
+  );
 
   return (
     <>
       <Header geolocation={geolocation} />
-      <form
-        action={buildUrlWithQueryParams('/signin/success', {}, queryParams)}
-        method="post"
-        onSubmit={({ target: form }) => {
-          onboardingFormSubmitOphanTracking(
-            page,
-            pageData,
-            // have to explicitly type as HTMLFormElement as typescript can't infer type of the event.target
-            form as HTMLFormElement,
-          );
-        }}
-      >
-        <CsrfFormField />
-        <h1>{name}</h1>
-        <p>{description}</p>
-        <Checkbox
-          name={id}
-          value={id}
-          label="Yes, sign me up"
-          defaultChecked={!!consented}
-        />
-        <button>Continue to The Guardian</button>
-      </form>
+      <div css={titleWrapper}>
+        <div css={[autoMargin, gridRow]}>
+          <h1 css={title}>Get the latest offers sent to your inbox</h1>
+        </div>
+      </div>
+      <div css={formBackground}>
+        <div css={[autoMargin, gridRowPadding]}>
+          <div css={[formWrapper]}>
+            <div css={[innerGridRow, formGridRow]}>
+              <div css={envelopeImageWrapper}>
+                <EnvelopeImage invertColors cssOverrides={envelopeImage} />
+              </div>
+              {renderForm()}
+            </div>
+          </div>
+        </div>
+      </div>
       <Footer />
     </>
   );

--- a/src/client/pages/SignInSuccess.tsx
+++ b/src/client/pages/SignInSuccess.tsx
@@ -136,7 +136,7 @@ const consentDescription = css`
       position: absolute;
       top: 0;
       right: 100%;
-      width: 60px;
+      width: 80px;
       height: 1px;
       background: ${neutral[86]};
     }
@@ -210,23 +210,25 @@ export const SignInSuccess = ({ consents }: SignInSuccessProps) => {
   return (
     <>
       <Header geolocation={geolocation} />
-      <div css={titleWrapper}>
-        <div css={[autoMargin, gridRow]}>
-          <h1 css={title}>Get the latest offers sent to your inbox</h1>
+      <main>
+        <div css={titleWrapper}>
+          <div css={[autoMargin, gridRow]}>
+            <h1 css={title}>Get the latest offers sent to your inbox</h1>
+          </div>
         </div>
-      </div>
-      <div css={formBackground}>
-        <div css={[autoMargin, gridRowPadding]}>
-          <div css={[formWrapper]}>
-            <div css={[innerGridRow, formGridRow]}>
-              <div css={envelopeImageWrapper}>
-                <EnvelopeImage invertColors cssOverrides={envelopeImage} />
+        <div css={formBackground}>
+          <div css={[autoMargin, gridRowPadding]}>
+            <div css={formWrapper}>
+              <div css={[innerGridRow, formGridRow]}>
+                <div css={envelopeImageWrapper}>
+                  <EnvelopeImage invertColors cssOverrides={envelopeImage} />
+                </div>
+                {renderForm()}
               </div>
-              {renderForm()}
             </div>
           </div>
         </div>
-      </div>
+      </main>
       <Footer />
     </>
   );

--- a/src/client/pages/SignInSuccess.tsx
+++ b/src/client/pages/SignInSuccess.tsx
@@ -1,0 +1,55 @@
+import React, { useContext } from 'react';
+import { Checkbox } from '@guardian/source-react-components';
+import { Header } from '@/client/components/Header';
+import { Footer } from '@/client/components/Footer';
+import { GeoLocation } from '@/shared/model/Geolocation';
+import { Consent } from '@/shared/model/Consent';
+import { QueryParams } from '@/shared/model/QueryParams';
+import { buildUrlWithQueryParams } from '@/shared/lib/routeUtils';
+import { CsrfFormField } from '@/client/components/CsrfFormField';
+import { onboardingFormSubmitOphanTracking } from '@/client/lib/consentsTracking';
+import { ClientState } from '@/shared/model/ClientState';
+import { ClientStateContext } from '@/client/components/ClientState';
+
+export type SignInSuccessProps = {
+  queryParams: QueryParams;
+  geolocation?: GeoLocation;
+  consents: Consent[];
+};
+
+export const SignInSuccess = ({ consents }: SignInSuccessProps) => {
+  const { id, name, description, consented } = consents[0];
+  const clientState: ClientState = useContext(ClientStateContext);
+  const { pageData = {}, queryParams } = clientState;
+  const { page = '', geolocation } = pageData;
+
+  return (
+    <>
+      <Header geolocation={geolocation} />
+      <form
+        action={buildUrlWithQueryParams('/signin/success', {}, queryParams)}
+        method="post"
+        onSubmit={({ target: form }) => {
+          onboardingFormSubmitOphanTracking(
+            page,
+            pageData,
+            // have to explicitly type as HTMLFormElement as typescript can't infer type of the event.target
+            form as HTMLFormElement,
+          );
+        }}
+      >
+        <CsrfFormField />
+        <h1>{name}</h1>
+        <p>{description}</p>
+        <Checkbox
+          name={id}
+          value={id}
+          label="Yes, sign me up"
+          defaultChecked={!!consented}
+        />
+        <button>Continue to The Guardian</button>
+      </form>
+      <Footer />
+    </>
+  );
+};

--- a/src/client/pages/SignInSuccess.tsx
+++ b/src/client/pages/SignInSuccess.tsx
@@ -1,171 +1,40 @@
 import React, { useContext } from 'react';
 import { css } from '@emotion/react';
-import {
-  body,
-  brand,
-  from,
-  headline,
-  neutral,
-  space,
-  titlepiece,
-  until,
-} from '@guardian/source-foundations';
-import { Button, Checkbox } from '@guardian/source-react-components';
-
+import { from, headline, until } from '@guardian/source-foundations';
+import { Button } from '@guardian/source-react-components';
+import { getAutoRow, gridItemColumnConsents } from '@/client/styles/Grid';
 import { Header } from '@/client/components/Header';
 import { Footer } from '@/client/components/Footer';
 import { GeoLocation } from '@/shared/model/Geolocation';
 import { Consent } from '@/shared/model/Consent';
-import { buildUrlWithQueryParams } from '@/shared/lib/routeUtils';
+import { CommunicationCard } from '@/client/components/CommunicationCard';
+import { CONSENT_IMAGES } from '@/client/models/ConsentImages';
 import { CsrfFormField } from '@/client/components/CsrfFormField';
+import { buildUrlWithQueryParams } from '@/shared/lib/routeUtils';
 import { onboardingFormSubmitOphanTracking } from '@/client/lib/consentsTracking';
 import { ClientState } from '@/shared/model/ClientState';
 import { ClientStateContext } from '@/client/components/ClientState';
-import {
-  gridItem,
-  gridRow,
-  gridRowPadding,
-  innerGridRow,
-} from '@/client/styles/Grid';
-import { EnvelopeImage } from '@/client/components/EnvelopeImage';
+import { ConsentsContent, controls } from '@/client/layouts/shared/Consents';
+import { mainStyles } from '@/client/layouts/ConsentsLayout';
+import { ConsentsBlueBackground } from '@/client/components/ConsentsBlueBackground';
 
-const titleSpanDefinition = {
-  DESKTOP: { start: 2, span: 10 },
-  LEFT_COL: { start: 2, span: 11 },
-  WIDE: { start: 2, span: 11 },
-};
+const heading = css`
+  ${headline.small({ fontWeight: 'bold' })}
 
-const envelopeSpanDefinition = {
-  DESKTOP: { start: 9, span: 3 },
-  LEFT_COL: { start: 11, span: 3 },
-  WIDE: { start: 13, span: 3 },
-};
-
-const formSpanDefinition = {
-  DESKTOP: { start: 2, span: 6 },
-  LEFT_COL: { start: 2, span: 6 },
-  WIDE: { start: 2, span: 6 },
-};
-
-const titleWrapper = css`
-  background: ${brand[400]};
-  border-top: 1px solid ${brand[600]};
-
-  ${from.desktop} {
-    border-top: none;
-    margin-top: 1px;
+  ${from.tablet} {
+    font-size: 32px;
   }
 `;
 
-const autoMargin = css`
-  margin: 0 auto;
+const continueButtonWrapper = css`
+  text-align: right;
 `;
 
-const title = css`
-  ${titlepiece.small()}
-  ${gridItem(titleSpanDefinition)}
-  font-size: 36px;
-  color: ${neutral[100]};
-  margin: 60px 0 70px;
-
-  ${from.desktop} {
-    ${titlepiece.large()}
-    margin: 60px 0 130px;
-  }
-`;
-
-const formStyles = css`
-  ${gridItem(formSpanDefinition)}
-
-  ${until.desktop} {
-    padding: 0 ${space[5]}px;
-  }
-`;
-
-const formBackground = css`
-  background: ${neutral[97]};
-  flex-grow: 1;
-`;
-
-const formWrapper = css`
-  background: ${neutral[100]};
-  border: 1px solid ${neutral[86]};
-  position: relative;
-  top: -${space[12]}px;
-
-  ${from.desktop} {
-    top: -72px;
-  }
-`;
-
-const formGridRow = css`
-  padding-bottom: 30px;
-
-  ${until.desktop} {
-    display: block;
-  }
-`;
-
-const consentTitle = css`
-  ${headline.xsmall({ fontWeight: 'bold' })}
-  margin: ${space[1]}px 0 ${space[9]}px;
-
-  ${from.desktop} {
-    ${headline.medium({ fontWeight: 'bold' })}
-  }
-`;
-
-const consentDescription = css`
-  ${body.medium()}
-  position: relative;
-
-  &::before {
-    display: block;
-    content: '';
+const continueButton = css`
+  ${until.tablet} {
     width: 100%;
-    height: 1px;
-    background: ${neutral[86]};
+    justify-content: center;
   }
-
-  ${from.desktop} {
-    font-size: 20px;
-
-    &::after {
-      display: block;
-      content: '';
-      position: absolute;
-      top: 0;
-      right: 100%;
-      width: 80px;
-      height: 1px;
-      background: ${neutral[86]};
-    }
-  }
-`;
-
-const envelopeImageWrapper = css`
-  ${gridItem(envelopeSpanDefinition)}
-  display: flex;
-  justify-content: center;
-
-  ${until.desktop} {
-    padding-top: 52px;
-    border-bottom: 1px solid ${neutral[86]};
-    overflow: hidden;
-  }
-
-  ${from.desktop} {
-    order: 2;
-  }
-`;
-
-const envelopeImage = css`
-  width: 220px;
-  margin-bottom: -26px;
-`;
-
-const button = css`
-  margin-top: ${space[4]}px;
 `;
 
 type SignInSuccessProps = {
@@ -173,61 +42,58 @@ type SignInSuccessProps = {
   consents: Consent[];
 };
 
-export const SignInSuccess = ({ consents }: SignInSuccessProps) => {
-  const { id, name, description, consented } = consents[0];
+export const SignInSuccess = ({
+  geolocation,
+  consents,
+}: SignInSuccessProps) => {
+  const autoRow = getAutoRow(1, gridItemColumnConsents);
   const clientState: ClientState = useContext(ClientStateContext);
   const { pageData = {}, queryParams } = clientState;
-  const { page = '', geolocation } = pageData;
-  const renderForm = () => (
-    <form
-      css={formStyles}
-      action={buildUrlWithQueryParams('/signin/success', {}, queryParams)}
-      method="post"
-      onSubmit={({ target: form }) => {
-        onboardingFormSubmitOphanTracking(
-          page,
-          pageData,
-          // have to explicitly type as HTMLFormElement as typescript can't infer type of the event.target
-          form as HTMLFormElement,
-        );
-      }}
-    >
-      <CsrfFormField />
-      <h2 css={consentTitle}>{name}</h2>
-      <p css={consentDescription}>{description}</p>
-      <Checkbox
-        name={id}
-        value={id}
-        label="Yes, sign me up"
-        defaultChecked={!!consented}
-      />
-      <Button type="submit" cssOverrides={button}>
-        Continue to The Guardian
-      </Button>
-    </form>
-  );
 
   return (
     <>
       <Header geolocation={geolocation} />
-      <main>
-        <div css={titleWrapper}>
-          <div css={[autoMargin, gridRow]}>
-            <h1 css={title}>Get the latest offers sent to your inbox</h1>
-          </div>
-        </div>
-        <div css={formBackground}>
-          <div css={[autoMargin, gridRowPadding]}>
-            <div css={formWrapper}>
-              <div css={[innerGridRow, formGridRow]}>
-                <div css={envelopeImageWrapper}>
-                  <EnvelopeImage invertColors cssOverrides={envelopeImage} />
-                </div>
-                {renderForm()}
-              </div>
+      <main css={mainStyles}>
+        <form
+          css={[autoRow()]}
+          action={buildUrlWithQueryParams('/signin/success', {}, queryParams)}
+          method="post"
+          onSubmit={({ target: form }) => {
+            onboardingFormSubmitOphanTracking(
+              'signin/success',
+              pageData,
+              // have to explicitly type as HTMLFormElement as typescript can't infer type of the event.target
+              form as HTMLFormElement,
+            );
+          }}
+        >
+          <CsrfFormField />
+          <ConsentsContent>
+            <h1 css={[heading, autoRow()]}>
+              Get the latest offers sent to your inbox
+            </h1>
+            <div css={[autoRow()]}>
+              {consents.map((consent) => (
+                <CommunicationCard
+                  key={consent.id}
+                  title={consent.name}
+                  titleLevel={2}
+                  body={consent.description}
+                  value={consent.id}
+                  checked={!!consent.consented}
+                  image={CONSENT_IMAGES[consent.id]}
+                />
+              ))}
             </div>
-          </div>
-        </div>
+          </ConsentsContent>
+          <ConsentsBlueBackground>
+            <div css={[autoRow(), controls, continueButtonWrapper]}>
+              <Button cssOverrides={continueButton} type="submit">
+                Continue to the Guardian
+              </Button>
+            </div>
+          </ConsentsBlueBackground>
+        </form>
       </main>
       <Footer />
     </>

--- a/src/client/pages/SignInSuccess.tsx
+++ b/src/client/pages/SignInSuccess.tsx
@@ -18,6 +18,12 @@ import { ConsentsContent, controls } from '@/client/layouts/shared/Consents';
 import { mainStyles } from '@/client/layouts/ConsentsLayout';
 import { ConsentsBlueBackground } from '@/client/components/ConsentsBlueBackground';
 
+const form = css`
+  display: flex;
+  flex: 1 0 auto;
+  flex-direction: column;
+`;
+
 const heading = css`
   ${headline.small({ fontWeight: 'bold' })}
 
@@ -55,7 +61,7 @@ export const SignInSuccess = ({
       <Header geolocation={geolocation} />
       <main css={mainStyles}>
         <form
-          css={[autoRow()]}
+          css={[form, autoRow()]}
           action={buildUrlWithQueryParams('/signin/success', {}, queryParams)}
           method="post"
           onSubmit={({ target: form }) => {
@@ -72,7 +78,7 @@ export const SignInSuccess = ({
             <h1 css={[heading, autoRow()]}>
               Get the latest offers sent to your inbox
             </h1>
-            <div css={[autoRow()]}>
+            <div css={autoRow()}>
               {consents.map((consent) => (
                 <CommunicationCard
                   key={consent.id}

--- a/src/client/pages/SignInSuccessPage.tsx
+++ b/src/client/pages/SignInSuccessPage.tsx
@@ -5,14 +5,8 @@ import { ClientStateContext } from '@/client/components/ClientState';
 
 export const SignInSuccessPage = () => {
   const clientState: ClientState = useContext(ClientStateContext);
-  const { pageData = {}, queryParams } = clientState;
+  const { pageData = {} } = clientState;
   const { geolocation, consents = [] } = pageData;
 
-  return (
-    <SignInSuccess
-      queryParams={queryParams}
-      geolocation={geolocation}
-      consents={consents}
-    />
-  );
+  return <SignInSuccess geolocation={geolocation} consents={consents} />;
 };

--- a/src/client/pages/SignInSuccessPage.tsx
+++ b/src/client/pages/SignInSuccessPage.tsx
@@ -1,0 +1,18 @@
+import React, { useContext } from 'react';
+import { SignInSuccess } from '@/client/pages/SignInSuccess';
+import { ClientState } from '@/shared/model/ClientState';
+import { ClientStateContext } from '@/client/components/ClientState';
+
+export const SignInSuccessPage = () => {
+  const clientState: ClientState = useContext(ClientStateContext);
+  const { pageData = {}, queryParams } = clientState;
+  const { geolocation, consents = [] } = pageData;
+
+  return (
+    <SignInSuccess
+      queryParams={queryParams}
+      geolocation={geolocation}
+      consents={consents}
+    />
+  );
+};

--- a/src/client/pages/SigninSuccess.stories.tsx
+++ b/src/client/pages/SigninSuccess.stories.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { Meta } from '@storybook/react';
+
+import { SignInSuccess } from './SignInSuccess';
+
+export default {
+  title: 'Pages/SignInSuccess',
+  component: SignInSuccess,
+  parameters: { layout: 'fullscreen' },
+} as Meta;
+
+const consents = [
+  {
+    id: 'supporter',
+    name: 'Supporting the Guardian',
+    description:
+      'Stay up-to-date with our latest offers and the aims of the organisation, as well as the ways to enjoy and support our journalism.',
+  },
+];
+
+export const Default = () => <SignInSuccess consents={consents} />;
+Default.storyName = 'default';

--- a/src/client/routes.tsx
+++ b/src/client/routes.tsx
@@ -16,6 +16,7 @@ import { ResendEmailVerificationPage } from '@/client/pages/ResendEmailVerificat
 import { UnexpectedErrorPage } from '@/client/pages/UnexpectedErrorPage';
 import { ClientState } from '@/shared/model/ClientState';
 import { SignInPage } from '@/client/pages/SignInPage';
+import { SignInSuccessPage } from '@/client/pages/SignInSuccessPage';
 import { MagicLinkPage } from '@/client/pages/MagicLinkPage';
 import { WelcomePage } from '@/client/pages/WelcomePage';
 import { WelcomeResendPage } from '@/client/pages/WelcomeResendPage';
@@ -41,6 +42,10 @@ const routes: Array<{
   {
     path: '/signin',
     element: <SignInPage />,
+  },
+  {
+    path: '/signin/success',
+    element: <SignInSuccessPage />,
   },
   {
     path: '/register',

--- a/src/client/styles/Grid.ts
+++ b/src/client/styles/Grid.ts
@@ -93,27 +93,24 @@ export enum MAX_WIDTH {
   WIDE = maxWidth(COLUMNS.WIDE, 60, space[5], space[5]),
 }
 
+const generateGridPaddingCss = (padding: number, maxWidth?: number) => `
+  padding-left: ${px(padding)};
+  padding-right: ${px(padding)};
+  max-width: ${maxWidth ? px(maxWidth) : '100%'};
+`;
+
 const generateGridRowCss = (
   padding: number,
   columnWidth: string,
   columnNumber: number,
-  maxWidth?: number,
 ) => `
     -ms-grid-columns: (${columnWidth} 20px\)[${
   columnNumber - 1
 }] ${columnWidth};
     grid-template-columns: repeat(${columnNumber}, ${columnWidth});
-    padding-left: ${px(padding)};
-    padding-right: ${px(padding)};
-    max-width: ${maxWidth ? px(maxWidth) : '100%'};
 `;
 
-// this styles should be applied to an element to make it behave as
-// the grid container, it defines the css on how all the breakpoints
-// should behave
-// anything items should be added inside this container, and use
-// either the autoRow/getAutoRow or manualRow functionality to layout the items
-export const gridRow = css`
+export const innerGridRow = css`
   display: -ms-grid;
   display: grid;
   width: 100%;
@@ -140,12 +137,7 @@ export const gridRow = css`
   }
 
   ${from.tablet} {
-    ${generateGridRowCss(
-      SPACING.TABLET,
-      COLUMN_WIDTH.TABLET,
-      COLUMNS.TABLET,
-      MAX_WIDTH.TABLET,
-    )}
+    ${generateGridRowCss(SPACING.TABLET, COLUMN_WIDTH.TABLET, COLUMNS.TABLET)}
   }
 
   ${from.desktop} {
@@ -153,7 +145,6 @@ export const gridRow = css`
       SPACING.DESKTOP,
       COLUMN_WIDTH.DESKTOP,
       COLUMNS.DESKTOP,
-      MAX_WIDTH.DESKTOP,
     )}
   }
 
@@ -162,18 +153,50 @@ export const gridRow = css`
       SPACING.LEFT_COL,
       COLUMN_WIDTH.LEFT_COL,
       COLUMNS.LEFT_COL,
-      MAX_WIDTH.LEFT_COL,
     )}
   }
 
   ${from.wide} {
-    ${generateGridRowCss(
-      SPACING.WIDE,
-      COLUMN_WIDTH.WIDE,
-      COLUMNS.WIDE,
-      MAX_WIDTH.WIDE,
-    )}
+    ${generateGridRowCss(SPACING.WIDE, COLUMN_WIDTH.WIDE, COLUMNS.WIDE)}
   }
+`;
+
+export const gridRowPadding = css`
+  ${generateGridPaddingCss(SPACING.MOBILE)}
+
+  ${from.mobileMedium} {
+    ${generateGridPaddingCss(SPACING.MOBILE_MEDIUM)}
+  }
+
+  ${from.mobileLandscape} {
+    ${generateGridPaddingCss(SPACING.MOBILE_LANDSCAPE)}
+  }
+
+  ${from.tablet} {
+    ${generateGridPaddingCss(SPACING.TABLET, MAX_WIDTH.TABLET)}
+  }
+
+  ${from.desktop} {
+    ${generateGridPaddingCss(SPACING.DESKTOP, MAX_WIDTH.DESKTOP)}
+  }
+
+  ${from.leftCol} {
+    ${generateGridPaddingCss(SPACING.LEFT_COL, MAX_WIDTH.LEFT_COL)}
+  }
+
+  ${from.wide} {
+    ${generateGridPaddingCss(SPACING.WIDE, MAX_WIDTH.WIDE)}
+  }
+`;
+
+// this styles should be applied to an element to make it behave as
+// the grid container, it defines the css on how all the breakpoints
+// should behave
+// anything items should be added inside this container, and use
+// either the autoRow/getAutoRow or manualRow functionality to layout the items
+export const gridRow = css`
+  ${innerGridRow}
+  ${gridRowPadding}
 `;
 
 const generateGridItemCss = (columnStart: number, columnSpan: number) => `

--- a/src/client/styles/Grid.ts
+++ b/src/client/styles/Grid.ts
@@ -111,7 +111,7 @@ const generateGridRowCss = (
 // this styles should be applied to an element to make it behave as
 // the grid container, it defines the css on how all the breakpoints
 // should behave
-// anything items should be added inside this container, and use
+// any items should be added inside this container, and use
 // either the autoRow/getAutoRow or manualRow functionality to layout the items
 export const gridRow = css`
   display: -ms-grid;

--- a/src/client/styles/Grid.ts
+++ b/src/client/styles/Grid.ts
@@ -93,24 +93,27 @@ export enum MAX_WIDTH {
   WIDE = maxWidth(COLUMNS.WIDE, 60, space[5], space[5]),
 }
 
-const generateGridPaddingCss = (padding: number, maxWidth?: number) => `
-  padding-left: ${px(padding)};
-  padding-right: ${px(padding)};
-  max-width: ${maxWidth ? px(maxWidth) : '100%'};
-`;
-
 const generateGridRowCss = (
   padding: number,
   columnWidth: string,
   columnNumber: number,
+  maxWidth?: number,
 ) => `
     -ms-grid-columns: (${columnWidth} 20px\)[${
   columnNumber - 1
 }] ${columnWidth};
     grid-template-columns: repeat(${columnNumber}, ${columnWidth});
+    padding-left: ${px(padding)};
+    padding-right: ${px(padding)};
+    max-width: ${maxWidth ? px(maxWidth) : '100%'};
 `;
 
-export const innerGridRow = css`
+// this styles should be applied to an element to make it behave as
+// the grid container, it defines the css on how all the breakpoints
+// should behave
+// anything items should be added inside this container, and use
+// either the autoRow/getAutoRow or manualRow functionality to layout the items
+export const gridRow = css`
   display: -ms-grid;
   display: grid;
   width: 100%;
@@ -137,7 +140,12 @@ export const innerGridRow = css`
   }
 
   ${from.tablet} {
-    ${generateGridRowCss(SPACING.TABLET, COLUMN_WIDTH.TABLET, COLUMNS.TABLET)}
+    ${generateGridRowCss(
+      SPACING.TABLET,
+      COLUMN_WIDTH.TABLET,
+      COLUMNS.TABLET,
+      MAX_WIDTH.TABLET,
+    )}
   }
 
   ${from.desktop} {
@@ -145,6 +153,7 @@ export const innerGridRow = css`
       SPACING.DESKTOP,
       COLUMN_WIDTH.DESKTOP,
       COLUMNS.DESKTOP,
+      MAX_WIDTH.DESKTOP,
     )}
   }
 
@@ -153,50 +162,18 @@ export const innerGridRow = css`
       SPACING.LEFT_COL,
       COLUMN_WIDTH.LEFT_COL,
       COLUMNS.LEFT_COL,
+      MAX_WIDTH.LEFT_COL,
     )}
   }
 
   ${from.wide} {
-    ${generateGridRowCss(SPACING.WIDE, COLUMN_WIDTH.WIDE, COLUMNS.WIDE)}
+    ${generateGridRowCss(
+      SPACING.WIDE,
+      COLUMN_WIDTH.WIDE,
+      COLUMNS.WIDE,
+      MAX_WIDTH.WIDE,
+    )}
   }
-`;
-
-export const gridRowPadding = css`
-  ${generateGridPaddingCss(SPACING.MOBILE)}
-
-  ${from.mobileMedium} {
-    ${generateGridPaddingCss(SPACING.MOBILE_MEDIUM)}
-  }
-
-  ${from.mobileLandscape} {
-    ${generateGridPaddingCss(SPACING.MOBILE_LANDSCAPE)}
-  }
-
-  ${from.tablet} {
-    ${generateGridPaddingCss(SPACING.TABLET, MAX_WIDTH.TABLET)}
-  }
-
-  ${from.desktop} {
-    ${generateGridPaddingCss(SPACING.DESKTOP, MAX_WIDTH.DESKTOP)}
-  }
-
-  ${from.leftCol} {
-    ${generateGridPaddingCss(SPACING.LEFT_COL, MAX_WIDTH.LEFT_COL)}
-  }
-
-  ${from.wide} {
-    ${generateGridPaddingCss(SPACING.WIDE, MAX_WIDTH.WIDE)}
-  }
-`;
-
-// this styles should be applied to an element to make it behave as
-// the grid container, it defines the css on how all the breakpoints
-// should behave
-// anything items should be added inside this container, and use
-// either the autoRow/getAutoRow or manualRow functionality to layout the items
-export const gridRow = css`
-  ${innerGridRow}
-  ${gridRowPadding}
 `;
 
 const generateGridItemCss = (columnStart: number, columnSpan: number) => `

--- a/src/server/controllers/changePassword.ts
+++ b/src/server/controllers/changePassword.ts
@@ -10,7 +10,7 @@ import {
   validate as validateToken,
   change as changePassword,
 } from '@/server/lib/idapi/changePassword';
-import { setIDAPICookies } from '@/server/lib/setIDAPICookies';
+import { setIDAPICookies } from '@/server/lib/idapi/setIDAPICookies';
 import { trackMetric } from '@/server/lib/trackMetric';
 import {
   readEncryptedStateCookie,

--- a/src/server/lib/experiments.ts
+++ b/src/server/lib/experiments.ts
@@ -1,0 +1,51 @@
+import { Request } from 'express';
+import { parse, stringify } from 'query-string';
+import ms from 'ms';
+import { getConfiguration } from '@/server/lib/getConfiguration';
+
+import { ResponseWithRequestState } from '@/server/models/Express';
+
+const RAN_EXPERIMENTS_COOKIE_NAME = 'GU_ran_experiments';
+const { isHttps } = getConfiguration();
+
+const getRanExperiments = (req: Request) => {
+  const ranExperimentsValue = req.cookies[RAN_EXPERIMENTS_COOKIE_NAME];
+
+  if (!ranExperimentsValue) return {};
+
+  return parse(ranExperimentsValue);
+};
+
+export const hasExperimentRun = (req: Request, experimentId: string) => {
+  const ranExperiments = getRanExperiments(req);
+  return experimentId in ranExperiments;
+};
+
+export const setExperimentRan = (
+  req: Request,
+  res: ResponseWithRequestState,
+  experimentId: string,
+  ran: boolean,
+) => {
+  const ranExperiments = getRanExperiments(req);
+  let newExperiments = {};
+
+  if (ran) {
+    newExperiments = {
+      ...ranExperiments,
+      [experimentId]: Date.now(),
+    };
+  } else {
+    // Using destructuring to omit property, so extracted variable is unused
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { [experimentId]: omit, ...otherExperiments } = ranExperiments;
+    newExperiments = otherExperiments;
+  }
+  const newValue = stringify(newExperiments);
+  res.cookie(RAN_EXPERIMENTS_COOKIE_NAME, newValue, {
+    httpOnly: true,
+    maxAge: ms('1yr'),
+    sameSite: 'strict',
+    secure: isHttps,
+  });
+};

--- a/src/server/lib/idapi/auth.ts
+++ b/src/server/lib/idapi/auth.ts
@@ -9,7 +9,11 @@ import {
 import { logger } from '@/server/lib/serverSideLogger';
 import { IdapiError } from '@/server/models/Error';
 import { IdapiErrorMessages, SignInErrors } from '@/shared/model/Errors';
-import { IDAPIAuthRedirect, IDAPIAuthStatus } from '@/shared/model/IDAPIAuth';
+import {
+  IDAPIAuthRedirect,
+  IDAPIAuthStatus,
+  IdapiCookies,
+} from '@/shared/model/IDAPIAuth';
 
 interface APIResponse {
   emailValidated: true;
@@ -92,10 +96,10 @@ export const authenticate = async (
       options: APIAddClientAccessToken(options, ip),
       queryParams: { format: 'cookies' },
     });
-    return response.cookies;
+    return response.cookies as IdapiCookies;
   } catch (error) {
     logger.error(`IDAPI Error auth authenticate '/auth?format=cookies'`, error);
-    handleError(error as IDAPIError);
+    return handleError(error as IDAPIError);
   }
 };
 

--- a/src/server/lib/idapi/changePassword.ts
+++ b/src/server/lib/idapi/changePassword.ts
@@ -12,7 +12,7 @@ import {
 } from '@/shared/model/Errors';
 import { logger } from '@/server/lib/serverSideLogger';
 import { IdapiError } from '@/server/models/Error';
-import { IdapiCookies } from '../setIDAPICookies';
+import { IdapiCookies } from '@/shared/model/IDAPIAuth';
 
 const handleError = ({ error, status = 500 }: IDAPIError) => {
   if (error.status === 'error' && error.errors?.length) {

--- a/src/server/lib/idapi/consents.ts
+++ b/src/server/lib/idapi/consents.ts
@@ -10,6 +10,7 @@ import { ConsentsErrors } from '@/shared/model/Errors';
 import { Consent } from '@/shared/model/Consent';
 import { UserConsent } from '@/shared/model/User';
 import { IdapiError } from '@/server/models/Error';
+import { read as getUser } from './user';
 
 const handleError = (): never => {
   throw new IdapiError({ message: ConsentsErrors.GENERIC, status: 500 });
@@ -32,7 +33,7 @@ const responseToEntity = (consent: ConsentAPIResponse): Consent => {
   };
 };
 
-export const read = async (): Promise<Consent[]> => {
+const read = async (): Promise<Consent[]> => {
   const options = APIGetOptions();
   try {
     return (
@@ -65,5 +66,51 @@ export const update = async (
   } catch (error) {
     logger.error(`IDAPI Error consents update  '/users/me/consents'`, error);
     return handleError();
+  }
+};
+
+export const getUserConsentsForPage = async (
+  pageConsents: string[],
+  ip: string,
+  sc_gu_u: string,
+): Promise<Consent[]> => {
+  const allConsents = await read();
+  const userConsents = (await getUser(ip, sc_gu_u)).consents;
+
+  return pageConsents
+    .map((id) => allConsents.find((consent) => consent.id === id))
+    .map((consent) => {
+      if (consent) {
+        let updated = consent;
+        const userConsent = userConsents.find((uc) => uc.id === consent.id);
+
+        if (userConsent) {
+          updated = {
+            ...updated,
+            consented: userConsent.consented,
+          };
+        }
+
+        return updated;
+      }
+    })
+    .filter(Boolean) as Consent[];
+};
+
+export const getConsentValueFromRequestBody = (
+  key: string,
+  body: { [key: string]: string },
+): boolean => {
+  if (body[key] === undefined || typeof body[key] !== 'string') {
+    return false;
+  }
+
+  switch (body[key]) {
+    case 'true':
+      return true;
+    case 'false':
+      return false;
+    default:
+      return !!body[key];
   }
 };

--- a/src/server/lib/idapi/setIDAPICookies.ts
+++ b/src/server/lib/idapi/setIDAPICookies.ts
@@ -1,16 +1,6 @@
 import { Response } from 'express';
 import { getConfiguration } from '@/server/lib/getConfiguration';
-
-interface IdapiCookie {
-  key: string;
-  value: string;
-  sessionCookie?: boolean;
-}
-
-export interface IdapiCookies {
-  values: Array<IdapiCookie>;
-  expiresAt: string;
-}
+import { IdapiCookies } from '@/shared/model/IDAPIAuth';
 
 const { baseUri } = getConfiguration();
 

--- a/src/server/lib/okta/openid-connect.ts
+++ b/src/server/lib/okta/openid-connect.ts
@@ -173,7 +173,7 @@ const AuthorizationStateCookieOptions: CookieOptions = {
   httpOnly: true,
   secure: !baseUri.includes('localhost'),
   signed: !baseUri.includes('localhost'),
-  sameSite: 'strict',
+  sameSite: 'lax',
 };
 
 /**

--- a/src/server/lib/okta/openid-connect.ts
+++ b/src/server/lib/okta/openid-connect.ts
@@ -173,7 +173,7 @@ const AuthorizationStateCookieOptions: CookieOptions = {
   httpOnly: true,
   secure: !baseUri.includes('localhost'),
   signed: !baseUri.includes('localhost'),
-  sameSite: 'lax',
+  sameSite: 'strict',
 };
 
 /**

--- a/src/server/lib/postSignInController.ts
+++ b/src/server/lib/postSignInController.ts
@@ -14,10 +14,9 @@ const postSignInController = async (
   req: Request,
   res: ResponseWithRequestState,
   idapiCookies: IdapiCookies,
+  returnUrl?: string,
 ) => {
   const state = res.locals;
-
-  const { returnUrl } = state.pageData;
   const redirectUrl = returnUrl || defaultReturnUri;
 
   const optInPromptActive = await (async () => {

--- a/src/server/lib/postSignInController.ts
+++ b/src/server/lib/postSignInController.ts
@@ -1,0 +1,67 @@
+import { Request } from 'express';
+import { ResponseWithRequestState } from '@/server/models/Express';
+import { getConfiguration } from '@/server/lib/getConfiguration';
+import { TEST_ID as OPT_IN_PROMPT_TEST_ID } from '@/shared/model/experiments/tests/opt-in-prompt';
+import { addReturnUrlToPath } from '@/server/lib/queryParams';
+import { CONSENTS_POST_SIGN_IN_PAGE, Consents } from '@/shared/model/Consent';
+import { getUserConsentsForPage } from '@/server/lib/idapi/consents';
+import { hasExperimentRun, setExperimentRan } from '@/server/lib/experiments';
+import { IdapiCookies } from '@/shared/model/IDAPIAuth';
+
+const { defaultReturnUri } = getConfiguration();
+
+const postSignInController = async (
+  req: Request,
+  res: ResponseWithRequestState,
+  idapiCookies: IdapiCookies,
+) => {
+  const state = res.locals;
+
+  const { returnUrl } = state.pageData;
+  const redirectUrl = returnUrl || defaultReturnUri;
+
+  const optInPromptActive = await (async () => {
+    if (!state.abTesting.participations[OPT_IN_PROMPT_TEST_ID]) {
+      return false;
+    }
+
+    // Treating paths that only differ due to trailing slash as equivalent
+    const noTrailingSlash = (str: string) => str.replace(/\/$/, '');
+    if (noTrailingSlash(redirectUrl) !== noTrailingSlash(defaultReturnUri)) {
+      return false;
+    }
+
+    if (hasExperimentRun(req, OPT_IN_PROMPT_TEST_ID)) {
+      return false;
+    } else {
+      setExperimentRan(req, res, OPT_IN_PROMPT_TEST_ID, true);
+    }
+
+    const sc_gu_u = idapiCookies.values.find(
+      ({ key }) => key === 'SC_GU_U',
+    )?.value;
+
+    if (!sc_gu_u) {
+      return false;
+    }
+
+    const consents = await getUserConsentsForPage(
+      CONSENTS_POST_SIGN_IN_PAGE,
+      req.ip,
+      sc_gu_u,
+    );
+
+    return !consents.find(({ id }) => id === Consents.SUPPORTER)?.consented;
+  })();
+
+  if (optInPromptActive) {
+    return res.redirect(
+      303,
+      addReturnUrlToPath('/signin/success', redirectUrl),
+    );
+  }
+
+  return res.redirect(303, redirectUrl);
+};
+
+export default postSignInController;

--- a/src/server/routes/oauth.ts
+++ b/src/server/routes/oauth.ts
@@ -13,7 +13,7 @@ import { logger } from '@/server/lib/serverSideLogger';
 import { trackMetric } from '@/server/lib/trackMetric';
 import { handleAsyncErrors } from '@/server/lib/expressWrappers';
 import { exchangeAccessTokenForCookies } from '@/server/lib/idapi/auth';
-import { setIDAPICookies } from '@/server/lib/setIDAPICookies';
+import { setIDAPICookies } from '@/server/lib/idapi/setIDAPICookies';
 import { SignInErrors } from '@/shared/model/Errors';
 import { updateEncryptedStateCookie } from '@/server/lib/encryptedStateCookie';
 import { addQueryParamsToPath } from '@/shared/lib/queryParams';

--- a/src/server/routes/oauth.ts
+++ b/src/server/routes/oauth.ts
@@ -16,7 +16,7 @@ import { setIDAPICookies } from '@/server/lib/idapi/setIDAPICookies';
 import { SignInErrors } from '@/shared/model/Errors';
 import { updateEncryptedStateCookie } from '@/server/lib/encryptedStateCookie';
 import { addQueryParamsToPath } from '@/shared/lib/queryParams';
-import postSignInController from '@/server/routes/signIn';
+import postSignInController from '@/server/lib/postSignInController';
 
 interface OAuthError {
   error: string;
@@ -158,7 +158,7 @@ router.get(
           )
         : authState.queryParams.returnUrl;
 
-      postSignInController(req, res, cookies);
+      postSignInController(req, res, cookies, returnUrl);
     } catch (error) {
       // check if it's an oauth/oidc error
       if (isOAuthError(error)) {

--- a/src/server/routes/signIn.ts
+++ b/src/server/routes/signIn.ts
@@ -186,6 +186,8 @@ const idapiSignInController = async (
   res: ResponseWithRequestState,
 ) => {
   const { email = '', password = '' } = req.body;
+  const { pageData } = res.locals;
+  const { returnUrl } = pageData;
 
   try {
     const cookies = await authenticateWithIdapi(email, password, req.ip);
@@ -194,7 +196,7 @@ const idapiSignInController = async (
 
     trackMetric('SignIn::Success');
 
-    return postSignInController(req, res, cookies);
+    return postSignInController(req, res, cookies, returnUrl);
   } catch (error) {
     logger.error(`${req.method} ${req.originalUrl}  Error`, error);
     const { message, status } =

--- a/src/server/routes/verifyEmail.ts
+++ b/src/server/routes/verifyEmail.ts
@@ -8,7 +8,7 @@ import {
 } from '@/server/lib/idapi/verifyEmail';
 import { logger } from '@/server/lib/serverSideLogger';
 import { renderer } from '@/server/lib/renderer';
-import { setIDAPICookies } from '@/server/lib/setIDAPICookies';
+import { setIDAPICookies } from '@/server/lib/idapi/setIDAPICookies';
 import { trackMetric } from '@/server/lib/trackMetric';
 import { ApiError } from '@/server/models/Error';
 import { ResponseWithRequestState } from '@/server/models/Express';

--- a/src/shared/model/Consent.ts
+++ b/src/shared/model/Consent.ts
@@ -17,3 +17,5 @@ export enum Consents {
 export const CONSENTS_DATA_PAGE: string[] = [Consents.PROFILING];
 
 export const CONSENTS_COMMUNICATION_PAGE: string[] = [Consents.SUPPORTER];
+
+export const CONSENTS_POST_SIGN_IN_PAGE: string[] = [Consents.SUPPORTER];

--- a/src/shared/model/IDAPIAuth.ts
+++ b/src/shared/model/IDAPIAuth.ts
@@ -11,3 +11,14 @@ export interface IDAPIAuthRedirect {
     url: string;
   };
 }
+
+export interface IdapiCookie {
+  key: string;
+  value: string;
+  sessionCookie?: boolean;
+}
+
+export interface IdapiCookies {
+  values: Array<IdapiCookie>;
+  expiresAt: string;
+}

--- a/src/shared/model/PageTitle.ts
+++ b/src/shared/model/PageTitle.ts
@@ -7,6 +7,7 @@ export type PageTitle =
   | 'Register'
   | 'Reset Password'
   | 'Sign in'
+  | 'Signed in'
   | 'Check Your Inbox'
   | 'Create Password'
   | 'Resend Create Password Email'

--- a/src/shared/model/Routes.ts
+++ b/src/shared/model/Routes.ts
@@ -31,6 +31,7 @@ export type RoutePaths =
   | '/set-password/expired'
   | '/set-password/resend'
   | '/signin'
+  | '/signin/success'
   | '/verify-email' //this can be removed once Jobs has been migrated
   | '/welcome'
   | '/welcome/:token'

--- a/src/shared/model/experiments/abSwitches.ts
+++ b/src/shared/model/experiments/abSwitches.ts
@@ -1,4 +1,5 @@
 export const abSwitches = {
   abExampleTest: false,
   abOnboardingNewslettersTest: true,
+  abOptInPromptPostSignIn: true,
 };

--- a/src/shared/model/experiments/abTests.ts
+++ b/src/shared/model/experiments/abTests.ts
@@ -1,6 +1,7 @@
 import { AB, ABTest, Participations } from '@guardian/ab-core';
 import { abSwitches } from './abSwitches';
 import { onboardingNewslettersTest } from './tests/onboarding-newsletters';
+import { optInPrompt } from './tests/opt-in-prompt';
 
 interface ABTestConfiguration {
   abTestSwitches: Record<string, boolean>;
@@ -10,7 +11,7 @@ interface ABTestConfiguration {
 }
 
 // Add AB tests to run in this array
-export const tests: ABTest[] = [onboardingNewslettersTest];
+export const tests: ABTest[] = [onboardingNewslettersTest, optInPrompt];
 
 const getDefaultABTestConfiguration = (): ABTestConfiguration => ({
   abTestSwitches: abSwitches,

--- a/src/shared/model/experiments/tests/opt-in-prompt.ts
+++ b/src/shared/model/experiments/tests/opt-in-prompt.ts
@@ -1,0 +1,25 @@
+import { ABTest } from '@guardian/ab-core';
+
+export const TEST_ID = 'OptInPromptPostSignIn';
+
+export const optInPrompt: ABTest = {
+  id: TEST_ID,
+  // TODO: change start / expiry before release
+  start: '2022-01-01',
+  expiry: '2022-12-31',
+  author: 'liam.duffy.freelancer@guardian.co.uk',
+  description:
+    'Testing prompting users to opt in to newsletter / marketing after sign in',
+  audience: 0.1,
+  audienceOffset: 0,
+  successMeasure: 'Understand impact on opt in rates',
+  audienceCriteria:
+    'Half of users viewing consent flow will see prompt after signing in',
+  canRun: () => true,
+  variants: [
+    {
+      id: 'only-variant',
+      test: () => {}, // eslint-disable-line @typescript-eslint/no-empty-function
+    },
+  ],
+};

--- a/src/shared/model/experiments/tests/opt-in-prompt.ts
+++ b/src/shared/model/experiments/tests/opt-in-prompt.ts
@@ -4,7 +4,6 @@ export const TEST_ID = 'OptInPromptPostSignIn';
 
 export const optInPrompt: ABTest = {
   id: TEST_ID,
-  // TODO: change start / expiry before release
   start: '2022-01-01',
   expiry: '2022-12-31',
   author: 'liam.duffy.freelancer@guardian.co.uk',

--- a/yarn.lock
+++ b/yarn.lock
@@ -2847,7 +2847,15 @@
   dependencies:
     defer-to-connect "^1.0.1"
 
-"@testing-library/dom@^8.0.0":
+"@testing-library/cypress@^8.0.2":
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/@testing-library/cypress/-/cypress-8.0.2.tgz#b13f0ff2424dec4368b6670dfbfb7e43af8eefc9"
+  integrity sha512-KVdm7n37sg/A4e3wKMD4zUl0NpzzVhx06V9Tf0hZHZ7nrZ4yFva6Zwg2EFF1VzHkEfN/ahUzRtT1qiW+vuWnJw==
+  dependencies:
+    "@babel/runtime" "^7.14.6"
+    "@testing-library/dom" "^8.1.0"
+
+"@testing-library/dom@^8.0.0", "@testing-library/dom@^8.1.0":
   version "8.11.3"
   resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-8.11.3.tgz#38fd63cbfe14557021e88982d931e33fb7c1a808"
   integrity sha512-9LId28I+lx70wUiZjLvi1DB/WT2zGOxUh46glrSNMaWVx849kKAluezVzZrXJfTKKoQTmEOutLes/bHg4Bj3aA==


### PR DESCRIPTION
## [Trello card](https://trello.com/c/K6J5oeog/3015-implement-opt-in-prompt-during-sign-in-flow-s)

## What does this change?

After sign in, this redirects users to a page prompting them to opt in to support marketing, if:

- They are in the a/b test (so we can control the rollout)
- The `returnUrl` query param is the default (this is to avoid adding extra friction into critical paths)
- They have not seen the prompt previously on the device they are using
- They have not previously consented to supporter marketing

~~Currently branched off `mh/update-onboarding-flow`.~~

Still need to do the following, hence the PR being in draft:

- [x] Implement design (needs to use bits from Michael's branch)
- [x] Add tests 

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

Set `GU_mvt_id cookie` to `1` and sign in with a user who is has not already consented to supporter marketing.

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

### Desktop

![image](https://user-images.githubusercontent.com/3338808/155142618-aefdf2f9-db34-4280-8927-b0f59d03130b.png)

### Tablet

![image](https://user-images.githubusercontent.com/3338808/155142694-2c3263ef-a17e-4f11-8e62-438d0996b1ce.png)

# Mobile

![image](https://user-images.githubusercontent.com/3338808/155142761-236fda6e-4091-4771-a042-5b6ce45b71d9.png)

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

- [ ] [Tested with screen reader](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#screen-readers)
- [ ] [Navigable with keyboard](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#keyboard-navigation)
- [ ] [Colour contrast passed](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#colour-contrast)
- [ ] [The change doesn't use only colour to convey meaning](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#use-of-colour)
