### PR TITLE
Override Jest 5s timeout for Supertest suite

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -13,7 +13,6 @@ module.exports = {
     '<rootDir>/node_modules/',
     'utils',
   ],
-  testTimeout: 15000,
   globals: {
     'ts-jest': {
       isolatedModules: true,

--- a/src/server/lib/__tests__/rate-limit/rateLimitMiddleware.test.ts
+++ b/src/server/lib/__tests__/rate-limit/rateLimitMiddleware.test.ts
@@ -30,6 +30,9 @@ const defaultEnv = {
   REDIS_SSL: 'false',
 };
 
+// Override the default 5s max timeout for these tests because Supertest takes some time to run.
+jest.setTimeout(10000);
+
 describe('rate limiter middleware', () => {
   beforeEach(() => {
     jest.clearAllMocks();


### PR DESCRIPTION
## What does this change?
A more sustainable fix for our Supertest suite timing out in Github actions than the temporary fix introduced by #1620 