### PR TITLE
Improve consistency of password form feedback section styles

### DIFF
--- a/src/client/components/PasswordForm.tsx
+++ b/src/client/components/PasswordForm.tsx
@@ -1,7 +1,7 @@
 import React, { ReactNode, useEffect, useState } from 'react';
 import {
   Button,
-  SvgCross,
+  SvgInfo,
   SvgAlertTriangle,
   SvgCheckmark,
 } from '@guardian/source-react-components';
@@ -46,31 +46,48 @@ type Props = {
   formTrackingName?: string;
 };
 
-const baseIconStyles = css`
-  display: inline-block;
+const feedbackMessageStyles = css`
+  display: flex;
+  align-items: flex-start;
+  min-height: ${space[6]}px;
+  div:first-of-type {
+    width: ${space[6]}px;
+  }
+`;
+
+const feedbackMessageIconStyles = css`
+  display: flex;
   position: relative;
   top: 3px;
   svg {
+    color: ${neutral[46]};
+  }
+`;
+
+const smallIconStyles = css`
+  svg {
     height: 18px;
     width: 18px;
+    position: relative;
   }
 `;
 
 const baseMessageStyles = css`
   ${textSans.small()};
-  margin-left: 3px;
-  display: inline-block;
   color: ${neutral[46]};
 `;
 
-const failureIconStyles = css`
+const errorIconStyles = css`
+  position: static;
   svg {
-    background: ${neutral[46]};
-    fill: ${neutral[100]};
-    height: 17px;
-    width: 17px;
-    border-radius: 50%;
+    fill: ${error['400']};
+    height: 24px;
+    width: 24px;
   }
+`;
+
+const redText = css`
+  color: ${error[400]};
 `;
 
 const form = css`
@@ -83,20 +100,33 @@ const passwordInput = css`
 
 const TooLong = () => {
   return (
-    <div>
-      <div css={[baseIconStyles, failureIconStyles]}>
-        <SvgCross />
+    <div css={feedbackMessageStyles}>
+      <div css={[feedbackMessageIconStyles, errorIconStyles]}>
+        <SvgAlertTriangle />
       </div>
-      <div css={baseMessageStyles}>{ShortPasswordFieldErrors.MAXIMUM_72}</div>
+      <div css={[baseMessageStyles, redText]}>
+        {ShortPasswordFieldErrors.MAXIMUM_72}
+      </div>
     </div>
   );
 };
 
 const TooShort = () => {
+  const infoIconStyles = css`
+    svg {
+      fill: ${neutral[46]};
+      border-radius: 50%;
+      // Bit of a hack - the SVG for the tick icon is positioned more fully
+      // inside its viewBox than the SVG for the info icon, so this forces the
+      // info icon to take up the same amount of pixel space.
+      transform: scale(1.355);
+    }
+  `;
+
   return (
-    <div>
-      <div css={[baseIconStyles, failureIconStyles]}>
-        <SvgCross />
+    <div css={feedbackMessageStyles}>
+      <div css={[feedbackMessageIconStyles, smallIconStyles, infoIconStyles]}>
+        <SvgInfo />
       </div>
       <div css={baseMessageStyles}>{ShortPasswordFieldErrors.AT_LEAST_8}</div>
     </div>
@@ -108,15 +138,15 @@ const Valid = () => {
     svg {
       background: ${success[400]};
       fill: ${neutral[100]};
-      height: 17px;
-      width: 17px;
       border-radius: 50%;
     }
   `;
 
   return (
-    <div>
-      <div css={[baseIconStyles, successIconStyles]}>
+    <div css={feedbackMessageStyles}>
+      <div
+        css={[feedbackMessageIconStyles, smallIconStyles, successIconStyles]}
+      >
         <SvgCheckmark />
       </div>
       <div
@@ -136,36 +166,22 @@ const Valid = () => {
 
 const Checking = () => {
   return (
-    <div>
+    <div css={feedbackMessageStyles}>
       <div css={baseMessageStyles}>Checking...</div>
     </div>
   );
 };
 
 const Weak = () => {
-  const errorIconStyles = css`
-    svg {
-      fill: ${error['400']};
-      height: 24px;
-      width: 24px;
-      margin-bottom: -4px;
-      margin-top: -4px;
-      margin-left: -4px;
-    }
-  `;
-
-  const redText = css`
-    color: ${error[400]};
-    font-weight: bold;
-  `;
-
   return (
-    <div css={baseMessageStyles}>
-      <div css={[baseIconStyles, errorIconStyles]}>
+    <div css={feedbackMessageStyles}>
+      <div css={[feedbackMessageIconStyles, errorIconStyles]}>
         <SvgAlertTriangle />
       </div>
-      <span css={redText}>Weak password:</span>{' '}
-      {ShortPasswordFieldErrors.COMMON_PASSWORD}
+      <div css={[baseMessageStyles, redText]}>
+        <strong>Weak password:</strong>{' '}
+        {ShortPasswordFieldErrors.COMMON_PASSWORD}
+      </div>
     </div>
   );
 };

--- a/src/client/components/PasswordForm.tsx
+++ b/src/client/components/PasswordForm.tsx
@@ -116,9 +116,9 @@ const TooShort = () => {
     svg {
       fill: ${neutral[46]};
       border-radius: 50%;
-      // Bit of a hack - the SVG for the tick icon is positioned more fully
-      // inside its viewBox than the SVG for the info icon, so this forces the
-      // info icon to take up the same amount of pixel space.
+      /* Bit of a hack - the SVG for the tick icon is positioned more fully
+       inside its viewBox than the SVG for the info icon, so this forces the
+       info icon to take up the same amount of pixel space. */
       transform: scale(1.355);
     }
   `;

--- a/src/shared/model/Errors.ts
+++ b/src/shared/model/Errors.ts
@@ -51,8 +51,8 @@ export enum PasswordFieldErrors {
 
 // shown below the password input field as the user types a password (before they click the submit button)
 export enum ShortPasswordFieldErrors {
-  AT_LEAST_8 = 'At least 8 characters',
-  MAXIMUM_72 = 'Maximum of 72 characters',
+  AT_LEAST_8 = 'At least 8 characters.',
+  MAXIMUM_72 = 'Maximum of 72 characters.',
   COMMON_PASSWORD = 'Please use a password that is hard to guess.',
 }
 


### PR DESCRIPTION
## What does this change?

The icons in the feedback section below the password form are now consistent following a go-through with @dom-whooley.

Figma: https://www.figma.com/file/ZDPonnBXbMhV2smf51Dylc/Sign-in-Journeys?node-id=4170%3A122898

Screenshots from Storybook:

<img width="657" alt="Screenshot 2022-03-16 at 16 50 17" src="https://user-images.githubusercontent.com/101555242/158646104-632dab07-6038-4693-a5a0-b0751e62302a.png">
<img width="654" alt="Screenshot 2022-03-16 at 16 50 26" src="https://user-images.githubusercontent.com/101555242/158646107-088ae60e-124c-435d-ba20-ffbc16fbff78.png">
<img width="664" alt="Screenshot 2022-03-16 at 16 50 34" src="https://user-images.githubusercontent.com/101555242/158646111-1c20a78c-5602-479b-ba62-2f5cf12ddd38.png">
<img width="667" alt="Screenshot 2022-03-16 at 16 50 51" src="https://user-images.githubusercontent.com/101555242/158646116-6f2fc90e-2958-4450-91a4-fc96df93559e.png">

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

- [X] [Tested with screen reader](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#screen-readers)
- [x] [Navigable with keyboard](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#keyboard-navigation)
- [x] [Colour contrast passed](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#colour-contrast)
- [X] [The change doesn't use only colour to convey meaning](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#use-of-colour)
