### PR TITLE
Actually enable a/b test for removing image

### DIFF
--- a/src/shared/model/experiments/abSwitches.ts
+++ b/src/shared/model/experiments/abSwitches.ts
@@ -1,4 +1,5 @@
 export const abSwitches = {
   abExampleTest: false,
   abOptInPromptPostSignIn: true,
+  abOptInPromptPostSignInImage: true,
 };

--- a/src/shared/model/experiments/abTests.ts
+++ b/src/shared/model/experiments/abTests.ts
@@ -1,6 +1,7 @@
 import { AB, ABTest, Participations } from '@guardian/ab-core';
 import { abSwitches } from './abSwitches';
 import { optInPrompt } from './tests/opt-in-prompt';
+import { optInPromptImage } from './tests/opt-in-prompt-image';
 
 interface ABTestConfiguration {
   abTestSwitches: Record<string, boolean>;
@@ -10,7 +11,7 @@ interface ABTestConfiguration {
 }
 
 // Add AB tests to run in this array
-export const tests: ABTest[] = [optInPrompt];
+export const tests: ABTest[] = [optInPrompt, optInPromptImage];
 
 const getDefaultABTestConfiguration = (): ABTestConfiguration => ({
   abTestSwitches: abSwitches,


### PR DESCRIPTION
## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

I made a mistake in #1569 when re-adding the a/b test for one thing, I accidentally disabled the a/b test for another thing.

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

As before, set GU_mvt_id to 0 to see the image, and to 1 to remove it.