### PR TITLE
Fix: Apps fallback option  where `fromURI=undefined` as string query parameter

### DIFF
--- a/scripts/okta/okta-login.js
+++ b/scripts/okta/okta-login.js
@@ -26,9 +26,9 @@
 
   // Variable holders for the Okta params we want to pass to our own login page
   // This is the URI to redirect to after the user has logged in and has a session set to complete the Authorization Code Flow from the SDK.
-  var fromURI = undefined;
+  var fromURI;
   // This is the client ID of the application that is calling the SDK and in turn performing the Authorization Code Flow. This parameter can be used to customise the experience our pages. We attempt to get it from the OktaUtil object, with the existing search parameters as a fallback option
-  var clientId = undefined;
+  var clientId;
 
   // force fallback flag, used to test fallback behaviour
   var forceFallback = searchParams.get('force_fallback');
@@ -61,8 +61,12 @@
   }
 
   // add the parameters to the params class
-  params.set('fromURI', fromURI);
-  params.set('appClientId', clientId);
+  if (fromURI) {
+    params.set('fromURI', fromURI);
+  }
+  if (clientId) {
+    params.set('appClientId', clientId);
+  }
   // set the useOkta flag
   params.set('useOkta', 'true');
 


### PR DESCRIPTION
## What does this change?

Fixes a bug where the `fromURI` parameter was still being passed through as `fromURI=undefined` in the query parameters, which was parsed as a string.

![chrome_hwzSywJYPG](https://user-images.githubusercontent.com/13315440/173532024-8c5d88c7-c932-4a59-a8d9-5b2220f27b56.png)

To fix this we first check if `fromURI` is defined before setting the parameter. 
