### PR TITLE
Run cypress tests in dev mode !

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -230,21 +230,39 @@ Integration tests are provided by [Cypress](https://cypress.io). They are all de
 
 First make sure that the development environment isn't running, since the following scripts will set them up automatically.
 
-You can then open the test runner using:
+We now support a development mode that allows you to make code changes to the server without having the restart cypress to check your changes against the tests.
+
+You can also run the tests with the production build (as is done in CI) without the ability to automatically reload the gateway server.
+
+You can then open the test runner in using:
 
 ```sh
+# to run in dev mode
+$ make cypress-mocked-dev
+# or to run in production mode
 $ make cypress-mocked
-# or
-$ ./cypress-mocked.sh
 ```
 
 You can also open the end to end test runner using:
 
 ```sh
+# to run in dev mode
+$ make cypress-ete-dev
+# or to run in production mode
 $ make cypress-ete
-# or
-$ ./cypress-ete.sh
 ```
+
+You can also run the Okta specific end to end tests using:
+
+```sh
+# to run in dev mode
+$ make cypress-ete-okta-dev
+# or to run in production mode
+$ make cypress-ete-okta
+```
+
+It's recommended to use the `make` commands rather than calling the file directly e.g `./cypress-ete-okta.sh`
+as the test runners use environment variables to check the running mode.
 
 To run the jest tests headless and automatically (how they are run on CI) use:
 

--- a/makefile
+++ b/makefile
@@ -68,7 +68,17 @@ cypress-mocked: clear
 	$(call log, "opening cypress using mocks")
 	@(./cypress-mocked.sh)
 
+cypress-mocked-dev: export DEV_MODE = true
+cypress-mocked-dev: clear
+	$(call log, "opening cypress in dev mode using mocks")
+	@(./cypress-mocked.sh)
+
 cypress-ete: clear
+	$(call log, "opening cypress")
+	@(./cypress-ete.sh)
+
+cypress-ete-dev: export DEV_MODE = true
+cypress-ete-dev: clear
 	$(call log, "opening cypress")
 	@(./cypress-ete.sh)
 
@@ -76,6 +86,14 @@ cypress-ete-okta: export USE_OKTA = true
 cypress-ete-okta: clear
 	$(call log, "opening cypress using okta tests")
 	@(./cypress-ete.sh)
+
+cypress-ete-okta-dev: export USE_OKTA = true
+cypress-ete-okta-dev: export DEV_MODE = true
+cypress-ete-okta-dev: clear
+	$(call log, "opening cypress in dev mode using okta tests")
+	@(./cypress-ete.sh)
+
+
 
 # helpers
 


### PR DESCRIPTION
## What does this change?
This makes a change to our cypress test runner scripts for `mocked` and `ete` (end to end) tests.

We now support a development mode that allows you to make code changes to the server without having the restart cypress to check your changes against the tests.

This should significantly speed up local development when using cypress. 🐎 

This is achieved by starting the server in `watch` mode rather than the production mode.

We support 2 modes as we still want the tests to run in a production like environment in CI.

To run the cypress tests in dev mode, use the following commands:

`make cypress-mocked-dev`

`make cypress-ete-dev`

`make cypress-ete-okta-dev`



