### PR TITLE
Fix email input validation for Samsung Internet

### DIFF
--- a/src/client/components/EmailInput.tsx
+++ b/src/client/components/EmailInput.tsx
@@ -77,8 +77,14 @@ export const EmailInput: React.FC<EmailInputProps> = ({
         // Transition error state when the input box loses focus.
         transitionState(e.target.validity);
       }}
-      onKeyDown={(e) => {
-        if (e.code === '') {
+      onInput={(e) => {
+        // We check the `composed` variable to see if the event originated from user input.
+        // This is so that we can run validation when users submit an email through a password manager.
+        // Composed is not supported in IE11, so we check to see if it's undefined first.
+        const notOriginatingFromUserInput =
+          e.nativeEvent.composed !== undefined && !e.nativeEvent.composed;
+
+        if (notOriginatingFromUserInput) {
           e.currentTarget.checkValidity();
           transitionState(e.currentTarget.validity);
         }


### PR DESCRIPTION
## What does this change?
We were previously relying on `e.code === ''` to validate emails when submitted through Lastpass. This failed in the Samsung Internet, where this condition evaluated to `true` when typing normally, causing the validation process to happen on every keystroke.

We change the check here to see if the input event is `composed` [^1] on input, skipping any events caused by user action but allowing us to validate the email field specifically for events like LastPass autofill input.

To quote the linked docs:

> All UA-dispatched UI events are composed (click/touch/mouseover/copy/paste, etc.). Most other types of events are not composed, and so will return false. For example, this includes synthetic events that are created without their composed option set to true.

- [x] Tested on CODE
- [x] Tested on Samsung Internet
- [x] Tested with LastPass in Chrome
- [x] Tested with Apple Password manager in Safari
- [x] Tested on Firefox
- [x] Tested on Safari
- [x] Tested on Chrome
- [x] Tested on IE11

[^1]: https://developer.mozilla.org/en-US/docs/Web/API/Event/composed