### PR TITLE
Disable reCAPTCHA middleware on DEV stage

### DIFF
--- a/src/server/lib/recaptcha.ts
+++ b/src/server/lib/recaptcha.ts
@@ -5,6 +5,7 @@ import { getConfiguration } from '@/server/lib/getConfiguration';
 import { logger } from '@/server/lib/serverSideLogger';
 import { trackMetric } from '@/server/lib/trackMetric';
 import { HttpError } from '@/server/models/Error';
+import { featureSwitches } from '@/shared/lib/featureSwitches';
 
 const {
   googleRecaptcha: { secretKey, siteKey },
@@ -47,13 +48,13 @@ const checkRecaptchaError = (req: Request, _: Response, next: NextFunction) => {
  * testing keys for reCAPTCHA are somehow broken; (2) express-recaptcha is
  * somehow broken; (3) the way we integrate it is somehow broken. To solve it,
  * we just automatically pass next() instead of running the middleware in the
- * DEV stage.
+ * DEV stage, unless the 'recaptchaEnabledDev' feature switch is set to true.
  *
  * TODO: Get to the bottom of this - it would be ideal if we didn't have to do
  * this workaround.
  */
 const handleRecaptcha =
-  stage === 'DEV'
+  stage === 'DEV' && featureSwitches.recaptchaEnabledDev
     ? (_: Request, __: Response, next: NextFunction) => next()
     : [recaptcha.middleware.verify, checkRecaptchaError];
 

--- a/src/server/lib/recaptcha.ts
+++ b/src/server/lib/recaptcha.ts
@@ -8,6 +8,7 @@ import { HttpError } from '@/server/models/Error';
 
 const {
   googleRecaptcha: { secretKey, siteKey },
+  stage,
 } = getConfiguration();
 
 const recaptcha = new RecaptchaV2(siteKey, secretKey);
@@ -38,7 +39,23 @@ const checkRecaptchaError = (req: Request, _: Response, next: NextFunction) => {
   next();
 };
 
-const handleRecaptcha = [recaptcha.middleware.verify, checkRecaptchaError];
+/**
+ * When running the handleRecaptcha middleware locally, we consistently saw a
+ * bug where the route handler would be called multiple times, causing 'Cannot
+ * set headers after they are sent to the client' errors and running everything
+ * in the handler multiple times. Our guesses for why this happens are (1) the
+ * testing keys for reCAPTCHA are somehow broken; (2) express-recaptcha is
+ * somehow broken; (3) the way we integrate it is somehow broken. To solve it,
+ * we just automatically pass next() instead of running the middleware in the
+ * DEV stage.
+ *
+ * TODO: Get to the bottom of this - it would be ideal if we didn't have to do
+ * this workaround.
+ */
+const handleRecaptcha =
+  stage === 'DEV'
+    ? (_: Request, __: Response, next: NextFunction) => next()
+    : [recaptcha.middleware.verify, checkRecaptchaError];
 
 /**
  * Protects a route with recaptcha.

--- a/src/shared/lib/featureSwitches.ts
+++ b/src/shared/lib/featureSwitches.ts
@@ -13,6 +13,8 @@ interface FeatureSwitches {
     CODE: boolean;
     PROD: boolean;
   };
+  // reCAPTCHA is disabled in the DEV stage by default.
+  recaptchaEnabledDev: boolean;
 }
 
 export const featureSwitches: FeatureSwitches = {
@@ -22,4 +24,5 @@ export const featureSwitches: FeatureSwitches = {
     CODE: true,
     PROD: false,
   },
+  recaptchaEnabledDev: false,
 };


### PR DESCRIPTION
## What does this change?

When running the handleRecaptcha middleware locally, we consistently saw a bug where the route handler would be called multiple times, causing 'Cannot set headers after they are sent to the client' errors and running everything in the handler multiple times. Our guesses for why this happens are:

1. The testing keys for reCAPTCHA are somehow broken;
2. `express-recaptcha` is somehow broken; 
3. The way we integrate it is somehow broken.

To solve it, I've set it up so we automatically pass `next()` instead of running the middleware in the `DEV` stage. The middleware still runs as before in other stages, as the bug doesn't seem to happen in production.

It would be best if at some point we actually got to the bottom of why the middleware was triggering the route handler multiple times, and fixed the bug at source.