### PR TITLE
Introduce the toggle switch to the Consents Data page & update opt out/in logic

### DIFF
--- a/src/client/components/ToggleSwitchInput.tsx
+++ b/src/client/components/ToggleSwitchInput.tsx
@@ -99,17 +99,9 @@ const switchStyles = css`
 
 export interface ToggleSwitchInputProps extends Props {
   /**
-   * Whether the ToggleSwitch is checked. This is necessary when using the
-   * [controlled approach](https://reactjs.org/docs/forms.html#controlled-components)
-   * (recommended) to form state management.
-   *
-   * Note: if you pass the `checked` prop, you MUST also pass an `onChange`
-   * handler, or the field will be rendered as read-only.
-   */
-  checked?: boolean;
-  /**
-   * When using the [uncontrolled approach](https://reactjs.org/docs/uncontrolled-components.html),
-   * use defaultChecked to indicate the whether the ToggleSwitch is checked initially.
+   * Whether the ToggleSwitch is checked.
+   * Gateway uses the [uncontrolled approach](https://reactjs.org/docs/uncontrolled-components.html),
+   * Use defaultChecked to indicate the whether the ToggleSwitch is checked initially.
    */
   defaultChecked?: boolean;
   /**
@@ -125,7 +117,6 @@ export interface ToggleSwitchInputProps extends Props {
 export const ToggleSwitchInput = ({
   id,
   label,
-  checked,
   defaultChecked,
   cssOverrides,
 }: ToggleSwitchInputProps): EmotionJSX.Element => {
@@ -141,7 +132,6 @@ export const ToggleSwitchInput = ({
         type="checkbox"
         role="switch"
         defaultChecked={defaultChecked}
-        checked={checked != undefined ? checked : defaultChecked}
         aria-labelledby={labelId}
       ></input>
       <span

--- a/src/client/pages/ConsentsConfirmation.stories.tsx
+++ b/src/client/pages/ConsentsConfirmation.stories.tsx
@@ -49,7 +49,7 @@ const subscribedNewsletters = [
 export const None = () => (
   <ConsentsConfirmation
     returnUrl=""
-    optedOutOfProfiling={true}
+    optedIntoProfiling={true}
     productConsents={[]}
     subscribedNewsletters={[]}
   />
@@ -61,7 +61,7 @@ None.story = {
 export const Profiling = () => (
   <ConsentsConfirmation
     returnUrl=""
-    optedOutOfProfiling={false}
+    optedIntoProfiling={false}
     productConsents={[]}
     subscribedNewsletters={[]}
   />
@@ -73,7 +73,7 @@ Profiling.story = {
 export const Newsletters = () => (
   <ConsentsConfirmation
     returnUrl=""
-    optedOutOfProfiling={true}
+    optedIntoProfiling={true}
     productConsents={[]}
     subscribedNewsletters={subscribedNewsletters}
   />
@@ -85,7 +85,7 @@ Newsletters.story = {
 export const Products = () => (
   <ConsentsConfirmation
     returnUrl=""
-    optedOutOfProfiling={true}
+    optedIntoProfiling={true}
     productConsents={productConsents}
     subscribedNewsletters={[]}
   />
@@ -97,7 +97,7 @@ Products.story = {
 export const Everything = () => (
   <ConsentsConfirmation
     returnUrl=""
-    optedOutOfProfiling={false}
+    optedIntoProfiling={false}
     productConsents={productConsents}
     subscribedNewsletters={subscribedNewsletters}
   />

--- a/src/client/pages/ConsentsConfirmation.tsx
+++ b/src/client/pages/ConsentsConfirmation.tsx
@@ -11,7 +11,12 @@ import { ConsentsSubHeader } from '@/client/components/ConsentsSubHeader';
 import { ConsentsBlueBackground } from '@/client/components/ConsentsBlueBackground';
 import { ConsentsHeader } from '@/client/components/ConsentsHeader';
 import { Footer } from '@/client/components/Footer';
-import { greyBorderTop, heading, text } from '@/client/styles/Consents';
+import {
+  greyBorderTop,
+  heading,
+  text,
+  textBold,
+} from '@/client/styles/Consents';
 import { Consent } from '@/shared/model/Consent';
 import { NewsLetter } from '@/shared/model/Newsletter';
 import {
@@ -45,8 +50,7 @@ const reviewTableRow = css`
 `;
 
 const reviewTableTextBold = css`
-  ${text}
-  font-weight: bold;
+  ${textBold}
   padding-bottom: ${space[2]}px;
 `;
 

--- a/src/client/pages/ConsentsConfirmation.tsx
+++ b/src/client/pages/ConsentsConfirmation.tsx
@@ -11,7 +11,7 @@ import { ConsentsSubHeader } from '@/client/components/ConsentsSubHeader';
 import { ConsentsBlueBackground } from '@/client/components/ConsentsBlueBackground';
 import { ConsentsHeader } from '@/client/components/ConsentsHeader';
 import { Footer } from '@/client/components/Footer';
-import { greyBorderTop, headingWithMq, text } from '@/client/styles/Consents';
+import { greyBorderTop, heading, text } from '@/client/styles/Consents';
 import { Consent } from '@/shared/model/Consent';
 import { NewsLetter } from '@/shared/model/Newsletter';
 import {
@@ -137,7 +137,7 @@ export const ConsentsConfirmation = ({
         />
         <section css={[sectionStyles]}>
           <ConsentsContent>
-            <h2 css={[headingWithMq, autoRow(), greyBorderTop]}>
+            <h2 css={[heading, autoRow(), greyBorderTop]}>
               Thank you for completing your registration
             </h2>
             {anyConsents ? (
@@ -209,7 +209,7 @@ export const ConsentsConfirmation = ({
             )}
             {!subscribedNewsletters.length && (
               <>
-                <h2 css={[headingWithMq, autoRow(), greyBorderTop, marginTop]}>
+                <h2 css={[heading, autoRow(), greyBorderTop, marginTop]}>
                   Guardian newsletters
                 </h2>
                 <p css={[text, autoRow()]}>Didn’t find anything you like?</p>

--- a/src/client/pages/ConsentsConfirmation.tsx
+++ b/src/client/pages/ConsentsConfirmation.tsx
@@ -32,7 +32,7 @@ type ConsentsConfirmationProps = {
   error?: string;
   success?: string;
   returnUrl: string;
-  optedOutOfProfiling: boolean;
+  optedIntoProfiling: boolean;
   productConsents: Consent[];
   subscribedNewsletters: NewsLetter[];
   geolocation?: GeoLocation;
@@ -118,13 +118,13 @@ export const ConsentsConfirmation = ({
   success,
   returnUrl,
   productConsents,
-  optedOutOfProfiling,
+  optedIntoProfiling,
   subscribedNewsletters,
   geolocation,
 }: ConsentsConfirmationProps) => {
   const autoRow = getAutoRow(1, gridItemColumnConsents);
   const anyConsents =
-    !optedOutOfProfiling ||
+    !optedIntoProfiling ||
     !!productConsents.length ||
     !!subscribedNewsletters.length;
   return (
@@ -186,7 +186,7 @@ export const ConsentsConfirmation = ({
                   ))}
                 </ReviewTableRow>
               )}
-              {!optedOutOfProfiling && (
+              {!!optedIntoProfiling && (
                 <ReviewTableRow title="Data">
                   <div css={consentStyles}>
                     <span css={iconStyles}>

--- a/src/client/pages/ConsentsConfirmationPage.tsx
+++ b/src/client/pages/ConsentsConfirmationPage.tsx
@@ -14,14 +14,14 @@ export const ConsentsConfirmationPage = () => {
     returnUrl = 'https://www.theguardian.com',
   } = pageData;
 
-  const optedOutOfProfiling = !!consents.find(
+  const optedIntoProfiling = !!consents.find(
     // If consent option present and consented === true, this means the user has expressed a
     // preference to NOT be contacted - eg. They opted OUT
     (consent) => consent.id === Consents.PROFILING && consent.consented,
   );
 
   const productConsents = consents.filter(
-    (c) => !c.id.includes('_optout') && c.consented,
+    (c) => !c.id.includes('_optin') && c.consented,
   );
 
   const subscribedNewsletters = newsletters.filter((n) => n.subscribed);
@@ -31,7 +31,7 @@ export const ConsentsConfirmationPage = () => {
       error={error}
       success={success}
       returnUrl={returnUrl}
-      optedOutOfProfiling={optedOutOfProfiling}
+      optedIntoProfiling={optedIntoProfiling}
       productConsents={productConsents}
       subscribedNewsletters={subscribedNewsletters}
     />

--- a/src/client/pages/ConsentsData.stories.tsx
+++ b/src/client/pages/ConsentsData.stories.tsx
@@ -17,7 +17,7 @@ NoDescription.story = {
 
 export const ConsentedTrue = () => (
   <ConsentsData
-    description="I do NOT wish to be contacted by the Guardian for market research purposes."
+    name="Allow the Guardian to analyse this data to improve marketing content"
     consented={true}
   />
 );
@@ -27,7 +27,7 @@ ConsentedTrue.story = {
 
 export const ConsentedFalse = () => (
   <ConsentsData
-    description="I do NOT wish to be contacted by the Guardian for market research purposes."
+    name="Allow the Guardian to analyse this data to improve marketing content"
     consented={false}
   />
 );

--- a/src/client/pages/ConsentsData.stories.tsx
+++ b/src/client/pages/ConsentsData.stories.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { Meta } from '@storybook/react';
 
 import { ConsentsData } from './ConsentsData';
+import { Consents } from '@/shared/model/Consent';
 
 export default {
   title: 'Pages/ConsentsData',
@@ -10,13 +11,14 @@ export default {
   parameters: { layout: 'fullscreen' },
 } as Meta;
 
-export const NoDescription = () => <ConsentsData />;
+export const NoDescription = () => <ConsentsData id={Consents.PROFILING} />;
 NoDescription.story = {
   name: 'with no description',
 };
 
 export const ConsentedTrue = () => (
   <ConsentsData
+    id={Consents.PROFILING}
     name="Allow the Guardian to analyse this data to improve marketing content"
     consented={true}
   />
@@ -27,6 +29,7 @@ ConsentedTrue.story = {
 
 export const ConsentedFalse = () => (
   <ConsentsData
+    id={Consents.PROFILING}
     name="Allow the Guardian to analyse this data to improve marketing content"
     consented={false}
   />

--- a/src/client/pages/ConsentsData.tsx
+++ b/src/client/pages/ConsentsData.tsx
@@ -104,8 +104,11 @@ export const ConsentsData = ({ id, consented, name }: ConsentsDataProps) => {
           <fieldset css={[switchRow, greyBorderTop, autoSwitchRow()]}>
             <ToggleSwitchInput
               id={id}
-              label={name}
-              defaultChecked={consented} // TODO inversion
+              // TODO replace with Consent.name once IDAPI model is updated
+              label={
+                'Allow the Guardian to analyse this data to improve marketing content'
+              }
+              defaultChecked={!!consented ? consented : true} // TODO check legitimate interest
               cssOverrides={[textBold, toggleSwitchAlignment]}
             />
           </fieldset>

--- a/src/client/pages/ConsentsData.tsx
+++ b/src/client/pages/ConsentsData.tsx
@@ -1,34 +1,78 @@
 import React from 'react';
 import { css } from '@emotion/react';
-import { neutral, space, textSans } from '@guardian/source-foundations';
-import { getAutoRow, gridItemColumnConsents } from '@/client/styles/Grid';
+import {
+  neutral,
+  space,
+  remSpace,
+  textSans,
+} from '@guardian/source-foundations';
+import {
+  getAutoRow,
+  gridItemColumnConsents,
+  gridItemToggleSwitch,
+} from '@/client/styles/Grid';
 import { CONSENTS_PAGES } from '@/client/models/ConsentsPages';
 import {
   heading,
   text,
-  headingMarginSpace6,
+  textBold,
   greyBorderTop,
 } from '@/client/styles/Consents';
-import { Checkbox, CheckboxGroup } from '@guardian/source-react-components';
 import { ConsentsLayout } from '@/client/layouts/ConsentsLayout';
-import { Consents } from '@/shared/model/Consent';
-
 import { ConsentsContent } from '@/client/layouts/shared/Consents';
+import { ExternalLink } from '../components/ExternalLink';
+import locations from '@/shared/lib/locations';
+import { ToggleSwitchInput } from '../components/ToggleSwitchInput';
 
 type ConsentsDataProps = {
   consented?: boolean;
   description?: string;
+  name?: string;
+  id: string;
 };
 
-const fieldset = css`
+const switchRow = css`
   border: 0;
   padding: 0;
   margin: ${space[4]}px 0 0 0;
   ${textSans.medium()}
 `;
 
-const checkboxLabel = css`
-  color: ${neutral[7]};
+const removeMargin = css`
+  margin: 0;
+`;
+
+const toggleSwitchAlignment = css`
+  justify-content: space-between;
+  button {
+    align-self: flex-start;
+    margin-top: 4px;
+  }
+`;
+
+const listBullets = css`
+  list-style: none;
+  line-height: ${remSpace[6]};
+  padding-left: 0;
+  text-indent: -18px; // second line indentation
+  margin-left: 18px; // second line indentation
+  li {
+    font-size: 17px;
+  }
+  li:first-of-type {
+    margin-top: ${space[2]}px;
+  }
+  // ::marker is not supported in IE11
+  li::before {
+    content: '';
+    margin-right: ${space[2]}px;
+    margin-top: ${space[2]}px;
+    background-color: ${neutral[86]};
+    display: inline-block;
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+  }
 `;
 
 const marketingText = css`
@@ -37,51 +81,52 @@ const marketingText = css`
   margin-top: ${space[4]}px;
 `;
 
-export const ConsentsData = ({ consented, description }: ConsentsDataProps) => {
+export const ConsentsData = ({ id, consented, name }: ConsentsDataProps) => {
   const autoRow = getAutoRow(1, gridItemColumnConsents);
-
-  const label = <span css={checkboxLabel}>{description}</span>;
+  const autoSwitchRow = getAutoRow(1, gridItemToggleSwitch);
 
   return (
     <ConsentsLayout title="Your data" current={CONSENTS_PAGES.YOUR_DATA}>
-      {description && (
+      {name && (
         <ConsentsContent>
-          <h2 css={[heading, greyBorderTop, autoRow()]}>
-            We never share your data without your permission
+          <h2 css={[heading, removeMargin, greyBorderTop, autoRow()]}>
+            What we mean by your data
           </h2>
-          <p css={[text, autoRow()]}>
-            We think carefully about our use of personal data and use it
-            responsibly. We have a team who are dedicated to keeping any data we
-            collect safe and secure. You can find out more about how The
-            Guardian aims to safeguard users data by going to the Privacy
-            section of the website.
-          </p>
-          <h2 css={[heading, headingMarginSpace6, autoRow()]}>
-            Using your data for marketing analysis
-          </h2>
-          <p css={[text, autoRow()]}>
-            From time to time we may use your personal data for marketing
-            analysis. That includes looking at what products or services you
-            have bought from us and what pages you have been viewing on
-            theguardian.com and other Guardian websites (e.g. Guardian Jobs or
-            Guardian Holidays). We do this to understand your interests and
-            preferences so that we can make our marketing communication more
-            relevant to you.
-          </p>
-          <div css={autoRow()}>
-            <p css={[marketingText, autoRow()]}>
-              I am happy for the Guardian to use my personal data for marketing
-              analysis purposes
+          <ul css={[text, listBullets, autoSwitchRow()]}>
+            <li>Information you provide e.g. email address</li>
+            <li>Products or services you buy from us</li>
+            <li>
+              Pages you view on theguardian.com or other Guardian websites when
+              signed in
+            </li>
+          </ul>
+
+          <fieldset css={[switchRow, greyBorderTop, autoSwitchRow()]}>
+            <ToggleSwitchInput
+              id={id}
+              label={name}
+              defaultChecked={consented} // TODO inversion
+              cssOverrides={[textBold, toggleSwitchAlignment]}
+            />
+          </fieldset>
+          <div css={[autoRow()]}>
+            <p css={[marketingText, greyBorderTop, autoRow()]}>
+              You can change your settings under&nbsp;
+              <ExternalLink
+                href={locations.MMA_EMAIL_PREFERENCES}
+                subdued={true}
+              >
+                Emails &amp; marketing
+              </ExternalLink>
+              &nbsp;on your Guardian account at any time.
             </p>
-            <fieldset css={[fieldset, autoRow()]}>
-              <CheckboxGroup name={Consents.PROFILING}>
-                <Checkbox
-                  value="consent-option"
-                  label={label}
-                  defaultChecked={consented}
-                />
-              </CheckboxGroup>
-            </fieldset>
+            <p css={[marketingText, autoRow()]}>
+              Learn how we use data in our{' '}
+              <ExternalLink href={locations.PRIVACY} subdued={true}>
+                privacy policy
+              </ExternalLink>
+              .
+            </p>
           </div>
         </ConsentsContent>
       )}

--- a/src/client/pages/ConsentsDataPage.tsx
+++ b/src/client/pages/ConsentsDataPage.tsx
@@ -18,6 +18,8 @@ export const ConsentsDataPage = () => {
     <ConsentsData
       consented={profiling_optout?.consented}
       description={profiling_optout?.description}
+      name={profiling_optout?.name}
+      id={profiling_optout?.id || Consents.PROFILING}
     />
   );
 };

--- a/src/client/pages/ConsentsDataPage.tsx
+++ b/src/client/pages/ConsentsDataPage.tsx
@@ -10,16 +10,16 @@ export const ConsentsDataPage = () => {
   const { pageData = {} } = clientState;
   const { consents = [] } = pageData;
 
-  const profiling_optout = consents.find(
+  const profiling = consents.find(
     (consent) => consent.id === Consents.PROFILING,
   );
 
   return (
     <ConsentsData
-      consented={profiling_optout?.consented}
-      description={profiling_optout?.description}
-      name={profiling_optout?.name}
-      id={profiling_optout?.id || Consents.PROFILING}
+      consented={profiling?.consented}
+      description={profiling?.description}
+      name={profiling?.name}
+      id={profiling?.id || Consents.PROFILING}
     />
   );
 };

--- a/src/client/styles/Consents.ts
+++ b/src/client/styles/Consents.ts
@@ -23,6 +23,11 @@ export const text = css`
   max-width: 640px;
 `;
 
+export const textBold = css`
+  ${text};
+  ${textSans.medium({ fontWeight: 'bold' })};
+`;
+
 export const greyBorderTop = css`
   border-top: 1px solid ${neutral[86]};
   padding-top: ${space[1]}px;

--- a/src/client/styles/Consents.ts
+++ b/src/client/styles/Consents.ts
@@ -1,6 +1,5 @@
 import { css } from '@emotion/react';
 import {
-  from,
   space,
   headline,
   textSans,
@@ -10,20 +9,11 @@ import {
 export const heading = css`
   color: ${neutral[0]};
   margin: 0 0 ${space[3]}px;
-  ${headline.xxsmall({ fontWeight: 'bold' })};
-  font-size: 17px;
+  ${headline.xxxsmall({ fontWeight: 'bold' })};
 `;
 
 export const headingMarginSpace6 = css`
   margin-top: ${space[6]}px;
-`;
-
-export const headingWithMq = css`
-  ${heading}
-
-  ${from.tablet} {
-    ${headline.xxsmall({ fontWeight: 'bold' })}
-  }
 `;
 
 export const text = css`

--- a/src/client/styles/Grid.ts
+++ b/src/client/styles/Grid.ts
@@ -246,6 +246,13 @@ export const gridItemSignInAndRegistration: SpanDefinition = {
   WIDE: { start: 4, span: 6 },
 };
 
+export const gridItemToggleSwitch: SpanDefinition = {
+  TABLET: { start: 1, span: 8 },
+  DESKTOP: { start: 3, span: 6 },
+  LEFT_COL: { start: 3, span: 6 },
+  WIDE: { start: 4, span: 6 },
+};
+
 export const getAutoRow = (
   offset = 0,
   spanDefinition?: SpanDefinition,

--- a/src/server/lib/__tests__/idapi/invertOptOutConsents.test.ts
+++ b/src/server/lib/__tests__/idapi/invertOptOutConsents.test.ts
@@ -1,0 +1,91 @@
+import { Consent } from '@/shared/model/Consent';
+import { UserConsent } from '@/shared/model/User';
+import {
+  invertOptOutConsents,
+  invertOptInConsents,
+} from '../../idapi/invertOptOutConsents';
+
+describe('invertConsents', () => {
+  const consentOptouts: Consent[] = [
+    {
+      id: 'A_optout',
+      description: '', // optional IDAPI value eg. 'I do NOT want' in original OPT OUT modelling,
+      name: 'Allow', // description/name values updated in IDAPI - see PR https://github.com/guardian/identity/pull/207
+      consented: true,
+    },
+    {
+      id: 'B_optout',
+      description: '',
+      name: 'Allow',
+    },
+    {
+      id: 'C',
+      description: '',
+      name: 'Consent C name',
+      consented: false,
+    },
+  ];
+
+  const consentOptins: Consent[] = [
+    {
+      id: 'A_optin',
+      description: '',
+      name: 'Allow',
+      consented: false,
+    },
+    {
+      id: 'B_optin',
+      description: '',
+      name: 'Allow',
+    },
+    {
+      id: 'C',
+      description: '',
+      name: 'Consent C name',
+      consented: false,
+    },
+  ];
+  test('invertOptOutConsents should correctly invert Consent type', () => {
+    expect(invertOptOutConsents(consentOptouts)).toEqual(consentOptins);
+  });
+  test('invertOptInConsents should correctly invert Consent type', () => {
+    expect(invertOptInConsents(consentOptins)).toEqual(consentOptouts);
+  });
+
+  const userConsentOptouts: UserConsent[] = [
+    {
+      id: 'A_optout',
+      consented: true,
+    },
+    {
+      id: 'B_optout',
+      consented: false,
+    },
+    {
+      id: 'C',
+      consented: false,
+    },
+  ];
+
+  const userConsentOptins: UserConsent[] = [
+    {
+      id: 'A_optin',
+      consented: false,
+    },
+    {
+      id: 'B_optin',
+      consented: true,
+    },
+    {
+      id: 'C',
+      consented: false,
+    },
+  ];
+
+  test('invertOptOutConsents should correctly invert UserConsent type', () => {
+    expect(invertOptOutConsents(userConsentOptouts)).toEqual(userConsentOptins);
+  });
+  test('invertOptInConsents should correctly invert UserConsent type', () => {
+    expect(invertOptInConsents(userConsentOptins)).toEqual(userConsentOptouts);
+  });
+});

--- a/src/server/lib/idapi/invertOptOutConsents.ts
+++ b/src/server/lib/idapi/invertOptOutConsents.ts
@@ -1,0 +1,38 @@
+import { Consent } from '@/shared/model/Consent';
+import { UserConsent } from '@/shared/model/User';
+
+/**
+ * See PR https://github.com/guardian/identity/pull/2079 for more details.
+ *
+ * Necessary due to business requirements changing the wording of opt out (legitimate interest)
+ * consents into opt ins for user UI/UX, but maintaining the consent model as an opt out (including IDs "eg. Profiling_Optout")
+ * due to downstream business integrations
+ *
+ * Intended for use in /src/server/lib/idapi/consents.ts  when user page consents are retrieved from the server
+ * and when user consent updates are posted back to the server.
+ */
+
+type ConversionString = '_optout' | '_optin';
+
+const invertConsents = <ConsentType extends UserConsent | Consent>(
+  input: ConversionString,
+  output: ConversionString,
+) => {
+  return (pageConsents: ConsentType[]) => {
+    return pageConsents.map((consent) => {
+      if (!consent.id.includes(input)) {
+        return consent;
+      }
+
+      return {
+        id: consent.id.replace(input, output),
+        ...('name' in consent && { name: consent.name }),
+        ...('description' in consent && { description: consent.description }),
+        ...('consented' in consent && { consented: !consent.consented }),
+      };
+    });
+  };
+};
+
+export const invertOptOutConsents = invertConsents('_optout', '_optin');
+export const invertOptInConsents = invertConsents('_optin', '_optout');

--- a/src/shared/model/Consent.ts
+++ b/src/shared/model/Consent.ts
@@ -6,7 +6,9 @@ export interface Consent {
 }
 
 export enum Consents {
-  PROFILING = 'profiling_optout',
+  // OPT OUT API CONSENTS (modeled as opt ins in Gateway)
+  PROFILING = 'profiling_optin',
+  // PRODUCT CONSENTS
   SUPPORTER = 'supporter',
   JOBS = 'jobs',
   HOLIDAYS = 'holidays',


### PR DESCRIPTION
## What does this change?

Builds on #1511 

Updates the Consents Data Page UI/UX to use a toggle switch and display updated consent wording. 
New consent wording is currently hardcoded to release first, followed by the  [Identity Model change](https://github.com/guardian/identity/pull/2079) 

## How to test

- [x] Unit Tests

TODO - Cypress Tests (in progress)

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images


## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

- [x] [Tested with screen reader](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#screen-readers)
- [x] [Navigable with keyboard](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#keyboard-navigation)
- [ ] [Colour contrast passed](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#colour-contrast)
- [ ] [The change doesn't use only colour to convey meaning](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#use-of-colour)
