### PR TITLE
useClientState hook

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -239,7 +239,7 @@ Sometimes data is needed by the client to render a specific component, e.g. an e
   making it possible to access data further down a component tree without having to manually pass props down at each level.
 - Pass the same data as JSON on the document, and use this for react hydration on the browser. Hydration is executed from the static bundle's entrypoint.
 
-It's then possible to access the state through the [`useContext`](https://reactjs.org/docs/hooks-reference.html#usecontext) hook in a descendent component.
+It's then possible to access the state through the [`useClientState`](../src/client/lib/hooks/useClientState.ts) hook in a descendent component.
 
 Here's an example of adding some test data to the client state.
 
@@ -293,16 +293,15 @@ const clientStateFromRequestStateLocals = ({
 };
 ```
 
-It's then possible to access it somewhere in the React app using the [`useContext`](https://reactjs.org/docs/hooks-reference.html#usecontext) hook:
+It's then possible to access it somewhere in the React app using the [`useClientState`](../src/client/lib/hooks/useClientState.ts) hook:
 
 ```tsx
-import React, { useContext } from 'react';
-import { ClientStateContext } from '@/client/components/ClientState';
+import useClientState from '@/client/lib/hooks/useClientState';
 
 // export some react component
 export const TestComponent = () => {
   // get the client state from the context
-  const clientState: ClientState = useContext(ClientStateContext);
+  const clientState = useClientState();
   // extract the data we need from the state
   const { test } = clientState;
 
@@ -312,19 +311,18 @@ export const TestComponent = () => {
 };
 ```
 
-In most cases you want to `useContext` outside a presentation component, and pass in the values you need as a prop to the component. This allows us to independently render this component in tests/storybook without relying on the rest of the app and state.
+In most cases you want to `useClientState` outside a presentation component, and pass in the values you need as a prop to the component. This allows us to independently render this component in tests/storybook without relying on the rest of the app and state.
 
 Here's a contrived example:
 
 ```tsx
 // container component
-import React, { useContext } from 'react';
-import { ClientStateContext } from '@/client/components/ClientState';
+import useClientState from '@/client/lib/hooks/useClientState';
 
 // export some react component
 export const TestContainer = () => {
   // get the client state from the context
-  const clientState: ClientState = useContext(ClientStateContext);
+  const clientState = useClientState();
   // extract the data we need from the state
   const { test } = clientState;
 
@@ -417,14 +415,13 @@ You can also use `addReturnUrlToPath` if all you need to add is the `returnUrl`,
 To access the query parameters on the client, you can use the [`ClientState`](../src/shared/model/ClientState.ts) to do so, as a `queryParams` object is available as a property on the `ClientState`. Again you can use the `addQueryParamsToPath` to convert the query parameters to a string, which can be appended on the client to a link/form action. Some contrived examples below:
 
 ```tsx
-import React, { useContext } from 'react';
-import { ClientStateContext } from '@/client/components/ClientState';
+import useClientState from '@/client/lib/hooks/useClientState';
 import { addQueryParamsToPath } from '@/shared/lib/queryParams';
 
 // export some react component
 export const TestContainer = () => {
   // get the client state from the context
-  const clientState: ClientState = useContext(ClientStateContext);
+  const clientState = useClientState();
   // extract the queryParams we need from the state
   const { queryParams } = clientState;
   // extract the values we need from the queryParam

--- a/src/client/components/ABTestDemo.tsx
+++ b/src/client/components/ABTestDemo.tsx
@@ -1,9 +1,9 @@
-import React, { useContext } from 'react';
+import React from 'react';
+
 import { useAB } from '@guardian/ab-react';
 import { tests } from '@/shared/model/experiments/abTests';
 import { exampleTest } from '@/shared/model/experiments/tests/example-test';
-import { ClientState } from '@/shared/model/ClientState';
-import { ClientStateContext } from './ClientState';
+import useClientState from '@/client/lib/hooks/useClientState';
 
 export const ABTestDemo = () => {
   // load the AB Hook
@@ -61,7 +61,7 @@ export const ABTestDemo = () => {
 
   // Example:
   // Load the client state
-  const clientState: ClientState = useContext(ClientStateContext);
+  const clientState = useClientState();
   // Get the AB Tests from clientState, these are the AB Tests the user is in with
   // format is { [key: string]: { variant: string }}
   const { abTesting: { participations = {} } = {} } = clientState;

--- a/src/client/components/ClientState.tsx
+++ b/src/client/components/ClientState.tsx
@@ -1,4 +1,5 @@
 import React, { createContext, FunctionComponent } from 'react';
+
 import { ClientState } from '@/shared/model/ClientState';
 
 export const defaultClientState = {

--- a/src/client/components/CsrfFormField.tsx
+++ b/src/client/components/CsrfFormField.tsx
@@ -1,6 +1,5 @@
-import React, { useContext } from 'react';
-import { ClientState } from '@/shared/model/ClientState';
-import { ClientStateContext } from '@/client/components/ClientState';
+import React from 'react';
+import useClientState from '@/client/lib/hooks/useClientState';
 import { css } from '@emotion/react';
 import { error, space, textSans } from '@guardian/source-foundations';
 
@@ -12,7 +11,7 @@ const csrfErrorStyle = css`
 `;
 
 export const CsrfFormField = () => {
-  const clientState: ClientState = useContext(ClientStateContext);
+  const clientState = useClientState();
 
   const { pageData: { fieldErrors } = {} } = clientState;
 

--- a/src/client/layouts/ConsentsLayout.tsx
+++ b/src/client/layouts/ConsentsLayout.tsx
@@ -1,7 +1,6 @@
-import React, { useContext, FunctionComponent } from 'react';
+import React, { FunctionComponent } from 'react';
 import { Footer } from '@/client/components/Footer';
-import { ClientState } from '@/shared/model/ClientState';
-import { ClientStateContext } from '@/client/components/ClientState';
+import useClientState from '@/client/lib/hooks/useClientState';
 import { css } from '@emotion/react';
 import {
   Button,
@@ -60,7 +59,7 @@ export const ConsentsLayout: FunctionComponent<ConsentsLayoutProps> = ({
   showContinueButton = true,
 }) => {
   const autoRow = getAutoRow(1, gridItemColumnConsents);
-  const clientState: ClientState = useContext(ClientStateContext);
+  const clientState = useClientState();
   const {
     pageData = {},
     globalMessage: { error, success } = {},

--- a/src/client/layouts/Main.tsx
+++ b/src/client/layouts/Main.tsx
@@ -1,4 +1,4 @@
-import React, { PropsWithChildren, useContext } from 'react';
+import React, { PropsWithChildren } from 'react';
 import { css } from '@emotion/react';
 import {
   from,
@@ -14,8 +14,7 @@ import {
 import { gridRow, gridItem, SpanDefinition } from '@/client/styles/Grid';
 import { Header } from '@/client/components/Header';
 import { Footer } from '@/client/components/Footer';
-import { ClientStateContext } from '@/client/components/ClientState';
-import { ClientState } from '@/shared/model/ClientState';
+import useClientState from '@/client/lib/hooks/useClientState';
 
 interface MainLayoutProps {
   pageHeader?: string;
@@ -138,7 +137,7 @@ export const MainLayout = ({
   errorOverride,
   errorContext,
 }: PropsWithChildren<MainLayoutProps>) => {
-  const clientState: ClientState = useContext(ClientStateContext);
+  const clientState = useClientState();
   const {
     globalMessage: { error, success } = {},
     pageData: { geolocation } = {},

--- a/src/client/layouts/MainGrid.tsx
+++ b/src/client/layouts/MainGrid.tsx
@@ -1,8 +1,7 @@
-import React, { useContext } from 'react';
+import React from 'react';
 import { gridRow, gridItem, SpanDefinition } from '@/client/styles/Grid';
 import { css } from '@emotion/react';
-import { ClientState } from '@/shared/model/ClientState';
-import { ClientStateContext } from '@/client/components/ClientState';
+import useClientState from '@/client/lib/hooks/useClientState';
 import { SubHeader } from '@/client/components/SubHeader';
 import { GlobalSuccess } from '@/client/components/GlobalSuccess';
 import { ErrorSummary } from '@guardian/source-react-components-development-kitchen';
@@ -55,7 +54,7 @@ export const MainGrid = ({
   children,
   gridSpanDefinition,
 }: Props) => {
-  const clientState: ClientState = useContext(ClientStateContext);
+  const clientState = useClientState();
   const { globalMessage: { error, success } = {} } = clientState;
 
   const successMessage = successOverride || success;

--- a/src/client/lib/hooks/useClientState.ts
+++ b/src/client/lib/hooks/useClientState.ts
@@ -1,0 +1,4 @@
+import { useContext } from 'react';
+import { ClientStateContext } from '@/client/components/ClientState';
+
+export default () => useContext(ClientStateContext);

--- a/src/client/pages/ChangePasswordCompletePage.tsx
+++ b/src/client/pages/ChangePasswordCompletePage.tsx
@@ -1,10 +1,9 @@
-import React, { useContext } from 'react';
-import { ClientState } from '@/shared/model/ClientState';
-import { ClientStateContext } from '@/client/components/ClientState';
+import React from 'react';
+import useClientState from '@/client/lib/hooks/useClientState';
 import { ChangePasswordComplete } from '@/client/pages/ChangePasswordComplete';
 
 export const ChangePasswordCompletePage = () => {
-  const clientState: ClientState = useContext(ClientStateContext);
+  const clientState = useClientState();
   const { pageData = {} } = clientState;
   const { returnUrl, email } = pageData;
   return (

--- a/src/client/pages/ChangePasswordPage.tsx
+++ b/src/client/pages/ChangePasswordPage.tsx
@@ -1,13 +1,12 @@
-import React, { useContext, useEffect } from 'react';
-import { ClientState } from '@/shared/model/ClientState';
+import React, { useEffect } from 'react';
 import { useParams } from 'react-router-dom';
-import { ClientStateContext } from '@/client/components/ClientState';
+import useClientState from '@/client/lib/hooks/useClientState';
 import { ChangePassword } from '@/client/pages/ChangePassword';
 import { buildUrl, buildUrlWithQueryParams } from '@/shared/lib/routeUtils';
 import { logger } from '@/client/lib/clientSideLogger';
 
 export const ChangePasswordPage = () => {
-  const clientState: ClientState = useContext(ClientStateContext);
+  const clientState = useClientState();
   const {
     pageData: { email = '', fieldErrors = [], timeUntilTokenExpiry } = {},
     queryParams,

--- a/src/client/pages/ConsentsCommunicationPage.tsx
+++ b/src/client/pages/ConsentsCommunicationPage.tsx
@@ -1,10 +1,9 @@
-import React, { useContext } from 'react';
-import { ClientState } from '@/shared/model/ClientState';
-import { ClientStateContext } from '@/client/components/ClientState';
+import React from 'react';
+import useClientState from '@/client/lib/hooks/useClientState';
 import { ConsentsCommunication } from '@/client/pages/ConsentsCommunication';
 
 export const ConsentsCommunicationPage = () => {
-  const clientState = useContext<ClientState>(ClientStateContext);
+  const clientState = useClientState();
 
   const { pageData = {} } = clientState;
   const { consents = [] } = pageData;

--- a/src/client/pages/ConsentsConfirmationPage.tsx
+++ b/src/client/pages/ConsentsConfirmationPage.tsx
@@ -1,11 +1,10 @@
-import React, { useContext } from 'react';
-import { ClientState } from '@/shared/model/ClientState';
-import { ClientStateContext } from '@/client/components/ClientState';
+import React from 'react';
+import useClientState from '@/client/lib/hooks/useClientState';
 import { ConsentsConfirmation } from '@/client/pages/ConsentsConfirmation';
 import { Consents } from '@/shared/model/Consent';
 
 export const ConsentsConfirmationPage = () => {
-  const clientState: ClientState = useContext(ClientStateContext);
+  const clientState = useClientState();
   const { pageData = {}, globalMessage: { error, success } = {} } = clientState;
 
   const {

--- a/src/client/pages/ConsentsDataPage.tsx
+++ b/src/client/pages/ConsentsDataPage.tsx
@@ -1,11 +1,10 @@
-import React, { useContext } from 'react';
-import { ClientStateContext } from '@/client/components/ClientState';
-import { ClientState } from '@/shared/model/ClientState';
+import React from 'react';
+import useClientState from '@/client/lib/hooks/useClientState';
 import { Consents } from '@/shared/model/Consent';
 import { ConsentsData } from '@/client/pages/ConsentsData';
 
 export const ConsentsDataPage = () => {
-  const clientState = useContext<ClientState>(ClientStateContext);
+  const clientState = useClientState();
 
   const { pageData = {} } = clientState;
   const { consents = [] } = pageData;

--- a/src/client/pages/ConsentsNewslettersPage.tsx
+++ b/src/client/pages/ConsentsNewslettersPage.tsx
@@ -1,10 +1,9 @@
-import React, { useContext } from 'react';
-import { ClientStateContext } from '@/client/components/ClientState';
-import { ClientState } from '@/shared/model/ClientState';
+import React from 'react';
+import useClientState from '@/client/lib/hooks/useClientState';
 import { ConsentsNewsletters } from '@/client/pages/ConsentsNewsletters';
 
 export const ConsentsNewslettersPage = () => {
-  const clientState = useContext<ClientState>(ClientStateContext);
+  const clientState = useClientState();
   const newsletters = clientState?.pageData?.newsletters ?? [];
 
   return <ConsentsNewsletters newsletters={newsletters} />;

--- a/src/client/pages/EmailSentPage.tsx
+++ b/src/client/pages/EmailSentPage.tsx
@@ -1,6 +1,5 @@
-import React, { useContext } from 'react';
-import { ClientState } from '@/shared/model/ClientState';
-import { ClientStateContext } from '@/client/components/ClientState';
+import React from 'react';
+import useClientState from '@/client/lib/hooks/useClientState';
 import { EmailSent } from '@/client/pages/EmailSent';
 import { buildQueryParamsString } from '@/shared/lib/queryParams';
 
@@ -10,7 +9,7 @@ interface Props {
 }
 
 export const EmailSentPage = ({ noAccountInfo, formTrackingName }: Props) => {
-  const clientState: ClientState = useContext(ClientStateContext);
+  const clientState = useClientState();
   const {
     pageData = {},
     queryParams,

--- a/src/client/pages/RegistrationEmailSentPage.tsx
+++ b/src/client/pages/RegistrationEmailSentPage.tsx
@@ -1,13 +1,12 @@
-import React, { useContext } from 'react';
-import { ClientState } from '@/shared/model/ClientState';
-import { ClientStateContext } from '@/client/components/ClientState';
+import React from 'react';
+import useClientState from '@/client/lib/hooks/useClientState';
 import { EmailSent } from '@/client/pages/EmailSent';
 import { buildQueryParamsString } from '@/shared/lib/queryParams';
 
 import { buildUrl, buildUrlWithQueryParams } from '@/shared/lib/routeUtils';
 
 export const RegistrationEmailSentPage = () => {
-  const clientState: ClientState = useContext(ClientStateContext);
+  const clientState = useClientState();
   const {
     pageData = {},
     queryParams,

--- a/src/client/pages/RegistrationPage.tsx
+++ b/src/client/pages/RegistrationPage.tsx
@@ -1,10 +1,9 @@
-import React, { useContext } from 'react';
-import { ClientState } from '@/shared/model/ClientState';
-import { ClientStateContext } from '@/client/components/ClientState';
+import React from 'react';
+import useClientState from '@/client/lib/hooks/useClientState';
 import { Registration } from '@/client/pages/Registration';
 
 export const RegistrationPage = () => {
-  const clientState: ClientState = useContext(ClientStateContext);
+  const clientState = useClientState();
   const {
     pageData = {},
     recaptchaConfig,

--- a/src/client/pages/ResendEmailVerificationPage.tsx
+++ b/src/client/pages/ResendEmailVerificationPage.tsx
@@ -1,14 +1,13 @@
-import React, { useContext } from 'react';
+import React from 'react';
 import { ResendEmailVerification } from '@/client/pages/ResendEmailVerification';
-import { ClientState } from '@/shared/model/ClientState';
-import { ClientStateContext } from '@/client/components/ClientState';
+import useClientState from '@/client/lib/hooks/useClientState';
 
 export const ResendEmailVerificationPage = () => {
   const {
     globalMessage: { success } = {},
     pageData: { email, signInPageUrl } = {},
     recaptchaConfig,
-  } = useContext<ClientState>(ClientStateContext);
+  } = useClientState();
 
   const { recaptchaSiteKey } = recaptchaConfig;
 

--- a/src/client/pages/ResendPasswordPage.tsx
+++ b/src/client/pages/ResendPasswordPage.tsx
@@ -1,12 +1,11 @@
-import React, { useContext, useEffect } from 'react';
-import { ClientState } from '@/shared/model/ClientState';
-import { ClientStateContext } from '@/client/components/ClientState';
+import React, { useEffect } from 'react';
+import useClientState from '@/client/lib/hooks/useClientState';
 import { ResetPassword } from '@/client/pages/ResetPassword';
 import { MainBodyText } from '@/client/components/MainBodyText';
 import { logger } from '@/client/lib/clientSideLogger';
 
 export const ResendPasswordPage = () => {
-  const clientState: ClientState = useContext(ClientStateContext);
+  const clientState = useClientState();
   const {
     pageData: { email = '' } = {},
     queryParams,

--- a/src/client/pages/ResetPasswordPage.tsx
+++ b/src/client/pages/ResetPasswordPage.tsx
@@ -1,11 +1,10 @@
-import React, { useContext } from 'react';
-import { ClientState } from '@/shared/model/ClientState';
-import { ClientStateContext } from '@/client/components/ClientState';
+import React from 'react';
+import useClientState from '@/client/lib/hooks/useClientState';
 import { ResetPassword } from '@/client/pages/ResetPassword';
 import { MainBodyText } from '@/client/components/MainBodyText';
 
 export const ResetPasswordPage = () => {
-  const clientState: ClientState = useContext(ClientStateContext);
+  const clientState = useClientState();
   const {
     pageData: { email = '' } = {},
     queryParams,

--- a/src/client/pages/ResetPasswordSessionExpiredPage.tsx
+++ b/src/client/pages/ResetPasswordSessionExpiredPage.tsx
@@ -1,12 +1,11 @@
-import React, { useContext, useEffect } from 'react';
-import { ClientState } from '@/shared/model/ClientState';
-import { ClientStateContext } from '@/client/components/ClientState';
+import React, { useEffect } from 'react';
+import useClientState from '@/client/lib/hooks/useClientState';
 import { ResetPassword } from '@/client/pages/ResetPassword';
 import { MainBodyText } from '@/client/components/MainBodyText';
 import { logger } from '@/client/lib/clientSideLogger';
 
 export const ResetPasswordSessionExpiredPage = () => {
-  const clientState: ClientState = useContext(ClientStateContext);
+  const clientState = useClientState();
   const {
     pageData: { email = '' } = {},
     queryParams,

--- a/src/client/pages/SetPasswordCompletePage.tsx
+++ b/src/client/pages/SetPasswordCompletePage.tsx
@@ -1,10 +1,9 @@
-import React, { useContext } from 'react';
-import { ClientState } from '@/shared/model/ClientState';
-import { ClientStateContext } from '@/client/components/ClientState';
+import React from 'react';
+import useClientState from '@/client/lib/hooks/useClientState';
 import { ChangePasswordComplete } from '@/client/pages/ChangePasswordComplete';
 
 export const SetPasswordCompletePage = () => {
-  const clientState: ClientState = useContext(ClientStateContext);
+  const clientState = useClientState();
   const { pageData = {} } = clientState;
   const { returnUrl, email } = pageData;
   return (

--- a/src/client/pages/SetPasswordPage.tsx
+++ b/src/client/pages/SetPasswordPage.tsx
@@ -1,14 +1,13 @@
-import React, { useContext, useEffect } from 'react';
+import React, { useEffect } from 'react';
 import { useParams } from 'react-router-dom';
-import { ClientState } from '@/shared/model/ClientState';
-import { ClientStateContext } from '@/client/components/ClientState';
+import useClientState from '@/client/lib/hooks/useClientState';
 
 import { ChangePassword } from '@/client/pages/ChangePassword';
 import { buildUrl, buildUrlWithQueryParams } from '@/shared/lib/routeUtils';
 import { logger } from '@/client/lib/clientSideLogger';
 
 export const SetPasswordPage = () => {
-  const clientState: ClientState = useContext(ClientStateContext);
+  const clientState = useClientState();
   const {
     pageData: { email = '', fieldErrors = [], timeUntilTokenExpiry } = {},
     queryParams,

--- a/src/client/pages/SetPasswordResendPage.tsx
+++ b/src/client/pages/SetPasswordResendPage.tsx
@@ -1,12 +1,11 @@
-import React, { useContext } from 'react';
-import { ClientState } from '@/shared/model/ClientState';
-import { ClientStateContext } from '@/client/components/ClientState';
+import React from 'react';
+import useClientState from '@/client/lib/hooks/useClientState';
 import { ResetPassword } from '@/client/pages/ResetPassword';
 import { MainBodyText } from '@/client/components/MainBodyText';
 import { buildUrl } from '@/shared/lib/routeUtils';
 
 export const SetPasswordResendPage = () => {
-  const clientState: ClientState = useContext(ClientStateContext);
+  const clientState = useClientState();
   const {
     pageData: { email = '' } = {},
     queryParams,

--- a/src/client/pages/SetPasswordSessionExpiredPage.tsx
+++ b/src/client/pages/SetPasswordSessionExpiredPage.tsx
@@ -1,13 +1,12 @@
-import React, { useContext, useEffect } from 'react';
-import { ClientState } from '@/shared/model/ClientState';
-import { ClientStateContext } from '@/client/components/ClientState';
+import React, { useEffect } from 'react';
+import useClientState from '@/client/lib/hooks/useClientState';
 import { ResetPassword } from '@/client/pages/ResetPassword';
 import { MainBodyText } from '@/client/components/MainBodyText';
 import { buildUrl } from '@/shared/lib/routeUtils';
 import { logger } from '@/client/lib/clientSideLogger';
 
 export const SetPasswordSessionExpiredPage = () => {
-  const clientState: ClientState = useContext(ClientStateContext);
+  const clientState = useClientState();
   const {
     pageData: { email = '' } = {},
     queryParams,

--- a/src/client/pages/SignInPage.tsx
+++ b/src/client/pages/SignInPage.tsx
@@ -1,11 +1,10 @@
-import React, { useContext } from 'react';
+import React from 'react';
 import { SignIn } from '@/client/pages/SignIn';
-import { ClientState } from '@/shared/model/ClientState';
-import { ClientStateContext } from '@/client/components/ClientState';
+import useClientState from '@/client/lib/hooks/useClientState';
 import { useRemoveEncryptedEmailParam } from '@/client/lib/hooks/useRemoveEncryptedEmailParam';
 
 export const SignInPage = () => {
-  const clientState: ClientState = useContext(ClientStateContext);
+  const clientState = useClientState();
   const {
     pageData = {},
     globalMessage = {},

--- a/src/client/pages/SignInSuccess.tsx
+++ b/src/client/pages/SignInSuccess.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import React from 'react';
 import { css } from '@emotion/react';
 import { from, headline, until } from '@guardian/source-foundations';
 import { Button } from '@guardian/source-react-components';
@@ -12,8 +12,7 @@ import { CONSENT_IMAGES } from '@/client/models/ConsentImages';
 import { CsrfFormField } from '@/client/components/CsrfFormField';
 import { buildUrlWithQueryParams } from '@/shared/lib/routeUtils';
 import { onboardingFormSubmitOphanTracking } from '@/client/lib/consentsTracking';
-import { ClientState } from '@/shared/model/ClientState';
-import { ClientStateContext } from '@/client/components/ClientState';
+import useClientState from '@/client/lib/hooks/useClientState';
 import { ConsentsContent, controls } from '@/client/layouts/shared/Consents';
 import { mainStyles } from '@/client/layouts/ConsentsLayout';
 import { ConsentsBlueBackground } from '@/client/components/ConsentsBlueBackground';
@@ -53,7 +52,7 @@ export const SignInSuccess = ({
   consents,
 }: SignInSuccessProps) => {
   const autoRow = getAutoRow(1, gridItemColumnConsents);
-  const clientState: ClientState = useContext(ClientStateContext);
+  const clientState = useClientState();
   const { pageData = {}, queryParams } = clientState;
 
   return (

--- a/src/client/pages/SignInSuccessPage.tsx
+++ b/src/client/pages/SignInSuccessPage.tsx
@@ -1,10 +1,9 @@
-import React, { useContext } from 'react';
+import React from 'react';
 import { SignInSuccess } from '@/client/pages/SignInSuccess';
-import { ClientState } from '@/shared/model/ClientState';
-import { ClientStateContext } from '@/client/components/ClientState';
+import useClientState from '@/client/lib/hooks/useClientState';
 
 export const SignInSuccessPage = () => {
-  const clientState: ClientState = useContext(ClientStateContext);
+  const clientState = useClientState();
   const { pageData = {} } = clientState;
   const { geolocation, consents = [] } = pageData;
 

--- a/src/client/pages/WelcomePage.tsx
+++ b/src/client/pages/WelcomePage.tsx
@@ -1,14 +1,13 @@
-import React, { useContext, useEffect } from 'react';
+import React, { useEffect } from 'react';
 import { useParams } from 'react-router-dom';
-import { ClientState } from '@/shared/model/ClientState';
-import { ClientStateContext } from '@/client/components/ClientState';
+import useClientState from '@/client/lib/hooks/useClientState';
 
 import { Welcome } from '@/client/pages/Welcome';
 import { buildUrl, buildUrlWithQueryParams } from '@/shared/lib/routeUtils';
 import { logger } from '@/client/lib/clientSideLogger';
 
 export const WelcomePage = () => {
-  const clientState: ClientState = useContext(ClientStateContext);
+  const clientState = useClientState();
   const {
     pageData: { email, fieldErrors = [], timeUntilTokenExpiry } = {},
     queryParams,

--- a/src/client/pages/WelcomePasswordAlreadySetPage.tsx
+++ b/src/client/pages/WelcomePasswordAlreadySetPage.tsx
@@ -1,10 +1,9 @@
-import React, { useContext } from 'react';
-import { ClientState } from '@/shared/model/ClientState';
-import { ClientStateContext } from '@/client/components/ClientState';
+import React from 'react';
+import useClientState from '@/client/lib/hooks/useClientState';
 import { Welcome } from '@/client/pages/Welcome';
 
 export const WelcomePasswordAlreadySetPage = () => {
-  const clientState: ClientState = useContext(ClientStateContext);
+  const clientState = useClientState();
   const { pageData: { email, fieldErrors = [] } = {} } = clientState;
 
   return (

--- a/src/client/pages/WelcomeResendPage.tsx
+++ b/src/client/pages/WelcomeResendPage.tsx
@@ -1,12 +1,11 @@
-import React, { useContext } from 'react';
-import { ClientState } from '@/shared/model/ClientState';
-import { ClientStateContext } from '@/client/components/ClientState';
+import React from 'react';
+import useClientState from '@/client/lib/hooks/useClientState';
 import { ResetPassword } from '@/client/pages/ResetPassword';
 import { MainBodyText } from '@/client/components/MainBodyText';
 import { buildUrl } from '@/shared/lib/routeUtils';
 
 export const WelcomeResendPage = () => {
-  const clientState: ClientState = useContext(ClientStateContext);
+  const clientState = useClientState();
   const {
     pageData: { email = '' } = {},
     queryParams,

--- a/src/client/pages/WelcomeSessionExpiredPage.tsx
+++ b/src/client/pages/WelcomeSessionExpiredPage.tsx
@@ -1,6 +1,5 @@
-import React, { useContext, useEffect } from 'react';
-import { ClientState } from '@/shared/model/ClientState';
-import { ClientStateContext } from '@/client/components/ClientState';
+import React, { useEffect } from 'react';
+import useClientState from '@/client/lib/hooks/useClientState';
 import { ResetPassword } from '@/client/pages/ResetPassword';
 
 import { MainBodyText } from '../components/MainBodyText';
@@ -8,7 +7,7 @@ import { buildUrl } from '@/shared/lib/routeUtils';
 import { logger } from '@/client/lib/clientSideLogger';
 
 export const WelcomeSessionExpiredPage = () => {
-  const clientState: ClientState = useContext(ClientStateContext);
+  const clientState = useClientState();
   const {
     pageData: { email = '' } = {},
     queryParams,


### PR DESCRIPTION
## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

This adds a `useClientState` hook, as an alternative to importing `ClientStateContext` and passing this into `useContext`. Slightly more convenient as it's just one function to import and call, instead of three imports (although I'm not sure if importing the `ClientState` was ever necessary, the type should be able to be inferred).

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->