### PR TITLE
Okta | Enable Okta feature switch in PROD

### DIFF
--- a/src/shared/lib/featureSwitches.ts
+++ b/src/shared/lib/featureSwitches.ts
@@ -22,7 +22,7 @@ export const featureSwitches: FeatureSwitches = {
   oktaEnabled: {
     DEV: true,
     CODE: true,
-    PROD: false,
+    PROD: true,
   },
   recaptchaEnabledDev: false,
 };


### PR DESCRIPTION
## What does this change?

Enables the Okta feature switch for production, but still keeps the `useOkta=true` query parameter.

This way we can enable Okta in PROD, but still be able to test it without users getting an Okta session set.