### PR TITLE
Handle case where email address is quite long on mobile

### DIFF
--- a/src/client/components/ConsentCard.stories.tsx
+++ b/src/client/components/ConsentCard.stories.tsx
@@ -11,9 +11,8 @@ export default {
 } as ComponentMeta<typeof ConsentCard>;
 
 type PartialProps = Partial<React.ComponentProps<typeof ConsentCard>>;
-type ConsentCardStory = Story<PartialProps>;
 
-const Template = (props: PartialProps) => (
+const Template: Story<PartialProps> = (props: PartialProps) => (
   <ConsentCard
     title="Consent Name"
     description="Consent description"
@@ -23,17 +22,17 @@ const Template = (props: PartialProps) => (
   />
 );
 
-export const Default: ConsentCardStory = Template.bind({});
+export const Default = Template.bind({});
 Default.storyName = 'default';
 
-export const Frequency: ConsentCardStory = Template.bind({});
+export const Frequency = Template.bind({});
 Frequency.storyName = 'with email frequency';
 Frequency.args = { frequency: 'Weekly' };
 
-export const HighlightColor: ConsentCardStory = Template.bind({});
+export const HighlightColor = Template.bind({});
 HighlightColor.storyName = 'with highlight color';
 HighlightColor.args = { highlightColor: news[400] };
 
-export const NoImage: ConsentCardStory = Template.bind({});
+export const NoImage = Template.bind({});
 NoImage.storyName = 'when there is no image';
 NoImage.args = { imagePath: undefined };

--- a/src/client/pages/Welcome.stories.tsx
+++ b/src/client/pages/Welcome.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Meta } from '@storybook/react';
+import { ComponentMeta, Story } from '@storybook/react';
 
 import { Welcome } from './Welcome';
 
@@ -7,44 +7,37 @@ export default {
   title: 'Pages/Welcome',
   component: Welcome,
   parameters: { layout: 'fullscreen' },
-} as Meta;
+} as ComponentMeta<typeof Welcome>;
 
-export const Default = () => <Welcome submitUrl="" fieldErrors={[]} />;
-Default.story = {
-  name: 'with defaults',
-};
+type PartialProps = Partial<React.ComponentProps<typeof Welcome>>;
 
-export const Email = () => (
-  <Welcome submitUrl="" email="example@theguardian.com" fieldErrors={[]} />
+const Template: Story<PartialProps> = (props) => (
+  <Welcome submitUrl="" fieldErrors={[]} {...props} />
 );
-Email.story = {
-  name: 'with email',
-};
 
-export const FieldErrorPW = () => (
-  <Welcome
-    submitUrl=""
-    email="example@theguardian.com"
-    fieldErrors={[
-      {
-        field: 'password',
-        message: 'Password must be between 8 and 72 characters.',
-      },
-    ]}
-  />
-);
-FieldErrorPW.story = {
-  name: 'with error on password',
-};
+export const Default = Template.bind({});
+Default.storyName = 'with defaults';
 
-export const PasswordAlreadySet = () => (
-  <Welcome
-    submitUrl=""
-    email="example@theguardian.com"
-    fieldErrors={[]}
-    passwordSet={true}
-  />
-);
-PasswordAlreadySet.story = {
-  name: 'with password already set',
+export const Email = Template.bind({});
+Email.args = { email: 'example@theguardian.com' };
+Email.storyName = 'with email';
+
+export const FieldErrorPW = Template.bind({});
+FieldErrorPW.args = {
+  email: 'example@theguardian.com',
+  fieldErrors: [
+    {
+      field: 'password',
+      message: 'Password must be between 8 and 72 characters.',
+    },
+  ],
 };
+FieldErrorPW.storyName = 'with error on password';
+
+export const PasswordAlreadySet = Template.bind({});
+PasswordAlreadySet.args = {
+  email: 'example@theguardian.com',
+  submitUrl: '',
+  passwordSet: true,
+};
+PasswordAlreadySet.storyName = 'with password already set';

--- a/src/client/pages/Welcome.tsx
+++ b/src/client/pages/Welcome.tsx
@@ -1,18 +1,18 @@
 import React from 'react';
+import { css } from '@emotion/react';
+import { space, until } from '@guardian/source-foundations';
+import {
+  LinkButton,
+  SvgArrowRightStraight,
+} from '@guardian/source-react-components';
+
 import { PasswordForm } from '@/client/components/PasswordForm';
 import { FieldError } from '@/shared/model/ClientState';
 import { ConsentsLayout } from '@/client/layouts/ConsentsLayout';
 import { getAutoRow, passwordFormSpanDef } from '@/client/styles/Grid';
 import { controls, text, greyBorderTop } from '@/client/styles/Consents';
 import { CONSENTS_PAGES } from '@/client/models/ConsentsPages';
-import {
-  LinkButton,
-  SvgArrowRightStraight,
-} from '@guardian/source-react-components';
-
-import { css } from '@emotion/react';
 import { buildUrl } from '@/shared/lib/routeUtils';
-import { space } from '@guardian/source-foundations';
 
 type Props = {
   submitUrl: string;
@@ -26,12 +26,17 @@ const linkButton = css`
   margin-top: ${space[3]}px;
 `;
 
-const passwordInstructions = css`
-  overflow: hidden;
-`;
-
 const emailSpan = css`
   font-weight: bold;
+
+  /* Avoid long emails causing the page to be scrollable horizontally */
+  ${until.tablet} {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    display: inline-block;
+    vertical-align: bottom;
+    max-width: 100%;
+  }
 `;
 
 export const Welcome = ({
@@ -48,7 +53,7 @@ export const Welcome = ({
       current={CONSENTS_PAGES.PASSWORD}
       showContinueButton={false}
     >
-      <p css={[text, greyBorderTop, passwordInstructions, autoRow()]}>
+      <p css={[text, greyBorderTop, autoRow()]}>
         {passwordSet
           ? 'Password already set for '
           : 'Please create a password for '}

--- a/src/client/pages/Welcome.tsx
+++ b/src/client/pages/Welcome.tsx
@@ -26,6 +26,10 @@ const linkButton = css`
   margin-top: ${space[3]}px;
 `;
 
+const passwordInstructions = css`
+  overflow: hidden;
+`;
+
 const emailSpan = css`
   font-weight: bold;
 `;
@@ -44,11 +48,11 @@ export const Welcome = ({
       current={CONSENTS_PAGES.PASSWORD}
       showContinueButton={false}
     >
-      <p css={[text, greyBorderTop, autoRow()]}>
+      <p css={[text, greyBorderTop, passwordInstructions, autoRow()]}>
         {passwordSet
           ? 'Password already set for '
-          : 'Please create a password for '}{' '}
-        {<span css={emailSpan}>{email}</span> || 'your new account'}
+          : 'Please create a password for '}
+        {email ? <span css={emailSpan}>{email}</span> : 'your new account'}
       </p>
       {passwordSet ? (
         <div css={[controls, autoRow()]}>


### PR DESCRIPTION
## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Stops long emails from causing horizontal scrolling to be possible on mobile.

Not the fanciest of solutions (I've just hidden overflowing content) but this is a bit of an edge case and all alternative solutions I could think of have drawbacks.

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

Go to the Welcome component's stories in Storybook and enter a really long email.

## Images

### Before

![Screenshot 2022-03-08 at 17-22-39 Pages Welcome - with email ⋅ Storybook](https://user-images.githubusercontent.com/3338808/157294140-36fbf457-2a7c-4c15-a6b9-08eecc4320ce.png)

### After

![Screenshot 2022-03-08 at 17-32-47 Pages Welcome - with email ⋅ Storybook](https://user-images.githubusercontent.com/3338808/157294167-a840fefc-b3e1-4a46-bf57-7e5ddde5215c.png)