### PR TITLE
Okta documentation | Sign in, Sign out, OAuth 2.0, and OpenID Connect

### DIFF
--- a/docs/okta/oauth.md
+++ b/docs/okta/oauth.md
@@ -1,0 +1,119 @@
+# OAuth 2.0 and OpenID connect
+
+Much of the following information is from the [Okta OAuth 2.0 and OpenID Connect Overview](https://developer.okta.com/docs/concepts/oauth-openid/), [oauth.com](https://oauth.com/), and [Auth0](https://auth0.com/docs/get-started/authentication-and-authorization-flow/which-oauth-2-0-flow-should-i-use#oauth-2-0-terminology).
+
+## Authentication API vs OAuth 2.0 vs OpenID Connect
+
+There are three major kinds of authentication that you can perform with Okta:
+
+- The [Authentication API](https://developer.okta.com/docs/reference/api/authn/) controls user access to our Okta org. It provides operations to authenticate users, recover forgotten passwords etc.
+
+- The OAuth 2.0 protocol controls authorization to access a protected resource, like a web app, native app, or backend service.
+
+- The OpenID Connect protocol is built on the OAuth 2.0 protocol and helps authenticate users and convey information about them. It is also more opinionated than plain OAuth 2.0, for example in its scope definitions.
+
+## OAuth 2.0
+
+OAuth 2.0 is a standard that apps use to provide client applications with access. If you would like to grant access to your application data in a secure way, then you want to use the OAuth 2.0 protocol.
+
+The OAuth 2.0 spec has four important roles:
+
+- The "authorization server" — Server that authenticates the "resource owner" and issues Access Tokens after getting proper authorization. In our case we use Okta as the authorization server, specifically we create a custom auth server in our Okta org that act as the authorization server.
+
+- The "resource owner" — Entity that can grant access to a protected resource. Typically, this is the end-user.
+
+- The "client" — The application that requests the access token from Okta and then passes it to the resource server.
+
+- The "resource server" — The server hosting the protected resources, accepts the access token and must verify that it's valid, and also . This is the API you want to access.
+
+Other important terms:
+
+- An OAuth 2.0 "grant" is the authorization given (or "granted") to the client by the user. Examples of grants are "authorization code" and "client credentials". Each OAuth grant has a corresponding flow, explained below.
+- The "access token" is issued by the authorization server in exchange for the grant.
+- The "refresh token" is an optional token that is exchanged for a new access token if the access token has expired.
+
+The usual OAuth 2.0 grant flow looks like this:
+
+- Client requests authorization from the resource owner (usually the user).
+- If the user gives authorization, the client passes the authorization grant to the authorization server (in this case Okta).
+- If the grant is valid, the authorization server returns an access token, possibly alongside a refresh and/or ID token.
+- The client now uses that access token to access the resource server.
+
+## OpenID Connect
+
+OpenID Connect is an authentication standard built on top of OAuth 2.0. It adds an additional token called an ID token. OpenID Connect also standardizes areas that OAuth 2.0 leaves up to choice, such as scopes, endpoint discovery, and dynamic registration of clients.
+
+Although OpenID Connect is built on top of OAuth 2.0, the OpenID Connect specification uses slightly different terms for the roles in the flows:
+
+- The "OpenID provider" — The authorization server that issues the ID token. In this case Okta is the OpenID provider.
+
+- The "end user" — Whose information is contained in the ID token
+
+- The "relying party" — The client application that requests the ID token from Okta
+
+- The "ID token" is issued by the OpenID Provider and contains information about the end user in the form of claims.
+
+- A "claim" is a piece of information about the end user.
+
+The high-level flow looks the same for both OpenID Connect and regular OAuth 2.0 flows. The primary difference is that an OpenID Connect flow results in an ID token, in addition to any access or refresh tokens.
+
+## OAuth 2.0 Flows/Grant Types
+
+OAuth 2.0 defines a number of flows to get an access token. These flows are called grant types. The links provide more information from Okta, and how they can be implemented.
+
+- Authorization Code Flow
+
+  - If you are building a server-side (or web) application that is capable of securely storing secrets, then the Authorization Code flow is the recommended method for controlling access to it.
+  - https://developer.okta.com/docs/concepts/oauth-openid/#authorization-code-flow
+
+- Authorization Code Flow with PKCE (Proof Key for Code Exchange)
+
+  - If you are building a native application, single page application, or a client-side heavy application, then the Authorization Code flow with a Proof Key for Code Exchange (PKCE) is the recommended method for controlling the access between your application and a resource server.
+  - The Authorization Code flow with PKCE is similar to the standard Authorization Code flow with an extra step at the beginning and an extra verification at the end.
+  - https://developer.okta.com/docs/concepts/oauth-openid/#authorization-code-flow-with-pkce
+
+- Client Credentials Flow
+
+  - The Client Credentials flow is recommended for server-side (AKA confidential) client applications with no end user, which normally describes machine-to-machine communication.
+  - The application needs to securely store its Client ID and secret and pass those to Okta in exchange for an access token.
+  - https://developer.okta.com/docs/concepts/oauth-openid/#client-credentials-flow
+
+- Implicit Flow
+
+  - The Implicit flow is **not a recommended approach**, as it is extremely challenging to implement the Implicit flow securely.
+  - The recommendation is to use Authorization Code Flow with PKCE if possible.
+  - If you are building a Single-Page Application (SPA) on browsers that don't support Web Crypto for PKCE, then the Implicit flow can be used for controlling access between your SPA and a resource server.
+  - The Implicit flow is intended for applications where the confidentiality of the client secret can't be guaranteed.
+  - https://developer.okta.com/docs/concepts/oauth-openid/#implicit-flow
+
+- Resource Owner Password Flow
+
+  - The Resource Owner Password flow is **not a recommended approach**.
+  - It is intended for applications for which no other flow works, as it requires your application code to be fully trusted and protected from credential-stealing attacks.
+  - It is made available primarily to provide a consistent and predictable integration pattern for legacy applications that can't otherwise be updated to a more secure flow such as the Authorization Code flow.
+  - This should be your last option, not your first choice.
+  - https://developer.okta.com/docs/concepts/oauth-openid/#resource-owner-password-flow
+
+Deciding which one is suited for your case depends mostly on your application type. In most cases the first three are the most suitable.
+
+## Gateway Usage
+
+Within Gateway we use OAuth 2.0 and OpenID Connect to interact with Okta on a number of user flows.
+
+We have implemented the Authorization Code Flow within this application. This is used in a number of places, including: [sign in](./signin.md), [sign out](./signout.md), change password, etc.
+
+We use the Authorization Code Flow to both authorise a user and get an access token, as well as check if the user has an Okta session.
+
+The [openid-client library](https://github.com/panva/node-openid-client) is used to help facilitate the OAuth 2.0 and OpenId Connect flows. This is an OpenId certified library, and sponsored by Auth0.
+
+Much of the setup for the library is done within [`src/server/lib/okta/openid-connect.ts`](../../src/server/lib/okta/openid-connect.ts). This file exports a `ProfileOpenIdClient` which is an instance of this library with the correct metadata, client id, client secret, and redirect uri set up. It also only exports a subset of the methods that we need to use within our application.
+
+We also use this file to set up helper methods to generate the `AuthorizationState`, which is used as the [`state`](https://developer.okta.com/docs/reference/api/oidc/#:~:text=Policy%3A%20no%2Dreferrer.-,state,-%3A) parameter in the authorization request.
+
+In [`src/server/lib/okta/oauth.ts`](../../src/server/lib/okta/oauth.ts) we expose the `performAuthorizationCodeFlow` method, which is used to generate the `/authorize` url for the Auth Code flow and redirect the browser to this url to start it.
+
+The redirect endpoint (`/oauth/authorization-code/callback`) is defined in [`src/server/routes/oauth.ts`](../../src/server/routes/oauth.ts). This is where the browser is redirected to from the authorization server during the flow. This checks the response we get back from the authorization server. If it completed successfully we get back an "auth code" which we can exchange for an access token, refresh token, and/or ID token. If it fails, we get back an error parameter which we deal with.
+
+This method is also used to retrieve Identity cookies from Identity API as part of the dual running of systems. To do this we get an access token from the authorization server, send this to the Identity API (the "resource server" in this case), which validates the token, and returns signed Identity cookies if so.
+
+Once all the checks are complete it will redirect the browser to an appropriate location.

--- a/docs/okta/signin.md
+++ b/docs/okta/signin.md
@@ -1,0 +1,108 @@
+# Sign In with Okta
+
+This document describes how we've implemented the sign in flow with Okta in Gateway. There are two parts to this, sign in with email + password, and sign in with social (_still TBD_).
+
+## Email + Password
+
+The bulk of the work to implement sign in with email and password with Okta was done in this PR: https://github.com/guardian/gateway/pull/1410, which has some additional information, and specific commits you can follow along.
+
+We use the [Okta Authentication API](https://developer.okta.com/docs/api/resources/authn) to implement this, specifically the [Primary authentication with public application](https://developer.okta.com/docs/reference/api/authn/#primary-authentication-with-public-application) operation.
+
+To create a session we [retrieve a session cookie through the OpenID Connect authorization endpoint](https://developer.okta.com/docs/guides/session-cookie/main/#retrieve-a-session-cookie-through-the-openid-connect-authorization-endpoint), which implements the [Authorization Code flow](https://developer.okta.com/docs/concepts/oauth-openid/#authorization-code-flow).
+
+More information about OAuth, OpenId Connect, and our usage of it, is available in the [./oauth.md](./oauth.md) document.
+
+As we don't want users with existing sessions to be shown the sign in page, we all implement an existing session check, which also utilises the same flow, if a session exists we complete the flow and refresh the existing session, if a session does not exist Okta responds with an `error=login_required` parameter which we can intercept and use.
+
+Throughout the implementation of the sign in code, there are many in line comments that explain what is happening.
+
+In general the steps of sign in with email and password are summarised as follows, assuming okta is enabled, this does not detail all technical requirements, just the main high level:
+
+- User navigates to `/signin`
+  - Check `EncryptedState` cookie for `signInRedirect` value
+    - if `true` render the sign in page, as we've checked for an existing session
+    - if `false` or `undefined` we need to check for an existing session
+      - Check for existing session by performing auth code flow by redirecting user to `/authorize`
+      - Okta will redirect to callback endpoint `/oauth/authorization-code/callback`
+        - if okta session exists, complete the auth code flow and refreshing identity cookies, redirect to original `returnUrl`
+        - if no okta session, okta returns `login_required` error, intercept this
+          - set the `EncryptedState` cookie for `signInRedirect` value to `true`
+          - redirect to sign in, now that `signInRedirect` is `true`, the page will render
+  - If sign in page shown
+    - user enters email and password, makes request to gateway `POST /signin`
+    - Use okta authenticate endpoint with the email and password `/api/v1/authn`
+      - If email/password wrong, show `email or password was incorrect` error
+      - If correct, okta returns a single use `sessionToken` which can be exchanged for an session cookie
+        - to exchange this for a session cookie, we perform the auth code flow, pass the `sessionToken` to `/authorize` and redirect to okta `/authorize`
+          - Okta will redirect to callback endpoint `/oauth/authorization-code/callback`
+          - if all good, a session cookie will be set on okta domain, complete the auth code flow and refreshing identity cookies
+          - redirect to original `returnUrl`
+
+Here are some sequence diagrams which show this flow in an alternate way:
+
+### No Okta session exists
+
+```mermaid
+sequenceDiagram
+  participant Browser
+  participant Gateway
+  participant Okta
+  participant Identity API
+  Browser->>Gateway: Request gateway /signin
+  note over Gateway: Sign in session is not checked<br/>(encryptedState.signInRedirect == false | undefined)
+  note over Gateway: <br/>We check session using Okta OAuth Auth Code flow<br/>using `prompt=none` means no okta login is shown,<br/>and "error" returned instead
+  Gateway->>Browser: Redirect request to OAuth auth code flow<br/>/authorize?prompt=none...<br>see notes for other parameters/implementation
+  Browser->>Okta: Request /authorize
+  note over Okta: check for existing session<br>in this case none exists
+  Okta->>Browser: Redirect request to gateway<br>/oauth/authorization-code/callback?error=login_required
+  Browser->>Gateway: Request /oauth/authorization-code/callback?error=login_required
+  note over Gateway: check for `error=login_required`<br/>set `encryptedState.signInRedirect = true` as cookie
+  Gateway->>Browser: Redirect request to gateway `/signin`
+  Browser->>Gateway: Request gateway /signin
+  note over Gateway: Sign in session is checked<br/>(encryptedState.signInRedirect == true)<br>remove/set to false from the encryptedState
+  Gateway->>Browser: Return rendered sign in page
+  Browser->>Gateway: Login form POST /signin (email + password)
+  Gateway->>Okta: Authenticate with Okta<br/>/authn with email + pw)
+  note over Okta: validate email + password
+  Okta->>Gateway: response with sessionToken<br/>+ email/okta_id
+  note over Gateway: Perform auth code flow to create<br>Okta session
+  Gateway->>Browser: Redirect request to OAuth auth code flow<br/>/authorize?prompt=none&sessionToken={sessionToken}...<br>see notes for other parameters/implementation
+  Browser->>Okta: Request /authorize
+  note over Okta: Use sessionToken to create an okta session on<br/>auth subdomain as cookie
+  Okta->>Browser: Redirect request to gateway<br>/oauth/authorization-code/callback?code={auth_code}...<br/>see notes for other parameters/implementation
+  Browser->>Gateway: Request to gateway<br>/oauth/authorization-code/callback?code={auth_code}...
+  opt Get IDAPI Cookies
+    Gateway->>Okta: exchange auth_code<br/>for access_token
+    Okta->>Gateway: Return access_token
+    Gateway->>Identity API: Request identity cookies for user using access_token
+    note over Identity API: check the access token is valid<br>create identity session/cookies if valid
+    Identity API->>Gateway: return signed identity cookie values
+  end
+  Gateway->>Browser: Redirect to return_url (usually on *.theguardian.com)<br>set identity cookies if applicable
+```
+
+### Okta session exists
+
+```mermaid
+sequenceDiagram
+  participant Browser
+  participant Gateway
+  participant Okta
+  participant Identity API
+  Browser->>Gateway: Request gateway /signin
+  note over Gateway: Sign in session is not checked<br/>(encryptedState.signInRedirect == false | undefined)
+  note over Gateway: <br/>We check session using Okta OAuth Auth Code flow<br/>using `prompt=none` means no okta login is shown
+  Gateway->>Browser: Redirect request to OAuth auth code flow<br/>/authorize?prompt=none...<br>see notes for other parameters/implementation
+  Browser->>Okta: Request /authorize
+  note over Okta: check for existing session<br>in this case session exists<br>Okta will refresh the existing session
+  Okta->>Browser: Redirect request to gateway<br>/oauth/authorization-code/callback?code={auth_code}...<br/>see notes for other parameters/implementation
+  Browser->>Gateway: Request to gateway<br>/oauth/authorization-code/callback?code={auth_code}...
+  opt Get IDAPI Cookies (dual running)
+    Gateway->>Okta: exchange auth_code<br/>for access_token
+    Okta->>Gateway: Return access_token
+    Gateway->>Identity API: Request identity cookies for user using access_token
+    note over Identity API: check the access token is valid<br>create identity session/cookies if valid
+    Identity API->>Gateway: return signed identity cookie values
+  end
+  Gateway->>Browser: Redirect to return_url (usually on *.theguardian.com)<br>set identity cookies if applicable
+```

--- a/docs/okta/signout.md
+++ b/docs/okta/signout.md
@@ -1,0 +1,68 @@
+# Sign Out with Okta
+
+Status: RFC
+
+This document describes how we've implemented the sign out flow with Okta in Gateway.
+
+In old (current) Identity land, when a user clicks the "sign out" button on the website, or visit the sign out link directly, if they have a valid session, determined using the `SC_GU_U` cookie, Identity API will invalidate all existing user sessions on all devices and browsers, and clear all Identity and related dotcom cookies on the current browser.
+
+Since we're dual running Identity and Okta sessions, this functionality should also be replicated with the Okta sign out for now.
+
+Okta provides an administrative API endpoint within the Users API to clear all user sessions, and we can use this to invalidate all sessions for a user, as well as revoke all access and refresh tokens that are currently valid.
+
+https://developer.okta.com/docs/reference/api/users/#clear-user-sessions
+
+This endpoint requires the okta `userId`, which we won't have access to initially, so we need to get an access/id token with this information.
+
+This means when a user lands on the `/signout` url, we first perform an auth code flow to get an access token, and then we can use that access token to get the user's id. We then use this user id to clear all sessions for that user.
+
+If there is no existing session then we'll render the sign in page.
+
+During the dual running of the system we also need to clear the Identity session too. We can use this access token or the SC_GU_U cookie to call Identity API (TBD which option) to do this.
+
+### User has existing session
+
+```mermaid
+sequenceDiagram
+  participant Browser
+  participant Gateway
+  participant Okta
+  participant Identity API
+  Browser->>Gateway: GET /signout?returnUrl=...
+  note over Gateway: <br/>We check session using Okta OAuth Auth Code flow<br/>using `prompt=none` means no okta login prompt shown<br/>and we get an access token with the okta userid
+  Gateway->>Browser: Redirect request to OAuth auth code flow<br/>/authorize?prompt=none...<br>see notes for other parameters/implementation
+  Browser->>Okta: Request /authorize
+  note over Okta: check for existing session<br>in this case session exists
+  Okta->>Browser: Redirect request to gateway<br>/oauth/authorization-code/signout?code={auth_code}...<br/>see notes for other parameters/implementation
+  Browser->>Gateway: Request to gateway<br>/oauth/authorization-code/signout?code={auth_code}...
+  Gateway->>Okta: exchange auth_code<br/>for access_token
+  Okta->>Gateway: Return access_token<br/>with userId
+  Gateway->>Okta: Clear user sessions<br/>using userId<br/>DELETE /api/v1/users/${userId}/sessions?oauthTokens=true
+  Okta->>Gateway: Return 204 No Content
+  opt Clear Identity Session (dual running)
+    Gateway->>Identity API: POST /unauth with SC_GU_U cookie
+    Identity API->>Gateway: Return GU_SO cookie
+  end
+  Gateway->>Browser: Redirect to returnUrl<br/>clear identity cookies
+```
+
+### User has no existing session
+
+```mermaid
+sequenceDiagram
+  participant Browser
+  participant Gateway
+  participant Okta
+  Browser->>Gateway: GET /signout?returnUrl=...
+  note over Gateway: <br/>We check session using Okta OAuth Auth Code flow<br/>using `prompt=none` means no okta login prompt shown
+  Gateway->>Browser: Redirect request to OAuth auth code flow<br/>/authorize?prompt=none...<br>see notes for other parameters/implementation
+  Browser->>Okta: Request /authorize
+  note over Okta: check for existing session<br>in this case session does not exists<br>Okta will respond with `error=login_required`
+  Okta->>Browser: Redirect request to gateway<br>/oauth/authorization-code/signout?error=login_required
+  Browser->>Gateway: Request /oauth/authorization-code/signout?error=login_required
+  note over Gateway: check for `error=login_required`<br/>set `encryptedState.signInRedirect = true` as cookie
+  Gateway->>Browser: Redirect request to gateway `/signin`
+  Browser->>Gateway: Request gateway /signin
+  note over Gateway: Sign in session is checked<br/>(encryptedState.signInRedirect == true)<br>remove/set to false from the encryptedState
+  Gateway->>Browser: Return rendered sign in page
+```

--- a/src/server/controllers/changePassword.ts
+++ b/src/server/controllers/changePassword.ts
@@ -30,7 +30,7 @@ import { resetPassword as resetPasswordInOkta } from '@/server/lib/okta/api/auth
 import { OktaError } from '@/server/models/okta/Error';
 import { addToGroup, GroupCode } from '@/server/lib/idapi/user';
 import { checkTokenInOkta } from '@/server/controllers/checkPasswordToken';
-import { performAuthCodeFlow } from '@/server/routes/signIn';
+import { performAuthorizationCodeFlow } from '@/server/lib/okta/oauth';
 
 const { okta } = getConfiguration();
 
@@ -194,7 +194,11 @@ const changePasswordInOkta = async (
       }
 
       // TODO: once sign out with Okta has been implemented, invalidate current sessions before kicking off code flow
-      return performAuthCodeFlow(res, sessionToken, successRedirectPath);
+      return performAuthorizationCodeFlow(
+        res,
+        sessionToken,
+        successRedirectPath,
+      );
     } else {
       throw new OktaError({ message: 'Okta state token missing' });
     }

--- a/src/server/lib/okta/oauth.ts
+++ b/src/server/lib/okta/oauth.ts
@@ -1,0 +1,50 @@
+import { ResponseWithRequestState } from '@/server/models/Express';
+import { getPersistableQueryParams } from '@/shared/lib/queryParams';
+import { RoutePaths } from '@/shared/model/Routes';
+import {
+  generateAuthorizationState,
+  setAuthorizationStateCookie,
+  ProfileOpenIdClient,
+} from '@/server/lib/okta/openid-connect';
+
+/**
+ * Method to perform the Authorization Code Flow
+ * for a) the sign in session check
+ * and b) post authentication (with the session token)
+ * @param res - the express response object
+ * @param sessionToken (optional) - if provided, we'll use this to set the session cookie
+ * @param confirmationPagePath (optional) - page to redirect the user to after authentication
+ * @returns 303 redirect to the okta /authorize endpoint
+ */
+export const performAuthorizationCodeFlow = (
+  res: ResponseWithRequestState,
+  sessionToken?: string,
+  confirmationPagePath?: RoutePaths,
+) => {
+  // firstly we generate and store a "state"
+  // as a http only, secure, signed session cookie
+  // which is a json object that contains a stateParam and the query params
+  // the stateParam is used to protect against csrf
+  const authState = generateAuthorizationState(
+    getPersistableQueryParams(res.locals.queryParams),
+    confirmationPagePath,
+  );
+  setAuthorizationStateCookie(authState, res);
+
+  // generate the /authorize endpoint url which we'll redirect the user too
+  const authorizeUrl = ProfileOpenIdClient.authorizationUrl({
+    // Don't prompt for authentication or consent
+    prompt: 'none',
+    // The sessionToken from authentication to exchange for session cookie
+    sessionToken,
+    // we send the generated stateParam as the state parameter
+    state: authState.stateParam,
+    // any scopes, by default the 'openid' scope is required
+    // the idapi_token_cookie_exchange scope is checked on IDAPI to return
+    // idapi cookies on authentication
+    scope: 'openid idapi_token_cookie_exchange',
+  });
+
+  // redirect the user to the /authorize endpoint
+  return res.redirect(303, authorizeUrl);
+};

--- a/src/server/routes/signIn.ts
+++ b/src/server/routes/signIn.ts
@@ -15,18 +15,11 @@ import { ApiError } from '@/server/models/Error';
 import { typedRouter as router } from '@/server/lib/typedRoutes';
 import { readEmailCookie } from '@/server/lib/emailCookie';
 import handleRecaptcha from '@/server/lib/recaptcha';
-import {
-  generateAuthorizationState,
-  ProfileOpenIdClient,
-  setAuthorizationStateCookie,
-} from '@/server/lib/okta/openid-connect';
 import { OktaError } from '@/server/models/okta/Error';
 import {
   readEncryptedStateCookie,
   updateEncryptedStateCookie,
 } from '@/server/lib/encryptedStateCookie';
-import { getPersistableQueryParams } from '@/shared/lib/queryParams';
-import { RoutePaths } from '@/shared/model/Routes';
 import { CONSENTS_POST_SIGN_IN_PAGE } from '@/shared/model/Consent';
 import {
   getUserConsentsForPage,
@@ -37,50 +30,9 @@ import { loginMiddleware } from '@/server/lib/middleware/login';
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { _ } from '@guardian/libs/dist/types/logger';
 import postSignInController from '@/server/lib/postSignInController';
+import { performAuthorizationCodeFlow } from '@/server/lib/okta/oauth';
 
 const { okta } = getConfiguration();
-
-/**
- * Method to perform the Authorization Code Flow
- * for a) the sign in session check
- * and b) post authentication (with the session token)
- * @param res - the express response object
- * @param sessionToken (optional) - if provided, we'll use this to set the session cookie
- * @param confirmationPagePath (optional) - page to redirect the user to after authentication
- * @returns 303 redirect to the okta /authorize endpoint
- */
-export const performAuthCodeFlow = (
-  res: ResponseWithRequestState,
-  sessionToken?: string,
-  confirmationPagePath?: RoutePaths,
-) => {
-  // firstly we generate and store a "state"
-  // as a http only, secure, signed session cookie
-  // which is a json object that contains a stateParam and the query params
-  // the stateParam is used to protect against csrf
-  const authState = generateAuthorizationState(
-    getPersistableQueryParams(res.locals.queryParams),
-    confirmationPagePath,
-  );
-  setAuthorizationStateCookie(authState, res);
-
-  // generate the /authorize endpoint url which we'll redirect the user too
-  const authorizeUrl = ProfileOpenIdClient.authorizationUrl({
-    // Don't prompt for authentication or consent
-    prompt: 'none',
-    // The sessionToken from authentication to exchange for session cookie
-    sessionToken,
-    // we send the generated stateParam as the state parameter
-    state: authState.stateParam,
-    // any scopes, by default the 'openid' scope is required
-    // the idapi_token_cookie_exchange scope is checked on IDAPI to return
-    // idapi cookies on authentication
-    scope: 'openid idapi_token_cookie_exchange',
-  });
-
-  // redirect the user to the /authorize endpoint
-  return res.redirect(303, authorizeUrl);
-};
 
 /**
  * Helper method to determine if a global error should show on the sign in page
@@ -158,7 +110,7 @@ router.get(
       } else {
         // sign in session check is not complete, so we want to check if a session exists
         // we do this by making an auth code request to okta
-        return performAuthCodeFlow(res);
+        return performAuthorizationCodeFlow(res);
       }
     } else {
       return showSignInPage(req, res);
@@ -259,7 +211,7 @@ const oktaSignInController = async (
     // we now need to generate an okta session
     // so we'll call the OIDC /authorize endpoint which sets a session cookie
     // we'll pretty much be performing the Authorization Code Flow
-    return performAuthCodeFlow(res, response.sessionToken);
+    return performAuthorizationCodeFlow(res, response.sessionToken);
   } catch (error) {
     trackMetric('OktaSignIn::Failure');
 


### PR DESCRIPTION
## What does this change?

Adds a whole bunch of documentation around OAuth 2.0, OpenId Connect, the sign in with email and password with Okta (much of which is a cleaned up version of this PR description: https://github.com/guardian/gateway/pull/1410), and sign out with Okta (RFC).

We also refactor the `performAuthorizationCodeFlow` method into it's own file as it was no longer just being used by the sign in flow.

