### PR TITLE
Show loading spinner when the form is disabled upon submit

### DIFF
--- a/src/client/components/MainForm.tsx
+++ b/src/client/components/MainForm.tsx
@@ -231,6 +231,7 @@ export const MainForm = ({
         isLoading={isFormDisabled}
         disabled={isFormDisabled}
         aria-disabled={isFormDisabled}
+        iconSide="right"
       >
         {submitButtonText}
       </Button>

--- a/src/client/components/MainForm.tsx
+++ b/src/client/components/MainForm.tsx
@@ -228,6 +228,7 @@ export const MainForm = ({
         type="submit"
         priority={submitButtonPriority}
         data-cy="main-form-submit-button"
+        isLoading={isFormDisabled}
         disabled={isFormDisabled}
         aria-disabled={isFormDisabled}
       >


### PR DESCRIPTION
## What does this change?
Adds a loading spinner to the `MainForm` component that we disable upon submit (introduced in #1506)

The loading spinner was added to the Button component in: https://github.com/guardian/source/pull/1275. The `iconSide` prop was also updated so the spinner displays on the right hand side.

This functionality is only used on the Reset Password form so far. We expect the spinner not to display in IE11 but the form to remain disabled as expected.

- [x] Tested in IE11

## Demonstration
_note: the spinner location has since been changed to the right_

https://user-images.githubusercontent.com/1771189/157062967-efd037c2-6ebb-4843-baaf-6b96a9fe6f56.mov

