### PR TITLE
Support creation of Jobs users directly through Okta

### DIFF
--- a/cypress/integration/ete-okta/jobs_terms.cy.ts
+++ b/cypress/integration/ete-okta/jobs_terms.cy.ts
@@ -1,0 +1,183 @@
+describe('Jobs terms and conditions flow in Okta', () => {
+  context('Accepts Jobs terms and conditions and sets their name', () => {
+    it('should redirect users with an invalid session cookie to reauthenticate', () => {
+      // load the consents page as its on the same domain
+      const termsAcceptPageUrl = `https://${Cypress.env(
+        'BASE_URI',
+      )}/agree/GRS?returnUrl=https://profile.thegulocal.com/signin?returnUrl=https%3A%2F%2Fm.code.dev-theguardian.com%2F&useOkta=true`;
+      cy.setCookie('sid', 'invalid-cookie');
+      cy.visit(termsAcceptPageUrl);
+      cy.url().should(
+        'include',
+        'https://profile.thegulocal.com/reauthenticate',
+      );
+    });
+
+    it('should redirect users with no session cookie to the signin page', () => {
+      // load the consents page as its on the same domain
+      const termsAcceptPageUrl = `https://${Cypress.env(
+        'BASE_URI',
+      )}/agree/GRS?useOkta=true&returnUrl=https://profile.thegulocal.com/healthcheck`;
+      cy.visit(termsAcceptPageUrl);
+      cy.url().should(
+        'include',
+        'https://profile.thegulocal.com/signin?returnUrl=https%3A%2F%2Fprofile.thegulocal.com%2Fhealthcheck&useOkta=true',
+      );
+    });
+
+    it('should show the jobs terms page for users who do not have first/last name set, but are jobs users', () => {
+      cy.createTestUser({
+        isUserEmailValidated: true,
+      })?.then(({ emailAddress, finalPassword }) => {
+        cy.visit('/signin?useOkta=true');
+        cy.get('input[name=email]').type(emailAddress);
+        cy.get('input[name=password]').type(finalPassword);
+
+        cy.get('[data-cy="sign-in-button"]').click();
+
+        cy.url().should('include', '/signin/success');
+
+        const termsAcceptPageUrl = `https://${Cypress.env(
+          'BASE_URI',
+        )}/agree/GRS?returnUrl=https://profile.thegulocal.com/healthcheck&useOkta=true`;
+
+        // Create a test user without a first/last name who has `isJobsUser` set to true.
+        cy.updateOktaTestUserProfile(emailAddress, {
+          firstName: '',
+          lastName: '',
+          isJobsUser: true,
+        }).then(() => {
+          cy.visit(termsAcceptPageUrl);
+          cy.contains('Please complete your details for');
+          cy.contains(emailAddress);
+          cy.contains('We will use these details on your job applications');
+
+          cy.get('input[name=firstName]').should('be.empty');
+          cy.get('input[name=secondName]').should('be.empty');
+
+          cy.get('input[name=firstName]').type('First Name');
+          cy.get('input[name=secondName]').type('Second Name');
+
+          cy.findByText('Save and continue').click();
+
+          // User should have `isJobsUser` set to true and First/Last name set to our custom values.
+          cy.getTestOktaUser(emailAddress).then(({ profile, status }) => {
+            const { firstName, lastName, isJobsUser } = profile;
+            expect(status).to.eq('ACTIVE');
+            expect(firstName).to.eq('First Name');
+            expect(lastName).to.eq('Second Name');
+            expect(isJobsUser).to.eq(true);
+          });
+        });
+      });
+    });
+
+    it('should redirect users who have already accepted the terms away', () => {
+      cy.createTestUser({
+        isUserEmailValidated: true,
+      })?.then(({ emailAddress, finalPassword }) => {
+        // load the consents page as its on the same domain
+        const termsAcceptPageUrl = `https://${Cypress.env(
+          'BASE_URI',
+        )}/agree/GRS?returnUrl=https://profile.thegulocal.com/healthcheck&useOkta=true`;
+
+        cy.visit('/signin?useOkta=true');
+        cy.get('input[name=email]').type(emailAddress);
+        cy.get('input[name=password]').type(finalPassword);
+
+        cy.get('[data-cy="sign-in-button"]').click();
+
+        cy.url().should('include', '/signin/success');
+
+        cy.updateOktaTestUserProfile(emailAddress, {
+          firstName: 'Test',
+          lastName: 'User',
+          isJobsUser: true,
+        }).then(() => {
+          cy.visit(termsAcceptPageUrl);
+
+          cy.url().should(
+            'include',
+            'https://profile.thegulocal.com/healthcheck',
+          );
+
+          const finalTermsAcceptPageUrl = `https://${Cypress.env(
+            'BASE_URI',
+          )}/agree/GRS?returnUrl=https://profile.thegulocal.com/maintenance`;
+
+          cy.visit(finalTermsAcceptPageUrl, { failOnStatusCode: false });
+
+          // Make sure the returnURL is respected.
+          cy.url().should(
+            'include',
+            'https://profile.thegulocal.com/maintenance',
+          );
+        });
+      });
+    });
+
+    it('should allow a non-jobs user to enter their first/last name and accept the terms', () => {
+      cy.createTestUser({
+        isUserEmailValidated: true,
+      })?.then(({ emailAddress, finalPassword }) => {
+        // load the consents page as its on the same domain
+        const termsAcceptPageUrl = `https://${Cypress.env(
+          'BASE_URI',
+        )}/agree/GRS?useOkta=true&returnUrl=https://jobs.theguardian.com/`;
+
+        cy.visit('/signin?useOkta=true');
+        cy.get('input[name=email]').type(emailAddress);
+        cy.get('input[name=password]').type(finalPassword);
+
+        cy.get('[data-cy="sign-in-button"]').click();
+
+        cy.url().should('include', '/signin/success');
+
+        cy.visit(termsAcceptPageUrl);
+
+        // check sign in has worked first
+        cy.url().should('include', `/agree/GRS`);
+        // check session cookie is set
+        cy.getCookie('sid').should('exist');
+        // check idapi cookies are set
+        cy.getCookie('SC_GU_U').should('exist');
+        cy.getCookie('SC_GU_LA').should('exist');
+        cy.getCookie('GU_U').should('exist');
+
+        cy.contains('Welcome to Guardian Jobs');
+
+        // User should not be a jobs user yet and have their original first/last name.
+        cy.getTestOktaUser(emailAddress).then(({ profile, status }) => {
+          const { firstName, lastName, isJobsUser } = profile;
+          expect(status).to.eq('ACTIVE');
+          cy.get('input[name=firstName]').should('contain.value', firstName);
+          cy.get('input[name=secondName]').should('contain.value', lastName);
+          expect(isJobsUser).to.eq(false);
+        });
+
+        cy.get('input[name=firstName]').clear().type('First Name');
+        cy.get('input[name=secondName]').clear().type('Second Name');
+
+        // Intercept the external redirect page.
+        // We just want to check that the redirect happens, not that the page loads.
+        cy.intercept('GET', 'https://jobs.theguardian.com/', (req) => {
+          req.reply(200);
+        });
+
+        cy.findByText('Continue').click();
+
+        // Make sure the returnURL is respected.
+        cy.url().should('include', 'https://jobs.theguardian.com/');
+
+        // User should have `isJobsUser` set to true and their First/Last name set.
+        cy.getTestOktaUser(emailAddress).then(({ profile, status }) => {
+          const { firstName, lastName, isJobsUser } = profile;
+          expect(status).to.eq('ACTIVE');
+          expect(firstName).to.eq('First Name');
+          expect(lastName).to.eq('Second Name');
+          expect(isJobsUser).to.eq(true);
+        });
+      });
+    });
+  });
+});

--- a/cypress/integration/ete/terms/jobs_terms.cy.ts
+++ b/cypress/integration/ete/terms/jobs_terms.cy.ts
@@ -160,7 +160,7 @@ describe('Jobs terms and conditions flow', () => {
     // Skipping this test for now, because of some flakiness where
     // users' first and last name aren't updated by the time we make the request
     // to /user/me to check their info.
-    it.skip('should allow a non-jobs user to enter their first/last name and accept the terms', () => {
+    it('should allow a non-jobs user to enter their first/last name and accept the terms', () => {
       cy.createTestUser({
         isUserEmailValidated: true,
       })?.then(({ emailAddress, finalPassword }) => {

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -30,6 +30,7 @@ import {
   getTestUserDetails,
   addToGRS,
   updateTestUser,
+  updateOktaTestUserProfile,
 } from './commands/testUser';
 
 Cypress.Commands.add('mockNext', mockNext);
@@ -62,3 +63,4 @@ Cypress.Commands.add('getOktaUserGroups', getOktaUserGroups);
 Cypress.Commands.add('getTestUserDetails', getTestUserDetails);
 Cypress.Commands.add('updateTestUser', updateTestUser);
 Cypress.Commands.add('addToGRS', addToGRS);
+Cypress.Commands.add('updateOktaTestUserProfile', updateOktaTestUserProfile);

--- a/cypress/support/commands/testUser.ts
+++ b/cypress/support/commands/testUser.ts
@@ -89,7 +89,6 @@ export const getTestUserDetails = () =>
         method: 'GET',
         headers: {
           'Content-Type': 'application/json',
-          Origin: 'https://profile.thegulocal.com',
           'X-GU-ID-Client-Access-Token': `Bearer ${Cypress.env(
             'IDAPI_CLIENT_ACCESS_TOKEN',
           )}`,
@@ -113,7 +112,6 @@ export const updateTestUser = (body: object) =>
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-          Origin: 'https://profile.thegulocal.com',
           'X-GU-ID-Client-Access-Token': `Bearer ${Cypress.env(
             'IDAPI_CLIENT_ACCESS_TOKEN',
           )}`,
@@ -137,7 +135,6 @@ export const addToGRS = () =>
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-          Origin: 'https://profile.thegulocal.com',
           'X-GU-ID-Client-Access-Token': `Bearer ${Cypress.env(
             'IDAPI_CLIENT_ACCESS_TOKEN',
           )}`,

--- a/src/server/lib/jobs.ts
+++ b/src/server/lib/jobs.ts
@@ -1,6 +1,33 @@
 import { addToGroup, GroupCode, updateName } from './idapi/user';
+import { updateUser } from './okta/api/users';
 
-const setupJobsUser = (
+export const setupJobsUserInOkta = (
+  firstName: string,
+  lastName: string,
+  id: string,
+) => {
+  if (firstName === '' || lastName === '') {
+    throw new Error('Empty values not permitted for first or last name.');
+  }
+  // When a jobs user is registering in Okta, we set the `isJobsUser` flag to true.
+  // We also want to set their first and last name as these are required fields for all Jobs users.
+  //
+  // Once user have `isJobsUser` set to true, they are no longer shown the /accept/GRS page
+  // they try to sign in to the Jobs site again.
+  //
+  // When `isJobsUser` is set to true, Madgex will see that the user belongs to the GRS group
+  // because we have made the `isJobsUser` flag the source of truth for this group membership
+  // when IDAPI returns the user's groups, overriding the value stored in Postgres.
+  return updateUser(id, {
+    profile: {
+      isJobsUser: true,
+      firstName,
+      lastName,
+    },
+  });
+};
+
+export const setupJobsUserInIDAPI = (
   firstName: string,
   secondName: string,
   ip: string,
@@ -21,5 +48,3 @@ const setupJobsUser = (
     addToGroup(GroupCode.GRS, ip, sc_gu_u),
   ]);
 };
-
-export default setupJobsUser;

--- a/src/server/lib/jobs.ts
+++ b/src/server/lib/jobs.ts
@@ -43,7 +43,7 @@ export const setupJobsUserInIDAPI = (
   // they try to sign in to the Jobs site for the first time.
   //
   // We can resolve both promises here because they are not dependent on each other.
-  return Promise.all([
+  return Promise.allSettled([
     updateName(firstName, secondName, ip, sc_gu_u),
     addToGroup(GroupCode.GRS, ip, sc_gu_u),
   ]);

--- a/src/server/lib/okta/api/users.ts
+++ b/src/server/lib/okta/api/users.ts
@@ -302,10 +302,13 @@ const handleUserResponse = async (
           id: user.id,
           status: user.status,
           profile: {
+            firstName: user.profile.firstName,
+            lastName: user.profile.lastName,
             email: user.profile.email,
             login: user.profile.login,
             isGuardianUser: user.profile.isGuardianUser,
             emailValidated: user.profile.emailValidated,
+            isJobsUser: user.profile.isJobsUser,
           },
           credentials: user.credentials,
         };

--- a/src/server/models/okta/User.ts
+++ b/src/server/models/okta/User.ts
@@ -15,6 +15,9 @@ interface UserProfile {
   googleExternalId?: string;
   appleExternalId?: string;
   facebookExternalId?: string;
+  isJobsUser?: boolean;
+  firstName?: string;
+  lastName?: string;
 }
 
 // https://developer.okta.com/docs/reference/api/users/#password-object
@@ -37,14 +40,20 @@ interface UserCredentials {
   provider: unknown;
 }
 
+type OktaUserFieldsInResponse =
+  | 'email'
+  | 'login'
+  | 'isGuardianUser'
+  | 'emailValidated'
+  | 'firstName'
+  | 'lastName'
+  | 'isJobsUser';
+
 // https://developer.okta.com/docs/reference/api/users/#user-object
 export interface UserResponse {
   id: string;
   status: string;
-  profile: Pick<
-    UserProfile,
-    'email' | 'login' | 'isGuardianUser' | 'emailValidated'
-  >;
+  profile: Pick<UserProfile, OktaUserFieldsInResponse>;
   credentials: UserCredentials;
 }
 

--- a/src/server/routes/agree.ts
+++ b/src/server/routes/agree.ts
@@ -71,7 +71,7 @@ const IDAPIAgreeGetController = async (
     return res.type('html').send(html);
   } catch (error) {
     logger.error(
-      `${req.method} ${req.originalUrl} Error Updating Jobs user in IDAPI`,
+      `${req.method} ${req.originalUrl} Error fetching Jobs user in IDAPI`,
       error,
     );
     // Redirect to /signin if an error occurs when fetching the users' data.
@@ -134,7 +134,7 @@ const OktaAgreeGetController = async (
     return res.type('html').send(html);
   } catch (error) {
     logger.error(
-      `${req.method} ${req.originalUrl} Error Updating Jobs user in Okta`,
+      `${req.method} ${req.originalUrl} Error fetching Jobs user in Okta`,
       error,
     );
     // Redirect to /signin if an error occurs when fetching the users' data.
@@ -182,7 +182,10 @@ router.post(
         trackMetric('JobsGRSGroupAgree::Success');
       }
     } catch (error) {
-      logger.error(`${req.method} ${req.originalUrl} Error`, error);
+      logger.error(
+        `${req.method} ${req.originalUrl} Error updating Jobs user information`,
+        error,
+      );
       trackMetric('JobsGRSGroupAgree::Failure');
     } finally {
       return res.redirect(303, returnUrl);

--- a/src/server/routes/agree.ts
+++ b/src/server/routes/agree.ts
@@ -70,7 +70,10 @@ const IDAPIAgreeGetController = async (
 
     return res.type('html').send(html);
   } catch (error) {
-    logger.error(`${req.method} ${req.originalUrl} Error`, error);
+    logger.error(
+      `${req.method} ${req.originalUrl} Error Updating Jobs user in IDAPI`,
+      error,
+    );
     // Redirect to /signin if an error occurs when fetching the users' data.
     return res.redirect(
       303,
@@ -130,7 +133,10 @@ const OktaAgreeGetController = async (
 
     return res.type('html').send(html);
   } catch (error) {
-    logger.error(`${req.method} ${req.originalUrl} Error`, error);
+    logger.error(
+      `${req.method} ${req.originalUrl} Error Updating Jobs user in Okta`,
+      error,
+    );
     // Redirect to /signin if an error occurs when fetching the users' data.
     return res.redirect(
       303,

--- a/src/server/routes/agree.ts
+++ b/src/server/routes/agree.ts
@@ -8,85 +8,173 @@ import { getConfiguration } from '../lib/getConfiguration';
 import { trackMetric } from '../lib/trackMetric';
 import deepmerge from 'deepmerge';
 import { addQueryParamsToUntypedPath } from '@/shared/lib/queryParams';
-import setupJobsUser from '../lib/jobs';
+import { setupJobsUserInIDAPI, setupJobsUserInOkta } from '../lib/jobs';
+import { getSession } from '../lib/okta/api/sessions';
+import { getUser } from '../lib/okta/api/users';
 
-const { defaultReturnUri, signInPageUrl } = getConfiguration();
+const { defaultReturnUri, signInPageUrl, okta } = getConfiguration();
 
-router.get(
-  '/agree/GRS',
-  async (req: Request, res: ResponseWithRequestState) => {
-    const SC_GU_U = req.cookies.SC_GU_U;
-    const state = res.locals;
-    const { returnUrl } = state.queryParams;
+const IDAPIAgreeGetController = async (
+  req: Request,
+  res: ResponseWithRequestState,
+) => {
+  const SC_GU_U = req.cookies.SC_GU_U;
+  const state = res.locals;
+  const { returnUrl } = state.queryParams;
 
-    // Redirect to /signin if no session cookie.
-    if (!SC_GU_U) {
+  // Redirect to /signin if no session cookie.
+  if (!SC_GU_U) {
+    return res.redirect(
+      303,
+      addQueryParamsToUntypedPath(signInPageUrl, res.locals.queryParams),
+    );
+  }
+
+  try {
+    const {
+      primaryEmailAddress,
+      privateFields: { firstName, secondName },
+      userGroups,
+    } = await read(req.ip, SC_GU_U);
+
+    const userBelongsToGRS = userGroups.find(
+      (group) => group.packageCode === 'GRS',
+    );
+
+    const userFullNameSet = !!firstName && !!secondName;
+
+    // The user is redirected immediately if they are already
+    // part of the group and have their name set.
+    if (userBelongsToGRS && userFullNameSet) {
+      const redirectUrl = returnUrl || defaultReturnUri;
       return res.redirect(
         303,
-        addQueryParamsToUntypedPath(signInPageUrl, res.locals.queryParams),
-      );
-    }
-
-    try {
-      const {
-        primaryEmailAddress,
-        privateFields: { firstName, secondName },
-        userGroups,
-      } = await read(req.ip, SC_GU_U);
-
-      const userBelongsToGRS = userGroups.find(
-        (group) => group.packageCode === 'GRS',
-      );
-
-      const userFullNameSet = !!firstName && !!secondName;
-
-      // The user is redirected immediately if they are already
-      // part of the group and have their name set.
-      if (userBelongsToGRS && userFullNameSet) {
-        const redirectUrl = returnUrl || defaultReturnUri;
-        return res.redirect(
-          303,
-          addQueryParamsToUntypedPath(redirectUrl, {
-            ...res.locals.queryParams,
-            returnUrl: '', // unset returnUrl so redirect won't point to itself.
-          }),
-        );
-      }
-
-      const html = renderer('/agree/GRS', {
-        requestState: deepmerge(res.locals, {
-          pageData: {
-            firstName,
-            secondName,
-            userBelongsToGRS,
-            email: primaryEmailAddress,
-          },
+        addQueryParamsToUntypedPath(redirectUrl, {
+          ...res.locals.queryParams,
+          returnUrl: '', // unset returnUrl so redirect won't point to itself.
         }),
-        pageTitle: 'Jobs',
-      });
-
-      return res.type('html').send(html);
-    } catch (error) {
-      logger.error(`${req.method} ${req.originalUrl} Error`, error);
-      // Redirect to /signin if an error occurs when fetching the users' data.
-      return res.redirect(
-        303,
-        addQueryParamsToUntypedPath(signInPageUrl, res.locals.queryParams),
       );
     }
-  },
-);
+
+    const html = renderer('/agree/GRS', {
+      requestState: deepmerge(res.locals, {
+        pageData: {
+          firstName,
+          secondName,
+          userBelongsToGRS,
+          email: primaryEmailAddress,
+        },
+      }),
+      pageTitle: 'Jobs',
+    });
+
+    return res.type('html').send(html);
+  } catch (error) {
+    logger.error(`${req.method} ${req.originalUrl} Error`, error);
+    // Redirect to /signin if an error occurs when fetching the users' data.
+    return res.redirect(
+      303,
+      addQueryParamsToUntypedPath(signInPageUrl, res.locals.queryParams),
+    );
+  }
+};
+
+const OktaAgreeGetController = async (
+  req: Request,
+  res: ResponseWithRequestState,
+) => {
+  const oktaSessionCookieId: string | undefined = req.cookies.sid;
+
+  const state = res.locals;
+  const { returnUrl } = state.queryParams;
+
+  // Redirect to /signin if no session cookie.
+  if (!oktaSessionCookieId) {
+    return res.redirect(
+      303,
+      addQueryParamsToUntypedPath(signInPageUrl, res.locals.queryParams),
+    );
+  }
+
+  try {
+    const { userId } = await getSession(oktaSessionCookieId);
+    const { profile } = await getUser(userId);
+    const { isJobsUser, firstName, lastName, email } = profile;
+
+    const userFullNameSet = !!firstName && !!lastName;
+
+    // The user is redirected immediately if they are already
+    // a jobs user and have they have their full name set.
+    if (isJobsUser && userFullNameSet) {
+      const redirectUrl = returnUrl || defaultReturnUri;
+      return res.redirect(
+        303,
+        addQueryParamsToUntypedPath(redirectUrl, {
+          ...res.locals.queryParams,
+          returnUrl: '', // unset returnUrl so redirect won't point to itself.
+        }),
+      );
+    }
+
+    const html = renderer('/agree/GRS', {
+      requestState: deepmerge(res.locals, {
+        pageData: {
+          firstName,
+          secondName: lastName,
+          userBelongsToGRS: isJobsUser,
+          email,
+        },
+      }),
+      pageTitle: 'Jobs',
+    });
+
+    return res.type('html').send(html);
+  } catch (error) {
+    logger.error(`${req.method} ${req.originalUrl} Error`, error);
+    // Redirect to /signin if an error occurs when fetching the users' data.
+    return res.redirect(
+      303,
+      addQueryParamsToUntypedPath(signInPageUrl, res.locals.queryParams),
+    );
+  }
+};
+
+router.get('/agree/GRS', (req: Request, res: ResponseWithRequestState) => {
+  const { useOkta } = res.locals.queryParams;
+  const oktaSessionCookieId: string | undefined = req.cookies.sid;
+
+  if (okta.enabled && useOkta && oktaSessionCookieId) {
+    return OktaAgreeGetController(req, res);
+  } else {
+    return IDAPIAgreeGetController(req, res);
+  }
+});
 
 router.post(
   '/agree/GRS',
   async (req: Request, res: ResponseWithRequestState) => {
+    const { useOkta } = res.locals.queryParams;
+    const oktaSessionCookieId: string | undefined = req.cookies.sid;
+
     const { queryParams } = res.locals;
     const { returnUrl } = queryParams;
     const { firstName, secondName } = req.body;
 
     try {
-      await setupJobsUser(firstName, secondName, req.ip, req.cookies.SC_GU_U);
-      trackMetric('JobsGRSGroupAgree::Success');
+      if (okta.enabled && useOkta && oktaSessionCookieId) {
+        // Get the id from Okta
+        const { userId } = await getSession(oktaSessionCookieId);
+        await setupJobsUserInOkta(firstName, secondName, userId);
+        trackMetric('JobsGRSGroupAgree::Success');
+      } else {
+        await setupJobsUserInIDAPI(
+          firstName,
+          secondName,
+          req.ip,
+          req.cookies.SC_GU_U,
+        );
+        trackMetric('JobsGRSGroupAgree::Success');
+      }
     } catch (error) {
       logger.error(`${req.method} ${req.originalUrl} Error`, error);
       trackMetric('JobsGRSGroupAgree::Failure');


### PR DESCRIPTION
## What does this change?
Now that we have positioned Okta as the arbiter of truth for the "GRS" group using the `isJobsUser` field, we are able to implement an Okta variant of the Jobs user registration and terms agreement flow.

The `GRS` keyword floats around still (of note in the URL: `/agree/GRS`). This is because Madgex still link to the `/agree/GRS` route, and this is not something we can change until after they've completed their integration with Okta.

The existing e2e tests for the Jobs agreement flow were ported into a separate Okta suite which has the same coverage as the IDAPI variant. Some e2e helper methods also didn't have the "retry on error" property set, this was set to hopefully reduce flakiness on the IDAPI side of the tests.