### PR TITLE
Rate limiter tweaks

### DIFF
--- a/src/server/lib/middleware/rateLimit.ts
+++ b/src/server/lib/middleware/rateLimit.ts
@@ -66,9 +66,10 @@ export const rateLimiterMiddleware = async (
 
   if (ratelimitBucketTypeIfHit) {
     // Cut down the size of the access token so we don't make the log line too long.
-    const truncatedAccessToken = rateLimitData.accessToken
-      ? rateLimitData.accessToken.substring(0, 6)
-      : '';
+    const truncatedAccessToken =
+      typeof rateLimitData.accessToken === 'string'
+        ? rateLimitData.accessToken.substring(0, 6)
+        : '';
 
     // We append `-Gateway` so that we can differentiate between IDAPI rate limit log entries.
     logger.info(

--- a/src/server/lib/middleware/rateLimit.ts
+++ b/src/server/lib/middleware/rateLimit.ts
@@ -65,6 +65,7 @@ export const rateLimiterMiddleware = async (
   });
 
   if (ratelimitBucketTypeIfHit) {
+    // Cut down the size of the access token so we don't make the log line too long.
     const truncatedAccessToken = rateLimitData.accessToken
       ? rateLimitData.accessToken.substring(0, 6)
       : '';

--- a/src/server/lib/middleware/rateLimit.ts
+++ b/src/server/lib/middleware/rateLimit.ts
@@ -65,9 +65,13 @@ export const rateLimiterMiddleware = async (
   });
 
   if (ratelimitBucketTypeIfHit) {
+    const truncatedAccessToken = rateLimitData.accessToken
+      ? rateLimitData.accessToken.substring(0, 6)
+      : '';
+
     // We append `-Gateway` so that we can differentiate between IDAPI rate limit log entries.
     logger.info(
-      `RateLimit-Gateway ${ratelimitBucketTypeIfHit}Bucket email=${rateLimitData.email} ip=${rateLimitData.ip} accessToken=${rateLimitData.accessToken} identity-gateway ${req.method} ${routePathDefinition}`,
+      `RateLimit-Gateway ${ratelimitBucketTypeIfHit}Bucket email=${rateLimitData.email} ip=${rateLimitData.ip} accessToken=${truncatedAccessToken} identity-gateway ${req.method} ${routePathDefinition}`,
     );
 
     trackMetric(rateLimitHitMetric(ratelimitBucketTypeIfHit));

--- a/src/server/lib/rate-limit/logger.ts
+++ b/src/server/lib/rate-limit/logger.ts
@@ -21,7 +21,7 @@ export const startGlobalBucketCapacityLogger = (
       if (keys) {
         // Flatten the result from Redis.
         const globalKeys = keys[0][1];
-        if (typeof globalKeys !== 'undefined') {
+        if (Array.isArray(globalKeys) && globalKeys.length > 0) {
           const globalValues = await redisClient.mget(globalKeys);
 
           if (globalValues) {

--- a/src/server/routes/consents.ts
+++ b/src/server/routes/consents.ts
@@ -192,23 +192,17 @@ export const consentPages: ConsentPage[] = [
   },
 ];
 
-router.get(
-  '/consents',
+router.get('/consents', loginMiddleware, (_: Request, res: Response) => {
+  const url = addQueryParamsToPath(
+    `${consentPages[0].path}`,
+    res.locals.queryParams,
+  );
 
-  loginMiddleware,
-  (_: Request, res: Response) => {
-    const url = addQueryParamsToPath(
-      `${consentPages[0].path}`,
-      res.locals.queryParams,
-    );
-
-    res.redirect(303, url);
-  },
-);
+  res.redirect(303, url);
+});
 
 router.get(
   '/consents/:page',
-
   loginMiddleware,
   handleAsyncErrors(async (req: Request, res: ResponseWithRequestState) => {
     let state = res.locals;
@@ -280,7 +274,6 @@ router.get(
 
 router.post(
   '/consents/:page',
-
   loginMiddleware,
   handleAsyncErrors(async (req: Request, res: ResponseWithRequestState) => {
     let state = res.locals;

--- a/src/server/routes/magicLink.ts
+++ b/src/server/routes/magicLink.ts
@@ -11,21 +11,16 @@ import { handleAsyncErrors } from '@/server/lib/expressWrappers';
 import { ApiError } from '@/server/models/Error';
 import handleRecaptcha from '@/server/lib/recaptcha';
 
-router.get(
-  '/magic-link',
-
-  (req: Request, res: ResponseWithRequestState) => {
-    const html = renderer('/magic-link', {
-      requestState: res.locals,
-      pageTitle: 'Sign in',
-    });
-    res.type('html').send(html);
-  },
-);
+router.get('/magic-link', (req: Request, res: ResponseWithRequestState) => {
+  const html = renderer('/magic-link', {
+    requestState: res.locals,
+    pageTitle: 'Sign in',
+  });
+  res.type('html').send(html);
+});
 
 router.post(
   '/magic-link',
-
   handleRecaptcha,
   handleAsyncErrors(async (req: Request, res: ResponseWithRequestState) => {
     let state = res.locals;
@@ -64,7 +59,6 @@ router.post(
 
 router.get(
   '/magic-link/email-sent',
-
   (_: Request, res: ResponseWithRequestState) => {
     const html = renderer('/magic-link/email-sent', {
       pageTitle: 'Sign in',

--- a/src/server/routes/oauth.ts
+++ b/src/server/routes/oauth.ts
@@ -54,7 +54,6 @@ const redirectForGenericError = (
 
 router.get(
   '/oauth/authorization-code/callback',
-
   handleAsyncErrors(async (req: Request, res: ResponseWithRequestState) => {
     try {
       // Determine which OpenIdClient to use, in DEV we use the DevProfileIdClient, otherwise we use the ProfileOpenIdClient

--- a/src/server/routes/register.ts
+++ b/src/server/routes/register.ts
@@ -36,7 +36,6 @@ const { okta } = getConfiguration();
 
 router.get(
   '/register',
-
   registerMiddleware,
   (req: Request, res: ResponseWithRequestState) => {
     const html = renderer('/register', {
@@ -49,7 +48,6 @@ router.get(
 
 router.get(
   '/register/email-sent',
-
   (req: Request, res: ResponseWithRequestState) => {
     const state = res.locals;
     const html = renderer('/register/email-sent', {
@@ -66,7 +64,6 @@ router.get(
 
 router.post(
   '/register/email-sent/resend',
-
   handleRecaptcha,
   handleAsyncErrors(async (req: Request, res: ResponseWithRequestState) => {
     const { useOkta } = res.locals.queryParams;
@@ -166,7 +163,6 @@ router.post(
 
 router.post(
   '/register',
-
   handleRecaptcha,
   registerMiddleware,
   handleAsyncErrors(async (req: Request, res: ResponseWithRequestState) => {

--- a/src/server/routes/resetPassword.ts
+++ b/src/server/routes/resetPassword.ts
@@ -11,26 +11,21 @@ import handleRecaptcha from '@/server/lib/recaptcha';
 import { sendChangePasswordEmailController } from '@/server/controllers/sendChangePasswordEmail';
 
 // reset password email form
-router.get(
-  '/reset-password',
-
-  (req: Request, res: ResponseWithRequestState) => {
-    const html = renderer('/reset-password', {
-      pageTitle: 'Reset Password',
-      requestState: deepmerge(res.locals, {
-        pageData: {
-          email: readEmailCookie(req),
-        },
-      }),
-    });
-    res.type('html').send(html);
-  },
-);
+router.get('/reset-password', (req: Request, res: ResponseWithRequestState) => {
+  const html = renderer('/reset-password', {
+    pageTitle: 'Reset Password',
+    requestState: deepmerge(res.locals, {
+      pageData: {
+        email: readEmailCookie(req),
+      },
+    }),
+  });
+  res.type('html').send(html);
+});
 
 // send reset password email
 router.post(
   '/reset-password',
-
   handleRecaptcha,
   sendChangePasswordEmailController(),
 );
@@ -38,7 +33,6 @@ router.post(
 // reset password email sent page
 router.get(
   '/reset-password/email-sent',
-
   (req: Request, res: ResponseWithRequestState) => {
     const html = renderer('/reset-password/email-sent', {
       pageTitle: 'Check Your Inbox',
@@ -56,7 +50,6 @@ router.get(
 // password updated confirmation page
 router.get(
   '/reset-password/complete',
-
   (req: Request, res: ResponseWithRequestState) => {
     const html = renderer('/reset-password/complete', {
       requestState: deepmerge(res.locals, {
@@ -73,7 +66,6 @@ router.get(
 // link expired page
 router.get(
   '/reset-password/resend',
-
   (_: Request, res: ResponseWithRequestState) => {
     const html = renderer('/reset-password/resend', {
       pageTitle: 'Resend Change Password Email',
@@ -86,7 +78,6 @@ router.get(
 // session timed out page
 router.get(
   '/reset-password/expired',
-
   (_: Request, res: ResponseWithRequestState) => {
     const html = renderer('/reset-password/expired', {
       pageTitle: 'Resend Change Password Email',
@@ -103,14 +94,12 @@ router.get(
 // reset password form
 router.get(
   '/reset-password/:token',
-
   checkPasswordTokenController('/reset-password', 'Change Password'),
 );
 
 // update password
 router.post(
   '/reset-password/:token',
-
   setPasswordController(
     '/reset-password',
     'Change Password',

--- a/src/server/routes/setPassword.ts
+++ b/src/server/routes/setPassword.ts
@@ -20,7 +20,6 @@ import { buildUrl } from '@/shared/lib/routeUtils';
 // set password complete page
 router.get(
   '/set-password/complete',
-
   (req: Request, res: ResponseWithRequestState) => {
     const email = readEmailCookie(req);
 
@@ -39,7 +38,6 @@ router.get(
 // resend "create (set) password" email page
 router.get(
   '/set-password/resend',
-
   (_: Request, res: ResponseWithRequestState) => {
     const html = renderer('/set-password/resend', {
       pageTitle: 'Resend Create Password Email',
@@ -52,7 +50,6 @@ router.get(
 // set password page session expired
 router.get(
   '/set-password/expired',
-
   (_: Request, res: ResponseWithRequestState) => {
     const html = renderer('/set-password/expired', {
       pageTitle: 'Resend Create Password Email',
@@ -65,7 +62,6 @@ router.get(
 // POST handler for resending "create (set) password" email
 router.post(
   '/set-password/resend',
-
   handleRecaptcha,
   handleAsyncErrors(async (req: Request, res: ResponseWithRequestState) => {
     const { email } = req.body;
@@ -119,7 +115,6 @@ router.post(
 // email sent page
 router.get(
   '/set-password/email-sent',
-
   (req: Request, res: ResponseWithRequestState) => {
     let state = res.locals;
 
@@ -144,14 +139,12 @@ router.get(
 // The below route must be defined below the other GET /set-password/* routes otherwise the other routes will fail
 router.get(
   '/set-password/:token',
-
   checkPasswordTokenController('/set-password', 'Create Password'),
 );
 
 // POST handler for set password page to set password
 router.post(
   '/set-password/:token',
-
   setPasswordController(
     '/set-password',
     'Create Password',

--- a/src/server/routes/signIn.ts
+++ b/src/server/routes/signIn.ts
@@ -83,7 +83,6 @@ const showSignInPage = async (req: Request, res: ResponseWithRequestState) => {
 
 router.get(
   '/signin',
-
   handleAsyncErrors(async (req: Request, res: ResponseWithRequestState) => {
     const { pageData } = res.locals;
     const { returnUrl } = pageData;

--- a/src/server/routes/signIn.ts
+++ b/src/server/routes/signIn.ts
@@ -111,7 +111,6 @@ router.get(
 
 router.post(
   '/signin',
-
   handleRecaptcha,
   handleAsyncErrors((req: Request, res: ResponseWithRequestState) => {
     const { useOkta } = res.locals.queryParams;
@@ -283,7 +282,6 @@ const optInPromptController = async (
 
 router.get(
   '/signin/success',
-
   loginMiddleware,
   handleAsyncErrors((req: Request, res: ResponseWithRequestState) =>
     optInPromptController(req, res),
@@ -292,7 +290,6 @@ router.get(
 
 router.post(
   '/signin/success',
-
   loginMiddleware,
   handleAsyncErrors(async (req: Request, res: ResponseWithRequestState) => {
     const state = res.locals;

--- a/src/server/routes/signOut.ts
+++ b/src/server/routes/signOut.ts
@@ -53,7 +53,6 @@ export const clearOktaCookies = (res: ResponseWithRequestState) => {
 
 router.get(
   '/signout',
-
   handleAsyncErrors(async (req: Request, res: ResponseWithRequestState) => {
     const { returnUrl } = res.locals.pageData;
 

--- a/src/server/routes/verifyEmail.ts
+++ b/src/server/routes/verifyEmail.ts
@@ -28,7 +28,6 @@ const profileUrl = getProfileUrl();
 
 router.get(
   '/verify-email',
-
   handleAsyncErrors(async (req: Request, res: ResponseWithRequestState) => {
     let state = res.locals;
 
@@ -85,7 +84,6 @@ router.get(
 
 router.post(
   '/verify-email',
-
   handleRecaptcha,
   handleAsyncErrors(async (req: Request, res: ResponseWithRequestState) => {
     let state = res.locals;
@@ -146,7 +144,6 @@ router.post(
 
 router.get(
   '/verify-email/:token',
-
   handleAsyncErrors(async (req: Request, res: ResponseWithRequestState) => {
     const { token } = req.params;
 

--- a/src/server/routes/welcome.ts
+++ b/src/server/routes/welcome.ts
@@ -24,35 +24,26 @@ const { okta } = getConfiguration();
 
 const router = Router();
 // resend account verification page
-router.get(
-  '/welcome/resend',
-
-  (_: Request, res: ResponseWithRequestState) => {
-    const html = renderer('/welcome/resend', {
-      pageTitle: 'Resend Welcome Email',
-      requestState: res.locals,
-    });
-    res.type('html').send(html);
-  },
-);
+router.get('/welcome/resend', (_: Request, res: ResponseWithRequestState) => {
+  const html = renderer('/welcome/resend', {
+    pageTitle: 'Resend Welcome Email',
+    requestState: res.locals,
+  });
+  res.type('html').send(html);
+});
 
 // resend account verification page, session expired
-router.get(
-  '/welcome/expired',
-
-  (_: Request, res: ResponseWithRequestState) => {
-    const html = renderer('/welcome/expired', {
-      pageTitle: 'Resend Welcome Email',
-      requestState: res.locals,
-    });
-    res.type('html').send(html);
-  },
-);
+router.get('/welcome/expired', (_: Request, res: ResponseWithRequestState) => {
+  const html = renderer('/welcome/expired', {
+    pageTitle: 'Resend Welcome Email',
+    requestState: res.locals,
+  });
+  res.type('html').send(html);
+});
 
 // POST form handler to resend account verification email
 router.post(
   '/welcome/resend',
-
   handleRecaptcha,
   handleAsyncErrors(async (req: Request, res: ResponseWithRequestState) => {
     const { useOkta } = res.locals.queryParams;
@@ -102,7 +93,6 @@ router.post(
 // email sent page
 router.get(
   '/welcome/email-sent',
-
   (req: Request, res: ResponseWithRequestState) => {
     let state = res.locals;
 
@@ -126,14 +116,12 @@ router.get(
 // welcome page, check token and display set password page
 router.get(
   '/welcome/:token',
-
   checkPasswordTokenController('/welcome', 'Welcome'),
 );
 
 // POST form handler to set password on welcome page
 router.post(
   '/welcome/:token',
-
   setPasswordController('/welcome', 'Welcome', consentPages[0].path),
 );
 


### PR DESCRIPTION
## What does this change?

* Truncates the access token that we log in the rate limiter middleware when the limit is hit. This is so that we don't exceed the maximum message size in Kibana
* Checks that the global bucket key array isn't empty.
* Extends middleware test to check that the correct rate limit exceeded messages are being logged.
* Removes some unnecessary newlines
