### PR TITLE
Use SameSite=lax for this cookie so it is sent on OAuth redirect in all browsers

### DIFF
--- a/src/server/lib/okta/openid-connect.ts
+++ b/src/server/lib/okta/openid-connect.ts
@@ -169,7 +169,7 @@ const AuthorizationStateCookieOptions: CookieOptions = {
   httpOnly: true,
   secure: !baseUri.includes('localhost'),
   signed: !baseUri.includes('localhost'),
-  sameSite: 'strict',
+  sameSite: 'lax',
 };
 
 /**
@@ -178,7 +178,7 @@ const AuthorizationStateCookieOptions: CookieOptions = {
  * as `${AuthorizationStateCookieName}`.
  *
  * This is stored on the client as a Secure,
- * Signed, HTTPOnly, SameSite=strict, session cookie.
+ * Signed, HTTPOnly, SameSite=lax, session cookie.
  * As it's only signed and not encrypted, no secret information
  * should be stored in the cookie. By signing the cookie
  * we can make sure that it hasn't been tampered by a malicious actor.


### PR DESCRIPTION
## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Adjusts Auth state cookie to have SameSite attribute Lax instead of Strict. This is because I noticed that on certain browsers (first saw the issue on Firefox, and then on Safari) the cookie is not sent with the oauth callback request otherwise. Some relevant discussion here (raised as bugs, but as they are seemingly following the spec, unlikely to be "fixed"):

https://bugzilla.mozilla.org/show_bug.cgi?id=1465402
https://bugs.webkit.org/show_bug.cgi?id=196375

"Strict" seems to only send the cookies when a user has intentionally clicked on a link, whereas "Lax" sends it on a server-side redirect as well. It's possible that a client-side meta redirect would work with "Strict" but that could result in a poorer user experience.

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

Visit `/signin?useOkta=true` using Safari or Firefox, and check if you can log in.