### PR TITLE
Add timeout to Cypress Github Actions

### DIFF
--- a/.github/workflows/cypress-ete-okta.yml
+++ b/.github/workflows/cypress-ete-okta.yml
@@ -94,7 +94,7 @@ jobs:
           wait-on-timeout: 60
           browser: chrome
           spec: cypress/integration/ete-okta/**/*.ts
-          config: '{"chromeWebSecurity": false,"baseUrl":"https://profile.thegulocal.com"}'
+          config: '{"chromeWebSecurity": false,"baseUrl":"https://profile.thegulocal.com","numTestsKeptInMemory":"1"}'
       - uses: actions/upload-artifact@v2
         if: failure()
         with:

--- a/.github/workflows/cypress-ete-okta.yml
+++ b/.github/workflows/cypress-ete-okta.yml
@@ -10,6 +10,7 @@ jobs:
   cypress-nginx-okta:
     name: Cypress (ete-okta)
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     services:
       redis:
         image: redis

--- a/.github/workflows/cypress-ete.yml
+++ b/.github/workflows/cypress-ete.yml
@@ -93,7 +93,7 @@ jobs:
           wait-on-timeout: 60
           browser: chrome
           spec: cypress/integration/ete/**/*.ts
-          config: '{"chromeWebSecurity": false,"baseUrl":"https://profile.thegulocal.com"}'
+          config: '{"chromeWebSecurity": false,"baseUrl":"https://profile.thegulocal.com","numTestsKeptInMemory":"1"}'
       - uses: actions/upload-artifact@v2
         if: failure()
         with:

--- a/.github/workflows/cypress-ete.yml
+++ b/.github/workflows/cypress-ete.yml
@@ -9,6 +9,7 @@ jobs:
   cypress-ete:
     name: Cypress (ete)
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     services:
       redis:
         image: redis

--- a/.github/workflows/cypress-mocked.yml
+++ b/.github/workflows/cypress-mocked.yml
@@ -87,7 +87,7 @@ jobs:
           wait-on-timeout: 60
           browser: chrome
           spec: cypress/integration/mocked/*.ts
-          config: '{"chromeWebSecurity": false,"baseUrl":"https://profile.thegulocal.com"}'
+          config: '{"chromeWebSecurity": false,"baseUrl":"https://profile.thegulocal.com","numTestsKeptInMemory":"1"}'
       - name: Upload screenshots
         uses: actions/upload-artifact@v2
         if: failure()

--- a/.github/workflows/cypress-mocked.yml
+++ b/.github/workflows/cypress-mocked.yml
@@ -4,6 +4,7 @@ jobs:
   cypress-mocked:
     name: Cypress (mocked)
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     services:
       redis:
         image: redis


### PR DESCRIPTION
## What does this change?

- Adds a timeout to the Cypress GitHub Actions to fail after 15 mins rather than the default 6 hours
  - While this doesn't solve flakiness, it should help to spot tests that are stuck
  - On success, most tests take less than 10 mins, so adding 5 mins for leeway
- Reduce `numTestsKeptInMemory` to `1` to help flakiness possibly
  - By reducing the number of tests in memory to 1, cypress only keeps 1 snapshot of tests in it's memory, this is useful for CI as we don't/can't inspect previous snapshots, and we just want to know the result.
  - This has the added benefit of reducing memory usage, which might reduce flakiness in cypress tests running in GitHub actions, especially those that seem to hang/freeze rather than fail.