### PR TITLE
Add `componentEventParam` tracking through query params

### DIFF
--- a/src/server/lib/__tests__/queryParams.test.ts
+++ b/src/server/lib/__tests__/queryParams.test.ts
@@ -37,6 +37,19 @@ describe('parseExpressQueryParams', () => {
     });
   });
 
+  describe('componentEventParams', () => {
+    test('it returns query params when componentEventParams is passed in', () => {
+      const input = {
+        componentEventParams:
+          'componentType%3Dsigningate%26componentId%3Dmain_variant_4%26abTestName%3DSignInGateMain%26abTestVariant%3Dmain-variant-4%26browserId%3DidFromPV_EPayYBwrFU6V13wZIDiMLw%26visitId%3DAYAIQL2G%26viewId%3Dl1q5pdg4slc3vzz68dzs',
+      };
+
+      const output = parseExpressQueryParams('GET', input);
+
+      expect(output).toEqual({ ...input, returnUrl: defaultReturnUri });
+    });
+  });
+
   describe('clientId', () => {
     test('it returns clientId in query params if valid', () => {
       const input = {

--- a/src/server/lib/idapi/auth.ts
+++ b/src/server/lib/idapi/auth.ts
@@ -14,6 +14,7 @@ import {
   IDAPIAuthStatus,
   IdapiCookies,
 } from '@/shared/model/IDAPIAuth';
+import { IdApiQueryParams } from '@/shared/model/IdapiQueryParams';
 
 interface APIResponse {
   emailValidated: true;
@@ -84,6 +85,7 @@ export const authenticate = async (
   email: string,
   password: string,
   ip: string,
+  trackingData: IdApiQueryParams = {},
 ) => {
   const options = APIPostOptions({
     email,
@@ -91,10 +93,11 @@ export const authenticate = async (
   });
 
   try {
+    const { ref, refViewId, componentEventParams } = trackingData;
     const response = await idapiFetch({
       path: '/auth',
       options: APIAddClientAccessToken(options, ip),
-      queryParams: { format: 'cookies' },
+      queryParams: { format: 'cookies', ref, refViewId, componentEventParams },
     });
     return response.cookies as IdapiCookies;
   } catch (error) {

--- a/src/server/lib/idapi/guest.ts
+++ b/src/server/lib/idapi/guest.ts
@@ -15,6 +15,7 @@ import {
   OphanConfig,
   sendOphanInteractionEventServer,
 } from '@/server/lib/ophan';
+import { IdApiQueryParams } from '@/shared/model/IdapiQueryParams';
 
 const { defaultReturnUri } = getConfiguration();
 
@@ -40,10 +41,7 @@ const handleError = ({ error, status = 500 }: IDAPIError) => {
 export const guest = async (
   email: string,
   ip: string,
-  returnUrl?: string,
-  refViewId?: string,
-  ref?: string,
-  clientId?: string,
+  trackingParams: IdApiQueryParams,
   ophanTrackingConfig?: OphanConfig,
 ): Promise<EmailType> => {
   const options = APIPostOptions({
@@ -51,6 +49,8 @@ export const guest = async (
   });
 
   try {
+    const { returnUrl, ref, refViewId, clientId } = trackingParams;
+
     await idapiFetch({
       path: '/guest',
       options: APIAddClientAccessToken(options, ip),

--- a/src/server/lib/idapi/user.ts
+++ b/src/server/lib/idapi/user.ts
@@ -21,6 +21,7 @@ import {
   OphanConfig,
   sendOphanInteractionEventServer,
 } from '@/server/lib/ophan';
+import { IdApiQueryParams } from '@/shared/model/IdapiQueryParams';
 
 interface APIResponse {
   user: User;
@@ -164,20 +165,25 @@ export const readUserType = async (
 export const sendAccountVerificationEmail = async (
   email: string,
   ip: string,
-  returnUrl: string,
-  ref?: string,
-  refViewId?: string,
-  clientId?: string,
+  trackingParams: IdApiQueryParams,
   ophanTrackingConfig?: OphanConfig,
 ) => {
   const options = APIPostOptions({
     'email-address': email,
   });
   try {
+    const { returnUrl, ref, refViewId, clientId, componentEventParams } =
+      trackingParams;
     await idapiFetch({
       path: '/user/send-account-verification-email',
       options: APIAddClientAccessToken(options, ip),
-      queryParams: { returnUrl, ref, refViewId, clientId },
+      queryParams: {
+        returnUrl,
+        ref,
+        refViewId,
+        clientId,
+        componentEventParams,
+      },
     });
     sendOphanInteractionEventServer(
       {
@@ -200,19 +206,18 @@ export const sendAccountVerificationEmail = async (
 export const sendAccountExistsEmail = async (
   email: string,
   ip: string,
-  returnUrl: string,
-  ref?: string,
-  refViewId?: string,
+  trackingParams: IdApiQueryParams,
   ophanTrackingConfig?: OphanConfig,
 ) => {
   const options = APIPostOptions({
     'email-address': email,
   });
   try {
+    const { returnUrl, ref, refViewId, componentEventParams } = trackingParams;
     await idapiFetch({
       path: '/user/send-account-exists-email',
       options: APIAddClientAccessToken(options, ip),
-      queryParams: { returnUrl, ref, refViewId },
+      queryParams: { returnUrl, ref, refViewId, componentEventParams },
     });
     sendOphanInteractionEventServer(
       {
@@ -235,19 +240,18 @@ export const sendAccountExistsEmail = async (
 export const sendAccountWithoutPasswordExistsEmail = async (
   email: string,
   ip: string,
-  returnUrl: string,
-  ref?: string,
-  refViewId?: string,
+  trackingParams: IdApiQueryParams,
   ophanTrackingConfig?: OphanConfig,
 ) => {
   const options = APIPostOptions({
     'email-address': email,
   });
   try {
+    const { returnUrl, ref, refViewId, componentEventParams } = trackingParams;
     await idapiFetch({
       path: '/user/send-account-without-password-exists-email',
       options: APIAddClientAccessToken(options, ip),
-      queryParams: { returnUrl, ref, refViewId },
+      queryParams: { returnUrl, ref, refViewId, componentEventParams },
     });
     sendOphanInteractionEventServer(
       {
@@ -270,19 +274,18 @@ export const sendAccountWithoutPasswordExistsEmail = async (
 export const sendCreatePasswordEmail = async (
   email: string,
   ip: string,
-  returnUrl: string,
-  ref?: string,
-  refViewId?: string,
+  trackingParams: IdApiQueryParams,
   ophanTrackingConfig?: OphanConfig,
 ) => {
   const options = APIPostOptions({
     'email-address': email,
   });
   try {
+    const { returnUrl, ref, refViewId, componentEventParams } = trackingParams;
     await idapiFetch({
       path: '/user/send-create-password-account-exists-email',
       options: APIAddClientAccessToken(options, ip),
-      queryParams: { returnUrl, ref, refViewId },
+      queryParams: { returnUrl, ref, refViewId, componentEventParams },
     });
     sendOphanInteractionEventServer(
       {

--- a/src/server/lib/queryParams.ts
+++ b/src/server/lib/queryParams.ts
@@ -41,6 +41,7 @@ export const parseExpressQueryParams = (
     error,
     error_description,
     useOkta,
+    componentEventParams,
   }: Record<keyof QueryParams, string | undefined>, // parameters from req.query
   // some parameters may be manually passed in req.body too,
   // generally for tracking purposes
@@ -55,6 +56,8 @@ export const parseExpressQueryParams = (
     recaptchaError: validateGetOnlyError(method, recaptchaError),
     refViewId: refViewId || bodyParams.refViewId,
     ref: (ref || bodyParams.ref) && validateRefUrl(ref || bodyParams.ref),
+    componentEventParams:
+      componentEventParams || bodyParams.componentEventParams,
     encryptedEmail,
     error,
     error_description,

--- a/src/server/routes/register.ts
+++ b/src/server/routes/register.ts
@@ -75,8 +75,7 @@ router.post(
     } else {
       const state = res.locals;
 
-      const { returnUrl, emailSentSuccess, ref, refViewId, clientId } =
-        state.queryParams;
+      const { emailSentSuccess } = state.queryParams;
 
       try {
         // read and parse the encrypted state cookie
@@ -100,10 +99,7 @@ router.post(
               await sendAccountVerificationEmail(
                 email,
                 req.ip,
-                returnUrl,
-                ref,
-                refViewId,
-                clientId,
+                state.queryParams,
                 state.ophanConfig,
               );
               break;
@@ -112,9 +108,7 @@ router.post(
               await sendAccountExistsEmail(
                 email,
                 req.ip,
-                returnUrl,
-                ref,
-                refViewId,
+                state.queryParams,
                 state.ophanConfig,
               );
               break;
@@ -124,9 +118,7 @@ router.post(
               await sendAccountWithoutPasswordExistsEmail(
                 email,
                 req.ip,
-                returnUrl,
-                ref,
-                refViewId,
+                state.queryParams,
                 state.ophanConfig,
               );
               break;
@@ -185,7 +177,6 @@ router.post(
       let state = res.locals;
 
       const { email = '' } = req.body;
-      const { returnUrl, ref, refViewId, clientId } = state.queryParams;
 
       try {
         // use idapi user type endpoint to determine user type
@@ -196,15 +187,7 @@ router.post(
           // new user, so call guest register endpoint to create user account without password
           // and automatically send account verification email
           case UserType.NEW:
-            await guest(
-              email,
-              req.ip,
-              returnUrl,
-              refViewId,
-              ref,
-              clientId,
-              state.ophanConfig,
-            );
+            await guest(email, req.ip, state.queryParams, state.ophanConfig);
             // set the encrypted state cookie in each case, so the next page is aware
             // of the email address and type of email sent
             // so if needed it can resend the correct email
@@ -219,9 +202,7 @@ router.post(
             await sendAccountExistsEmail(
               email,
               req.ip,
-              returnUrl,
-              ref,
-              refViewId,
+              state.queryParams,
               state.ophanConfig,
             );
             setEncryptedStateCookie(res, {
@@ -235,9 +216,7 @@ router.post(
             await sendAccountWithoutPasswordExistsEmail(
               email,
               req.ip,
-              returnUrl,
-              ref,
-              refViewId,
+              state.queryParams,
               state.ophanConfig,
             );
             setEncryptedStateCookie(res, {

--- a/src/server/routes/setPassword.ts
+++ b/src/server/routes/setPassword.ts
@@ -70,15 +70,13 @@ router.post(
   handleAsyncErrors(async (req: Request, res: ResponseWithRequestState) => {
     const { email } = req.body;
     const state = res.locals;
-    const { returnUrl, emailSentSuccess, ref, refViewId } = state.queryParams;
+    const { emailSentSuccess } = state.queryParams;
 
     try {
       await sendCreatePasswordEmail(
         email,
         req.ip,
-        returnUrl,
-        ref,
-        refViewId,
+        state.queryParams,
         state.ophanConfig,
       );
 

--- a/src/server/routes/signIn.ts
+++ b/src/server/routes/signIn.ts
@@ -135,7 +135,12 @@ const idapiSignInController = async (
   const { returnUrl } = pageData;
 
   try {
-    const cookies = await authenticateWithIdapi(email, password, req.ip);
+    const cookies = await authenticateWithIdapi(
+      email,
+      password,
+      req.ip,
+      res.locals.queryParams,
+    );
 
     setIDAPICookies(res, cookies);
 

--- a/src/server/routes/welcome.ts
+++ b/src/server/routes/welcome.ts
@@ -61,17 +61,13 @@ router.post(
     } else {
       const { email } = req.body;
       const state = res.locals;
-      const { returnUrl, emailSentSuccess, ref, refViewId, clientId } =
-        state.queryParams;
+      const { emailSentSuccess } = state.queryParams;
 
       try {
         await sendAccountVerificationEmail(
           email,
           req.ip,
-          returnUrl,
-          ref,
-          refViewId,
-          clientId,
+          state.queryParams,
           state.ophanConfig,
         );
 

--- a/src/shared/__tests__/queryParams.test.ts
+++ b/src/shared/__tests__/queryParams.test.ts
@@ -19,6 +19,7 @@ describe('getPersistableQueryParams', () => {
       error: 'error',
       ref: 'ref',
       refViewId: 'refViewId',
+      componentEventParams: 'componentEventParams',
     };
 
     const output = getPersistableQueryParams(input);
@@ -28,6 +29,7 @@ describe('getPersistableQueryParams', () => {
       clientId: 'jobs',
       ref: 'ref',
       refViewId: 'refViewId',
+      componentEventParams: 'componentEventParams',
       useOkta: undefined,
     };
 
@@ -47,12 +49,13 @@ describe('addQueryParamsToPath', () => {
       error: 'error',
       ref: 'ref',
       refViewId: 'refViewId',
+      componentEventParams: 'componentEventParams',
     };
 
     const output = addQueryParamsToPath('/newsletters', input);
 
     expect(output).toEqual(
-      '/newsletters?clientId=jobs&ref=ref&refViewId=refViewId&returnUrl=returnUrl',
+      '/newsletters?clientId=jobs&componentEventParams=componentEventParams&ref=ref&refViewId=refViewId&returnUrl=returnUrl',
     );
   });
 
@@ -67,6 +70,7 @@ describe('addQueryParamsToPath', () => {
       error: 'error',
       ref: 'ref',
       refViewId: 'refViewId',
+      componentEventParams: 'componentEventParams',
     };
 
     const inputOverride: Partial<QueryParams> = {
@@ -78,7 +82,7 @@ describe('addQueryParamsToPath', () => {
     const output = addQueryParamsToPath('/newsletters', input, inputOverride);
 
     expect(output).toEqual(
-      '/newsletters?clientId=jobs&csrfError=true&encryptedEmail=an%20encrypted%20email&recaptchaError=true&ref=ref&refViewId=refViewId&returnUrl=returnUrl',
+      '/newsletters?clientId=jobs&componentEventParams=componentEventParams&csrfError=true&encryptedEmail=an%20encrypted%20email&recaptchaError=true&ref=ref&refViewId=refViewId&returnUrl=returnUrl',
     );
   });
 });

--- a/src/shared/lib/queryParams.ts
+++ b/src/shared/lib/queryParams.ts
@@ -6,6 +6,10 @@ import {
 import { IdApiQueryParams } from '../model/IdapiQueryParams';
 import { AllRoutes } from '../model/Routes';
 
+/**
+ * @param params QueryParams object with all query parameters
+ * @returns PersistableQueryParams - object with query parameters to persist between requests
+ */
 export const getPersistableQueryParams = (
   params: QueryParams,
 ): PersistableQueryParams => ({
@@ -14,6 +18,7 @@ export const getPersistableQueryParams = (
   ref: params.ref,
   refViewId: params.refViewId,
   useOkta: params.useOkta,
+  componentEventParams: params.componentEventParams,
 });
 
 /**

--- a/src/shared/model/IdapiQueryParams.ts
+++ b/src/shared/model/IdapiQueryParams.ts
@@ -1,9 +1,9 @@
-import { StringifiableRecord } from 'query-string';
+import { PersistableQueryParams } from './QueryParams';
 
 /**
  * IdApiQueryParams are query parameters
  * that are expected when sending requests to IdApi
  */
-export interface IdApiQueryParams extends StringifiableRecord {
+export interface IdApiQueryParams extends Partial<PersistableQueryParams> {
   format?: string;
 }

--- a/src/shared/model/QueryParams.ts
+++ b/src/shared/model/QueryParams.ts
@@ -9,6 +9,16 @@ export interface TrackingQueryParams {
   // that the user was on to use for tracking referrals
   // https://github.com/guardian/ophan/blob/70b658e785c490c411670bbd3c7fde62ae0224fc/the-slab/app/extractors/ReferrerExtractor.scala#L129
   refViewId?: string;
+  // componentEventsParams is included so that we can pass Ophan ComponentEvent information to IDAPI, allowing us to
+  // fire Ophan ComponentEvent on the server with information (componentType, abTest, etc.) from the frontend client
+  // the value of componentEventParams should be passed as a URL encoded string of key value pairs in the form of key=value,
+  // forExample componentType=SIGN_IN_GATE&componentId=inital_test&abTestName=SignInGateFirstTest&abTestVariant=variant&viewId=k2oj70c85n0d0fbtl6tg would be url encoded as componentType%3DSIGN_IN_GATE%26componentId%3Dinital_test%26abTestName%3DSignInGateFirstTest%26abTestVariant%3Dvariant%26viewId%3Dk2oj70c85n0d0fbtl6tg
+  // the valid keys for the componentEventParams componentType, componentId, abTestName, abTestVariant, viewId, browserId (optional, but in most cases you'd want this), visitId (optional, same as browserId)
+  // these correspond to whats required by the Ophan ComponentEvent (https://dashboard.ophan.co.uk/docs/thrift/componentevent.html)
+  // if IDAPI doesn't find the required keys in componentEventParams or fails to parse componentEventParams then the Ophan ComponentEvent will not be fired
+  // we URL encode the value of componentEventParams due to the number of keys available
+  // as well as getting confused with other parameters, so we thought it best to pass it as a URL encoded string, and then do the decoding once it gets to IDAPI
+  componentEventParams?: string;
 }
 
 /**


### PR DESCRIPTION
## What does this change?

During the migration of the sign in and register pages from [identity-frontend](https://github.com/guardian/identity-frontend) to gateway, the tracking of events on frontend and DCR were missed from the migration, specifically using component event params to track how users would sign in and register from those systems.

This commit readds the `componentEventParams` query parameter, and makes sure that it is passed through to identity-api through the sign in and register endpoints.

We also update some types and function calls to clean up the tracking functionality too.
