### PR TITLE
Sign out with Okta

### DIFF
--- a/cypress/integration/mocked/okta_sign_out.spec.ts
+++ b/cypress/integration/mocked/okta_sign_out.spec.ts
@@ -1,0 +1,43 @@
+describe('Sign out flow', () => {
+  context('Signs a user out', () => {
+    beforeEach(() => {
+      cy.mockPurge();
+    });
+    it('Removes Okta cookies and dotcom cookies when signing out', () => {
+      cy.mockPattern(
+        200,
+        {
+          id: 'test',
+          login: 'user@example.com',
+          userId: 'userId',
+          status: 'ACTIVE',
+          expiresAt: '2016-01-03T09:13:17.000Z',
+          lastPasswordVerification: '2016-01-03T07:02:00.000Z',
+          lastFactorVerification: null,
+          amr: ['pwd'],
+          idp: {
+            id: '01a2bcdef3GHIJKLMNOP',
+            type: 'OKTA',
+          },
+          mfaActive: true,
+        },
+        '/api/v1/sessions/the_sid_cookie',
+      );
+
+      cy.mockPattern(204, {}, '/api/v1/users/userId/sessions');
+
+      cy.mockPattern(200, {}, '/unauth');
+
+      cy.setCookie('sid', `the_sid_cookie`);
+
+      //visit the register page to set the cookie on the correct domain (localhost)
+      cy.visit('/register');
+      //
+      cy.getCookie('sid').should('exist');
+
+      cy.request('/signout').then(() => {
+        cy.getCookie('sid').should('not.exist');
+      });
+    });
+  });
+});

--- a/cypress/integration/mocked/sign_out.spec.ts
+++ b/cypress/integration/mocked/sign_out.spec.ts
@@ -56,18 +56,22 @@ describe('Sign out flow', () => {
       });
 
       // mock IDAPI sign-out cookie response
-      cy.mockNext(200, {
-        status: 'ok',
-        cookies: {
-          values: [
-            {
-              key: 'GU_SO',
-              value: 'the_GU_SO_cookie',
-            },
-          ],
-          expiresAt: new Date(Date.now() + 1800000 /* 30min */).toISOString(),
+      cy.mockPattern(
+        200,
+        {
+          status: 'ok',
+          cookies: {
+            values: [
+              {
+                key: 'GU_SO',
+                value: 'the_GU_SO_cookie',
+              },
+            ],
+            expiresAt: new Date(Date.now() + 1800000 /* 30min */).toISOString(),
+          },
         },
-      });
+        '/unauth',
+      );
 
       cy.request('/signout').then(() => {
         cy.getCookie('GU_SO').should('exist');

--- a/src/server/lib/__tests__/okta/api/sessions.test.ts
+++ b/src/server/lib/__tests__/okta/api/sessions.test.ts
@@ -1,0 +1,66 @@
+import { mocked } from 'jest-mock';
+import { fetch } from '@/server/lib/fetch';
+import type { Response, RequestInfo, RequestInit } from 'node-fetch';
+import { getSession } from '@/server/lib/okta/api/sessions';
+import { OktaError } from '@/server/models/okta/Error';
+
+const sessionId = '123';
+
+// mocked configuration
+jest.mock('@/server/lib/getConfiguration', () => ({
+  getConfiguration: () => ({
+    okta: {
+      enabled: true,
+      orgUrl: 'someOrgUrl',
+      token: 'token',
+      authServerId: 'authServerId',
+      clientId: 'clientId',
+      clientSecret: 'clientSecret',
+    },
+  }),
+}));
+
+// mocked fetch
+jest.mock('@/server/lib/fetch');
+const mockedFetch =
+  mocked<(url: RequestInfo, init?: RequestInit) => Partial<Promise<Response>>>(
+    fetch,
+  );
+/* eslint-disable @typescript-eslint/no-explicit-any */
+const json = jest.fn() as jest.MockedFunction<any>;
+
+describe('okta#signOutUser', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('should sign out a user given a current valid session', async () => {
+    const sessionData = {
+      id: '123',
+      login: 'email@example.com',
+      userId: '123',
+      expiresAt: '2016-01-03T09:13:17.000Z',
+      status: 'ACTIVE',
+      lastPasswordVerification: '2016-01-03T07:02:00.000Z',
+      mfaActive: false,
+    };
+
+    json.mockResolvedValueOnce(sessionData);
+    mockedFetch.mockReturnValueOnce(
+      Promise.resolve({ ok: true, status: 200, json } as Response),
+    );
+
+    const sessionResponse = await getSession(sessionId);
+    expect(sessionResponse).toEqual(sessionData);
+  });
+
+  test('should throw an error after invalid session response from Okta', async () => {
+    mockedFetch.mockReturnValueOnce(
+      Promise.resolve({ ok: false, status: 404 } as Response),
+    );
+
+    await expect(getSession(sessionId)).rejects.toThrowError(
+      new OktaError({ message: 'Could not parse Okta error response' }),
+    );
+  });
+});

--- a/src/server/lib/__tests__/okta/api/users.test.ts
+++ b/src/server/lib/__tests__/okta/api/users.test.ts
@@ -3,6 +3,7 @@ import { fetch } from '@/server/lib/fetch';
 import type { Response, RequestInfo, RequestInit } from 'node-fetch';
 import {
   activateUser,
+  clearUserSessions,
   createUser,
   getUser,
   reactivateUser,
@@ -254,6 +255,39 @@ describe('okta#reactivateUser', () => {
     await expect(reactivateUser(userId)).rejects.toThrow(
       new OktaError({
         message: "This operation is not allowed in the user's current status.",
+      }),
+    );
+  });
+});
+
+describe('okta#clearUserSessions', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('should clear user sessions', async () => {
+    mockedFetch.mockReturnValueOnce(Promise.resolve({ ok: true } as Response));
+
+    await expect(clearUserSessions(userId)).resolves.toEqual(undefined);
+  });
+
+  test('should throw an error when a user session cannot be cleared', async () => {
+    const errorResponse = {
+      errorCode: 'E0000007',
+      errorSummary: 'Not found: Resource not found: <userId> (User)',
+      errorLink: 'E0000007',
+      errorId: 'oaeZm9ypzgqQOq0n4PYgiFlZQ',
+      errorCauses: [],
+    };
+
+    json.mockResolvedValueOnce(errorResponse);
+    mockedFetch.mockReturnValueOnce(
+      Promise.resolve({ ok: false, status: 404, json } as Response),
+    );
+
+    await expect(clearUserSessions(userId)).rejects.toThrow(
+      new OktaError({
+        message: 'Not found: Resource not found: <userId> (User)',
       }),
     );
   });

--- a/src/server/lib/idapi/unauth.ts
+++ b/src/server/lib/idapi/unauth.ts
@@ -14,7 +14,7 @@ const handleError = ({ status = 500 }: IDAPIError) => {
   throw new IdapiError({ message: GenericErrors.DEFAULT, status });
 };
 
-export const logout = async (
+export const logoutFromIDAPI = async (
   sc_gu_u: string,
   ip: string,
 ): Promise<IdapiCookies | undefined> => {

--- a/src/server/lib/okta/api/sessions.ts
+++ b/src/server/lib/okta/api/sessions.ts
@@ -1,7 +1,6 @@
 import { OktaError } from '@/server/models/okta/Error';
 import { SessionResponse } from '@/server/models/okta/Session';
-import { buildUrl, ExtractRouteParams } from '@/shared/lib/routeUtils';
-import { OktaApiRoutePaths } from '@/shared/model/Routes';
+import { buildUrl } from '@/shared/lib/routeUtils';
 import { joinUrl } from '@guardian/libs';
 import { getConfiguration } from '../../getConfiguration';
 import { handleErrorResponse } from './errors';
@@ -16,13 +15,19 @@ const { okta } = getConfiguration();
  *
  * https://developer.okta.com/docs/reference/api/sessions/#get-session
  *
- * @param sessionId Okta user ID
- * @returns Promise<void>
+ * The Okta API returns the users session details on success or
+ * returns a 404 on error.
+ *
+ * We convert a successful API response to a Session response,
+ * or throw an error on a failed response.
+ *
+ * @param sessionId Okta session ID
+ * @returns Promise<SessionResponse>
  */
-export const getSession = async <P extends OktaApiRoutePaths>(
-  sessionId: ExtractRouteParams<P>,
+export const getSession = async (
+  sessionId: string,
 ): Promise<SessionResponse> => {
-  const path = buildUrl('/api/v1/sessions/:id', sessionId);
+  const path = buildUrl('/api/v1/sessions/:sessionId', { sessionId });
   return fetch(joinUrl(okta.orgUrl, path), {
     headers: { ...defaultHeaders, ...authorizationHeader() },
   }).then(handleSessionResponse);

--- a/src/server/lib/okta/api/sessions.ts
+++ b/src/server/lib/okta/api/sessions.ts
@@ -1,0 +1,57 @@
+import { OktaError } from '@/server/models/okta/Error';
+import { SessionResponse } from '@/server/models/okta/Session';
+import { buildUrl, ExtractRouteParams } from '@/shared/lib/routeUtils';
+import { OktaApiRoutePaths } from '@/shared/model/Routes';
+import { joinUrl } from '@guardian/libs';
+import { getConfiguration } from '../../getConfiguration';
+import { handleErrorResponse } from './errors';
+import { defaultHeaders, authorizationHeader } from './headers';
+import { Response } from 'node-fetch';
+import { fetch } from '@/server/lib/fetch';
+
+const { okta } = getConfiguration();
+
+/**
+ * Get a User session by session Id
+ *
+ * https://developer.okta.com/docs/reference/api/sessions/#get-session
+ *
+ * @param sessionId Okta user ID
+ * @returns Promise<void>
+ */
+export const getSession = async <P extends OktaApiRoutePaths>(
+  sessionId: ExtractRouteParams<P>,
+): Promise<SessionResponse> => {
+  const path = buildUrl('/api/v1/sessions/:id', sessionId);
+  return fetch(joinUrl(okta.orgUrl, path), {
+    headers: { ...defaultHeaders, ...authorizationHeader() },
+  }).then(handleSessionResponse);
+};
+
+const handleSessionResponse = async (
+  response: Response,
+): Promise<SessionResponse> => {
+  if (response.ok) {
+    try {
+      return await response.json().then((json) => {
+        const session = json as SessionResponse;
+        return {
+          id: session.id,
+          login: session.login,
+          userId: session.userId,
+          expiresAt: session.expiresAt,
+          status: session.status,
+          lastPasswordVerification: session.lastPasswordVerification,
+          lastFactorVerification: session.lastFactorVerification,
+          mfaActive: session.mfaActive,
+        };
+      });
+    } catch (error) {
+      throw new OktaError({
+        message: 'Could not parse Okta session response',
+      });
+    }
+  } else {
+    return await handleErrorResponse(response);
+  }
+};

--- a/src/server/lib/okta/api/sessions.ts
+++ b/src/server/lib/okta/api/sessions.ts
@@ -33,7 +33,7 @@ export const getSession = async (
   }).then(handleSessionResponse);
 };
 
-const handleSessionResponse = async (
+export const handleSessionResponse = async (
   response: Response,
 ): Promise<SessionResponse> => {
   if (response.ok) {

--- a/src/server/lib/okta/api/users.ts
+++ b/src/server/lib/okta/api/users.ts
@@ -1,10 +1,5 @@
 import { getConfiguration } from '@/server/lib/getConfiguration';
-import {
-  buildApiUrlWithQueryParams,
-  buildUrl,
-  ExtractRouteParams,
-} from '@/shared/lib/routeUtils';
-import { OktaApiRoutePaths } from '@/shared/model/Routes';
+import { buildApiUrlWithQueryParams, buildUrl } from '@/shared/lib/routeUtils';
 import { joinUrl } from '@guardian/libs';
 import { fetch } from '@/server/lib/fetch';
 import {
@@ -61,11 +56,11 @@ export const createUser = async (
  *
  * @returns Promise<UserResponse>
  */
-export const updateUser = async <P extends OktaApiRoutePaths>(
-  id: ExtractRouteParams<P>,
+export const updateUser = async (
+  id: string,
   body: UserUpdateRequest,
 ): Promise<UserResponse> => {
-  const path = buildUrl('/api/v1/users/:id', id);
+  const path = buildUrl('/api/v1/users/:id', { id });
   return await fetch(joinUrl(okta.orgUrl, path), {
     method: 'POST',
     body: JSON.stringify(body),
@@ -83,10 +78,9 @@ export const updateUser = async <P extends OktaApiRoutePaths>(
  *
  * @returns Promise<UserResponse>
  */
-export const getUser = async <P extends OktaApiRoutePaths>(
-  id: ExtractRouteParams<P>,
-): Promise<UserResponse> => {
-  const path = buildUrl('/api/v1/users/:id', id);
+
+export const getUser = async (id: string): Promise<UserResponse> => {
+  const path = buildUrl('/api/v1/users/:id', { id });
   return fetch(joinUrl(okta.orgUrl, path), {
     headers: { ...defaultHeaders, ...authorizationHeader() },
   }).then(handleUserResponse);
@@ -111,12 +105,10 @@ export const getUser = async <P extends OktaApiRoutePaths>(
  *
  * @returns Promise<void>
  */
-export const activateUser = async <P extends OktaApiRoutePaths>(
-  id: ExtractRouteParams<P>,
-): Promise<void> => {
+export const activateUser = async (id: string): Promise<void> => {
   const path = buildApiUrlWithQueryParams(
     '/api/v1/users/:id/lifecycle/activate',
-    id,
+    { id },
     { sendEmail: true },
   );
   return await fetch(joinUrl(okta.orgUrl, path), {
@@ -142,12 +134,10 @@ export const activateUser = async <P extends OktaApiRoutePaths>(
  *
  * @returns Promise<void>
  */
-export const reactivateUser = async <P extends OktaApiRoutePaths>(
-  id: ExtractRouteParams<P>,
-): Promise<void> => {
+export const reactivateUser = async (id: string): Promise<void> => {
   const path = buildApiUrlWithQueryParams(
     '/api/v1/users/:id/lifecycle/reactivate',
-    id,
+    { id },
     { sendEmail: true },
   );
   return await fetch(joinUrl(okta.orgUrl, path), {
@@ -168,13 +158,17 @@ export const reactivateUser = async <P extends OktaApiRoutePaths>(
  * @param oauthTokens (optional, default: `true`) Revoke issued OpenID Connect and OAuth refresh and access tokens
  * @returns Promise<void>
  */
-export const clearUserSessions = async <P extends OktaApiRoutePaths>(
-  id: ExtractRouteParams<P>,
+export const clearUserSessions = async (
+  id: string,
   oauthTokens = true,
 ): Promise<void> => {
-  const path = buildApiUrlWithQueryParams('/api/v1/users/:id/sessions', id, {
-    oauthTokens,
-  });
+  const path = buildApiUrlWithQueryParams(
+    '/api/v1/users/:id/sessions',
+    { id },
+    {
+      oauthTokens,
+    },
+  );
   return await fetch(joinUrl(okta.orgUrl, path), {
     method: 'DELETE',
     headers: { ...defaultHeaders, ...authorizationHeader() },

--- a/src/server/lib/okta/api/users.ts
+++ b/src/server/lib/okta/api/users.ts
@@ -157,12 +157,38 @@ export const reactivateUser = async <P extends OktaApiRoutePaths>(
 };
 
 /**
+ * Clear User sessions
+ *
+ * Removes all active identity provider sessions. This forces the user to authenticate on the next operation.
+ * Optionally revokes OpenID Connect and OAuth refresh and access tokens issued to the user.
+ *
+ * https://developer.okta.com/docs/reference/api/users/#clear-user-sessions
+ *
+ * @param id Okta user ID
+ * @param oauthTokens (optional, default: `true`) Revoke issued OpenID Connect and OAuth refresh and access tokens
+ * @returns Promise<void>
+ */
+export const clearUserSessions = async <P extends OktaApiRoutePaths>(
+  id: ExtractRouteParams<P>,
+  oauthTokens = true,
+): Promise<void> => {
+  const path = buildApiUrlWithQueryParams('/api/v1/users/:id/sessions', id, {
+    oauthTokens,
+  });
+  return await fetch(joinUrl(okta.orgUrl, path), {
+    method: 'DELETE',
+    headers: { ...defaultHeaders, ...authorizationHeader() },
+  }).then(handleVoidResponse);
+};
+
+/*
  * @name handleUserResponse
  * @description Handles the response from Okta's /users endpoint
  * and converts it to a UserResponse object
  * @param response node-fetch response object
  * @returns Promise<UserResponse>
  */
+
 const handleUserResponse = async (
   response: Response,
 ): Promise<UserResponse> => {

--- a/src/server/lib/okta/register.ts
+++ b/src/server/lib/okta/register.ts
@@ -36,15 +36,15 @@ export const register = async (email: string): Promise<UserResponse> => {
       error.name === 'ApiValidationError' &&
       causesInclude(error.causes, 'already exists')
     ) {
-      const user = await getUser({ id: email });
+      const user = await getUser(email);
       const { status } = user;
       switch (status) {
         case Status.STAGED: {
-          await activateUser({ id: user.id });
+          await activateUser(user.id);
           return user;
         }
         case Status.PROVISIONED: {
-          await reactivateUser({ id: user.id });
+          await reactivateUser(user.id);
           return user;
         }
         case Status.ACTIVE || Status.RECOVERY || Status.PASSWORD_EXPIRED: {
@@ -77,15 +77,15 @@ export const register = async (email: string): Promise<UserResponse> => {
  * @returns {Promise<UserResponse>} Promise that resolves to the user object
  */
 export const resendRegistrationEmail = async (email: string) => {
-  const user: UserResponse = await getUser({ id: email });
+  const user: UserResponse = await getUser(email);
   const { status } = user;
   switch (status) {
     case Status.STAGED: {
-      await activateUser({ id: email });
+      await activateUser(email);
       break;
     }
     case Status.PROVISIONED: {
-      await reactivateUser({ id: email });
+      await reactivateUser(email);
       break;
     }
     // TODO: implement reset password email & emails for other user STATUSES

--- a/src/server/lib/okta/validateEmail.ts
+++ b/src/server/lib/okta/validateEmail.ts
@@ -13,15 +13,12 @@ export const validateEmailAndPasswordSetSecurely = async (
   id: string,
 ): Promise<UserResponse> => {
   const timestamp = new Date().toISOString();
-  return await updateUser(
-    { id },
-    {
-      profile: {
-        emailValidated: true,
-        lastEmailValidatedTimestamp: timestamp,
-        passwordSetSecurely: true,
-        lastPasswordSetSecurelyTimestamp: timestamp,
-      },
+  return await updateUser(id, {
+    profile: {
+      emailValidated: true,
+      lastEmailValidatedTimestamp: timestamp,
+      passwordSetSecurely: true,
+      lastPasswordSetSecurelyTimestamp: timestamp,
     },
-  );
+  });
 };

--- a/src/server/models/Metrics.ts
+++ b/src/server/models/Metrics.ts
@@ -21,6 +21,7 @@ type ConditionalMetrics =
   | 'OktaRegistration'
   | 'OktaRegistrationResendEmail'
   | 'OktaSignIn'
+  | 'OktaSignOut'
   | 'OktaUpdatePassword'
   | 'OktaValidatePasswordToken'
   | 'OktaWelcomeResendEmail'

--- a/src/server/models/okta/Session.ts
+++ b/src/server/models/okta/Session.ts
@@ -1,0 +1,14 @@
+// Session object definition https://developer.okta.com/docs/reference/api/sessions/#session-properties
+
+export interface SessionResponse {
+  id: string;
+  login: string;
+  userId: string;
+  expiresAt: string;
+  status: 'ACTIVE' | 'MFA_REQUIRED' | 'MFA_ENROLL';
+  lastPasswordVerification: string;
+  lastFactorVerification: string;
+  // amr: string;
+  // idp: string;
+  mfaActive: boolean;
+}

--- a/src/server/routes/signOut.ts
+++ b/src/server/routes/signOut.ts
@@ -42,7 +42,8 @@ const clearDotComCookies = (res: ResponseWithRequestState) => {
 
 const clearOktaCookies = (res: ResponseWithRequestState) => {
   res.cookie(OKTA_COOKIE_NAME, '', {
-    domain: baseUri,
+    //remove the port number from domain if one exists
+    domain: baseUri.split(':')[0],
     maxAge: 0, // set to 0 to expire cookie immediately, and clear these cookies
   });
 };

--- a/src/server/routes/signOut.ts
+++ b/src/server/routes/signOut.ts
@@ -1,7 +1,7 @@
 import { Request } from 'express';
 import { typedRouter as router } from '@/server/lib/typedRoutes';
 import { ResponseWithRequestState } from '@/server/models/Express';
-import { logout } from '@/server/lib/idapi/unauth';
+import { logoutFromIDAPI } from '@/server/lib/idapi/unauth';
 import { handleAsyncErrors } from '@/server/lib/expressWrappers';
 import { logger } from '@/server/lib/serverSideLogger';
 import { getConfiguration } from '@/server/lib/getConfiguration';
@@ -12,6 +12,8 @@ import {
 import { deleteAuthorizationStateCookie } from '../lib/okta/openid-connect';
 import { clearEncryptedStateCookie } from '../lib/encryptedStateCookie';
 import { trackMetric } from '../lib/trackMetric';
+import { clearUserSessions } from '../lib/okta/api/users';
+import { getSession } from '../lib/okta/api/sessions';
 
 const { defaultReturnUri, baseUri } = getConfiguration();
 
@@ -21,6 +23,8 @@ const DotComCookies = [
   'gu_recurring_contributor',
   'gu_digital_subscriber',
 ];
+
+const OKTA_COOKIE_NAME = 'sid';
 
 const clearDotComCookies = (res: ResponseWithRequestState) => {
   // the baseUri is profile.theguardian.com so we strip the 'profile' as the cookie domain should be .theguardian.com
@@ -36,49 +40,87 @@ const clearDotComCookies = (res: ResponseWithRequestState) => {
   });
 };
 
+const clearOktaCookies = (res: ResponseWithRequestState) => {
+  res.cookie(OKTA_COOKIE_NAME, '', {
+    domain: baseUri,
+    maxAge: 0, // set to 0 to expire cookie immediately, and clear these cookies
+  });
+};
+
 router.get(
   '/signout',
   handleAsyncErrors(async (req: Request, res: ResponseWithRequestState) => {
     const state = res.locals;
     const { returnUrl } = state.pageData;
 
-    try {
-      // get the SC_GU_U cookie here
-      const sc_gu_u: string | undefined = req.cookies.SC_GU_U;
+    //We try the logout operations independently of each other and don't care about the results
+    await Promise.allSettled([
+      signOutFromOkta(req, res),
+      signOutFromIDAPI(req, res),
+    ]);
+    // clear dotcom cookies
+    clearDotComCookies(res);
 
-      // only attempt log out if we have a SC_GU_U cookie
-      if (sc_gu_u) {
-        // perform the logout and get back the GU_SO cookie
-        const cookies = await logout(sc_gu_u, req.ip);
+    // clear gateway specific cookies
+    deleteAuthorizationStateCookie(res);
+    clearEncryptedStateCookie(res);
 
-        // set the GU_SO cookie
-        if (cookies) {
-          setIDAPICookies(res, cookies);
-        }
-
-        trackMetric('SignOut::Success');
-      }
-    } catch (error) {
-      logger.error(`${req.method} ${req.originalUrl}  Error`, error);
-      trackMetric('SignOut::Failure');
-    } finally {
-      // we want to clear the IDAPI cookies anyway even if there was an
-      // idapi error so that we don't prevent users from logging out on their
-      // browser at least
-
-      // clear the IDAPI cookies
-      clearIDAPICookies(res);
-
-      // clear dotcom cookies
-      clearDotComCookies(res);
-
-      // clear gateway specific cookies
-      deleteAuthorizationStateCookie(res);
-      clearEncryptedStateCookie(res);
-
-      return res.redirect(303, returnUrl || defaultReturnUri);
-    }
+    return res.redirect(303, returnUrl || defaultReturnUri);
   }),
 );
+
+const signOutFromIDAPI = async (
+  req: Request,
+  res: ResponseWithRequestState,
+): Promise<void> => {
+  try {
+    // get the SC_GU_U cookie here
+    const sc_gu_u: string | undefined = req.cookies.SC_GU_U;
+
+    // attempt log out from Identity if we have a SC_GU_U cookie
+    if (sc_gu_u) {
+      // perform the logout and get back the GU_SO cookie
+      const cookies = await logoutFromIDAPI(sc_gu_u, req.ip);
+
+      // set the GU_SO cookie
+      if (cookies) {
+        setIDAPICookies(res, cookies);
+      }
+    }
+
+    trackMetric('SignOut::Success');
+  } catch (error) {
+    logger.error(`${req.method} ${req.originalUrl}  Error`, error);
+    trackMetric('SignOut::Failure');
+  } finally {
+    // we want to clear the IDAPI cookies anyway even if there was an
+    // idapi error so that we don't prevent users from logging out on their
+    // browser at least
+
+    // clear the IDAPI cookies
+    clearIDAPICookies(res);
+  }
+};
+
+const signOutFromOkta = async (
+  req: Request,
+  res: ResponseWithRequestState,
+): Promise<void> => {
+  try {
+    // attempt to log out from Okta if we have Okta session cookie
+    const oktaSessionCookieId: string | undefined = req.cookies.sid;
+
+    if (oktaSessionCookieId) {
+      const { userId } = await getSession(oktaSessionCookieId);
+      await clearUserSessions(userId);
+    }
+  } catch (error) {
+    logger.error(`${req.method} ${req.originalUrl}  Error`, error);
+    trackMetric('OktaSignOut::Failure');
+  } finally {
+    //clear okta cookie
+    clearOktaCookies(res);
+  }
+};
 
 export default router.router;

--- a/src/shared/model/Routes.ts
+++ b/src/shared/model/Routes.ts
@@ -77,7 +77,8 @@ export type OktaApiRoutePaths =
   | '/api/v1/users'
   | '/api/v1/users/:id'
   | '/api/v1/users/:id/lifecycle/activate'
-  | '/api/v1/users/:id/lifecycle/reactivate';
+  | '/api/v1/users/:id/lifecycle/reactivate'
+  | '/api/v1/users/:id/sessions';
 
 export type PasswordRoutePath = Extract<
   '/reset-password' | '/set-password' | '/welcome',

--- a/src/shared/model/Routes.ts
+++ b/src/shared/model/Routes.ts
@@ -74,7 +74,7 @@ export type OktaApiRoutePaths =
   | '/api/v1/authn/credentials/reset_password'
   | '/api/v1/authn/recovery/password'
   | '/api/v1/authn/recovery/token'
-  | '/api/v1/sessions/:id'
+  | '/api/v1/sessions/:sessionId'
   | '/api/v1/users'
   | '/api/v1/users/:id'
   | '/api/v1/users/:id/lifecycle/activate'

--- a/src/shared/model/Routes.ts
+++ b/src/shared/model/Routes.ts
@@ -74,6 +74,7 @@ export type OktaApiRoutePaths =
   | '/api/v1/authn/credentials/reset_password'
   | '/api/v1/authn/recovery/password'
   | '/api/v1/authn/recovery/token'
+  | '/api/v1/sessions/:id'
   | '/api/v1/users'
   | '/api/v1/users/:id'
   | '/api/v1/users/:id/lifecycle/activate'


### PR DESCRIPTION
## What does this change?
Adds Okta sign out functionality. When a user visits the `/signout` url, they will now also have:

1.  Their Okta sessions invalidated
2.  Their Okta `sid` cookie removed

This is in addition to current functionality from https://github.com/guardian/gateway/pull/1476

This PR 

- checks the users current session (via the `sid` cookie) against the okta sessions API (https://developer.okta.com/docs/reference/api/sessions/#get-session)
- removes the users current Okta session via the users API (https://developer.okta.com/docs/reference/api/users/#clear-user-sessions)
- refactors some wrapper functions to okta api calls to take simpler types.

## How to test

This has been tested manually in code.
And mocked tests have been added

Automated end to end tests are awaiting changes to CI so will follow in another PR
