### PR TITLE
Add ToggleSwitchInput

### DIFF
--- a/src/client/components/ToggleSwitchInput.stories.tsx
+++ b/src/client/components/ToggleSwitchInput.stories.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { Meta } from '@storybook/react';
+
+import { ToggleSwitchInput, ToggleSwitchInputProps } from './ToggleSwitchInput';
+
+export default {
+  title: 'Components/ToggleSwitchInput',
+  component: ToggleSwitchInput,
+  args: {},
+} as Meta<ToggleSwitchInputProps>;
+
+// *****************************************************************************
+
+export const NoLabel = (props: Partial<ToggleSwitchInputProps>) => (
+  <ToggleSwitchInput {...props} />
+);
+NoLabel.storyName = 'Default form switch';
+
+// *****************************************************************************
+
+export const WithLabel = (props: Partial<ToggleSwitchInputProps>) => (
+  <ToggleSwitchInput label={'I am a label'} {...props} />
+);
+
+WithLabel.storyName = 'Form switch with label';

--- a/src/client/components/ToggleSwitchInput.tsx
+++ b/src/client/components/ToggleSwitchInput.tsx
@@ -1,0 +1,154 @@
+import React from 'react';
+import type { EmotionJSX } from '@emotion/react/types/jsx-namespace';
+import type { Props } from '@guardian/source-react-components';
+import { css } from '@emotion/react';
+import {
+  neutral,
+  success,
+  textSans,
+  focusHalo,
+  visuallyHidden,
+  descriptionId,
+  generateSourceId,
+} from '@guardian/source-foundations';
+
+const inputStyles = css`
+  ${visuallyHidden}
+`;
+
+const labelStyles = css`
+  user-select: none;
+  position: relative;
+  ${textSans.small()};
+  display: flex;
+  color: ${neutral[7]};
+  align-items: center;
+  cursor: pointer;
+`;
+
+const siblingStyles = css`
+  input + span {
+    background-color: rgba(153, 153, 153, 0.5);
+  }
+
+  input:focus + span {
+    ${focusHalo};
+  }
+
+  input:checked + span {
+    background: ${success[500]};
+  }
+
+  input:checked + span:before {
+    opacity: 1;
+    z-index: 1;
+  }
+
+  input:checked + span:after {
+    left: 1.375rem;
+    background: ${neutral[100]};
+  }
+`;
+
+const switchStyles = css`
+  flex: none;
+  border: none;
+  margin: 0px 0px 0px 8px;
+  padding: 0;
+  display: inline-block;
+  text-align: center;
+  position: relative;
+  transition: background-color 150ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  cursor: pointer;
+  width: 2.75rem;
+  height: 1.5rem;
+  border-radius: 15.5px;
+
+  &:before,
+  &:after {
+    box-sizing: border-box;
+  }
+
+  &:before {
+    content: '';
+    position: absolute;
+    top: 6px;
+    height: 11px;
+    width: 6px;
+    right: 10px;
+    opacity: 0;
+    border-bottom: 2px solid ${success[400]};
+    border-right: 2px solid ${success[400]};
+    transform: rotate(45deg);
+    transition: opacity 0.1s ease-in;
+  }
+
+  &:after {
+    content: '';
+    position: absolute;
+    border-radius: 50%;
+    background: #fff;
+    will-change: left;
+    transition: left 0.15s ease-in-out;
+    height: 18px;
+    width: 18px;
+    top: 3px;
+    left: 4px;
+  }
+`;
+
+export interface ToggleSwitchInputProps extends Props {
+  /**
+   * Whether the ToggleSwitch is checked. This is necessary when using the
+   * [controlled approach](https://reactjs.org/docs/forms.html#controlled-components)
+   * (recommended) to form state management.
+   *
+   * Note: if you pass the `checked` prop, you MUST also pass an `onChange`
+   * handler, or the field will be rendered as read-only.
+   */
+  checked?: boolean;
+  /**
+   * When using the [uncontrolled approach](https://reactjs.org/docs/uncontrolled-components.html),
+   * use defaultChecked to indicate the whether the ToggleSwitch is checked initially.
+   */
+  defaultChecked?: boolean;
+  /**
+   * Optional Id for the switch. Defaults to a generated indexed Source ID e.g. "src-component-XXX}"
+   */
+  id?: string;
+  /**
+   * Appears to the left of the switch by default.
+   */
+  label?: string;
+}
+
+export const ToggleSwitchInput = ({
+  id,
+  label,
+  checked,
+  defaultChecked,
+  cssOverrides,
+}: ToggleSwitchInputProps): EmotionJSX.Element => {
+  const switchName = id ?? generateSourceId();
+  const labelId = descriptionId(switchName);
+
+  return (
+    <label id={labelId} css={[labelStyles, siblingStyles, cssOverrides]}>
+      {label}
+      <input
+        css={inputStyles}
+        name={switchName}
+        type="checkbox"
+        role="switch"
+        defaultChecked={defaultChecked}
+        checked={checked != undefined ? checked : defaultChecked}
+        aria-labelledby={labelId}
+      ></input>
+      <span
+        aria-hidden="true"
+        aria-labelledby={labelId}
+        css={switchStyles}
+      ></span>
+    </label>
+  );
+};


### PR DESCRIPTION
## What does this change?

Adds a new Toggle Switch Input component that can be used for uncontrolled React form submissions

We had to create new switch component that functioned as a form input, not a button. 

This component is an adaptation of the Guardian Source Toggle but simplified for our use case. Stylings have been lifted and simplified. 


## Images

![image](https://user-images.githubusercontent.com/32312712/154690124-c78c7b53-8b7a-4220-901c-03eb8367342b.png)

Intended usage: 
![image](https://user-images.githubusercontent.com/32312712/154690074-922680e5-1f64-4af4-86e3-0d01318824ef.png)

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

- [x] [Tested with screen reader](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#screen-readers)
- [x] [Navigable with keyboard](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#keyboard-navigation)
- [ ] [Colour contrast passed](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#colour-contrast)
- [x] [The change doesn't use only colour to convey meaning](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#use-of-colour)

### Cross browser and device testing

-  [x] Tested with touch screen device
- [x] Chrome 77+ 
- [x] Firefox 68+ 
- [x] Edge 17+ 
- [x] Safari 12+ 
- [x] IE11

### Responsiveness

<!--
If there are guidelines around how much content the
component can support, or how wide its container
may get, please specify them in the documentation section
-->

-   [x] Tested at all breakpoints
-   [x] Tested with with long text
-   [x] Stretched to fill a wide container

### Documentation

-   [ ] Full API surface area is documented in the README
-   [x] Examples in Storybook

<!--
If we need to make changes to the documentation website,
please specify them here
-->

