### PR TITLE
Fix copy for newsletters consent page in new design

### DIFF
--- a/src/client/pages/ConsentsNewsletters.tsx
+++ b/src/client/pages/ConsentsNewsletters.tsx
@@ -60,9 +60,13 @@ export const ConsentsNewsletters = ({
         <h2 css={[heading, greyBorderTop, autoRow()]}>
           Free newsletters from the Guardian
         </h2>
-        <p css={[text, paragraphSpacing, autoRow()]}>
+        <p css={[text, autoRow()]}>
           Our newsletters help you get closer to our quality, independent
           journalism.
+        </p>
+        <p css={[text, paragraphSpacing, autoRow()]}>
+          Newsletters may contain information about Guardian products, services
+          and chosen charities or online advertisements.
         </p>
         <div css={autoRow()}>
           {newsletters.map((newsletter, i) => (

--- a/src/shared/model/experiments/tests/onboarding-newsletters.ts
+++ b/src/shared/model/experiments/tests/onboarding-newsletters.ts
@@ -6,7 +6,7 @@ export const TEST_VARIANT = 'test';
 
 export const onboardingNewslettersTest: ABTest = {
   id: TEST_ID,
-  start: '2022-01-11',
+  start: '2022-02-11',
   expiry: '2022-02-19',
   author: 'liam.duffy.freelancer@guardian.co.uk',
   description: 'Testing alternative newsletter options in onboarding flow',


### PR DESCRIPTION
## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Some messaging on the newsletters consent page

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

View the newsletters consent page (can just use storybook for this really)

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

The following text is included:

> Newsletters may contain information about Guardian products, services and chosen charities or online advertisements.

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

- [ ] [Tested with screen reader](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#screen-readers)
- [ ] [Navigable with keyboard](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#keyboard-navigation)
- [ ] [Colour contrast passed](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#colour-contrast)
- [ ] [The change doesn't use only colour to convey meaning](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#use-of-colour)
