### PR TITLE
Dependency | Update helmet to 5

### DIFF
--- a/package.json
+++ b/package.json
@@ -136,7 +136,7 @@
     "deepmerge": "^4.2.2",
     "express": "^4.17.2",
     "express-recaptcha": "^5.0.2",
-    "helmet": "^4.6.0",
+    "helmet": "^5.0.2",
     "http-errors": "^1.8.1",
     "js-sha1": "^0.6.0",
     "jsonwebtoken": "^8.5.1",

--- a/src/server/lib/middleware/helmet.ts
+++ b/src/server/lib/middleware/helmet.ts
@@ -1,4 +1,4 @@
-import { default as helmet } from 'helmet';
+import helmet, { HelmetOptions } from 'helmet';
 import { getConfiguration } from '@/server/lib/getConfiguration';
 
 const { baseUri, gaUID, apiDomain, idapiBaseUrl, stage } = getConfiguration();
@@ -38,7 +38,7 @@ const scriptSrc = [
 ];
 if (stage === 'DEV') scriptSrc.push(HELMET_OPTIONS.UNSAFE_EVAL);
 
-const helmetConfig = {
+const helmetConfig: HelmetOptions = {
   contentSecurityPolicy: {
     directives: {
       baseUri: [HELMET_OPTIONS.NONE],
@@ -66,8 +66,10 @@ const helmetConfig = {
         CSP_VALID_URI.SENTRY,
       ],
       frameSrc: [CSP_VALID_URI.CMP, CSP_VALID_URI.GOOGLE_RECAPTCHA],
+      formAction: null,
     },
   },
+  crossOriginEmbedderPolicy: false,
 };
 
 export const helmetMiddleware = helmet(helmetConfig);

--- a/yarn.lock
+++ b/yarn.lock
@@ -9856,10 +9856,10 @@ he@^1.2.0:
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
 
-helmet@^4.6.0:
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/helmet/-/helmet-4.6.0.tgz#579971196ba93c5978eb019e4e8ec0e50076b4df"
-  integrity sha512-HVqALKZlR95ROkrnesdhbbZJFi/rIVSoNq6f3jA/9u6MIbTsPh3xZwihjeI5+DO/2sOV6HMHooXcEOuwskHpTg==
+helmet@^5.0.2:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/helmet/-/helmet-5.0.2.tgz#3264ec6bab96c82deaf65e3403c369424cb2366c"
+  integrity sha512-QWlwUZZ8BtlvwYVTSDTBChGf8EOcQ2LkGMnQJxSzD1mUu8CCjXJZq/BXP8eWw4kikRnzlhtYo3lCk0ucmYA3Vg==
 
 highlight.js@^10.1.1, highlight.js@~10.7.0:
   version "10.7.3"


### PR DESCRIPTION
## What does this change?
Updates [helmet](https://github.com/helmetjs/helmet) from 4.6.0 to 5.0.2.

This was a major version upgrade with breaking changes.

Specifically according to the [changelog](https://github.com/helmetjs/helmet/blob/main/CHANGELOG.md#500---2022-01-02):

<li><strong>Breaking:</strong> <code>helmet.contentSecurityPolicy</code>: <code>useDefaults</code> option now defaults to <code>true</code></li>
<li><strong>Breaking:</strong> <code>helmet.contentSecurityPolicy</code>: <code>form-action</code> directive is now set to <code>'self'</code> by default</li>
<li><strong>Breaking:</strong> <code>helmet.crossOriginEmbedderPolicy</code> is enabled by default</li>
<li><strong>Breaking:</strong> <code>helmet.crossOriginOpenerPolicy</code> is enabled by default</li>
<li><strong>Breaking:</strong> <code>helmet.crossOriginResourcePolicy</code> is enabled by default</li>

After testing the project with each of the breaking changes individually, we determined that the `helmet.crossOriginEmbedderPolicy` the one causing issues, as we were loading cross-origin resources, specifically recaptcha and the CMP banner, so we've disabled this for now.

The other one of concern was the `form-action` set to `self` by default, this one was a concern as according to [MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/form-action) in some cases a redirect after POST is blocked by this CSP. While internal redirects worked when set to `self` i.e within context of `profile.` subdomain, when attempting to redirect after sign in to the homepage/return url this was blocked in Chrome and Safari, so we have to explicitly disable this for now by setting to `null`.

![image](https://user-images.githubusercontent.com/13315440/151788327-39f0c18c-1ea5-44a5-9716-890635e01937.png)

## Tested
- [x] Local
- [x] CODE