### PR TITLE
Fix signed cookie issue when running on localhost

### DIFF
--- a/src/server/lib/okta/openid-connect.ts
+++ b/src/server/lib/okta/openid-connect.ts
@@ -211,8 +211,9 @@ export const setAuthorizationStateCookie = (
 export const getAuthorizationStateCookie = (
   req: Request,
 ): AuthorizationState | null => {
-  const stateCookie = req.signedCookies[AuthorizationStateCookieName];
-
+  const stateCookie = baseUri.includes('localhost')
+    ? req.cookies[AuthorizationStateCookieName]
+    : req.signedCookies[AuthorizationStateCookieName];
   if (!stateCookie) {
     return null;
   }


### PR DESCRIPTION
## What does this change?
We cannot access cookies from `req.signedCookies` when `signed=false` is set on the cookie. This was causing problems when running on localhost.

Here, we change the logic to pull the `AuthorisationStateCookie` from `req.cookies` when running on localhost. 