### PR TITLE
Updating url validator to also expect a hostname for app redirects

### DIFF
--- a/src/server/lib/__tests__/validateUrl.test.ts
+++ b/src/server/lib/__tests__/validateUrl.test.ts
@@ -40,7 +40,8 @@ describe('validateReturnUrl', () => {
   });
 
   test('it should handle an native app redirect returnUrl - android live', () => {
-    const input = 'com.theguardian:/authentication/callback';
+    const input =
+      'com.guardian://profile.theguardian.com/authentication/callback';
 
     const output = validateReturnUrl(input);
 
@@ -48,17 +49,20 @@ describe('validateReturnUrl', () => {
   });
 
   test('it should remove an native app redirect returnUrl with query params  - android live', () => {
-    const input = 'com.theguardian:/authentication/callback?foo=bar';
+    const input =
+      'com.guardian://profile.theguardian.com/authentication/callback?foo=bar';
 
     const output = validateReturnUrl(input);
 
-    const expected = 'com.theguardian:/authentication/callback';
+    const expected =
+      'com.guardian://profile.theguardian.com/authentication/callback';
 
     expect(output).toEqual(expected);
   });
 
   test('it should handle an native app redirect returnUrl - android live debug', () => {
-    const input = 'com.theguardian.debug:/authentication/callback';
+    const input =
+      'com.guardian.debug://profile.theguardian.com/authentication/callback';
 
     const output = validateReturnUrl(input);
 
@@ -66,17 +70,20 @@ describe('validateReturnUrl', () => {
   });
 
   test('it should remove an native app redirect returnUrl with query params  - android live debug', () => {
-    const input = 'com.theguardian.debug:/authentication/callback?foo=bar';
+    const input =
+      'com.guardian.debug://profile.theguardian.com/authentication/callback?foo=bar';
 
     const output = validateReturnUrl(input);
 
-    const expected = 'com.theguardian.debug:/authentication/callback';
+    const expected =
+      'com.guardian.debug://profile.theguardian.com/authentication/callback';
 
     expect(output).toEqual(expected);
   });
 
   test('it should handle an native app redirect returnUrl - iOS live', () => {
-    const input = 'uk.co.guardian.iphone2:/authentication/callback';
+    const input =
+      'uk.co.guardian.iphone2://profile.theguardian.com/authentication/callback';
 
     const output = validateReturnUrl(input);
 
@@ -84,17 +91,20 @@ describe('validateReturnUrl', () => {
   });
 
   test('it should remove an native app redirect returnUrl with query params  - iOS live', () => {
-    const input = 'uk.co.guardian.iphone2:/authentication/callback?foo=bar';
+    const input =
+      'uk.co.guardian.iphone2://profile.theguardian.com/authentication/callback?foo=bar';
 
     const output = validateReturnUrl(input);
 
-    const expected = 'uk.co.guardian.iphone2:/authentication/callback';
+    const expected =
+      'uk.co.guardian.iphone2://profile.theguardian.com/authentication/callback';
 
     expect(output).toEqual(expected);
   });
 
   test('it should handle an native app redirect returnUrl - ios live debug', () => {
-    const input = 'uk.co.guardian.iphone2.debug:/authentication/callback';
+    const input =
+      'uk.co.guardian.iphone2.debug://profile.theguardian.com/authentication/callback';
 
     const output = validateReturnUrl(input);
 
@@ -103,21 +113,23 @@ describe('validateReturnUrl', () => {
 
   test('it should remove an native app redirect returnUrl with query params  - ios live debug', () => {
     const input =
-      'uk.co.guardian.iphone2.debug:/authentication/callback?foo=bar';
+      'uk.co.guardian.iphone2.debug://profile.theguardian.com/authentication/callback?foo=bar';
 
     const output = validateReturnUrl(input);
 
-    const expected = 'uk.co.guardian.iphone2.debug:/authentication/callback';
+    const expected =
+      'uk.co.guardian.iphone2.debug://profile.theguardian.com/authentication/callback';
 
     expect(output).toEqual(expected);
   });
 
   test('it should return default returnUrl if app redirect is malformed', () => {
-    const input1 = 'com.thegrauniad.live-app:/authentication/callback';
+    const input1 =
+      'com.thegrauniad.live-app://profile.theguardian.com/authentication/callback';
     const output1 = validateReturnUrl(input1);
     expect(output1).toEqual(defaultReturnUri);
 
-    const input2 = 'com.theguardian:/auth/callback';
+    const input2 = 'com.guardian://profile.theguardian.com/auth/callback';
     const output2 = validateReturnUrl(input2);
     expect(output2).toEqual(defaultReturnUri);
   });

--- a/src/server/lib/validateUrl.ts
+++ b/src/server/lib/validateUrl.ts
@@ -5,15 +5,16 @@ const validHostnames = [
   '.theguardian.com',
   '.code.dev-theguardian.com',
   '.thegulocal.com',
+  'profile.theguardian.com',
 ];
 
 // valid app custom url schemes
 // TODO: update documentation on how to add new app clients
 export const validAppProtocols = [
   // android live app
-  'com.theguardian:',
+  'com.guardian:',
   // android live app debug
-  'com.theguardian.debug:',
+  'com.guardian.debug:',
   // iOS live app
   'uk.co.guardian.iphone2:',
   // iOS live app debug
@@ -37,10 +38,16 @@ export const validateReturnUrl = (returnUrl = ''): string => {
     // and identity hostname, with the callback path
     if (
       validAppProtocols.includes(url.protocol) &&
-      validAppPathnames.includes(url.pathname)
+      validAppPathnames.includes(url.pathname) &&
+      validHostnames.includes(url.hostname)
     ) {
       // return the uri without query params
-      return `${url.protocol}${url.pathname}`;
+      return `${url.protocol}//${url.hostname}${url.pathname}`;
+    }
+
+    //This guards against invalid protocol, including app ones
+    if (url.protocol !== 'https:') {
+      throw 'Invalid protocol';
     }
 
     // check the hostname is valid


### PR DESCRIPTION
## What does this change?

This PR updates the returnUrl config for apps. 

Currently android require both `scheme` and `host` attributes when you handle a `deeplink` in android 

```
android:path
android:pathPrefix
android:pathPattern

These attributes are meaningful only if the `scheme` and `host` attributes are also specified for the filter.
```
https://developer.android.com/guide/topics/manifest/data-element#path

For this reason we are adding a hostname into the returnUrl for apps, and have chosen `profile.theguardian.com`.
This means the new returnUrl will be:

`com.guardian://profile.theguardian.com/authentication/callback`

The changes made were:

- Changed the android package name to com.guardian
- Added a check for the hostname
- Returned the `profile.theguardian.com` hostname when building the android returnUrl
- Added a guard for invalid protocol as only `https` 





## How to test
Confirmed this works whilst pairing with @mohammad-haque in CODE