### PR TITLE
Okta | Check for breached password when setting a new password

### DIFF
--- a/cypress/integration/mocked/okta_change_password.cy.ts
+++ b/cypress/integration/mocked/okta_change_password.cy.ts
@@ -17,6 +17,8 @@
  * Password set successfully                        | show password updated confirmation page
  */
 
+import { randomPassword } from '../../support/commands/testUser';
+
 describe('Change password in Okta', () => {
   context('reset password page', () => {
     const email = 'mrtest@theguardian.com';
@@ -139,7 +141,7 @@ describe('Change password in Okta', () => {
 
       cy.visit(`/reset-password/token?useOkta=true`);
 
-      cy.get('input[name="password"]').type('mysuperduperpassword');
+      cy.get('input[name="password"]').type(randomPassword());
       cy.get('button[type="submit"]').click();
 
       cy.contains('Link expired');
@@ -154,7 +156,7 @@ describe('Change password in Okta', () => {
 
       cy.visit(`/reset-password/token?useOkta=true`);
 
-      cy.get('input[name="password"]').type('mysuperduperpassword');
+      cy.get('input[name="password"]').type(randomPassword());
       cy.get('button[type="submit"]').click();
 
       cy.contains('Reset password');
@@ -173,7 +175,7 @@ describe('Change password in Okta', () => {
       cy.visit(`/reset-password/token?useOkta=true`);
       cy.clearCookie('GU_GATEWAY_STATE');
 
-      cy.get('input[name="password"]').type('mysuperduperpassword');
+      cy.get('input[name="password"]').type(randomPassword());
       cy.get('button[type="submit"]').click();
 
       cy.contains('Reset password');
@@ -192,7 +194,7 @@ describe('Change password in Okta', () => {
       cy.visit(`/reset-password/token?useOkta=true`);
       cy.clearCookie('GU_GATEWAY_STATE');
 
-      cy.get('input[name="password"]').type('mysuperduperpassword');
+      cy.get('input[name="password"]').type(randomPassword());
       cy.get('button[type="submit"]').click();
 
       cy.contains('Link expired');
@@ -213,7 +215,7 @@ describe('Change password in Okta', () => {
 
       cy.visit(`/reset-password/token?useOkta=true`);
 
-      cy.get('input[name="password"]').type('mysuperduperpassword');
+      cy.get('input[name="password"]').type(randomPassword());
       cy.get('button[type="submit"]').click();
 
       cy.contains('Reset password');
@@ -236,7 +238,7 @@ describe('Change password in Okta', () => {
 
       // even though this test is for a short password, we enter a valid password here to bypass
       // client-side password complexity checks in order to test the server-side response
-      cy.get('input[name="password"]').type('mysuperduperpassword');
+      cy.get('input[name="password"]').type(randomPassword());
       cy.get('button[type="submit"]').click();
 
       cy.contains('Reset password');
@@ -256,7 +258,7 @@ describe('Change password in Okta', () => {
 
       cy.visit(`/reset-password/token?useOkta=true`);
 
-      cy.get('input[name="password"]').type('mysuperduperpassword');
+      cy.get('input[name="password"]').type(randomPassword());
       cy.get('button[type="submit"]').click();
 
       cy.contains('Reset password');
@@ -274,7 +276,7 @@ describe('Change password in Okta', () => {
 
       cy.visit(`/reset-password/token?useOkta=true`);
 
-      cy.get('input[name="password"]').type('mysuperduperpassword');
+      cy.get('input[name="password"]').type(randomPassword());
       cy.get('button[type="submit"]').click();
 
       cy.contains('Reset password');
@@ -294,7 +296,7 @@ describe('Change password in Okta', () => {
 
       cy.visit(`/reset-password/token?useOkta=true`);
 
-      cy.get('input[name="password"]').type('mysuperduperpassword');
+      cy.get('input[name="password"]').type(randomPassword());
       cy.get('button[type="submit"]').click();
 
       cy.contains('Reset password');

--- a/src/server/lib/__tests__/breachedPasswordCheck.test.ts
+++ b/src/server/lib/__tests__/breachedPasswordCheck.test.ts
@@ -1,0 +1,80 @@
+import { mocked } from 'jest-mock';
+import { fetch } from '@/server/lib/fetch';
+import type { Response, RequestInfo, RequestInit } from 'node-fetch';
+import { isBreachedPassword } from '../breachedPasswordCheck';
+
+// mocked trackMetric
+jest.mock('@/server/lib/trackMetric', () => ({
+  trackMetric: jest.fn(),
+}));
+
+// mocked logger
+jest.mock('@/server/lib/serverSideLogger', () => ({
+  logger: {
+    warn: jest.fn(),
+  },
+}));
+
+// mocked fetch
+jest.mock('@/server/lib/fetch');
+const mockedFetch =
+  mocked<(url: RequestInfo, init?: RequestInit) => Partial<Promise<Response>>>(
+    fetch,
+  );
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+const text = jest.fn() as jest.MockedFunction<any>;
+
+describe('lib#breachedPasswordCheck', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('isBreachedPassword should return true if common/breached password', async () => {
+    text.mockResolvedValueOnce(`
+      1C12D46C02461550809D10EF62DDEE99F75:2
+      1CB7055517A54D1B0F1847EB84904E69438:2
+      1CC93AEF7B58A1B631CB55BF3A3A3750285:3
+      1D2DA4053E34E76F6576ED1DA63134B5E2A:2
+      1D72CD07550416C216D8AD296BF5C0AE8E0:10
+      1DE027315DE413921A63F1700938AF80965:1
+      1E2AAA439972480CEC7F16C795BBB429372:1
+      1E3687A61BFCE35F69B7408158101C8E414:1
+      1E4C9B93F3F0682250B6CF8331B7EE68FD8:3861493
+    `);
+    mockedFetch.mockReturnValueOnce(
+      Promise.resolve({ ok: true, status: 200, text } as Response),
+    );
+
+    const breached = await isBreachedPassword('password');
+    expect(breached).toEqual(true);
+  });
+
+  test('isBreachedPassword should return false if not common/breached password', async () => {
+    text.mockResolvedValueOnce(`
+      1C12D46C02461550809D10EF62DDEE99F75:2
+      1CB7055517A54D1B0F1847EB84904E69438:2
+      1CC93AEF7B58A1B631CB55BF3A3A3750285:3
+      1D2DA4053E34E76F6576ED1DA63134B5E2A:2
+      1D72CD07550416C216D8AD296BF5C0AE8E0:10
+      1DE027315DE413921A63F1700938AF80965:1
+      1E2AAA439972480CEC7F16C795BBB429372:1
+      1E3687A61BFCE35F69B7408158101C8E414:1
+    `);
+    mockedFetch.mockReturnValueOnce(
+      Promise.resolve({ ok: true, status: 200, text } as Response),
+    );
+
+    const breached = await isBreachedPassword('password');
+    expect(breached).toEqual(false);
+  });
+
+  test('isBreachedPassword should return false if status not 200', async () => {
+    mockedFetch.mockReturnValueOnce(
+      Promise.resolve({ ok: true, status: 500 } as Response),
+    );
+
+    const breached = await isBreachedPassword('password');
+    expect(breached).toEqual(false);
+  });
+});

--- a/src/server/lib/breachedPasswordCheck.ts
+++ b/src/server/lib/breachedPasswordCheck.ts
@@ -1,0 +1,75 @@
+import { createHash } from 'crypto';
+import { fetch } from '@/server/lib/fetch';
+import { logger } from '@/server/lib/serverSideLogger';
+import { trackMetric } from '@/server/lib/trackMetric';
+
+/**
+ * @name: isBreachedPassword
+ * @description: Checks if a password has previously been in a data breach by checking the Pwned Passwords API
+ *
+ * The documentation for the pwned password API is here for more detail:
+ * https://haveibeenpwned.com/API/v3#PwnedPasswords
+ *
+ * This method returns true only if the password has been in a data breach.
+ *
+ * We return false otherwise. This could be the case that the password has not been in a data breach, or if there is an error with the API/fetch call. This way we don't block the user from changing their password should there be an error.
+ *
+ * @param {string} password Password to check against the Pwned Passwords API
+ * @returns {boolean} True if the password has been in a data breach, false if it hasn't been breached or there was an API error
+ */
+export const isBreachedPassword = async (
+  password: string,
+): Promise<boolean> => {
+  try {
+    // the Pwned Passwords API uses SHA1 hashes of the password
+    // so we need to hash the password before sending it to the API
+    const hash = createHash('sha1').update(password).digest('hex');
+
+    // the Pwned Passwords API uses the first 5 characters of the hash
+    // which is what we need to send to the API
+    // so store the first 5 characters of the hash
+    const first5 = hash.substring(0, 5);
+
+    // the Pwned Passwords API returns a list of hashes that could match the
+    // remaining characters of the hash
+    // so store the remaining characters of the hash
+    const remaining = hash.substring(5);
+
+    // call the Pwned Passwords API to check if the password has been in a data breach
+    // by sending the first 5 characters of the hash
+    const response = await fetch(
+      `https://api.pwnedpasswords.com/range/${first5}`,
+    );
+
+    // check if we got an 2xx response, in the documentation it says that a
+    // 200 response is returned for all hashes between 00000 and FFFFF
+    if (response.ok) {
+      trackMetric('BreachedPasswordCheck::Success');
+
+      // the response is a string that delimits the full SHA-1 hash and the password count with a colon (:) and each line with a CRLF.
+      // so parse the response as a string
+      const text = await response.text();
+
+      // check if the remaining characters of the hash is in the response
+      // if it is, then the password has been in a data breach
+      // if it isn't, then the password has not been in a data breach
+      if (text.includes(remaining.toUpperCase())) {
+        // the password has been in a data breach, so return true
+        return true;
+      }
+    } else {
+      // something went wrong with the Pwned Passwords API, so we log the error
+      trackMetric('BreachedPasswordCheck::Failure');
+
+      logger.warn('breach password check failed with status', response.status);
+    }
+
+    // return false as the password is not breached or a fallback in case the api is down
+    return false;
+  } catch (error) {
+    trackMetric('BreachedPasswordCheck::Failure');
+
+    logger.warn('breach password check failed with error', error);
+    return false;
+  }
+};

--- a/src/server/lib/validatePasswordField.ts
+++ b/src/server/lib/validatePasswordField.ts
@@ -75,6 +75,15 @@ export const getErrorMessage = (error: unknown) => {
         },
       ],
     };
+  } else if (error instanceof ApiError && error.field === 'password') {
+    return {
+      fieldErrors: [
+        {
+          field: 'password',
+          message: error.message,
+        },
+      ],
+    };
   } else {
     return {
       globalError: ChangePasswordErrors.GENERIC,

--- a/src/server/models/Metrics.ts
+++ b/src/server/models/Metrics.ts
@@ -18,6 +18,7 @@ type RateLimitMetrics = BucketType;
 // i.e ::Success or ::Failure
 type ConditionalMetrics =
   | 'AccountVerification'
+  | 'BreachedPasswordCheck'
   | `${EmailMetrics}EmailSend`
   | 'EmailValidated'
   | `${'Get' | 'Post'}ConsentsPage-${string}`


### PR DESCRIPTION
## What does this change?

IDAPI would check against the breached passwords api when setting a password on the server. This functionality was not added to gateway when we migrated the setting of passwords to Okta.

This helps to form a 3 line defense against the setting of weak password.

Firstly there is already an existing client side check in the browser against the breached passwords API which should catch most cases. However we should not rely purely on client side checks.

So we add this server side check to also check for breached passwords before we send the password to the Okta API to be set. This prevents users who bypass the client side check from setting a week password. this is what's set up in this PR.

Finally there is a 3rd check within Okta itself to check against it's own dictionary. This will be enabled by this PR: https://github.com/guardian/identity-platform/pull/549