### PR TITLE
Add white borders to email buttons to improve keyboard navigation a11y

### DIFF
--- a/src/email/components/Button.tsx
+++ b/src/email/components/Button.tsx
@@ -22,6 +22,7 @@ export const Button = ({ children, href }: Props) => (
         fontFamily="Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif"
         fontWeight={700}
         fontSize="17px"
+        cssClass="guardian-email-button"
       >
         {children}
       </MjmlButton>

--- a/src/email/components/Page.tsx
+++ b/src/email/components/Page.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Mjml, MjmlHead, MjmlBody, MjmlTitle } from 'mjml-react';
+import { Mjml, MjmlHead, MjmlBody, MjmlTitle, MjmlStyle } from 'mjml-react';
 
 type Props = { children: React.ReactNode; title: string };
 
@@ -8,6 +8,13 @@ export const Page = ({ children, title }: Props) => (
   <Mjml>
     <MjmlHead>
       <MjmlTitle>{`${title} | The Guardian`}</MjmlTitle>
+      <MjmlStyle inline={true}>
+        {/* Adding a 2px white border around the anchor tag creates visual distinction between the 
+        button and the outline added to it in web email clients on keyboard focus. As an 'inline'
+        MJML style, these styles will only be applied if a '.guardian-email-button' element is present
+        on the page. */}
+        {`.guardian-email-button a { border: 2px solid #ffffff; border-radius: 21px !important; }`}
+      </MjmlStyle>
     </MjmlHead>
     <MjmlBody width={600}>{children}</MjmlBody>
   </Mjml>


### PR DESCRIPTION
## What does this change?

Adds a 2px white border to email buttons, which creates visual space between the edge of the button and the outline glow added by browser in web email clients, making the outline more visible.

## Have we considered potential risks?

As `border` declarations on anchor tags [do not work in the Outlook non-web client](https://github.com/mjmlio/mjml/issues/2452), it would be good to know how the emails look in Outlook after these CSS changes. I would be surprised if Outlook even has the same sort of outline glow.

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

- [x] [Tested with screen reader](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#screen-readers)
- [x] [Navigable with keyboard](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#keyboard-navigation)
- [x] [Colour contrast passed](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#colour-contrast)
- [x] [The change doesn't use only colour to convey meaning](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#use-of-colour)
