### PR TITLE
Remove minification on MJML renderer

### DIFF
--- a/src/email/templates/renderedTemplates.ts
+++ b/src/email/templates/renderedTemplates.ts
@@ -13,12 +13,16 @@ import { ResetPasswordText } from './ResetPassword/ResetPasswordText';
 import { Verify } from './Verify/Verify';
 import { VerifyText } from './Verify/VerifyText';
 
-import { render } from 'mjml-react';
+import { render as mjmlRender } from 'mjml-react';
 
 type EmailRenderResult = {
   plain: string;
   html: string;
 };
+
+// The minify option is deprecated in mjml-react's minification library, so we
+// turn off minification here. Cf: https://github.com/wix-incubator/mjml-react/issues/58
+const render = (input: JSX.Element) => mjmlRender(input, { minify: false });
 
 export const renderedAccidentalEmail = {
   plain: AccidentalEmailText(),


### PR DESCRIPTION
## What does this change?

The standard `mjml-react` `render()` function gives us the following error when run:

```
"minify" option is deprecated in mjml-core and only available in mjml cli.
```

As per [this issue](https://github.com/wix-incubator/mjml-react/issues/58), the simple fix is to disable minification, which is what is done in this PR. There appears to be a PR in the works, but it's been blocked due to some disagreement between the PR author and the package maintainers. In the meantime, if need be, we can minify the HTML output ourselves with our minifier of choice. 