### PR TITLE
fix hover style for eye part of password input field

### DIFF
--- a/src/client/components/PasswordInput.tsx
+++ b/src/client/components/PasswordInput.tsx
@@ -6,7 +6,7 @@ import {
 } from '@guardian/source-react-components';
 import React, { useState } from 'react';
 import { css } from '@emotion/react';
-import { neutral, height } from '@guardian/source-foundations';
+import { neutral, height, focusHalo } from '@guardian/source-foundations';
 import {
   disableAutofillBackground,
   noBorderRadius,
@@ -105,6 +105,9 @@ const EyeSymbol = ({
     padding-top: 4px;
     margin-left: 0;
     margin-right: 0;
+    :focus {
+      ${focusHalo};
+    }
   `;
 
   return (


### PR DESCRIPTION
## What does this change?
Made the focus style for the eye button consistent with the other fields

**before:**

https://user-images.githubusercontent.com/15324270/175987671-e5b580d1-b384-41e8-82db-6fe81a1cd21a.mov

**after**

https://user-images.githubusercontent.com/15324270/175987974-54897a7c-8508-4c28-9465-02211a776e34.mov



