### PR TITLE
feat: Add no-sequences eslint rule

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -33,7 +33,8 @@
     ],
     "no-var": "error",
     "no-param-reassign": "error",
-    "prefer-const": "error"
+    "prefer-const": "error",
+    "no-sequences": "error"
   },
   "overrides": [
     {


### PR DESCRIPTION
## What does this change?

@coldlink caught a nasty bug here: https://github.com/guardian/gateway/pull/1623 where an errant comma operator changed the execution logic of the code. This PR adds the [`no-sequences` eslint rule](https://eslint.org/docs/rules/no-sequences), which correctly errors on the bug:

```
➜ yarn lint
yarn run v1.22.17
$ eslint . --ext .ts,.tsx

/Users/raphael_kabo/code/gateway/src/server/routes/signOut.ts
  72:39  error  Unexpected use of comma operator  no-sequences

✖ 1 problem (1 error, 0 warnings)

error Command failed with exit code 1.
```

In the unlikely case do want to use the comma operator, `no-sequences` allows us to do so as long as the operands of the operator are inside parentheses.