### PR TITLE
Add `gu-cmp-disabled` cookie for redirect to manage/signin CODE

### DIFF
--- a/cypress/integration/mocked/okta_register.spec.ts
+++ b/cypress/integration/mocked/okta_register.spec.ts
@@ -105,6 +105,9 @@ describe('Okta Register flow', () => {
 
       setSidCookie();
 
+      // disable the cmp on the redirect
+      cy.setCookie('gu-cmp-disabled', 'true');
+
       cy.visit('/register?useOkta=true');
 
       cy.url().should(

--- a/cypress/integration/mocked/okta_sign_in.spec.ts
+++ b/cypress/integration/mocked/okta_sign_in.spec.ts
@@ -31,7 +31,11 @@ describe('Sign in flow', () => {
 
       cy.setCookie('sid', `the_sid_cookie`);
 
+      // disable the cmp  on the redirect
+      cy.setCookie('gu-cmp-disabled', 'true');
+
       cy.visit('/signin?useOkta=true');
+
       // The code version of manage will redirect the user twice,
       // once to manage.code.dev-theguardian.com and then because the user is not signed in
       // a 2nd redirect to profile.code.dev-theguardian.com,


### PR DESCRIPTION
## What does this change?

Fixes an issue where the CMP banner would appear when redirecting to the manage and signin page on the CODE environment from Cypress.

This randomly started causing test failures in cypress with a `(uncaught exception)Error: no IAB consent framework found on the page` error.

Adding the ``gu-cmp-disabled=true` cookie on the redirect to the CODE environments fixes the issue as it stops the CMP from attempting to load.