### PR TITLE
Use consents layout main height styling for ConsentsConfirmation

### DIFF
--- a/src/client/layouts/ConsentsLayout.tsx
+++ b/src/client/layouts/ConsentsLayout.tsx
@@ -36,7 +36,7 @@ const form = css`
   flex-direction: column;
 `;
 
-const mainStyles = css`
+export const mainStyles = css`
   display: flex;
   flex-direction: column;
   flex: 1 0 auto;

--- a/src/client/pages/ConsentsConfirmation.tsx
+++ b/src/client/pages/ConsentsConfirmation.tsx
@@ -61,7 +61,8 @@ const ReviewTableRow: FunctionComponent<{ title: string }> = ({
 );
 
 const continueBoxFlex = css`
-  flex: 0 0 auto;
+  display: flex;
+  flex: 1 0 auto;
 `;
 
 const sectionStyles = css`

--- a/src/client/pages/ConsentsConfirmation.tsx
+++ b/src/client/pages/ConsentsConfirmation.tsx
@@ -21,6 +21,7 @@ import {
 import { GeoLocation } from '@/shared/model/Geolocation';
 import { SvgTickRound } from '@guardian/source-react-components';
 import locations from '@/shared/lib/locations';
+import { mainStyles } from '@/client/layouts/ConsentsLayout';
 
 type ConsentsConfirmationProps = {
   error?: string;
@@ -128,7 +129,7 @@ export const ConsentsConfirmation = ({
         success={success}
         geolocation={geolocation}
       />
-      <main>
+      <main css={mainStyles}>
         <ConsentsSubHeader
           autoRow={autoRow}
           title="Your registration is complete"


### PR DESCRIPTION
## What does this change?
Fixes the `ConsentsConfirmation` page so that it grows as expected on larger viewports.


## Before
![Screenshot 2022-02-16 at 14 48 26](https://user-images.githubusercontent.com/1771189/154297909-b5d9097a-4f42-4cd0-bed5-f020425dca8d.png)


## After
![Screenshot 2022-02-16 at 15 27 56](https://user-images.githubusercontent.com/1771189/154297934-65fbcb98-0c74-4e49-8bd2-ba1f6ce2cced.png)

