### PR TITLE
Revert check for Sentry consent

### DIFF
--- a/src/client/static/hydration.tsx
+++ b/src/client/static/hydration.tsx
@@ -9,10 +9,6 @@ import { tests } from '@/shared/model/experiments/abTests';
 import { abSwitches } from '@/shared/model/experiments/abSwitches';
 import * as Sentry from '@sentry/browser';
 import { Integrations } from '@sentry/tracing';
-import {
-  getConsentFor,
-  onConsentChange,
-} from '@guardian/consent-management-platform';
 
 export const hydrateApp = () => {
   const routingConfig: RoutingConfig = JSON.parse(
@@ -26,28 +22,18 @@ export const hydrateApp = () => {
     sentryConfig: { stage, build, dsn },
   } = clientState;
 
-  const initSentryWhenConsented = () => {
-    onConsentChange((consentState) => {
-      const sentryConsentGranted = getConsentFor('sentry', consentState);
-      if (sentryConsentGranted && dsn) {
-        Sentry.init({
-          dsn,
-          integrations: [new Integrations.BrowserTracing()],
-          environment: stage,
-          release: `gateway@${build}`,
-          // If you want to log something all the time, wrap your call to
-          // Sentry in a new Transaction and set `sampled` to true.
-          // An example of this is in clientSideLogger.ts
-          sampleRate: 0.2,
-        });
-      } else {
-        // Close the sentry client if consent changes to disallow logging.
-        Sentry.close();
-      }
+  if (dsn) {
+    Sentry.init({
+      dsn,
+      integrations: [new Integrations.BrowserTracing()],
+      environment: stage,
+      release: `gateway@${build}`,
+      // If you want to log something all the time, wrap your call to
+      // Sentry in a new Transaction and set `sampled` to true.
+      // An example of this is in clientSideLogger.ts
+      sampleRate: 0.2,
     });
-  };
-
-  initSentryWhenConsented();
+  }
 
   hydrate(
     <ABProvider


### PR DESCRIPTION
## What does this change?
It was confirmed that we do not need explicit consent for users to enable Sentry as it is listed as an "essential vendor". As a result we're removing the check in this PR

A wider set of improvements to dynamically import Sentry and add a logging queue for before it is in progress here: #1462 