### PR TITLE
Use Consent.name for Data Page

### DIFF
--- a/cypress/support/idapi/consent.ts
+++ b/cypress/support/idapi/consent.ts
@@ -25,9 +25,9 @@ export const allConsents = [
     id: 'market_research_optout',
     isOptOut: true,
     isChannel: false,
-    name: 'Market Research Optout',
+    name: 'Allow the Guardian to contact me for market research purposes',
     description:
-      'I do NOT wish to be contacted by the Guardian for market research purposes.',
+      'From time to time we may contact you for market research purposes inviting you to complete a survey, or take part in a group discussion. Normally, this invitation would be sent via email, but we may also contact you by phone.',
   },
   {
     id: 'offers',
@@ -41,25 +41,19 @@ export const allConsents = [
     id: 'post_optout',
     isOptOut: true,
     isChannel: false,
-    name: 'Post Optout',
-    description:
-      'I do NOT wish to receive communications from the Guardian by post.',
+    name: 'Allow the Guardian to send communications by post',
   },
   {
     id: 'profiling_optout',
     isOptOut: true,
     isChannel: false,
-    name: 'Profiling Optout',
-    description:
-      'I do NOT want the Guardian to use my personal data for marketing analysis.',
+    name: 'Allow the Guardian to analyse this data to improve marketing content',
   },
   {
     id: 'phone_optout',
     isOptOut: true,
     isChannel: true,
-    name: 'Telephone Optout',
-    description:
-      'I do NOT wish to receive communications from the Guardian by telephone.',
+    name: 'Allow the Guardian to send communications by telephone',
   },
   {
     id: 'supporter',

--- a/src/client/pages/ConsentsData.tsx
+++ b/src/client/pages/ConsentsData.tsx
@@ -128,10 +128,7 @@ export const ConsentsData = ({ id, consented, name }: ConsentsDataProps) => {
           <fieldset css={[switchRow, greyBorderTop, autoSwitchRow()]}>
             <ToggleSwitchInput
               id={id}
-              // TODO replace with Consent.name once IDAPI model is updated
-              label={
-                'Allow the Guardian to analyse this data to improve marketing content'
-              }
+              label={name}
               defaultChecked={consented ?? true} // legitimate interests so defaults to true
               cssOverrides={[labelStyles, toggleSwitchAlignment]}
             />


### PR DESCRIPTION
## What does this change?

We need to hard code the new opt out consent wordings so that we could implement the toggle before updating the Consent model in the API.

Once the [Identity Model update PR](https://github.com/guardian/identity/pull/2079) is released we can use that response instead.
## How to test

- [x] tested in Code

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

- [ ] [Tested with screen reader](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#screen-readers)
- [ ] [Navigable with keyboard](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#keyboard-navigation)
- [ ] [Colour contrast passed](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#colour-contrast)
- [ ] [The change doesn't use only colour to convey meaning](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#use-of-colour)
