### PR TITLE
Clean up opt in prompt a/b test

### DIFF
--- a/cypress/integration/ete-okta/sign_in/sign_in.spec.ts
+++ b/cypress/integration/ete-okta/sign_in/sign_in.spec.ts
@@ -1,6 +1,10 @@
 import * as SignIn from '../../ete/sign_in/sign_in.shared';
 
 describe('Sign in flow, Okta enabled', () => {
+  beforeEach(() => {
+    SignIn.beforeEach();
+  });
+
   context('Terms and Conditions links', () => {
     it(...SignIn.linksToTheGoogleTermsOfServicePage(true));
     it(...SignIn.linksToTheGooglePrivacyPolicyPage(true));

--- a/cypress/integration/ete/sign_in/sign_in.shared.ts
+++ b/cypress/integration/ete/sign_in/sign_in.shared.ts
@@ -1,7 +1,17 @@
+import { stringify } from 'query-string';
+
 const oauthBaseUrl = 'https://oauth.code.dev-theguardian.com';
 const returnUrl =
   'https://www.theguardian.com/world/2013/jun/09/edward-snowden-nsa-whistleblower-surveillance';
 const defaultReturnUrl = 'https://m.code.dev-theguardian.com';
+
+export const beforeEach = () => {
+  // Disable redirect to /signin/success by default
+  cy.setCookie(
+    'GU_ran_experiments',
+    stringify({ OptInPromptPostSignIn: Date.now() }),
+  );
+};
 
 export const linksToTheGoogleTermsOfServicePage = (isOkta = false) => {
   return [

--- a/cypress/integration/ete/sign_in/sign_in.spec.ts
+++ b/cypress/integration/ete/sign_in/sign_in.spec.ts
@@ -1,6 +1,10 @@
 import * as SignIn from './sign_in.shared';
 
 describe('Sign in flow, Okta disabled', () => {
+  beforeEach(() => {
+    SignIn.beforeEach();
+  });
+
   context('Terms and Conditions links', () => {
     it(...SignIn.linksToTheGoogleTermsOfServicePage());
     it(...SignIn.linksToTheGooglePrivacyPolicyPage());

--- a/cypress/integration/mocked/post_sign_in_prompt.ts
+++ b/cypress/integration/mocked/post_sign_in_prompt.ts
@@ -7,6 +7,7 @@ import {
   verifiedUserWithNoConsent,
   createUser,
   USER_ENDPOINT,
+  USER_CONSENTS_ENDPOINT,
 } from '../../support/idapi/user';
 import { setAuthCookies } from '../../support/idapi/cookie';
 import { injectAndCheckAxe } from '../../support/cypress-axe';
@@ -33,26 +34,26 @@ describe('Post sign-in prompt', () => {
     });
   });
 
-  it('Has no detectable a11y violations on prompt page', () => {
+  it('has no detectable a11y violations on prompt page', () => {
     cy.visit('/signin/success');
     injectAndCheckAxe();
   });
 
-  it('Allows user to opt in and continue', () => {
+  it('allows user to opt in and continue', () => {
     cy.visit('/signin/success');
     const checkbox = cy.findByLabelText('Yes, sign me up');
     checkbox.should('not.be.checked');
     checkbox.click();
 
     // mock form save success
-    cy.mockNext(200);
+    cy.mockAll(200, {}, USER_CONSENTS_ENDPOINT);
 
     cy.findByText('Continue to the Guardian').click();
     cy.lastPayloadIs([{ id: 'supporter', consented: true }]);
     cy.url().should('include', defaultReturnUrl);
   });
 
-  it('Allows user to opt out and continue', () => {
+  it('allows user to opt out and continue', () => {
     const supporterConsent = allConsents.find(({ id }) => id === 'supporter');
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const consentData = [{ ...supporterConsent!, consented: true }];
@@ -63,21 +64,56 @@ describe('Post sign-in prompt', () => {
     checkbox.click();
 
     // mock form save success
-    cy.mockNext(200);
+    cy.mockAll(200, {}, USER_CONSENTS_ENDPOINT);
 
     cy.findByText('Continue to the Guardian').click();
     cy.lastPayloadIs([{ id: 'supporter', consented: false }]);
     cy.url().should('include', defaultReturnUrl);
   });
 
-  it('Allows user to continue to different returnUrl', () => {
+  it('allows user to continue to different returnUrl', () => {
     cy.visit(`/signin/success?returnUrl=${encodeURIComponent(returnUrl)}`);
 
     // mock form save success
-    cy.mockNext(200);
+    cy.mockAll(200, {}, USER_CONSENTS_ENDPOINT);
 
     cy.findByText('Continue to the Guardian').click();
     cy.lastPayloadIs([{ id: 'supporter', consented: false }]);
     cy.url().should('include', returnUrl);
+  });
+
+  it('fails silently if submit fails', () => {
+    cy.mockAll(500, {}, USER_CONSENTS_ENDPOINT);
+    cy.visit('/signin/success');
+    cy.findByLabelText('Yes, sign me up').click();
+
+    cy.findByText('Continue to the Guardian').click();
+    cy.lastPayloadIs([{ id: 'supporter', consented: true }]);
+    cy.url().should('include', defaultReturnUrl);
+  });
+
+  it('redirects to returnUrl if fetching consents fails', () => {
+    cy.mockAll(500, {}, CONSENTS_ENDPOINT);
+    /**
+     * Using cy.request instead of cy.visit as we only need to test the redirect
+     * and cy.intercept does not seem to work here
+     */
+    cy.request({
+      url: '/signin/success',
+      followRedirect: false,
+    }).then((response) =>
+      expect(response.redirectedToUrl).to.contain(defaultReturnUrl),
+    );
+  });
+
+  it('redirects to returnUrl if fetching user consents fails', () => {
+    cy.mockAll(500, undefined, USER_ENDPOINT);
+    // Using cy.request instead of cy.visit, see above for reasoning.
+    cy.request({
+      url: '/signin/success',
+      followRedirect: false,
+    }).then((response) =>
+      expect(response.redirectedToUrl).to.contain(defaultReturnUrl),
+    );
   });
 });

--- a/cypress/integration/mocked/post_sign_in_prompt.ts
+++ b/cypress/integration/mocked/post_sign_in_prompt.ts
@@ -82,14 +82,26 @@ describe('Post sign-in prompt', () => {
     cy.url().should('include', returnUrl);
   });
 
-  it('fails silently if submit fails', () => {
+  it('fails silently if submit fails, but user did not consent', () => {
+    cy.mockAll(500, {}, USER_CONSENTS_ENDPOINT);
+    cy.visit('/signin/success');
+
+    cy.findByText('Continue to the Guardian').click();
+    cy.lastPayloadIs([{ id: 'supporter', consented: false }]);
+    cy.url().should('include', defaultReturnUrl);
+  });
+
+  it('shows error if submit fails and user did consent', () => {
     cy.mockAll(500, {}, USER_CONSENTS_ENDPOINT);
     cy.visit('/signin/success');
     cy.findByLabelText('Yes, sign me up').click();
 
     cy.findByText('Continue to the Guardian').click();
     cy.lastPayloadIs([{ id: 'supporter', consented: true }]);
-    cy.url().should('include', defaultReturnUrl);
+    cy.url().should('include', '/signin/success');
+    cy.findByText(
+      'There was a problem saving your choice, please try again.',
+    ).should('exist');
   });
 
   it('redirects to returnUrl if fetching consents fails', () => {

--- a/cypress/integration/mocked/register.spec.ts
+++ b/cypress/integration/mocked/register.spec.ts
@@ -4,7 +4,6 @@ import { invalidEmailAddress } from '../../support/idapi/guest';
 describe('Registration flow', () => {
   beforeEach(() => {
     cy.mockPurge();
-    cy.fixture('users').as('users');
   });
 
   context('A11y checks', () => {

--- a/cypress/integration/mocked/sign_in.spec.ts
+++ b/cypress/integration/mocked/sign_in.spec.ts
@@ -343,12 +343,6 @@ describe('Sign in flow', () => {
       );
     });
 
-    it('unless no mvt id', () => {
-      cy.clearCookie('GU_mvt_id');
-      signIn();
-      cy.url().should('include', defaultReturnUrl);
-    });
-
     it('unless returnUrl is not default', () => {
       signIn(returnUrl);
       cy.url().should('include', returnUrl);
@@ -377,6 +371,18 @@ describe('Sign in flow', () => {
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       const consentData = [{ ...supporterConsent!, consented: true }];
       cy.mockAll(200, createUser(consentData), USER_ENDPOINT);
+      signIn();
+      cy.url().should('include', defaultReturnUrl);
+    });
+
+    it('unless fetching consents fails', () => {
+      cy.mockAll(500, undefined, CONSENTS_ENDPOINT);
+      signIn();
+      cy.url().should('include', defaultReturnUrl);
+    });
+
+    it('unless fetching user consents fails', () => {
+      cy.mockAll(500, undefined, USER_ENDPOINT);
       signIn();
       cy.url().should('include', defaultReturnUrl);
     });

--- a/cypress/integration/mocked/sign_in.spec.ts
+++ b/cypress/integration/mocked/sign_in.spec.ts
@@ -11,7 +11,6 @@ import {
 describe('Sign in flow', () => {
   beforeEach(() => {
     cy.mockPurge();
-    cy.fixture('users').as('users');
   });
 
   context('A11y checks', () => {
@@ -308,7 +307,6 @@ describe('Sign in flow', () => {
     beforeEach(() => {
       cy.mockAll(200, allConsents, CONSENTS_ENDPOINT);
       cy.mockAll(200, verifiedUserWithNoConsent, USER_ENDPOINT);
-      cy.setCookie('GU_mvt_id', '1');
       // Intercept the pages that we would redirect to.
       // We just want to check that the redirect happens, not that the page loads.
       cy.intercept('GET', '/signin/success*', (req) => {

--- a/cypress/support/idapi/user.ts
+++ b/cypress/support/idapi/user.ts
@@ -2,6 +2,8 @@ import { defaultUserConsent } from './consent';
 
 export const USER_ENDPOINT = '/user/me';
 
+export const USER_CONSENTS_ENDPOINT = '/users/me/consents';
+
 export const USER_ERRORS = {
   GENERIC: 'There was a problem retrieving your details, please try again.',
 };

--- a/src/client/components/GlobalError.stories.tsx
+++ b/src/client/components/GlobalError.stories.tsx
@@ -11,7 +11,7 @@ export default {
 export const Default = () => (
   <GlobalError
     link={{
-      link: '',
+      link: 'https://example.com',
       linkText: 'click here',
     }}
     error="An error message. For more information"
@@ -22,7 +22,7 @@ Default.storyName = 'default';
 export const Left = () => (
   <GlobalError
     link={{
-      link: '',
+      link: 'https://example.com',
       linkText: 'click here',
     }}
     error="An error message. For more information"

--- a/src/client/components/GlobalError.tsx
+++ b/src/client/components/GlobalError.tsx
@@ -75,7 +75,7 @@ export const GlobalError = ({ error, link, left }: GlobalErrorProps) => {
           <div>
             {error}
             &nbsp;
-            <ExternalLink href={link.link} css={errorLink} subdued={true}>
+            <ExternalLink href={link.link} css={errorLink} target="_blank">
               {link.linkText}
             </ExternalLink>
           </div>

--- a/src/server/lib/postSignInController.ts
+++ b/src/server/lib/postSignInController.ts
@@ -1,12 +1,14 @@
 import { Request } from 'express';
 import { ResponseWithRequestState } from '@/server/models/Express';
 import { getConfiguration } from '@/server/lib/getConfiguration';
-import { TEST_ID as OPT_IN_PROMPT_TEST_ID } from '@/shared/model/experiments/tests/opt-in-prompt';
 import { addReturnUrlToPath } from '@/server/lib/queryParams';
 import { CONSENTS_POST_SIGN_IN_PAGE, Consents } from '@/shared/model/Consent';
 import { getUserConsentsForPage } from '@/server/lib/idapi/consents';
 import { hasExperimentRun, setExperimentRan } from '@/server/lib/experiments';
 import { IdapiCookies } from '@/shared/model/IDAPIAuth';
+import { logger } from '@/server/lib/serverSideLogger';
+
+const OPT_IN_PROMPT_TEST_ID = 'OptInPromptPostSignIn';
 
 const { defaultReturnUri } = getConfiguration();
 
@@ -16,14 +18,9 @@ const postSignInController = async (
   idapiCookies: IdapiCookies,
   returnUrl?: string,
 ) => {
-  const state = res.locals;
   const redirectUrl = returnUrl || defaultReturnUri;
 
   const optInPromptActive = await (async () => {
-    if (!state.abTesting.participations[OPT_IN_PROMPT_TEST_ID]) {
-      return false;
-    }
-
     // Treating paths that only differ due to trailing slash as equivalent
     const noTrailingSlash = (str: string) => str.replace(/\/$/, '');
     if (noTrailingSlash(redirectUrl) !== noTrailingSlash(defaultReturnUri)) {
@@ -44,13 +41,18 @@ const postSignInController = async (
       return false;
     }
 
-    const consents = await getUserConsentsForPage(
-      CONSENTS_POST_SIGN_IN_PAGE,
-      req.ip,
-      sc_gu_u,
-    );
+    try {
+      const consents = await getUserConsentsForPage(
+        CONSENTS_POST_SIGN_IN_PAGE,
+        req.ip,
+        sc_gu_u,
+      );
 
-    return !consents.find(({ id }) => id === Consents.SUPPORTER)?.consented;
+      return !consents.find(({ id }) => id === Consents.SUPPORTER)?.consented;
+    } catch (error) {
+      logger.error(`${req.method} ${req.originalUrl}  Error`, error);
+      return false;
+    }
   })();
 
   if (optInPromptActive) {

--- a/src/server/lib/postSignInController.ts
+++ b/src/server/lib/postSignInController.ts
@@ -7,6 +7,7 @@ import { getUserConsentsForPage } from '@/server/lib/idapi/consents';
 import { hasExperimentRun, setExperimentRan } from '@/server/lib/experiments';
 import { IdapiCookies } from '@/shared/model/IDAPIAuth';
 import { logger } from '@/server/lib/serverSideLogger';
+import { trackMetric } from '@/server/lib/trackMetric';
 
 const OPT_IN_PROMPT_TEST_ID = 'OptInPromptPostSignIn';
 
@@ -51,6 +52,7 @@ const postSignInController = async (
       return !consents.find(({ id }) => id === Consents.SUPPORTER)?.consented;
     } catch (error) {
       logger.error(`${req.method} ${req.originalUrl}  Error`, error);
+      trackMetric('PostSignInPromptRedirect::Failure');
       return false;
     }
   })();

--- a/src/server/models/Metrics.ts
+++ b/src/server/models/Metrics.ts
@@ -24,6 +24,8 @@ type ConditionalMetrics =
   | 'OktaUpdatePassword'
   | 'OktaValidatePasswordToken'
   | 'OktaWelcomeResendEmail'
+  | 'PostSignInPrompt'
+  | 'PostSignInPromptRedirect'
   | 'Register'
   | 'SendMagicLink'
   | 'SendValidationEmail'

--- a/src/server/routes/signIn.ts
+++ b/src/server/routes/signIn.ts
@@ -297,6 +297,7 @@ router.post(
       await patchConsents(req.ip, sc_gu_u, consents);
     } catch (error) {
       logger.error(`${req.method} ${req.originalUrl}  Error`, error);
+      trackMetric('PostSignInPrompt::Failure');
 
       /**
        * If user has consented, show them their preference failed to save

--- a/src/server/routes/signIn.ts
+++ b/src/server/routes/signIn.ts
@@ -279,7 +279,11 @@ router.post(
       consented: getConsentValueFromRequestBody(id, req.body),
     }));
 
-    await patchConsents(req.ip, sc_gu_u, consents);
+    try {
+      await patchConsents(req.ip, sc_gu_u, consents);
+    } catch (error) {
+      logger.error(`${req.method} ${req.originalUrl}  Error`, error);
+    }
 
     return res.redirect(303, redirectUrl);
   }),

--- a/src/shared/model/experiments/abSwitches.ts
+++ b/src/shared/model/experiments/abSwitches.ts
@@ -1,5 +1,4 @@
 export const abSwitches = {
   abExampleTest: false,
-  abOptInPromptPostSignIn: true,
   abOptInPromptPostSignInImage: true,
 };

--- a/src/shared/model/experiments/abTests.ts
+++ b/src/shared/model/experiments/abTests.ts
@@ -1,6 +1,5 @@
 import { AB, ABTest, Participations } from '@guardian/ab-core';
 import { abSwitches } from './abSwitches';
-import { optInPrompt } from './tests/opt-in-prompt';
 import { optInPromptImage } from './tests/opt-in-prompt-image';
 
 interface ABTestConfiguration {
@@ -11,7 +10,7 @@ interface ABTestConfiguration {
 }
 
 // Add AB tests to run in this array
-export const tests: ABTest[] = [optInPrompt, optInPromptImage];
+export const tests: ABTest[] = [optInPromptImage];
 
 const getDefaultABTestConfiguration = (): ABTestConfiguration => ({
   abTestSwitches: abSwitches,


### PR DESCRIPTION
## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Adding better error handling (at the suggestion of @ob6160) around the fetching of consents, and seeing if this at least allows e2e tests to pass.

I should probably also change the e2e tests so that they don't rely on a network error being caught to pass. This would likely involve creating specific test cases where the user will be sent to the prompt, and also where they won't. This PR is in draft until that is added.

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

N/A, this should not result in any user facing changes.
