### PR TITLE
MVP3 | Fix sign in and register inactivity alarms with Okta

### DIFF
--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -600,7 +600,10 @@ Resources:
             Metric:
               Namespace: Gateway
               MetricName: 'SignIn::Success'
-            Period: 60
+              Dimensions:
+                - Name: Stage
+                  Value: !Ref 'Stage'
+            Period: 1200
             Stat: Sum
             Unit: Count
           ReturnData: false
@@ -609,21 +612,20 @@ Resources:
             Metric:
               Namespace: Gateway
               MetricName: 'OktaSignIn::Success'
-            Period: 60
+              Dimensions:
+                - Name: Stage
+                  Value: !Ref 'Stage'
+            Period: 1200
             Stat: Sum
             Unit: Count
           ReturnData: false
       ComparisonOperator: LessThanThreshold
       Threshold: 1
-      Period: 1200
       EvaluationPeriods: 1
       AlarmActions:
         - !Ref 'TopicSendEmail'
       InsufficientDataActions:
         - !Ref 'TopicSendEmail'
-      Dimensions:
-        - Name: Stage
-          Value: !Ref 'Stage'
   RegisterInactivityAlarm:
     Type: AWS::CloudWatch::Alarm
     Condition: IsProd
@@ -641,7 +643,10 @@ Resources:
             Metric:
               Namespace: Gateway
               MetricName: 'Register::Success'
-            Period: 60
+              Dimensions:
+                - Name: Stage
+                  Value: !Ref 'Stage'
+            Period: 3600
             Stat: Sum
             Unit: Count
           ReturnData: false
@@ -650,18 +655,17 @@ Resources:
             Metric:
               Namespace: Gateway
               MetricName: 'OktaRegistration::Success'
-            Period: 60
+              Dimensions:
+                - Name: Stage
+                  Value: !Ref 'Stage'
+            Period: 3600
             Stat: Sum
             Unit: Count
           ReturnData: false
       ComparisonOperator: LessThanThreshold
       Threshold: 1
-      Period: 3600
       EvaluationPeriods: 1
       AlarmActions:
         - !Ref 'TopicSendEmail'
       InsufficientDataActions:
         - !Ref 'TopicSendEmail'
-      Dimensions:
-        - Name: Stage
-          Value: !Ref 'Stage'


### PR DESCRIPTION
## What does this change?

In #1798 I added alarms for Okta Sign In and Registration, however this caused cloudformation errors when attempting to deploy.

This PR fixes the issues that the couldformation errors identified within the AWS console.

This has also been tested by manually deploying the cloudformation file within the AWS console itself.