### PR TITLE
Close active Okta session on POST to /signin and /reauthenticate

### DIFF
--- a/cypress/integration/ete-okta/reauthenticate.cy.ts
+++ b/cypress/integration/ete-okta/reauthenticate.cy.ts
@@ -1,0 +1,87 @@
+import { stringify } from 'query-string';
+
+describe('Reauthenticate flow, Okta enabled', () => {
+  beforeEach(() => {
+    // Disable redirect to /signin/success by default
+    cy.setCookie(
+      'GU_ran_experiments',
+      stringify({ OptInPromptPostSignIn: Date.now() }),
+    );
+  });
+  it('keeps User A signed in when User A attempts to reauthenticate', () => {
+    cy.createTestUser({ isUserEmailValidated: true })?.then(
+      ({ emailAddress, finalPassword }) => {
+        // Intercept the external redirect page.
+        // We just want to check that the redirect happens, not that the page loads.
+        cy.intercept('GET', 'https://m.code.dev-theguardian.com/', (req) => {
+          req.reply(200);
+        });
+        // First, sign in
+        cy.visit('/signin?useOkta=true');
+        cy.get('input[name=email]').type(emailAddress);
+        cy.get('input[name=password]').type(finalPassword);
+        cy.get('[data-cy="sign-in-button"]').click();
+        cy.url().should('include', 'https://m.code.dev-theguardian.com/');
+
+        // Then, try to reauthenticate
+        cy.visit('/reauthenticate?useOkta=true');
+        cy.get('input[name=email]').type(emailAddress);
+        cy.get('input[name=password]').type(finalPassword);
+        cy.get('[data-cy="sign-in-button"]').click();
+        cy.url().should('include', 'https://m.code.dev-theguardian.com/');
+
+        // Get the current session data
+        cy.getCookie('sid').then((sidCookie) => {
+          const sid = sidCookie?.value;
+          expect(sid).to.exist;
+          if (sid) {
+            cy.getCurrentOktaSession(sid).then((session) => {
+              expect(session.login).to.equal(emailAddress);
+            });
+          }
+        });
+      },
+    );
+  });
+  it('signs in User B when User B attempts to reauthenticate while User A is logged in', () => {
+    // Create User A
+    cy.createTestUser({ isUserEmailValidated: true })?.then(
+      ({ emailAddress: emailAddressA, finalPassword: finalPasswordA }) => {
+        // Intercept the external redirect page.
+        // We just want to check that the redirect happens, not that the page loads.
+        cy.intercept('GET', 'https://m.code.dev-theguardian.com/', (req) => {
+          req.reply(200);
+        });
+        // First, sign in as User A
+        cy.visit('/signin?useOkta=true');
+        cy.get('input[name=email]').type(emailAddressA);
+        cy.get('input[name=password]').type(finalPasswordA);
+        cy.get('[data-cy="sign-in-button"]').click();
+        cy.url().should('include', 'https://m.code.dev-theguardian.com/');
+
+        // Create User B
+        cy.createTestUser({ isUserEmailValidated: true })?.then(
+          ({ emailAddress: emailAddressB, finalPassword: finalPasswordB }) => {
+            // Then, try to reauthenticate as User B
+            cy.visit('/reauthenticate?useOkta=true');
+            cy.get('input[name=email]').type(emailAddressB);
+            cy.get('input[name=password]').type(finalPasswordB);
+            cy.get('[data-cy="sign-in-button"]').click();
+            cy.url().should('include', 'https://m.code.dev-theguardian.com/');
+
+            // Get the current session data
+            cy.getCookie('sid').then((sidCookie) => {
+              const sid = sidCookie?.value;
+              expect(sid).to.exist;
+              if (sid) {
+                cy.getCurrentOktaSession(sid).then((session) => {
+                  expect(session.login).to.equal(emailAddressB);
+                });
+              }
+            });
+          },
+        );
+      },
+    );
+  });
+});

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -31,6 +31,7 @@ import {
   addToGRS,
   updateTestUser,
   updateOktaTestUserProfile,
+  getCurrentOktaSession,
 } from './commands/testUser';
 
 Cypress.Commands.add('mockNext', mockNext);
@@ -64,3 +65,4 @@ Cypress.Commands.add('getTestUserDetails', getTestUserDetails);
 Cypress.Commands.add('updateTestUser', updateTestUser);
 Cypress.Commands.add('addToGRS', addToGRS);
 Cypress.Commands.add('updateOktaTestUserProfile', updateOktaTestUserProfile);
+Cypress.Commands.add('getCurrentOktaSession', getCurrentOktaSession);

--- a/cypress/support/commands/testUser.ts
+++ b/cypress/support/commands/testUser.ts
@@ -1,5 +1,9 @@
 import { v4 as uuidv4 } from 'uuid';
-import { TokenResponse, UserResponse } from '@/server/models/okta/User';
+import {
+  TokenResponse,
+  UserResponse,
+  SessionResponse,
+} from '@/server/models/okta/User';
 import { Group } from '@/server/models/okta/Group';
 
 declare global {
@@ -19,6 +23,7 @@ declare global {
       addToGRS: typeof addToGRS;
       updateTestUser: typeof updateTestUser;
       updateOktaTestUserProfile: typeof updateOktaTestUserProfile;
+      getCurrentOktaSession: typeof getCurrentOktaSession;
     }
   }
 }
@@ -394,5 +399,25 @@ export const findEmailValidatedOktaGroupId = () => {
     throw new Error(
       'Failed to get ID of GuardianUser-EmailValidated group: ' + error,
     );
+  }
+};
+
+export const getCurrentOktaSession = (sid: string) => {
+  try {
+    return cy
+      .request({
+        url: `${Cypress.env('OKTA_ORG_URL')}/api/v1/sessions/${sid}`,
+        method: 'GET',
+        headers: {
+          Authorization: `SSWS ${Cypress.env('OKTA_API_TOKEN')}`,
+        },
+        retryOnStatusCodeFailure: true,
+      })
+      .then((res) => {
+        const session = res.body as SessionResponse;
+        return cy.wrap(session);
+      });
+  } catch (error) {
+    throw new Error('Failed to get current Okta session: ' + error);
   }
 };

--- a/src/client/pages/SignIn.stories.tsx
+++ b/src/client/pages/SignIn.stories.tsx
@@ -14,7 +14,7 @@ export default {
     queryParams: {
       returnUrl: 'https://www.theguardian.com/uk',
     },
-    displayRegisterTab: true,
+    isReauthenticate: false,
   },
 } as Meta<SignInProps>;
 
@@ -63,7 +63,7 @@ InvalidRecaptcha.story = {
 };
 
 export const WithoutRegisterButton = (args: SignInProps) => (
-  <SignIn {...args} displayRegisterTab={false} />
+  <SignIn {...args} isReauthenticate />
 );
 WithoutRegisterButton.story = {
   name: 'without register button',

--- a/src/client/pages/SignIn.tsx
+++ b/src/client/pages/SignIn.tsx
@@ -30,9 +30,7 @@ export type SignInProps = {
   email?: string;
   error?: string;
   recaptchaSiteKey: string;
-  // The register tab is hidden on the /reauthenticate version of the sign-in
-  // page, but displayed on the vanilla /signin version.
-  displayRegisterTab: boolean;
+  isReauthenticate?: boolean;
 };
 
 const passwordInput = css`
@@ -133,7 +131,7 @@ export const SignIn = ({
   error: pageLevelError,
   queryParams,
   recaptchaSiteKey,
-  displayRegisterTab,
+  isReauthenticate = false,
 }: SignInProps) => {
   const formTrackingName = 'sign-in';
   const signInFormRef = createRef<HTMLFormElement>();
@@ -192,9 +190,9 @@ export const SignIn = ({
     isActive: false,
   };
 
-  const tabs: TabType[] = displayRegisterTab
-    ? [signInTab, registerTab]
-    : [signInTab];
+  const tabs: TabType[] = isReauthenticate
+    ? [signInTab]
+    : [signInTab, registerTab];
 
   return (
     <>
@@ -214,7 +212,11 @@ export const SignIn = ({
       >
         <form
           method="post"
-          action={buildUrlWithQueryParams('/signin', {}, queryParams)}
+          action={buildUrlWithQueryParams(
+            isReauthenticate ? '/reauthenticate' : '/signin',
+            {},
+            queryParams,
+          )}
           ref={signInFormRef}
           onSubmit={handleSubmit}
           onFocus={(e) => trackFormFocusBlur(formTrackingName, e, 'focus')}

--- a/src/client/pages/SignInPage.tsx
+++ b/src/client/pages/SignInPage.tsx
@@ -3,7 +3,11 @@ import { SignIn } from '@/client/pages/SignIn';
 import useClientState from '@/client/lib/hooks/useClientState';
 import { useRemoveEncryptedEmailParam } from '@/client/lib/hooks/useRemoveEncryptedEmailParam';
 
-export const SignInPage = () => {
+interface Props {
+  isReauthenticate?: boolean;
+}
+
+export const SignInPage = ({ isReauthenticate = false }: Props) => {
   const clientState = useClientState();
   const {
     pageData = {},
@@ -11,7 +15,7 @@ export const SignInPage = () => {
     queryParams,
     recaptchaConfig,
   } = clientState;
-  const { email, displayRegisterTab = true } = pageData;
+  const { email } = pageData;
   const { error } = globalMessage;
   const { recaptchaSiteKey } = recaptchaConfig;
 
@@ -23,7 +27,7 @@ export const SignInPage = () => {
       error={error}
       queryParams={queryParams}
       recaptchaSiteKey={recaptchaSiteKey}
-      displayRegisterTab={displayRegisterTab}
+      isReauthenticate={isReauthenticate}
     />
   );
 };

--- a/src/client/routes.tsx
+++ b/src/client/routes.tsx
@@ -50,7 +50,7 @@ const routes: Array<{
   },
   {
     path: '/reauthenticate',
-    element: <SignInPage />,
+    element: <SignInPage isReauthenticate />,
   },
   {
     path: '/register',

--- a/src/server/controllers/changePassword.ts
+++ b/src/server/controllers/changePassword.ts
@@ -216,9 +216,10 @@ const changePasswordInOkta = async (
       });
 
       // TODO: once sign out with Okta has been implemented, invalidate current sessions before kicking off code flow
-      return performAuthorizationCodeFlow(req, res, {
+      return await performAuthorizationCodeFlow(req, res, {
         sessionToken,
         confirmationPagePath: successRedirectPath,
+        closeExistingSession: true,
       });
     } else {
       throw new OktaError({ message: 'Okta state token missing' });

--- a/src/server/lib/okta/api/sessions.ts
+++ b/src/server/lib/okta/api/sessions.ts
@@ -33,6 +33,29 @@ export const getSession = async (
   }).then(handleSessionResponse);
 };
 
+/**
+ * Close a User session by session Id
+ *
+ * https://developer.okta.com/docs/reference/api/sessions/#close-session
+ *
+ * The Okta API closes the users session on success or
+ * returns a 404 on invalid.
+ *
+ * @param sessionId Okta session ID
+ * @returns Promise<boolean>
+ */
+export const closeSession = async (sessionId: string): Promise<undefined> => {
+  const path = buildUrl('/api/v1/sessions/:sessionId', { sessionId });
+  const response = await fetch(joinUrl(okta.orgUrl, path), {
+    method: 'DELETE',
+    headers: { ...defaultHeaders, ...authorizationHeader() },
+  });
+
+  if (!(response.ok || response.status === 404)) {
+    return handleErrorResponse(response);
+  }
+};
+
 export const handleSessionResponse = async (
   response: Response,
 ): Promise<SessionResponse> => {

--- a/src/server/lib/okta/oauth.ts
+++ b/src/server/lib/okta/oauth.ts
@@ -8,6 +8,7 @@ import {
   ProfileOpenIdClientRedirectUris,
   getOpenIdClient,
 } from '@/server/lib/okta/openid-connect';
+import { closeSession } from './api/sessions';
 
 /**
  * @name performAuthorizationCodeFlow
@@ -15,24 +16,37 @@ import {
  *
  * Used for post authentication with the session token to set a session cookie.
  *
+ * @param req - the express request object
  * @param res - the express response object
  * @param sessionToken (optional) - if provided, we'll use this to set the session cookie
  * @param confirmationPagePath (optional) - page to redirect the user to after authentication
+ * @param idp (optional) - okta id of the social identity provider to use
+ * @param closeExistingSession (optional) - if true, we'll close any existing okta session before calling the authorization code flow
  * @returns 303 redirect to the okta /authorize endpoint
  */
-export const performAuthorizationCodeFlow = (
+export const performAuthorizationCodeFlow = async (
   req: Request,
   res: ResponseWithRequestState,
   {
     sessionToken,
     confirmationPagePath,
     idp,
+    closeExistingSession,
   }: {
     sessionToken?: string;
     confirmationPagePath?: RoutePaths;
     idp?: string;
+    closeExistingSession?: boolean;
   } = {},
 ) => {
+  if (closeExistingSession) {
+    const oktaSessionCookieId: string | undefined = req.cookies.sid;
+    // clear existing okta session cookie if it exists
+    if (oktaSessionCookieId) {
+      await closeSession(oktaSessionCookieId);
+    }
+  }
+
   // Determine which OpenIdClient to use, in DEV we use the DevProfileIdClient, otherwise we use the ProfileOpenIdClient
   const OpenIdClient = getOpenIdClient(req);
 
@@ -48,8 +62,10 @@ export const performAuthorizationCodeFlow = (
 
   // generate the /authorize endpoint url which we'll redirect the user too
   const authorizeUrl = OpenIdClient.authorizationUrl({
-    // Don't prompt for authentication or consent if idp parameter is not provided
-    prompt: !idp ? 'none' : undefined,
+    // Prompt for login if the idp is provided to make sure the user sees
+    // the social provider login page
+    // Don't prompt for authentication if the idp is not provided (default behaviour)
+    prompt: idp ? 'login' : 'none',
     // The sessionToken from authentication to exchange for session cookie
     sessionToken,
     // we send the generated stateParam as the state parameter

--- a/src/server/models/okta/User.ts
+++ b/src/server/models/okta/User.ts
@@ -101,3 +101,12 @@ export enum Status {
   PASSWORD_RESET = 'PASSWORD_RESET',
   SUSPENDED = 'SUSPENDED',
 }
+
+// https://developer.okta.com/docs/reference/api/sessions/#session-object
+export interface SessionResponse {
+  id: string;
+  login: string;
+  userId: string;
+  expiresAt: string;
+  status: string;
+}

--- a/src/shared/model/ClientState.ts
+++ b/src/shared/model/ClientState.ts
@@ -46,10 +46,6 @@ export interface PageData {
   firstName?: string;
   secondName?: string;
   userBelongsToGRS?: boolean;
-
-  // Sign in page specific (we want to hide the register tab when the user
-  // already has an active session but may need to reauthenticate)
-  displayRegisterTab?: boolean;
 }
 
 export interface RecaptchaConfig {


### PR DESCRIPTION
## What does this change?

This resolves:

1. A problem with the `/reauthenticate` page:
    - Given **User A** is signed in with Okta
    - When **User B** POSTS from the `/reauthenticate` page
    - Then, after verifying their login details, Okta will [keep **User A** signed in despite **User B**'s details being entered](https://developer.okta.com/docs/guides/session-cookie/main/).
    This is becasue "Okta Classic orgs ignore the sessionToken in a request if there is already a session cookie set in the browser." For more on these flows and our new solution, see `docs/reauthenticate.md`.
3. A bug where a user who was already logged in would end up in an endless loop after POSTing from `/reauthenticate`, because a piece of code would see they had a valid `sid` cookie and send them straight back to `/reauthenticate`.

The solution: In the `performAuthorizationCodeFlow` function, we pass a parameter to close the existing session. If true, before attempting to negotiate with Okta for a new session, we call an Okta endpoint to close the existing session on the current browser. When Okta tries to set a new session, it will see that the `sid` cookie is now invalid, and overwrite it with a new one. This parameter is currently set to `true` for all calls to POST `/signin` and `/reauthenticate`.

## Caveats

Due to the new behaviour, if the user is signed in elsewhere on the Guardian on the same browser using [OpenID Connect access tokens](https://developer.okta.com/docs/concepts/oauth-openid/), these tokens will _not_ be destroyed during reauthenticate flow. We do not currently use these tokens, but may do in future. This can lead to a situation where **User A** is logged in on theguardian.com, but **User B** is logged into MMA, or similar.