### PR TITLE
Okta | Fix Apps Okta Params

### DIFF
--- a/src/server/controllers/checkPasswordToken.ts
+++ b/src/server/controllers/checkPasswordToken.ts
@@ -168,10 +168,16 @@ export const checkTokenInOkta = async (
     // get the returnUrl
     const returnUrl = getReturnUrl(res.locals, encryptedStateQueryParams);
 
+    // get fromURI and appClientId, which are parameters from the Okta SDK
+    // and unique to this request
+    const { fromURI, appClientId } = res.locals.queryParams;
+
     // finally generate the queryParams object to merge in with the requestState
     // with the correct returnUrl for this request
     const queryParams = deepmerge(encryptedStateQueryParams, {
       returnUrl,
+      fromURI,
+      appClientId,
     });
 
     const html = renderer(

--- a/src/server/controllers/sendChangePasswordEmail.ts
+++ b/src/server/controllers/sendChangePasswordEmail.ts
@@ -12,7 +12,7 @@ import { trackMetric } from '@/server/lib/trackMetric';
 import { emailSendMetric } from '@/server/models/Metrics';
 import {
   addQueryParamsToPath,
-  getPersistableQueryParams,
+  getPersistableQueryParamsWithoutOktaParams,
 } from '@/shared/lib/queryParams';
 import { logger } from '@/server/lib/serverSideLogger';
 import { ApiError } from '@/server/models/Error';
@@ -147,7 +147,9 @@ const sendEmailInOkta = async (
       email,
       // We set queryParams here to allow state to be persisted as part of the registration flow,
       // because we are unable to pass these query parameters via the email activation link in Okta email templates
-      queryParams: getPersistableQueryParams(res.locals.queryParams),
+      queryParams: getPersistableQueryParamsWithoutOktaParams(
+        res.locals.queryParams,
+      ),
     });
 
     sendOphanEvent(state.ophanConfig);

--- a/src/server/routes/register.ts
+++ b/src/server/routes/register.ts
@@ -25,7 +25,7 @@ import { ApiError } from '@/server/models/Error';
 import { ResponseWithRequestState } from '@/server/models/Express';
 import {
   addQueryParamsToPath,
-  getPersistableQueryParams,
+  getPersistableQueryParamsWithoutOktaParams,
 } from '@/shared/lib/queryParams';
 import { EmailType } from '@/shared/model/EmailType';
 import { GenericErrors, RegistrationErrors } from '@/shared/model/Errors';
@@ -277,7 +277,9 @@ const OktaRegistration = async (
       status: user.status,
       // We set queryParams here to allow state to be persisted as part of the registration flow,
       // because we are unable to pass these query parameters via the email activation link in Okta email templates
-      queryParams: getPersistableQueryParams(res.locals.queryParams),
+      queryParams: getPersistableQueryParamsWithoutOktaParams(
+        res.locals.queryParams,
+      ),
     });
 
     trackMetric('OktaRegistration::Success');

--- a/src/shared/lib/queryParams.ts
+++ b/src/shared/lib/queryParams.ts
@@ -24,6 +24,21 @@ export const getPersistableQueryParams = (
 });
 
 /**
+ * @param params QueryParams object with all query parameters
+ * @returns PersistableQueryParams - object with query parameters to persist between requests but without the appClientId and fromURI params which are Okta specific
+ */
+export const getPersistableQueryParamsWithoutOktaParams = (
+  params: QueryParams,
+): PersistableQueryParams => {
+  const persistableQueryParams = getPersistableQueryParams(params);
+  // eslint-disable-next-line functional/immutable-data
+  delete persistableQueryParams.appClientId;
+  // eslint-disable-next-line functional/immutable-data
+  delete persistableQueryParams.fromURI;
+  return persistableQueryParams;
+};
+
+/**
  *
  * @param path a path segment of a url that is typed as part of RoutePaths
  * @param params QueryParams - any query params to be added to the path


### PR DESCRIPTION
## What does this change?

Apps had noticed an issue when setting up the registration flow with the interception approach in Okta where they noticed a "state mismatch" when performing the Authorization Code Flow with PKCE within the app.

After some mobbing, we found that the expected state was on the second call to the `signin` method from within the Okta SDK (to open the welcome page), but the received state was the one on the first call to the `signin` method (to open the sign in/register page). This was unexpected/

After some further investigation we noticed that the functionality to preserve query params on the same browser, through the use of the encrypted state cookie, was the culprit for this issue. When the welcome page loaded, instead of reading the query params from that request itself, it instead read the query params from the encrypted state cookie if they existed. Because the `fromURI` and `appClientId` parameters were also on this encrypted state cookie, they took priority over the ones on the request itself, causing a mismatch in the state when redirecting back to the app, i.e we used the `fromURI` from the encrypted state cookie to redirect back to the app, which was the `fromURI` of the initial call to `signin` from the SDK. This caused a state mismatch.

To fix this we made sure not to add the  `appClientId` and `fromURI` parameters to the encrypted state cookie when sending a registration or reset password email through Okta, and also making sure to read the same parameters from the query params of the request when loading the change password or welcome page (in the `checkPasswordToken` controller).

We also changed and added tests to check this behaviour.

## Summary of Changes

- Fix: Not to add the `appClientId` and `fromURI` parameters to the encrypted state cookie when sending an email through Okta by using the new `getPersistableQueryParamsWithoutOktaParams` method
- Fix: Read the `appClientId` and `fromURI` parameter from the `res.locals.queryParams` in `checkPasswordToken` controller
- Adds and updates cypress tests to check this behaviour works as expected 