### PR TITLE
Native Apps redirect from Sign In/Registration test

### DIFF
--- a/src/server/lib/__tests__/validateUrl.test.ts
+++ b/src/server/lib/__tests__/validateUrl.test.ts
@@ -38,6 +38,89 @@ describe('validateReturnUrl', () => {
 
     expect(output).toEqual(defaultReturnUri);
   });
+
+  test('it should handle an native app redirect returnUrl - android live', () => {
+    const input = 'com.theguardian:/authentication/callback';
+
+    const output = validateReturnUrl(input);
+
+    expect(output).toEqual(input);
+  });
+
+  test('it should remove an native app redirect returnUrl with query params  - android live', () => {
+    const input = 'com.theguardian:/authentication/callback?foo=bar';
+
+    const output = validateReturnUrl(input);
+
+    const expected = 'com.theguardian:/authentication/callback';
+
+    expect(output).toEqual(expected);
+  });
+
+  test('it should handle an native app redirect returnUrl - android live debug', () => {
+    const input = 'com.theguardian.debug:/authentication/callback';
+
+    const output = validateReturnUrl(input);
+
+    expect(output).toEqual(input);
+  });
+
+  test('it should remove an native app redirect returnUrl with query params  - android live debug', () => {
+    const input = 'com.theguardian.debug:/authentication/callback?foo=bar';
+
+    const output = validateReturnUrl(input);
+
+    const expected = 'com.theguardian.debug:/authentication/callback';
+
+    expect(output).toEqual(expected);
+  });
+
+  test('it should handle an native app redirect returnUrl - iOS live', () => {
+    const input = 'uk.co.guardian.iphone2:/authentication/callback';
+
+    const output = validateReturnUrl(input);
+
+    expect(output).toEqual(input);
+  });
+
+  test('it should remove an native app redirect returnUrl with query params  - iOS live', () => {
+    const input = 'uk.co.guardian.iphone2:/authentication/callback?foo=bar';
+
+    const output = validateReturnUrl(input);
+
+    const expected = 'uk.co.guardian.iphone2:/authentication/callback';
+
+    expect(output).toEqual(expected);
+  });
+
+  test('it should handle an native app redirect returnUrl - ios live debug', () => {
+    const input = 'uk.co.guardian.iphone2.debug:/authentication/callback';
+
+    const output = validateReturnUrl(input);
+
+    expect(output).toEqual(input);
+  });
+
+  test('it should remove an native app redirect returnUrl with query params  - ios live debug', () => {
+    const input =
+      'uk.co.guardian.iphone2.debug:/authentication/callback?foo=bar';
+
+    const output = validateReturnUrl(input);
+
+    const expected = 'uk.co.guardian.iphone2.debug:/authentication/callback';
+
+    expect(output).toEqual(expected);
+  });
+
+  test('it should return default returnUrl if app redirect is malformed', () => {
+    const input1 = 'com.thegrauniad.live-app:/authentication/callback';
+    const output1 = validateReturnUrl(input1);
+    expect(output1).toEqual(defaultReturnUri);
+
+    const input2 = 'com.theguardian:/auth/callback';
+    const output2 = validateReturnUrl(input2);
+    expect(output2).toEqual(defaultReturnUri);
+  });
 });
 
 describe('validateRefUrl', () => {

--- a/src/server/lib/validateUrl.ts
+++ b/src/server/lib/validateUrl.ts
@@ -1,10 +1,27 @@
 import { getConfiguration } from '@/server/lib/getConfiguration';
 
+// valid web hostnames
 const validHostnames = [
   '.theguardian.com',
   '.code.dev-theguardian.com',
   '.thegulocal.com',
 ];
+
+// valid app custom url schemes
+// TODO: update documentation on how to add new app clients
+export const validAppProtocols = [
+  // android live app
+  'com.theguardian:',
+  // android live app debug
+  'com.theguardian.debug:',
+  // iOS live app
+  'uk.co.guardian.iphone2:',
+  // iOS live app debug
+  'uk.co.guardian.iphone2.debug:',
+];
+
+// valid app custom pathnames
+const validAppPathnames = ['/authentication/callback'];
 
 const invalidPaths = ['/signin', '/register'];
 
@@ -15,6 +32,16 @@ export const validateReturnUrl = (returnUrl = ''): string => {
     // we decode the returnUrl as we cant know for sure if it's been encoded or not
     // so decode just to be safe
     const url = new URL(decodeURIComponent(returnUrl));
+
+    // we first want to check for an app redirect using the x-gu: custom protocol
+    // and identity hostname, with the callback path
+    if (
+      validAppProtocols.includes(url.protocol) &&
+      validAppPathnames.includes(url.pathname)
+    ) {
+      // return the uri without query params
+      return `${url.protocol}${url.pathname}`;
+    }
 
     // check the hostname is valid
     if (!validHostnames.some((hostname) => url.hostname.endsWith(hostname))) {

--- a/src/server/routes/oauth.ts
+++ b/src/server/routes/oauth.ts
@@ -19,6 +19,7 @@ import { updateEncryptedStateCookie } from '@/server/lib/encryptedStateCookie';
 import { addQueryParamsToPath } from '@/shared/lib/queryParams';
 import postSignInController from '@/server/lib/postSignInController';
 import { getConfiguration } from '@/server/lib/getConfiguration';
+import { validAppProtocols } from '../lib/validateUrl';
 
 interface OAuthError {
   error: string;
@@ -166,6 +167,16 @@ router.get(
             authState.queryParams,
           )
         : authState.queryParams.returnUrl;
+
+      // TODO: This is a temp hack to handle the apps redirects
+      // back to the deep link from sign in/registration
+      // the hard coded query param is also temp to test if they're
+      // able to read data we send back
+      if (
+        validAppProtocols.some((protocol) => returnUrl.startsWith(protocol))
+      ) {
+        return res.redirect(303, `${returnUrl}?reason=signin`);
+      }
 
       postSignInController(req, res, cookies, returnUrl);
     } catch (error) {


### PR DESCRIPTION
## What does this change?

Testing out setting up a custom redirect scheme for apps. This is a WIP implementation that will need to be cleaned up before Okta is released fully in production.

This is so the apps teams can test their integration against CODE without having to worry about deploying a specific branch to CODE each time.