### PR TITLE
Changes to client side logging with Sentry

### DIFF
--- a/src/client/lib/clientSideLogger.ts
+++ b/src/client/lib/clientSideLogger.ts
@@ -34,7 +34,7 @@ class ClientSideLogger extends BaseLogger {
       typeof error.message === 'string'
     ) {
       Sentry.captureException(error, { extra });
-      return transaction.finish();
+      return transaction?.finish();
     }
 
     if (error) {
@@ -42,12 +42,12 @@ class ClientSideLogger extends BaseLogger {
         level: getSentryLevel(level),
         extra,
       });
-      return transaction.finish();
+      return transaction?.finish();
     }
 
-    // `extra` is a free-form object that we can use to specify extra information in our logs.
+    // should it be needed, `extra` is a free-form object that we can use to add additional debug info to Sentry logs.
     Sentry.captureMessage(message, { level: getSentryLevel(level), extra });
-    return transaction.finish();
+    return transaction?.finish();
   }
 
   // eslint-disable-next-line

--- a/src/client/pages/ChangePasswordPage.tsx
+++ b/src/client/pages/ChangePasswordPage.tsx
@@ -21,13 +21,17 @@ export const ChangePasswordPage = () => {
     // we redirect to the session expired page
     // if the token expires while the user is on the current page
     if (typeof window !== 'undefined' && timeUntilTokenExpiry) {
-      logger.info(
-        `Change password page: loaded successfully with a token expiry of: ${timeUntilTokenExpiry}`,
-      );
+      logger.info(`Change password page: loaded successfully`, undefined, {
+        timeUntilTokenExpiry,
+      });
       setTimeout(() => {
         // logging to debug scenarios where users are seeing an expired token page with a supposedly valid token.
         logger.info(
-          `Change password page: redirecting to token expired page after: ${timeUntilTokenExpiry}ms`,
+          `Change password page: redirecting to token expired page`,
+          undefined,
+          {
+            timeUntilTokenExpiry,
+          },
         );
         window.location.replace(buildUrl('/reset-password/expired'));
       }, timeUntilTokenExpiry);

--- a/src/client/pages/ResendPasswordPage.tsx
+++ b/src/client/pages/ResendPasswordPage.tsx
@@ -19,11 +19,13 @@ export const ResendPasswordPage = () => {
     if (typeof window !== 'undefined') {
       const suppliedToken = window.location.pathname.split('/').pop();
       // logging to debug scenarios where users are seeing an invalid token page with a supposedly valid token.
-      logger.info(
-        suppliedToken === 'resend'
-          ? 'Reset password: link expired page shown'
-          : `Reset password: link expired page shown with token: ${suppliedToken}`,
-      );
+      if (suppliedToken === 'resend') {
+        logger.info('Reset password: link expired page shown');
+      } else {
+        logger.info('Reset password: link expired page shown', undefined, {
+          suppliedToken,
+        });
+      }
     }
   }, []);
 

--- a/src/client/pages/SetPasswordPage.tsx
+++ b/src/client/pages/SetPasswordPage.tsx
@@ -22,12 +22,14 @@ export const SetPasswordPage = () => {
     // we redirect to the session expired page
     // if the token expires while the user is on the current page
     if (typeof window !== 'undefined' && timeUntilTokenExpiry) {
-      logger.info(
-        `Set password page: loaded successfully with a token expiry of: ${timeUntilTokenExpiry}`,
-      );
+      logger.info(`Set password page: loaded successfully`, undefined, {
+        timeUntilTokenExpiry,
+      });
       setTimeout(() => {
         logger.info(
-          `Set password page: redirecting to token expired page after: ${timeUntilTokenExpiry}ms`,
+          `Set password page: redirecting to token expired page`,
+          undefined,
+          { timeUntilTokenExpiry },
         );
         window.location.replace(buildUrl('/set-password/expired'));
       }, timeUntilTokenExpiry);

--- a/src/client/pages/WelcomePage.tsx
+++ b/src/client/pages/WelcomePage.tsx
@@ -22,12 +22,14 @@ export const WelcomePage = () => {
     // we redirect to the session expired page
     // if the token expires while the user is on the current page
     if (typeof window !== 'undefined' && timeUntilTokenExpiry) {
-      logger.info(
-        `Welcome page: loaded successfully with a token expiry of: ${timeUntilTokenExpiry}`,
-      );
+      logger.info(`Welcome page: loaded successfully`, undefined, {
+        timeUntilTokenExpiry,
+      });
       setTimeout(() => {
         logger.info(
-          `Welcome page: redirecting to token expired page after: ${timeUntilTokenExpiry}ms`,
+          `Welcome page: redirecting to token expired page`,
+          undefined,
+          { timeUntilTokenExpiry },
         );
         window.location.replace(buildUrl('/welcome/expired'));
       }, timeUntilTokenExpiry);

--- a/src/client/static/hydration.tsx
+++ b/src/client/static/hydration.tsx
@@ -9,6 +9,10 @@ import { tests } from '@/shared/model/experiments/abTests';
 import { abSwitches } from '@/shared/model/experiments/abSwitches';
 import * as Sentry from '@sentry/browser';
 import { Integrations } from '@sentry/tracing';
+import {
+  getConsentFor,
+  onConsentChange,
+} from '@guardian/consent-management-platform';
 
 export const hydrateApp = () => {
   const routingConfig: RoutingConfig = JSON.parse(
@@ -22,16 +26,25 @@ export const hydrateApp = () => {
     sentryConfig: { stage, build, dsn },
   } = clientState;
 
-  // Disable Sentry client side logging during local development.
-  if (dsn) {
-    Sentry.init({
-      dsn,
-      integrations: [new Integrations.BrowserTracing()],
-      environment: stage,
-      release: `gateway@${build}`,
-      tracesSampleRate: 0.2,
+  const initSentryWhenConsented = () => {
+    onConsentChange((consentState) => {
+      const sentryConsentGranted = getConsentFor('sentry', consentState);
+      if (sentryConsentGranted && dsn) {
+        Sentry.init({
+          dsn,
+          integrations: [new Integrations.BrowserTracing()],
+          environment: stage,
+          release: `gateway@${build}`,
+          // If you want to log something all the time, wrap your call to
+          // Sentry in a new Transaction and set `sampled` to true.
+          // An example of this is in clientSideLogger.ts
+          sampleRate: 0.2,
+        });
+      }
     });
-  }
+  };
+
+  initSentryWhenConsented();
 
   hydrate(
     <ABProvider

--- a/src/client/static/hydration.tsx
+++ b/src/client/static/hydration.tsx
@@ -40,6 +40,9 @@ export const hydrateApp = () => {
           // An example of this is in clientSideLogger.ts
           sampleRate: 0.2,
         });
+      } else {
+        // Close the sentry client if consent changes to disallow logging.
+        Sentry.close();
       }
     });
   };


### PR DESCRIPTION
## What does this change?
We recently added some extra client-side event tracking around the reset password, change password and welcome page flows in #1446

The logs introduced in that PR inserted some volatile variables in logged Sentry messages. This meant that it didn't group them correctly. Here we modify the logging so that these values are contained instead in the Sentry `extras` object as additional debug data.

Secondly we tweak the client side logger to ensure that each log message is wrapped in a [Sentry Transaction](https://docs.sentry.io/product/performance/transaction-summary/). This lets us override the sample rate of 20% and ensure that Sentry keeps track of all intentional logging that we add to the platform.

Finally we add a check for user consent before initialising the Sentry logger. If the user consent changes, the Sentry logger is initialised or destroyed as appropriate.
