### PR TITLE
Add Focus Manager Decorator global to Storybook

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -3,10 +3,13 @@ import { Breakpoints } from '@/client/models/Style';
 import React from 'react';
 import { FocusStyleManager } from '@guardian/source-foundations';
 
+/* Source provides a global utility that manages the appearance of focus styles. When enabled,
+ * focus styles will be hidden while the user interacts using the mouse.
+ * They will appear when the tab key is pressed to begin keyboard navigation. */
 export const FocusManagerDecorator = (storyFn) => {
   React.useEffect(() => {
     FocusStyleManager.onlyShowFocusOnTabs();
-  });
+  }, []);
 
   return <>{storyFn()}</>;
 };

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,5 +1,15 @@
 import { INITIAL_VIEWPORTS } from '@storybook/addon-viewport';
 import { Breakpoints } from '@/client/models/Style';
+import React from 'react';
+import { FocusStyleManager } from '@guardian/source-foundations';
+
+export const FocusManagerDecorator = (storyFn) => {
+  React.useEffect(() => {
+    FocusStyleManager.onlyShowFocusOnTabs();
+  });
+
+  return <>{storyFn()}</>;
+};
 
 const customViewports = {};
 for (let breakpoint in Breakpoints) {
@@ -14,6 +24,8 @@ for (let breakpoint in Breakpoints) {
     };
   }
 }
+
+export const decorators = [FocusManagerDecorator];
 
 export const parameters = {
   actions: { argTypesRegex: '^on[A-Z].*' },


### PR DESCRIPTION
## What does this change?
Adds the Source Focus Style Manager to the global Storybook environment so that developing components in Storybook accurately reflect how their styling behaves in production. 

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

- [ ] [Tested with screen reader](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#screen-readers)
- [ ] [Navigable with keyboard](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#keyboard-navigation)
- [ ] [Colour contrast passed](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#colour-contrast)
- [ ] [The change doesn't use only colour to convey meaning](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#use-of-colour)
