### PR TITLE
Use CSS defaults from source-foundations

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -1,5 +1,6 @@
 const path = require('path');
 const babelConfig = require('../babel.config');
+const { resets } = require('@guardian/source-foundations');
 
 module.exports = {
   stories: ['../src/**/*.stories.mdx', '../src/**/*.stories.@(js|jsx|ts|tsx)'],
@@ -11,6 +12,12 @@ module.exports = {
     options.presets.push('@emotion/babel-preset-css-prop');
     return options;
   },
+  previewHead: (head) => `
+    ${head}
+    <style>
+      ${resets.defaults}
+    </style>
+  `,
   webpackFinal: async (config) => {
     // Add the @client alias to prevent imports using it from failing
     // Nb. __dirname is the current working directory, so .storybook in this case

--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -14,10 +14,6 @@
     flex-direction: column;
   }
 
-  * {
-    box-sizing: border-box;
-  }
-
   /* Badge is hidden for Gateway, because we're using
   the legal text to do this job */
   .grecaptcha-badge {

--- a/src/client/app.tsx
+++ b/src/client/app.tsx
@@ -1,5 +1,7 @@
 import React, { useEffect } from 'react';
 import { css, Global } from '@emotion/react';
+import { resets } from '@guardian/source-foundations';
+
 import { fontFaces } from '@/client/lib/fonts';
 import { ClientStateProvider } from '@/client/components/ClientState';
 import { ClientState } from '@/shared/model/ClientState';
@@ -28,6 +30,7 @@ export const App = (props: ClientState) => {
     <>
       <Global
         styles={css`
+          ${resets.defaults}
           ${fontFaces}
           html {
             height: 100%;
@@ -39,9 +42,6 @@ export const App = (props: ClientState) => {
             min-height: 100%;
             display: flex;
             flex-direction: column;
-          }
-          * {
-            box-sizing: border-box;
           }
           // Badge is hidden for Gateway, because we're using
           // the legal text to do this job

--- a/src/client/components/BackToTop.tsx
+++ b/src/client/components/BackToTop.tsx
@@ -49,8 +49,8 @@ const icon = css`
     border-bottom: 0;
     border-right: 0;
     content: '';
-    height: 12px;
-    width: 12px;
+    height: 14px;
+    width: 14px;
     transform: rotate(45deg);
   }
 `;

--- a/src/client/components/ConsentsSubHeader.tsx
+++ b/src/client/components/ConsentsSubHeader.tsx
@@ -146,8 +146,6 @@ const li = (index: number, status: PageStatus) => {
       height: ${CIRCLE_DIAMETER}px;
       position: absolute;
       left: -${CIRCLE_RADIUS}px;
-      /* TODO: apply this to psuedo elements globally */
-      box-sizing: border-box;
       ${status === 'active' &&
       `
         background: ${neutral[100]};

--- a/src/client/components/ToggleSwitchInput.tsx
+++ b/src/client/components/ToggleSwitchInput.tsx
@@ -64,11 +64,6 @@ const switchStyles = css`
   height: 1.5rem;
   border-radius: 15.5px;
 
-  &:before,
-  &:after {
-    box-sizing: border-box;
-  }
-
   &:before {
     content: '';
     position: absolute;


### PR DESCRIPTION
## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Use CSS [defaults from source-foundations](https://github.com/guardian/source/blob/main/packages/@guardian/source-foundations/src/utils/resets.ts#L31-L52). Should only change how we use psuedo elements, which currently have `box-sizing: border-box;` added on a case-by-case basis.

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

Storybook and the actual app define the global styles separately, so it makes sense to have a click around and test that things look okay in the app as well as just using Chromatic.
