### PR TITLE
Intercepting the Okta SDK calls

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -48,5 +48,6 @@
     "react": {
       "version": "detect"
     }
-  }
+  },
+  "ignorePatterns": ["scripts/okta/**/*"]
 }

--- a/docs/okta/native-apps-integration-guide.md
+++ b/docs/okta/native-apps-integration-guide.md
@@ -1,68 +1,108 @@
 # Native apps integration with Okta
 
-## Authentication
-
-The approach for both sign in and registration in native apps uses the Okta SDK along with a in-app browser tab (iOS: `SFSafariViewController`/`SFAuthenticationSession`, Android: `CustomTabsService` (Custom Tab)). First use the in-app browser tab to authenticate against the identity sign in and registration pages and get an Okta session cookie set in the user's browser. At the end of this process we redirect back into the application, and use the Okta SDK `signin`/`signInWithBrowser` with the `prompt=none` option to get the OAuth tokens, specifically the `id_token`, `access_token` and `refresh_token`. Once the tokens are received, checking the validity of these tokens is enough to check if the user is signed in, instead of having to perform the full login flow again.
-
 See [RFC 8252: OAuth 2.0 for Mobile and Native Apps](https://datatracker.ietf.org/doc/html/rfc8252) for the full recommendations. Specifically, the [Platform-Specific Implementation Details](https://datatracker.ietf.org/doc/html/rfc8252#appendix-B) section of the RFC describes the best practices for each platform - [iOS](https://datatracker.ietf.org/doc/html/rfc8252#appendix-B.1), [Android](https://datatracker.ietf.org/doc/html/rfc8252#appendix-B.2).
 
 To hand control back to the App Native layer from the In-App Browser Tab we recommend [private-use URI scheme](https://datatracker.ietf.org/doc/html/rfc8252#section-7.1) (referred to as "custom URL scheme") redirects and [claimed "https" scheme URIs](https://datatracker.ietf.org/doc/html/rfc8252#section-7.2) (known as "Universal Links"). From our testing and POC implementation, we found that "custom URL schemes" worked better for redirects from the "in-app browser tab", however using this approach we should be careful not to send any identifiable information to the redirect URL, and when handling the redirect not to take any action with an unindented side effect.
+
+However the below should be enough to implement the flows.
+
+## Authentication (Sign in and Registration)
+
+The approach for both sign in and registration in native apps uses the Okta SDK methods to launch the authentication flow and handle the OAuth2/OIDC flow. From the Identity side, the call to the Okta own login page is intercepted and we redirect to our own login page with the parameters provided from the Okta hosted sign in page.
+
+The SDKs we're using are the [Okta OIDC iOS SDK](https://github.com/okta/okta-oidc-ios) and [Okta OIDC Android SDK](https://github.com/okta/okta-oidc-android).
+
+To initiate login or registration the app with use the SDK to call the relevant method. In Android this is done by calling `.signIn(...)` and in iOS by calling `.signInWithBrowser(...)`, without any additional parameters. The SDK uses this method to launch the Authorization Code Flow with PKCE. It will launch an in-app browser tab (iOS: `ASWebAuthenticationSession`, Android: `CustomTabsService` (Custom Tab)) to check if a user session exists in Okta.
+
+If a user session exists, Okta will redirect back to the app with an authorization code. The app will then use the SDK to exchange the authorization code for any tokens, usually the `id_token`, `access_token` and `refresh_token`. These tokens are stored in the SDK and can be used to authenticate the user, and authorize the app to access other resources. Once the tokens are received, checking the validity of these tokens is enough to check if the use is signed in, instead of having to perform the full login flow again.
+
+If no user session exists, Okta will attempt to show it's own login page. When the browser attempts to load this page, we perform a JavaScript redirect to our own login page instead with any parameters that are required to complete the Authorization Code flow in the Native App. At this point the user can navigate between sign in and registration.
+
+If the user signs in successfully, a session cookie will be set in the browser, and we complete sign in by redirecting the user back to the `fromURI` parameter. This will redirect the user to Okta, which will then redirect the user back to the app with the authorization code, and as above this is exchanged for tokens.
+
+Registration works a bit differently. The user will navigate to the registration page, enter their email, and be sent a registration email. The user will then have to navigate to their inbox, and click the link in the email. The app should intercept this link using the [claimed "https" scheme URIs](https://datatracker.ietf.org/doc/html/rfc8252#section-7.2) (known as "Universal Links"). The token should be extracted from this link, and passed to the SDK `.signIn(...)`/`.signInWithBrowser(...)` method as an additional parameter called `activation_token`. This will again launch the in-app browser to the Okta login page, on that page we check for this `activation_token` parameter and then redirect to our own set password/welcome page. The user will then set their password, get a session set, and we complete sign in by redirecting the user back to the `fromURI` parameter. Again, This will redirect the user to Okta, which will then redirect the user back to the app with the authorization code, and as above this is exchanged for tokens.
+
+### How the interception works
+
+This is not necessary to know for the apps implementation, but useful for context.
+
+We customise the Okta hosted login page to not load the sign in widget, but instead redirect the user to our own login page. Luckily through the Okta dashboard we're able to customise the HTML, and in turn the JavaScript that is loaded.
+
+From the Okta hosted login page we need to pass the following parameters to our own login page:
+
+- **`fromURI`**: This is the URI to redirect to after the user has logged in and has a session set to complete the Authorization Code Flow from the SDK.
+- **`clientId`**: This is the client ID of the application that is calling the SDK and in turn performing the Authorization Code Flow. This parameter can be used to customise the experience our pages.
+
+In the SDK we're also able to pass additional parameters, which we can use to pass the `activation_token` from the user's email link. This can then be used to direct the user to the create password/welcome page instead of the login page, and complete the authorization code flow from there.
+
+The custom javascript for this can be seen in [`scripts/okta/okta-login.js`](../../scripts/okta/okta-login.js). And the custom HTML can be seen in [`scripts/okta/okta-login.html`](../../scripts/okta/okta-login.html).
+
+The code is rendered in the Okta hosted sign in page at `/login/login.htm`
+
+We get the `fromURI` and `clientId` from the javascript in the hosted sign in page, which are passed in by Okta using parameters from the SDK.
+
+If these exist, then we can redirect the user to the sign in page which will persist the `fromURI` through the login process, and redirect the user back to the callback uri supplied to the app with the `authorization_code` the Okta SDK should then finish as normal.
+
+To initiate sign-in from the app, you can call this via the Okta SDK using `.signInWithBrowser(from: self)` in iOS or `.signIn(this, null)` in Android.
+
+We also support the scenario where we want to log the user in once they have exchanged the activation_token from their email inbox and set their password, this is the 2nd step of the registration flow.
+
+To initiate 2nd step of the registration flow from the app, you can call this via the Okta SDK using `.signInWithBrowser(additionalParameters: [activation_token: {activationToken}])` or `.signIn(this, payload)` in Android, where `payload` can be seen [here](https://github.com/okta/okta-oidc-android#sign-in-with-a-browser), with an `.addParameter("activation_token", activationToken)`.
 
 The general steps for native apps integration are shown in this high level diagram:
 
 ```mermaid
 sequenceDiagram
 autonumber
-  participant NativeLayer
-  participant InAppBrowserTab
-  participant Gateway
-  participant Okta
 
-  opt generally handled by app/identity (Authentication/Session Setting)
-    NativeLayer->>InAppBrowserTab: Open Browser Tab:<br/>`https://profile.theguardian.com/{signin|register}`
-    InAppBrowserTab->>Gateway: Request `/signin` or `/register`
-    Gateway->>InAppBrowserTab: Show requested page
-    note over NativeLayer,Gateway: User takes action to sign in or register and<br/>a session gets set in the browser through<br/>the in-app browser tab
-    Gateway->>InAppBrowserTab: Redirect back to app after<br/>session cookie set <br/>using custom URL scheme
-    InAppBrowserTab->>NativeLayer: Handle redirect request<br/>in-app browser tab to app<br/>using custom URL scheme
-    note over NativeLayer: Handle the callback<br/>request from the in-app browser<br/>tab to the native layer.<br/>The SDK will handle the rest of the following steps
-  end
-  opt generally handled by Okta SDK (Authorization)
-    NativeLayer->>InAppBrowserTab: Call `signin`/`signInWithBrowser`<br/>with the `prompt=none` option method to perform<br />Authorization Code Flow with PKCE
-    note over InAppBrowserTab: SDK will launch another in-app browser<br/>tab to handle the session check,<br/> and redirect back to the app with
-    InAppBrowserTab->>Okta: call OAuth /authorize?prompt=none
-    note over Okta: session check
-    Okta->>InAppBrowserTab: Redirect request to app with the `auth_code` parameter<br/>oauth redirect_uri
-    InAppBrowserTab->>NativeLayer: Handle redirect request<br/>in-app browser tab to app<br/>oauth redirect_uri?auth_code={code}
-    NativeLayer->>Okta: SDK uses auth_code to call OAuth /token to get OAuth tokens
-    Okta->>NativeLayer: Return tokens to SDK
-    note over NativeLayer: the SDK manages the tokens, which can now be used to<br/>authenticate requests, and for checking the user's<br/>session
-  end
+participant NativeLayer
+participant InAppBrowserTab
+participant Gateway
+participant Okta
+
+NativeLayer->>InAppBrowserTab: Call `signin`/`signInWithBrowser`<br/>to perform<br />Authorization Code Flow with PKCE
+note over InAppBrowserTab: SDK will launch another in-app browser<br/>tab to handle the session check,<br/> and redirect back to the app with auth code
+InAppBrowserTab->>Okta: call OAuth /authorize
+note over Okta: session check
+opt no existing session
+  Okta->>InAppBrowserTab: Return /login/login.html
+  note over InAppBrowserTab: Load html, run JS redirect<br> to /signin or /welcome/:token<br> with fromURI and clientId params
+  InAppBrowserTab->>Gateway: Request /signin or /welcome/:token with params
+  Gateway->>InAppBrowserTab: Load /signin or /welcome/:token
+  note over InAppBrowserTab: User sign in with<br>email+password/social/set password<br>session set in browser<br>redirect to fromURI
+  InAppBrowserTab->>Okta: Request fromUri
+end
+Okta->>InAppBrowserTab: Redirect request to app with the `auth_code` parameter<br/>oauth redirect_uri
+InAppBrowserTab->>NativeLayer: Handle redirect request<br/>in-app browser tab to app<br/>oauth redirect_uri?auth_code={code}
+NativeLayer->>Okta: SDK uses auth_code to call OAuth /token to get OAuth tokens
+Okta->>NativeLayer: Return tokens to SDK
+note over NativeLayer: the SDK manages the tokens, which can now be used to<br/>authenticate requests, and for checking the user's<br/>session
 ```
 
 ## Setup
 
 To setup a native app, we will need to register the application as an client within Okta. The identity team will be able to do this for you. We will need to know 3 things, all do do with redirects.
 
-1. A redirect URI for redirection from sign in and registration pages (authentication).
-   - This is the URI that the native app will be redirected to after a user signs in or registers on the profile subdomain and gets a session cookie set in the browser.
-   - This callback should be used to call the Okta SDK `signin`/`signInWithBrowser` with the `prompt=none` option to get the OAuth tokens, specifically the `id_token`, `access_token` and `refresh_token`.
-   - We suggest a custom URL scheme for this URI, which we can identify (`your-app:/authentication/callback`).
-   - e.g. `com.theguardian.app:/authentication/callback`
-2. A redirect callback URI for Okta authorization callback
+1. A redirect callback URI for Okta authorization callback
    - This is used by the Okta SDK to redirect back to after performing the authorization code flow with PKCE used to get OAuth tokens if a session is set.
    - Similar to above we suggest a custom URL scheme for this URI, which we can identify (`your-app:/authorization/callback`).
-   - e.g. `com.theguardian.app:/authorization/callback`
-3. A redirect callback URI for Okta logout callback
+   - e.g. `com.theguardian.app.oauth:/authorization/callback`
+2. A redirect callback URI for Okta logout callback
    - This is used by the Okta SDK to redirect back to after calling the logout method in the SDK.
    - Similar to above we suggest a custom URL scheme for this URI, which we can identify (`your-app:/logout/callback`).
-   - e.g. `com.theguardian.app:/logout/callback`
+   - e.g. `com.theguardian.app.oauth:/logout/callback`
+3. A redirect URI for handling generic redirects from identity to app as a fallback
+   - Due to the possibility that Okta may change how things work with their login page, we need a fallback to allow users to sign in should the interception fail
+   - This endpoint will ONLY be called if the interception fails
+   - See fallback section below for more details about this
+   - We suggest a custom URL scheme for this URI, which we can identify (`your-app://identity/fallback`).
+   - e.g. `com.theguardian.app://identity/fallback`
 
-No 1. will have to be handled by the native app itself by registering the custom url scheme.
+No 1. will be handled by the Okta SDK.
 
-No 2. will be handled by the Okta SDK.
+No 2. may have to be handled by the application rather than the Okta SDK to handle post logout clean up.
 
-No 3. may have to be handled by the application rather than the Okta SDK to handle post logout clean up.
+No 3. will have to be handled by the native app itself by registering the custom url scheme.
 
 We will need a set for the PROD, CODE, and possibly DEV environments.
 
@@ -72,108 +112,131 @@ Once the app is set up within Okta and this project. The Identity team will give
 | ------------------- | ---------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
 | Client ID           | `client_id`/`clientId`                         | The client ID from the app integration that was created                                                                                                                                                           | `0ux3rutxocxFX9xyz3t9`                                                            |
 | Issuer              | `discovery_uri`/`issuer`                       | Domain of the Okta app, followed by the OAuth authorization server. We use a custom authorization server rather than the default one as it lets us customise lifetimes of tokens                                  | `https://profile.theguardian.com/oauth2/aus2qtyn7pS1YsVLs0x7`                     |
-| Logout Redirect URI | `end_session_redirect_uri`/`logoutRedirectUri` | The post-logout redirect URI from the app integration that was created                                                                                                                                            | `com.theguardian.app:/logout/callback`                                            |
-| Redirect URI        | `redirect_uri`/`redirectUri`                   | The Redirect URI from the app integration that was created                                                                                                                                                        | `com.theguardian.app:/authorization/callback`                                     |
+| Logout Redirect URI | `end_session_redirect_uri`/`logoutRedirectUri` | The post-logout redirect URI from the app integration that was created                                                                                                                                            | `com.theguardian.app.oauth:/logout/callback`                                      |
+| Redirect URI        | `redirect_uri`/`redirectUri`                   | The Redirect URI from the app integration that was created                                                                                                                                                        | `com.theguardian.app.oauth:/authorization/callback`                               |
 | Scopes              | `scopes`                                       | Default permissions for the OAuth tokens, you'll want `openid profile offline_access` at the minimum. Information about the scopes can be seen [here](https://developer.okta.com/docs/reference/api/oidc/#scopes) | `openid profile offline_access` or json `["openid", "profile", "offline_access"]` |
 
-## Full sign in diagram
+## Diagrams
+
+### Sign In
 
 Much of the following is adopted from [signin.md](signin.md), with changes to fit the native apps implementation. Apps should only need to be aware of what's happening in the native layer, but the full flow is useful for understanding the interaction between the native layer and the identity system. User interaction is implied.
 
 ```mermaid
 sequenceDiagram
-  participant NativeLayer
-  participant InAppBrowserTab
-  participant Gateway
-  participant Okta
-  NativeLayer->>InAppBrowserTab: Open Browser Tab:<br/>`https://profile.theguardian.com/signin`
-  alt no existing session
-    InAppBrowserTab->>Gateway: Request gateway /signin
-    note over Gateway: Sign in session is not checked<br/>(encryptedState.signInRedirect == false | undefined)
-    note over Gateway: <br/>We check session using Okta OAuth Auth Code flow<br/>using `prompt=none` means no okta login is shown,<br/>and "error" returned instead
-    Gateway->>InAppBrowserTab: Redirect request to OAuth auth code flow<br/>/authorize?prompt=none...<br>see notes for other parameters/implementation
-    InAppBrowserTab->>Okta: Request /authorize
-    note over Okta: check for existing session<br>in this case none exists
-    Okta->>InAppBrowserTab: Redirect request to gateway<br>/oauth/authorization-code/callback?error=login_required
-    InAppBrowserTab->>Gateway: Request /oauth/authorization-code/callback?error=login_required
-    note over Gateway: check for `error=login_required`<br/>set `encryptedState.signInRedirect = true` as cookie
-    Gateway->>InAppBrowserTab: Redirect request to gateway `/signin`
-    InAppBrowserTab->>Gateway: Request gateway /signin
-    note over Gateway: Sign in session is checked<br/>(encryptedState.signInRedirect == true)<br>remove/set to false from the encryptedState
-    Gateway->>InAppBrowserTab: Return rendered sign in page
-    InAppBrowserTab->>Gateway: Login form POST /signin (email + password)
-    Gateway->>Okta: Authenticate with Okta<br/>/authn with email + pw)
-    note over Okta: validate email + password
-    Okta->>Gateway: response with sessionToken<br/>+ email/okta_id
-    note over Gateway: Perform auth code flow to create<br>Okta session
-    Gateway->>InAppBrowserTab: Redirect request to OAuth auth code flow<br/>/authorize?prompt=none&sessionToken={sessionToken}...<br>see notes for other parameters/implementation
-    InAppBrowserTab->>Okta: Request /authorize
-    note over Okta: Use sessionToken to create an okta session on<br/>auth subdomain as cookie
-  else existing existing session
-    InAppBrowserTab->>Gateway: Request gateway /signin
-    note over Gateway: Sign in session is not checked<br/>(encryptedState.signInRedirect == false | undefined)
-    note over Gateway: <br/>We check session using Okta OAuth Auth Code flow<br/>using `prompt=none` means no okta login is shown
-    Gateway->>InAppBrowserTab: Redirect request to OAuth auth code flow<br/>/authorize?prompt=none...<br>see notes for other parameters/implementation
-    InAppBrowserTab->>Okta: Request /authorize
-    note over Okta: check for existing session<br>in this case session exists<br>Okta will refresh the existing session
-  end
-  Okta->>InAppBrowserTab: Redirect request to gateway<br>/oauth/authorization-code/callback?code={auth_code}...<br/>see notes for other parameters/implementation
-  InAppBrowserTab->>Gateway: Request to gateway<br>/oauth/authorization-code/callback?code={auth_code}...
-  Gateway->>InAppBrowserTab: Redirect to return_url (app callback using custom url scheme)<br/> e.g. `com.theguardian.app:/authentication/callback`
-  InAppBrowserTab->>NativeLayer: Handle redirect request<br/>in-app browser tab to app<br/>e.g. `com.theguardian.app:/authentication/callback`
-  note over NativeLayer: Handle the callback<br/>request from the in-app browser<br/>tab to the native layer.<br/>At this point use the SDK for the rest of the flow,<br/>to check the okta session and get the<br/>relevant OAuth tokens.
-  NativeLayer->>InAppBrowserTab: Call `signin`/`signInWithBrowser`<br/>with the `prompt=none` option method to perform<br />Authorization Code Flow with PKCE
-  note over InAppBrowserTab: SDK will launch another in-app browser<br/>tab to handle the session check,<br/> and redirect back to the app with
-  InAppBrowserTab->>Okta: call OAuth /authorize?prompt=none
-  note over Okta: session check
-  Okta->>InAppBrowserTab: Redirect request to app with the `auth_code` parameter<br/>e.g. `com.theguardian.app:/authorization/callback?auth_code={auth_code}`
-  InAppBrowserTab->>NativeLayer: Handle redirect request<br/>in-app browser tab to app<br/>e.g.`com.theguardian.app:/authorization/callback?auth_code={auth_code}`
-  NativeLayer->>Okta: SDK uses auth_code to call OAuth /token to get OAuth tokens
-  Okta->>NativeLayer: Return tokens to SDK
-  note over NativeLayer: the SDK manages the tokens, which can now be used to<br/>authenticate requests, and for checking the user's<br/>session
+autonumber
+
+participant NativeLayer
+participant InAppBrowserTab
+participant Gateway
+participant Okta
+
+NativeLayer ->> InAppBrowserTab: Call `signin`/`signInWithBrowser`<br/>to perform<br />Authorization Code Flow with PKCE
+note over InAppBrowserTab: SDK will launch another in-app browser<br/>tab to handle the session check,<br/> and redirect back to the app with auth code
+InAppBrowserTab->>Okta: call OAuth /authorize
+note over Okta: Existing session check
+opt no existing session
+  Okta->>InAppBrowserTab: Redirect request to /login/login.html
+  InAppBrowserTab->>Okta: Request  /login/login.html
+  Okta->>InAppBrowserTab: Return /login/login.html
+  note over InAppBrowserTab: Run JS script<br>This redirect to /signin or /welcome/:token<br> with fromURI and clientId params
+  InAppBrowserTab->>Gateway: Request /signin
+  Gateway->>InAppBrowserTab: Return /signin
+  InAppBrowserTab ->> Gateway: Login form POST /signin (email + password)
+  Gateway ->> Okta: Authenticate with Okta<br/>/authn with email + pw)
+  note over Okta: validate email + password
+  Okta ->> Gateway: response with sessionToken<br/>+ email/okta_id
+  note over Gateway: Perform auth code flow to create<br>Okta session
+  Gateway ->> InAppBrowserTab: Redirect request to OAuth auth code flow<br/>/authorize?prompt=none&sessionToken={sessionToken}...<br>see notes for other parameters/implementation
+  InAppBrowserTab ->> Okta: Request /authorize
+  note over Okta: Use sessionToken to create an okta session on<br/>auth subdomain as cookie
+  Okta ->> InAppBrowserTab: Redirect request to gateway<br>/oauth/authorization-code/callback?code={auth_code}...<br/>see notes for other parameters/implementation
+  InAppBrowserTab ->> Gateway: Request to gateway<br>/oauth/authorization-code/callback?code={auth_code}...
+  Gateway ->> InAppBrowserTab: Redirect to fromURI parameter<br/> e.g. `/authorize?okta_key={okta_key}`
+  InAppBrowserTab ->> Okta: Request /authorize?okta_key={okta_key}
+  note over Okta: Session check<br>at this point session exists<br>in all scenarios
+end
+Okta ->> InAppBrowserTab: Redirect request to app with the `auth_code` parameter<br/>e.g. `com.theguardian.app.oauth:/authorization/callback?auth_code={auth_code}`
+InAppBrowserTab ->> NativeLayer: Handle redirect request<br/>in-app browser tab to app<br/>e.g.`com.theguardian.app.oauth:/authorization/callback?auth_code={auth_code}`
+NativeLayer ->> Okta: SDK uses auth_code to call OAuth /token to get OAuth tokens
+Okta ->> NativeLayer: Return tokens to SDK
+note over NativeLayer: the SDK manages the tokens, which can now be used to<br/>authenticate requests, and for checking the user's<br/>session
 ```
 
-## Full registration diagram
+## Registration
 
 Similar to sign in, much of the following is adopted from [registration.md](registration.md), with changes to fit the native apps implementation. Apps should only need to be aware of what's happening in the native layer, but the full flow is useful for understanding the interaction between the native layer and the identity system. User interaction is implied.
 
-// TODO: Add full registration document/details
+The start of this flow is very similar to the sign in journey.
 
 ```mermaid
 sequenceDiagram
-  participant NativeLayer
-  participant InAppBrowserTab
-  participant Gateway
-  participant Okta
-  participant EmailInbox
-  NativeLayer->>InAppBrowserTab: Open Browser Tab:<br/>`https://profile.theguardian.com/register`
-  InAppBrowserTab->>Gateway: Request gateway /register
-  Gateway->>InAppBrowserTab: Return rendered register page
-  InAppBrowserTab->>Gateway: POST /register with email
-  note over Gateway: Registration with Okta handled by Gateway
-  Gateway->>Okta: Create user in Okta
-  par
-    Okta->>EmailInbox: Send activation email
-    Okta->>Gateway: OK response
+autonumber
+
+participant NativeLayer
+participant InAppBrowserTab
+participant Gateway
+participant Okta
+participant EmailInbox
+
+NativeLayer ->> InAppBrowserTab: Call `signin`/`signInWithBrowser`<br/>to perform<br />Authorization Code Flow with PKCE
+note over InAppBrowserTab: SDK will launch another in-app browser<br/>tab to handle the session check
+InAppBrowserTab ->> Okta: call OAuth /authorize
+note over Okta: Existing session check
+alt
+  Okta ->> InAppBrowserTab: Redirect request to /login/login.html
+  InAppBrowserTab ->> Okta: Request  /login/login.html
+  Okta ->> InAppBrowserTab: Return /login/login.html
+  note over InAppBrowserTab: Run JS script<br>This redirect to /signin<br> with fromURI and clientId params
+  InAppBrowserTab ->> Gateway: Request /signin
+  Gateway ->> InAppBrowserTab: Return /signin
+  InAppBrowserTab ->> Gateway: Request /register
+  Gateway ->> InAppBrowserTab: Return /register
+  InAppBrowserTab  ->>  Gateway: Login form POST /register (email)
+  Gateway ->> Okta: register with Okta (no password) POST /api/v1/users?activate=false
+  Okta ->> Gateway: user response object status: STAGED
+  par Okta setup account
+    Gateway ->> Okta: activate user POST /api/v1/users/${userId}/lifecycle/activate?sendEmail=true
+    Okta ->> Gateway: activation token status: PROVISIONED
+  and
+    Okta ->> EmailInbox: Activation email
   end
-  Gateway->>InAppBrowserTab: Show email sent page<br/>with link to email inbox
-  note over InAppBrowserTab,EmailInbox: Assume user clicks activation link in email on same device
-  EmailInbox->>InAppBrowserTab: Click link in email /welcome/{activationToken}
-  InAppBrowserTab->>Gateway: GET /welcome/{activationToken}
-  note over Gateway: Validate token in Okta
-  Gateway->>InAppBrowserTab: Return rendered welcome/<br/>set password page
+  Gateway ->> InAppBrowserTab: Redirect to /register/email-sent
+  InAppBrowserTab ->> Gateway: Request /register/email-sent
+  Gateway ->> InAppBrowserTab: Return /register/email-sent
+  note over InAppBrowserTab: At this point the user<br>has to navigate to the email inbox<br/>and click the activation<br>link to activate their account.<br>The app should intercept this link<br>and handle the activation<br>process.
+  EmailInbox ->> InAppBrowserTab: Click link in email /welcome/{activationToken}
+  InAppBrowserTab ->> NativeLayer: Intercept activation link<br/>in-app browser tab to app
+  note over NativeLayer: Extract token from link<br/>and use SDK methods
+  NativeLayer ->> InAppBrowserTab: Call `signin`/`signInWithBrowser`<br/>to perform<br />Authorization Code Flow with PKCE<br>pass `activation_token` as additional parameter
+  note over InAppBrowserTab: SDK will launch another in-app browser<br/>tab to handle the session check
+  InAppBrowserTab ->> Okta: call OAuth /authorize
+  note over Okta: Existing session check
+  Okta ->> InAppBrowserTab: Redirect request to /login/login.html
+  InAppBrowserTab ->> Okta: Request  /login/login.html
+  Okta ->> InAppBrowserTab: Return /login/login.html
+  note over InAppBrowserTab: Run JS script redirect<br>/welcome/:token<br>with fromURI and clientId params
+  InAppBrowserTab ->> Gateway: Request /welcome/:token
+  Gateway ->> InAppBrowserTab: Return /welcome/:token
   InAppBrowserTab->>Gateway: POST /welcome/{activationToken} with password
-  note over Gateway:set password and add session
-  Gateway->>InAppBrowserTab: Redirect to return_url (app callback using custom url scheme)<br/> e.g. `com.theguardian.app:/authentication/callback`
-  InAppBrowserTab->>NativeLayer: Handle redirect request<br/>in-app browser tab to app<br/>e.g. `com.theguardian.app:/authentication/callback`
-  note over NativeLayer: Handle the callback<br/>request from the in-app browser<br/>tab to the native layer.<br/>At this point use the SDK for the rest of the flow,<br/>to check the okta session and get the<br/>relevant OAuth tokens.
-  NativeLayer->>InAppBrowserTab: Call `signin`/`signInWithBrowser`<br/>with the `prompt=none` option method to perform<br />Authorization Code Flow with PKCE
-  note over InAppBrowserTab: SDK will launch another in-app browser<br/>tab to handle the session check,<br/> and redirect back to the app with
-  InAppBrowserTab->>Okta: call OAuth /authorize?prompt=none
-  note over Okta: session check
-  Okta->>InAppBrowserTab: Redirect request to app with the `auth_code` parameter<br/>e.g. `com.theguardian.app:/authorization/callback?auth_code={auth_code}`
-  InAppBrowserTab->>NativeLayer: Handle redirect request<br/>in-app browser tab to app<br/>e.g.`com.theguardian.app:/authorization/callback?auth_code={auth_code}`
-  NativeLayer->>Okta: SDK uses auth_code to call OAuth /token to get OAuth tokens
-  Okta->>NativeLayer: Return tokens to SDK
-  note over NativeLayer: the SDK manages the tokens, which can now be used to<br/>authenticate requests, and for checking the user's<br/>session
+  Gateway ->> Okta: Set password return session token
+  note over Gateway: Perform auth code flow to create<br>Okta session
+  Gateway ->> InAppBrowserTab: Redirect request to OAuth auth code flow<br/>/authorize?prompt=none&sessionToken={sessionToken}...<br>see notes for other parameters/implementation
+  InAppBrowserTab ->> Okta: Request /authorize
+  note over Okta: Use sessionToken to create an okta session on<br/>auth subdomain as cookie
+  Okta ->> InAppBrowserTab: Redirect request to gateway<br>/oauth/authorization-code/callback?code={auth_code}...<br/>see notes for other parameters/implementation
+  InAppBrowserTab ->> Gateway: Request to gateway<br>/oauth/authorization-code/callback?code={auth_code}...
+  Gateway ->> InAppBrowserTab: Redirect to fromURI parameter<br/> e.g. `/authorize?okta_key={okta_key}`
+  InAppBrowserTab ->> Okta: Request /authorize?okta_key={okta_key}
+  note over Okta: Session check<br>at this point session exists<br>in all scenarios
+end
+Okta ->> InAppBrowserTab: Redirect request to app with the `auth_code` parameter<br/>e.g. `com.theguardian.app.oauth:/authorization/callback?auth_code={auth_code}`
+InAppBrowserTab ->> NativeLayer: Handle redirect request<br/>in-app browser tab to app<br/>e.g.`com.theguardian.app.oauth:/authorization/callback?auth_code={auth_code}`
+NativeLayer ->> Okta: SDK uses auth_code to call OAuth /token to get OAuth tokens
+Okta ->> NativeLayer: Return tokens to SDK
+note over NativeLayer: the SDK manages the tokens, which can now be used to<br/>authenticate requests, and for checking the user's<br/>session
 ```
+
+## Fallback
+
+TODO

--- a/scripts/okta/login-default.html
+++ b/scripts/okta/login-default.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+<html>
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex,nofollow" />
+    <!-- Styles generated from theme -->
+    <link href="{{themedStylesUrl}}" rel="stylesheet" type="text/css" />
+    <!-- Favicon from theme -->
+    <link rel="shortcut icon" href="{{faviconUrl}}" type="image/x-icon" />
+
+    <title>{{pageTitle}}</title>
+    {{{SignInWidgetResources}}}
+  </head>
+  <body>
+    <div
+      class="login-bg-image tb--background"
+      style="background-image: {{bgImageUrl}}"
+    ></div>
+    <div id="okta-login-container"></div>
+
+    <!--
+        "OktaUtil" defines a global OktaUtil object
+        that contains methods used to complete the Okta login flow.
+     -->
+    {{{OktaUtil}}}
+
+    <script type="text/javascript">
+      // "config" object contains default widget configuration
+      // with any custom overrides defined in your admin settings.
+      var config = OktaUtil.getSignInWidgetConfig();
+
+      // Render the Okta Sign-In Widget
+      var oktaSignIn = new OktaSignIn(config);
+      oktaSignIn.renderEl(
+        { el: '#okta-login-container' },
+        OktaUtil.completeLogin,
+        function (error) {
+          // Logs errors that occur when configuring the widget.
+          // Remove or replace this with your own custom error handler.
+          console.log(error.message, error);
+        },
+      );
+    </script>
+  </body>
+</html>

--- a/scripts/okta/okta-login.html
+++ b/scripts/okta/okta-login.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+<html>
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex,nofollow" />
+    <link
+      rel="icon"
+      href="https://static.guim.co.uk/images/favicon-32x32.ico"
+    />
+    <title>The Guardian | Login</title>
+    <script src="https://polyfill.io/v3/polyfill.min.js?features=URLSearchParams"></script>
+  </head>
+  <body>
+    {{{OktaUtil}}}
+    <script src="https://cdn.jsdelivr.net/gh/guardian/gateway@main/scripts/okta/okta-login.min.js"></script>
+  </body>
+</html>

--- a/scripts/okta/okta-login.js
+++ b/scripts/okta/okta-login.js
@@ -1,0 +1,41 @@
+// This file is the custom JavaScript for the Okta Login page.
+// We use this file to redirect users from the login page to our custom login/welcome page on Gateway.
+// This is so we can use the Okta SDKs, but still use our own custom login pages.
+
+// We use jsdelivr to load this script, the automatic minification reduces the size.
+// e.g. <script src="https://cdn.jsdelivr.net/gh/guardian/gateway@main/scripts/okta/okta-login.min.js"></script>
+
+// If testing out changes for a particular branch you can change the branch it's looking for in the custom HTML itself.
+// e.g. for a branch called `feature-branch-xyz`
+// <script src="https://cdn.jsdelivr.net/gh/guardian/gateway@feature-branch-xyz/scripts/okta/okta-login.min.js"></script>
+// or commit
+// <script src="https://cdn.jsdelivr.net/gh/guardian/gateway@df4557838d25ab7991130acc4cbe92e6ab063e6d/scripts/okta/okta-login.min.js"></script>
+
+// use IIFE to avoid global scope pollution on the Okta hosted login page
+(function () {
+  // set up params class to hold the parameters we'll be passing to our own login page
+  const params = new URLSearchParams();
+
+  // get the parameters from the Okta hosted login page
+  const fromURI = window.OktaUtil.getSignInWidgetConfig().relayState;
+  const clientId = window.OktaUtil.getRequestContext().target.clientId;
+
+  // add the parameters to the params class
+  params.set('fromURI', fromURI);
+  params.set('clientId', clientId);
+  // set the useOkta flag
+  params.set('useOkta', 'true');
+
+  // check the Okta hosted login page query params for an activation toke
+  const searchParams = new URLSearchParams(window.location.search);
+  const activationToken = searchParams.get('activation_token');
+  if (activationToken) {
+    // if we have an activation token, we know we need to go to the create password/welcome page
+    window.location.replace(
+      '/welcome/' + activationToken + '?' + params.toString(),
+    );
+  } else {
+    // if we don't have an activation token, we need to go to the sign in page
+    window.location.replace('/signin?' + params.toString());
+  }
+})();

--- a/src/server/lib/queryParams.ts
+++ b/src/server/lib/queryParams.ts
@@ -42,6 +42,8 @@ export const parseExpressQueryParams = (
     error_description,
     useOkta,
     componentEventParams,
+    fromURI,
+    appClientId,
   }: Record<keyof QueryParams, string | undefined>, // parameters from req.query
   // some parameters may be manually passed in req.body too,
   // generally for tracking purposes
@@ -62,6 +64,8 @@ export const parseExpressQueryParams = (
     error,
     error_description,
     useOkta: isStringBoolean(useOkta),
+    fromURI,
+    appClientId,
   };
 };
 

--- a/src/server/routes/oauth.ts
+++ b/src/server/routes/oauth.ts
@@ -150,14 +150,22 @@ router.get(
           )
         : authState.queryParams.returnUrl;
 
-      // TODO: This is a temp hack to handle the apps redirects
+      // This is a fallback to handle the apps redirects
       // back to the deep link from sign in/registration
       // the hard coded query param is also temp to test if they're
       // able to read data we send back
       if (
         validAppProtocols.some((protocol) => returnUrl.startsWith(protocol))
       ) {
-        return res.redirect(303, `${returnUrl}?reason=signin`);
+        return res.redirect(303, returnUrl);
+      }
+
+      // We only use to this option if the app does not provide a deep link with a custom scheme
+      // This allows the native apps to complete the authorization code flow for the app.
+      // the fromURI parameter is an undocumented feature from Okta that allows us to
+      // rejoin the authorization code flow after we have set a session cookie on our own platform
+      if (authState.queryParams.fromURI) {
+        return res.redirect(303, authState.queryParams.fromURI);
       }
 
       postSignInController(req, res, cookies, returnUrl);

--- a/src/shared/__tests__/queryParams.test.ts
+++ b/src/shared/__tests__/queryParams.test.ts
@@ -20,6 +20,8 @@ describe('getPersistableQueryParams', () => {
       ref: 'ref',
       refViewId: 'refViewId',
       componentEventParams: 'componentEventParams',
+      fromURI: 'fromURI',
+      appClientId: 'appClientId',
     };
 
     const output = getPersistableQueryParams(input);
@@ -31,6 +33,8 @@ describe('getPersistableQueryParams', () => {
       refViewId: 'refViewId',
       componentEventParams: 'componentEventParams',
       useOkta: undefined,
+      fromURI: 'fromURI',
+      appClientId: 'appClientId',
     };
 
     expect(output).toStrictEqual(expected);

--- a/src/shared/lib/queryParams.ts
+++ b/src/shared/lib/queryParams.ts
@@ -19,6 +19,8 @@ export const getPersistableQueryParams = (
   refViewId: params.refViewId,
   useOkta: params.useOkta,
   componentEventParams: params.componentEventParams,
+  fromURI: params.fromURI,
+  appClientId: params.appClientId,
 });
 
 /**

--- a/src/shared/model/QueryParams.ts
+++ b/src/shared/model/QueryParams.ts
@@ -33,6 +33,12 @@ export interface PersistableQueryParams
   returnUrl: string;
   useOkta?: boolean;
   clientId?: ValidClientId;
+  // This is the fromURI query parameter from Otka authorization code flow
+  // that we intercept in fastly. We can send a user back to this uri
+  // to complete the authorization code flow for that application
+  fromURI?: string;
+  // This is the client Id of a calling application in Okta (ie iOS app etc)
+  appClientId?: string;
 }
 
 /**


### PR DESCRIPTION
## What does this change?

This PR is to add information about the interception of the Okta SDK calls proposal we are going with for our native apps implementation.

We will be intercepting the calls to Okta on the `/login/login.htm` call. By loading the Okta hosted sign in page on this URL, and then using JavaScript to redirect the user immediately to our own sign in/register pages.

Since we're unable to terraform the implementation of the Okta hosted sign in page, we are hosting it here.

We add the [custom HTML](scripts/okta/okta-login.html) that we'll be using to this PR, along with the [custom JS](scripts/okta/okta-login.js). We also keep a [backup](scripts/okta/login-default.html) of the default okta login page for reference.

The custom JS is used to pass two parameters form the Okta hosted sign in page, to the gateway pages, specifically the `clientId` and `fromURI`, these are persisted on all following gateway pages.

The `clientId` is set so we can know what app the user has come from, which is the Okta ID of the OAuth application in Okta relating to the native app

The `fromURI` parameter is an Okta set undocumented parameter that represent the users authorization code flow parameters, and allows us to complete the authorization code flow after logging the user in.

This PR also rewrites the [integration guide](docs/okta/native-apps-integration-guide.md) for apps with all this new information.

## TODO
- [ ] Add details/POC about the fallback route