### PR TITLE
Change logo to standard logo

### DIFF
--- a/src/client/components/ConsentsHeader.tsx
+++ b/src/client/components/ConsentsHeader.tsx
@@ -3,17 +3,15 @@ import { GlobalError } from '@/client/components/GlobalError';
 import { GlobalSuccess } from '@/client/components/GlobalSuccess';
 import { Header } from '@/client/components/Header';
 import { DEFAULT_ERROR_LINK } from '@/client/lib/ErrorLink';
-import { GeoLocation } from '@/shared/model/Geolocation';
 
 type Props = {
   error?: string;
   success?: string;
-  geolocation?: GeoLocation;
 };
 
-export const ConsentsHeader = ({ error, success, geolocation }: Props) => (
+export const ConsentsHeader = ({ error, success }: Props) => (
   <>
-    <Header geolocation={geolocation} />
+    <Header />
     {error && <GlobalError error={error} link={DEFAULT_ERROR_LINK} left />}
     {success && <GlobalSuccess success={success} />}
   </>

--- a/src/client/components/Header.stories.tsx
+++ b/src/client/components/Header.stories.tsx
@@ -33,8 +33,5 @@ Mobile.parameters = {
   },
 };
 
-export const GeoGB = () => <Header geolocation="GB" />;
-GeoGB.storyName = 'with geolocation GB';
-
-export const GeoNotGB = () => <Header geolocation="ROW" />;
-GeoNotGB.storyName = 'with geolocation not GB';
+export const GeoGB = () => <Header />;
+GeoGB.storyName = 'with defaults';

--- a/src/client/components/Header.tsx
+++ b/src/client/components/Header.tsx
@@ -3,11 +3,6 @@ import { css } from '@emotion/react';
 import { brand, from, space } from '@guardian/source-foundations';
 import { Logo } from '@guardian/source-react-components-development-kitchen';
 import { gridRow, manualRow, SpanDefinition } from '@/client/styles/Grid';
-import { GeoLocation } from '@/shared/model/Geolocation';
-
-interface HeaderProps {
-  geolocation?: GeoLocation;
-}
 
 const marginStyles = css`
   margin-top: ${space[5]}px;
@@ -52,11 +47,11 @@ const headerSpanDefinition: SpanDefinition = {
   },
 };
 
-export const Header = ({ geolocation }: HeaderProps) => (
+export const Header = () => (
   <header id="top" css={backgroundColor}>
     <div css={[gridRow, marginStyles]}>
       <div css={[manualRow(1, headerSpanDefinition), headerGridRightToLeft]}>
-        <Logo logoType={geolocation === 'GB' ? 'bestWebsite' : 'anniversary'} />
+        <Logo />
       </div>
     </div>
   </header>

--- a/src/client/layouts/ConsentsLayout.tsx
+++ b/src/client/layouts/ConsentsLayout.tsx
@@ -44,16 +44,11 @@ export const ConsentsLayout: FunctionComponent<ConsentsLayoutProps> = ({
 }) => {
   const autoRow = getAutoRow(1, gridItemColumnConsents);
   const clientState = useClientState();
-  const { pageData = {}, globalMessage: { error, success } = {} } = clientState;
-  const { geolocation } = pageData;
+  const { globalMessage: { error, success } = {} } = clientState;
 
   return (
     <>
-      <ConsentsHeader
-        error={error}
-        success={success}
-        geolocation={geolocation}
-      />
+      <ConsentsHeader error={error} success={success} />
       <main css={mainStyles}>
         <ConsentsSubHeader autoRow={autoRow} title={title} current={current} />
         {children && (

--- a/src/client/layouts/Main.tsx
+++ b/src/client/layouts/Main.tsx
@@ -138,10 +138,7 @@ export const MainLayout = ({
   errorContext,
 }: PropsWithChildren<MainLayoutProps>) => {
   const clientState = useClientState();
-  const {
-    globalMessage: { error, success } = {},
-    pageData: { geolocation } = {},
-  } = clientState;
+  const { globalMessage: { error, success } = {} } = clientState;
 
   const successMessage = successOverride || success;
   const errorMessage = errorOverride || error;
@@ -151,7 +148,7 @@ export const MainLayout = ({
 
   return (
     <>
-      <Header geolocation={geolocation} />
+      <Header />
       <main css={[mainStyles, gridRow]}>
         <section css={gridItem(gridSpanDefinition)}>
           {errorMessage && (

--- a/src/client/pages/Registration.tsx
+++ b/src/client/pages/Registration.tsx
@@ -20,7 +20,6 @@ import locations from '@/shared/lib/locations';
 import { EmailInput } from '@/client/components/EmailInput';
 import { buildUrlWithQueryParams } from '@/shared/lib/routeUtils';
 import { QueryParams } from '@/shared/model/QueryParams';
-import { GeoLocation } from '@/shared/model/Geolocation';
 import { RefTrackingFormFields } from '@/client/components/RefTrackingFormFields';
 import { trackFormFocusBlur, trackFormSubmit } from '@/client/lib/ophan';
 import { logger } from '@/client/lib/clientSideLogger';
@@ -31,7 +30,6 @@ export type RegistrationProps = {
   recaptchaSiteKey: string;
   oauthBaseUrl: string;
   queryParams: QueryParams;
-  geolocation?: GeoLocation;
 };
 
 const registerButton = css`
@@ -66,7 +64,6 @@ export const Registration = ({
   recaptchaSiteKey,
   oauthBaseUrl,
   queryParams,
-  geolocation,
 }: RegistrationProps) => {
   const formTrackingName = 'register';
   const registerFormRef = createRef<HTMLFormElement>();
@@ -110,7 +107,7 @@ export const Registration = ({
 
   return (
     <>
-      <Header geolocation={geolocation} />
+      <Header />
       <Nav
         tabs={[
           {

--- a/src/client/pages/RegistrationPage.tsx
+++ b/src/client/pages/RegistrationPage.tsx
@@ -10,7 +10,7 @@ export const RegistrationPage = () => {
     clientHosts,
     queryParams,
   } = clientState;
-  const { returnUrl, email, geolocation } = pageData;
+  const { returnUrl, email } = pageData;
   const { oauthBaseUrl } = clientHosts;
   const { recaptchaSiteKey } = recaptchaConfig;
 
@@ -21,7 +21,6 @@ export const RegistrationPage = () => {
       recaptchaSiteKey={recaptchaSiteKey}
       oauthBaseUrl={oauthBaseUrl}
       queryParams={queryParams}
-      geolocation={geolocation}
     />
   );
 };

--- a/src/client/pages/SignIn.tsx
+++ b/src/client/pages/SignIn.tsx
@@ -15,7 +15,6 @@ import { Divider } from '@guardian/source-react-components-development-kitchen';
 import { CaptchaErrors, SignInErrors } from '@/shared/model/Errors';
 import { EmailInput } from '@/client/components/EmailInput';
 import { buildUrlWithQueryParams } from '@/shared/lib/routeUtils';
-import { GeoLocation } from '@/shared/model/Geolocation';
 import { QueryParams } from '@/shared/model/QueryParams';
 import { DetailedRecaptchaError } from '@/client/components/DetailedRecaptchaError';
 import useRecaptcha, {
@@ -32,7 +31,6 @@ export type SignInProps = {
   email?: string;
   error?: string;
   oauthBaseUrl: string;
-  geolocation?: GeoLocation;
   recaptchaSiteKey: string;
 };
 
@@ -136,7 +134,6 @@ export const SignIn = ({
   error: pageLevelError,
   oauthBaseUrl,
   queryParams,
-  geolocation,
   recaptchaSiteKey,
 }: SignInProps) => {
   const formTrackingName = 'sign-in';
@@ -184,7 +181,7 @@ export const SignIn = ({
 
   return (
     <>
-      <Header geolocation={geolocation} />
+      <Header />
       <Nav
         tabs={[
           {

--- a/src/client/pages/SignInPage.tsx
+++ b/src/client/pages/SignInPage.tsx
@@ -12,7 +12,7 @@ export const SignInPage = () => {
     queryParams,
     recaptchaConfig,
   } = clientState;
-  const { returnUrl, email, geolocation } = pageData;
+  const { returnUrl, email } = pageData;
   const { error } = globalMessage;
   const { oauthBaseUrl } = clientHosts;
   const { recaptchaSiteKey } = recaptchaConfig;
@@ -26,7 +26,6 @@ export const SignInPage = () => {
       error={error}
       oauthBaseUrl={oauthBaseUrl}
       queryParams={queryParams}
-      geolocation={geolocation}
       recaptchaSiteKey={recaptchaSiteKey}
     />
   );

--- a/src/email/components/Header.tsx
+++ b/src/email/components/Header.tsx
@@ -3,8 +3,8 @@ import React from 'react';
 import { MjmlSection, MjmlColumn, MjmlImage } from 'mjml-react';
 import { brandBackground } from '@guardian/source-foundations';
 
-// header should be 72px in height, using the width 144px of the design, and 6px of top/bottom padding
-// we get to 72px height, with the image dimensions itself being 600x250 (anniversary logo)
+// header should be 72px in height, using the width 192px of the design, and 6px of top/bottom padding
+// we get to 72px height, with the image dimensions itself being 250px height
 export const Header = () => (
   <MjmlSection
     background-color={brandBackground.primary}
@@ -14,9 +14,9 @@ export const Header = () => (
     <MjmlColumn>
       <MjmlImage
         padding="6px 0px"
-        width="144px"
+        width="149px"
         align="right"
-        src="https://s3-eu-west-1.amazonaws.com/identity-public-email-assets/logo.white.med.anniversary.png"
+        src="https://uploads.guim.co.uk/2022/05/04/guardian.logo.white.med.250.png"
       />
     </MjmlColumn>
   </MjmlSection>


### PR DESCRIPTION
## What does this change?

Remove the anniversary logo and replace it with the standard logo on web and emails.

Since we're using the standard logo everywhere now, we no longer need the `geolocation` parameter on the logo for visitors from outside the UK.

| Viewport | Screenshot |
| - | - |
| Mobile | ![60929d168594f80039336501-hveleqkkgr chromatic com_iframe html_args= id=components-header--mobile viewMode=story(iPhone SE)](https://user-images.githubusercontent.com/13315440/166520104-11da369e-5ae4-4c09-aa72-232491362f7a.png) |
| Tablet | ![60929d168594f80039336501-hveleqkkgr chromatic com_iframe html_args= id=components-header--mobile viewMode=story(iPad Air)](https://user-images.githubusercontent.com/13315440/166520132-144aaeea-f09b-4df3-8f91-cc29676a61d3.png) |
| Desktop | ![60929d168594f80039336501-hveleqkkgr chromatic com_iframe html_args= id=components-header--mobile viewMode=story](https://user-images.githubusercontent.com/13315440/166520147-ed30a0c8-5417-44cd-a201-82b18ec6f12c.png) |
| Email | ![chrome_lmLlnB1JYf](https://user-images.githubusercontent.com/13315440/166688597-1cd493eb-c2be-49fd-a9b2-6c80bb0370c4.png) |

Storybook Main Layout: https://60929d168594f80039336501-avaodwhmff.chromatic.com/?path=/story/layout-main--with-form-and-recaptcha

Storybook Email Layout: https://60929d168594f80039336501-avaodwhmff.chromatic.com/?path=/story/email-components-page--default

**_Note to reviewers:_**
Be sure to review the chromatic changes too!


### Post merge

Create PR in Identity to update the email templates.