### PR TITLE
Making consent routes type safe

### DIFF
--- a/src/server/routes/consents.ts
+++ b/src/server/routes/consents.ts
@@ -40,7 +40,7 @@ import { fourZeroFourRender } from '@/server/lib/middleware/404';
 import { handleAsyncErrors } from '@/server/lib/expressWrappers';
 import { logger } from '@/server/lib/serverSideLogger';
 import { ApiError } from '@/server/models/Error';
-import { RoutePaths } from '@/shared/model/Routes';
+import { ConsentPath, RoutePaths } from '@/shared/model/Routes';
 import { PageTitle } from '@/shared/model/PageTitle';
 import {
   TEST_ID as ONBOARDING_NEWSLETTERS_TEST_ID,
@@ -48,7 +48,7 @@ import {
 } from '@/shared/model/experiments/tests/onboarding-newsletters';
 
 interface ConsentPage {
-  page: string;
+  page: ConsentPath;
   path: RoutePaths;
   read: (
     ip: string,
@@ -112,7 +112,7 @@ export const consentPages: ConsentPage[] = [
     },
   },
   {
-    page: '/newsletters'.slice(1),
+    page: 'newsletters',
     path: '/consents/newsletters',
     pageTitle: CONSENTS_PAGES.NEWSLETTERS,
     read: async (ip, sc_gu_u, geo, newsLettersTestActive) => {
@@ -120,13 +120,13 @@ export const consentPages: ConsentPage[] = [
         ? TestNewsletterMap
         : NewsletterMap;
       return {
-        page: '/newsletters'.slice(1),
+        page: 'newsletters',
         newsletters: await getUserNewsletterSubscriptions(
           newsletterMap.get(geo) as string[],
           ip,
           sc_gu_u,
         ),
-        previousPage: '/communication'.slice(1),
+        previousPage: 'communication',
       };
     },
     update: async (ip, sc_gu_u, body) => {

--- a/src/shared/model/ClientState.ts
+++ b/src/shared/model/ClientState.ts
@@ -5,6 +5,7 @@ import { EmailType } from '@/shared/model/EmailType';
 import { QueryParams } from '@/shared/model/QueryParams';
 import { Participations } from '@guardian/ab-core';
 import { Stage } from '@/server/models/Configuration';
+import { ConsentPath } from '@/shared/model/Routes';
 
 export interface FieldError {
   field: string;
@@ -36,8 +37,8 @@ export interface PageData {
   // onboarding specific
   newsletters?: NewsLetter[];
   consents?: Consent[];
-  page?: string;
-  previousPage?: string;
+  page?: ConsentPath;
+  previousPage?: ConsentPath;
   // reset password token specific
   timeUntilTokenExpiry?: number;
 }

--- a/src/shared/model/Routes.ts
+++ b/src/shared/model/Routes.ts
@@ -1,3 +1,5 @@
+export type ConsentPath = 'communication' | 'newsletters' | 'data' | 'review';
+
 /**
  * These are all the accepted url routes for this application
  * If you want to add a new route, it will need to be added below
@@ -6,10 +8,7 @@ export type RoutePaths =
   | '/404'
   | '/consents'
   | '/consents/:page'
-  | '/consents/communication'
-  | '/consents/data'
-  | '/consents/newsletters'
-  | '/consents/review'
+  | `/consents/${ConsentPath}`
   | '/error'
   | '/magic-link' //this is not being used until MVP4
   | '/magic-link/email-sent' //this is not being used until MVP4


### PR DESCRIPTION
## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Removes unusual use of `slice()` and makes routes type-safe.

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

Relying on the automated tests should be fine for this one I think.