### PR TITLE
Add Jest test for security headers, improve Supertest setup

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -12,6 +12,7 @@ module.exports = {
     '<rootDir>/cypress/',
     '<rootDir>/node_modules/',
     'utils',
+    '<rootDir>/src/server/lib/__tests__/sharedConfig.ts',
   ],
   globals: {
     'ts-jest': {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1,19 +1,13 @@
-import { default as express, Express } from 'express';
+import createServer from '@/server/server';
 import { logger } from '@/server/lib/serverSideLogger';
-import { getConfiguration } from '@/server/lib/getConfiguration';
-import { applyMiddleware } from '@/server/lib/middleware';
 import redisClient from '@/server/lib/redis/redisClient';
 import { startGlobalBucketCapacityLogger } from '@/server/lib/rate-limit';
-
+import { getConfiguration } from '@/server/lib/getConfiguration';
 const { port, rateLimiter } = getConfiguration();
 
-const server: Express = express();
+const server = createServer();
 
-applyMiddleware(server);
-
-const serverInstance = server.listen(port);
-
-server.set('trust proxy', true);
+server.listen(port);
 
 logger.info(`server running on port ${port}`);
 
@@ -24,5 +18,3 @@ if (
 ) {
   startGlobalBucketCapacityLogger(redisClient, 5000);
 }
-
-export default serverInstance;

--- a/src/server/lib/__tests__/headers.test.ts
+++ b/src/server/lib/__tests__/headers.test.ts
@@ -1,0 +1,123 @@
+import { ValidRoutePathsArray } from '@/shared/model/Routes';
+import Redis from 'ioredis-mock';
+import request from 'supertest';
+import {
+  defaultRateLimiterConfiguration,
+  getServerInstance,
+} from './sharedConfig';
+
+// Override the default 5s max timeout for these tests because Supertest takes some time to run.
+jest.setTimeout(10000);
+
+/**
+ * We mock a section of our app infrastruture so that the routes that Supertest
+ * runs complete without throwing early errors. We're only testing the headers
+ * we set in middleware here.
+ */
+jest.mock('@/server/lib/getAssets', () => ({
+  getAssets: () => ({
+    main: { js: 'mocked' },
+    vendors: { js: 'mocked' },
+    runtime: { js: 'mocked' },
+  }),
+}));
+jest.mock('@/server/lib/serverSideLogger', () => ({
+  logger: {
+    info: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+jest.mock('aws-sdk');
+jest.mock('@/server/lib/getAssets', () => ({
+  getAssets: () => ({
+    main: { js: 'mocked' },
+    vendors: { js: 'mocked' },
+    runtime: { js: 'mocked' },
+  }),
+}));
+jest.mock('@/server/lib/serverSideLogger', () => ({
+  logger: {
+    info: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+jest.mock('@/server/lib/redis/redisClient', () => new Redis());
+jest.mock('@/server/lib/middleware/login', () => ({
+  loginMiddleware: jest.fn((req, res, next) => next()),
+}));
+jest.mock('@/server/lib/IDAPIFetch');
+
+describe('Content Security Policy headers', () => {
+  test.each(ValidRoutePathsArray)(
+    'returns CSP headers for %s',
+    async (route) => {
+      const server = await getServerInstance(defaultRateLimiterConfiguration);
+      const response = await request(server).get(route);
+      // Dynamically import getConfiguration so the changes to the environment
+      // variables are reflected inside the getConfiguration() call
+      const { getConfiguration } = await import(
+        '@/server/lib/getConfiguration'
+      );
+      const { baseUri, apiDomain } = getConfiguration();
+      // Is the CSP header set?
+      expect(response.header).toHaveProperty('content-security-policy');
+      const splitCSPHeader =
+        response.header['content-security-policy'].split(';');
+      // Does the CSP header match what we expect it to be? If the CSP settings
+      // in Helmet are updated, we expect to need to update these tests.
+      expect(splitCSPHeader).toContain("base-uri 'none'");
+      expect(splitCSPHeader).toContain("default-src 'none'");
+      expect(splitCSPHeader).toContain(
+        [
+          'script-src',
+          baseUri,
+          "'sha256-411aj9j2RJj78RLGlCL/KDMK0fe6OEh8Vp6NzyYIkP4='",
+          'www.google-analytics.com',
+          'sourcepoint.theguardian.com',
+          'gdpr-tcfv2.sp-prod.net',
+          'ccpa.sp-prod.net',
+          'ccpa-service.sp-prod.net',
+          'ccpa-notice.sp-prod.net',
+          'cdn.privacy-mgmt.com',
+          'www.google.com',
+          'www.gstatic.com',
+          'assets.guim.co.uk',
+          "'unsafe-eval'",
+        ].join(' '),
+      );
+      expect(splitCSPHeader).toContain(
+        `img-src ${baseUri} static.guim.co.uk ophan.theguardian.com www.google-analytics.com www.google.com`,
+      );
+      expect(splitCSPHeader).toContain('font-src assets.guim.co.uk');
+      expect(splitCSPHeader).toContain(
+        [
+          'connect-src',
+          'www.google-analytics.com',
+          'vendorlist.consensu.org',
+          `consent-logs.${apiDomain}`,
+          'sourcepoint.theguardian.com',
+          'gdpr-tcfv2.sp-prod.net',
+          'ccpa.sp-prod.net',
+          'ccpa-service.sp-prod.net',
+          'ccpa-notice.sp-prod.net',
+          'cdn.privacy-mgmt.com',
+          'api.nextgen.guardianapps.co.uk',
+          'https://api.pwnedpasswords.com',
+          'localhost:1234',
+          'www.google.com',
+          'o14302.ingest.sentry.io',
+        ].join(' '),
+      );
+      expect(splitCSPHeader).toContain('block-all-mixed-content');
+      expect(splitCSPHeader).toContain("object-src 'none'");
+      expect(splitCSPHeader).toContain("script-src-attr 'none'");
+      expect(splitCSPHeader).toContain('upgrade-insecure-requests');
+
+      // Is the STS header set?
+      expect(response.header).toHaveProperty('strict-transport-security');
+      expect(response.header['strict-transport-security']).toBe(
+        'max-age=15552000; includeSubDomains',
+      );
+    },
+  );
+});

--- a/src/server/lib/__tests__/sharedConfig.ts
+++ b/src/server/lib/__tests__/sharedConfig.ts
@@ -1,0 +1,63 @@
+import { RateLimiterConfiguration } from '@/server/lib/rate-limit';
+
+export const defaultRateLimiterConfiguration = {
+  enabled: false,
+  settings: {
+    logOnly: false,
+    trackBucketCapacity: false,
+  },
+  defaultBuckets: {
+    globalBucket: { capacity: 500, addTokenMs: 50 },
+    ipBucket: { capacity: 100, addTokenMs: 50 },
+    emailBucket: { capacity: 100, addTokenMs: 50 },
+    oktaIdentifierBucket: { capacity: 100, addTokenMs: 50 },
+    accessTokenBucket: { capacity: 100, addTokenMs: 50 },
+  },
+  routeBuckets: {},
+};
+
+export const defaultEnv = {
+  PORT: '9000',
+  IDAPI_CLIENT_ACCESS_TOKEN: 'idapi_api_key',
+  IDAPI_BASE_URL: 'http://localhost:1234',
+  OAUTH_BASE_URL: 'http://localhost:5678',
+  BASE_URI: 'base-uri',
+  DEFAULT_RETURN_URI: 'default-return-uri',
+  SIGN_IN_PAGE_URL: 'sign-in-page-url',
+  STAGE: 'DEV',
+  IS_HTTPS: 'true',
+  APP_SECRET: 'app-secret',
+  GOOGLE_RECAPTCHA_SITE_KEY: 'recaptcha-site',
+  GOOGLE_RECAPTCHA_SECRET_KEY: 'recaptcha-secret',
+  ENCRYPTION_SECRET_KEY:
+    'f3d87b231ddd6f50d99e227c5bc9b7cbb649387b321008df412fd73805ac2e32',
+  OKTA_ORG_URL: 'oktaorgurl',
+  OKTA_API_TOKEN: 'oktatoken',
+  OKTA_CUSTOM_OAUTH_SERVER: 'customoauthserverid',
+  OKTA_CLIENT_ID: 'oktaclientid',
+  OKTA_CLIENT_SECRET: 'oktaclientsecret',
+  OKTA_IDP_APPLE: 'okta-idp-apple',
+  OKTA_IDP_GOOGLE: 'okta-idp-google',
+  OKTA_IDP_FACEBOOK: 'okta-idp-facebook',
+  SENTRY_DSN: 'sentry-dsn',
+  GITHUB_RUN_NUMBER: '5',
+  REDIS_PASSWORD: 'redispassword',
+  REDIS_HOST: 'localhost:1234',
+  REDIS_SSL: 'false',
+};
+
+export const getServerInstance = async (
+  rateLimiterConfig: RateLimiterConfiguration = defaultRateLimiterConfiguration,
+) => {
+  // eslint-disable-next-line functional/immutable-data
+  process.env = {
+    ...defaultEnv,
+    RATE_LIMITER_CONFIG: JSON.stringify(rateLimiterConfig),
+  };
+
+  // Start the application server.
+  const { default: server } = await import('@/server/server');
+  const serverInstance = server();
+
+  return serverInstance;
+};

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -1,0 +1,14 @@
+import { default as express, Express } from 'express';
+import { applyMiddleware } from '@/server/lib/middleware';
+
+const createServer = (): Express => {
+  const server: Express = express();
+  // This is set to true to allow Express to read IP address values from
+  // X-Forwarded-For header values (cf. https://expressjs.com/en/guide/behind-proxies.html)
+  // This is necessary for accurately logging the IP address in rate limiter calls.
+  server.set('trust proxy', true);
+  applyMiddleware(server);
+  return server;
+};
+
+export default createServer;


### PR DESCRIPTION
## What does this change?

As part of our threat mitigation tasks, we should make sure that our [CSP](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) setup is working as expected.

This PR adds a new Jest test (`headers.test.ts`) which checks every route listed in the array `ValidRoutePathsArray` in `@/shared/model/Routes` for the presence of a CSP header, and checks that all the parameters in it are set as we've defined them. It also adds a check for the [STS](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security) header. As this is not an E2E test, every route in the array may not run as expected, especially since we mock a lot of the server infrastructure during the tests - but every route should come back with CSP and STS headers, which are tested for here.

We use [Supertest](https://www.npmjs.com/package/supertest) to test the server, and as part of improving the way it works and making the tests less flaky, I've made a few changes to the way the Express server is run:

- Instead of running both `express()` and `express.listen()` in one file, I've split the functionality into two files. `@/server/server.ts` exports a function, `createServer()`, which creates an Express server, sets up its middleware, and returns it. `@/server/index.ts` executes this function and begins the server listener. Although the standard server functionality is now in two files, no behaviour has changed in the way the app is started and run.
- As a result of this change, Supertest now imports and uses just the `createServer()` function, not the listener. This means that Supertest itself has full control over how ports are opened and closed during testing, which prevents [a lot of flaky behaviour](https://github.com/visionmedia/supertest/issues/568) involving ports not being closed properly. This allows us to continue running our tests in parallel and will make it easier to add more Supertest tests in future.
- I've also moved the function that @ob6160 created to spin up a testing server into a separate file, `sharedConfig.ts`, which allows us to use it across tests in future. I've made some changes to Olly's rate limiter tests as a result of all this refactoring.