### PR TITLE
Okta | Update session expiry behaviour

### DIFF
--- a/cypress/integration/mocked/okta_change_password.cy.ts
+++ b/cypress/integration/mocked/okta_change_password.cy.ts
@@ -126,12 +126,6 @@ describe('Change password in Okta', () => {
       }).as('breachCheck');
     };
 
-    it('shows the session expired page if the token is expired', () => {
-      mockPasswordResetSuccess(new Date(Date.now() - 1000));
-      cy.visit(`/reset-password/fake_token?useOkta=true`);
-      cy.contains('Session timed out');
-    });
-
     it('shows the link expired page if the state token and the recovery token are invalid', () => {
       interceptBreachPasswordCheck();
 
@@ -151,6 +145,7 @@ describe('Change password in Okta', () => {
       interceptBreachPasswordCheck();
 
       mockValidateRecoveryTokenSuccess();
+      mockValidateRecoveryTokenSuccess();
       mockPasswordResetInvalidStateTokenFailure();
       mockValidateRecoveryTokenSuccess();
 
@@ -166,26 +161,7 @@ describe('Change password in Okta', () => {
       );
     });
 
-    it('shows the password reset page with errors if state token is absent but recovery token is still valid', () => {
-      interceptBreachPasswordCheck();
-
-      mockValidateRecoveryTokenSuccess();
-      mockValidateRecoveryTokenSuccess();
-
-      cy.visit(`/reset-password/token?useOkta=true`);
-      cy.clearCookie('GU_GATEWAY_STATE');
-
-      cy.get('input[name="password"]').type(randomPassword());
-      cy.get('button[type="submit"]').click();
-
-      cy.contains('Reset password');
-      cy.contains(`Please enter your new password for ${email}`);
-      cy.contains(
-        'There was a problem changing your password, please try again.',
-      );
-    });
-
-    it('shows the link expired page if state token is absent and recovery token is invalid', () => {
+    it('shows the link expired page if recovery token is invalid after submitting password', () => {
       interceptBreachPasswordCheck();
 
       mockValidateRecoveryTokenSuccess();
@@ -306,6 +282,7 @@ describe('Change password in Okta', () => {
     it('shows the password updated page on successful update', () => {
       interceptBreachPasswordCheck();
 
+      mockValidateRecoveryTokenSuccess();
       mockValidateRecoveryTokenSuccess();
       mockPasswordResetSuccess();
       mockUpdateUserSuccess();

--- a/src/server/controllers/checkPasswordToken.ts
+++ b/src/server/controllers/checkPasswordToken.ts
@@ -145,14 +145,14 @@ export const checkTokenInOkta = async (
   const { token } = req.params;
 
   try {
-    const { stateToken, expiresAt, _embedded } = await validateTokenInOkta({
+    // Verify that the recovery token is still valid. If invalid, this will
+    // return an error and we will show the link expired page.
+    const { _embedded } = await validateTokenInOkta({
       recoveryToken: token,
     });
     const email = _embedded?.user.profile.login;
-    const timeUntilTokenExpiry =
-      expiresAt && Date.parse(expiresAt) - Date.now();
 
-    updateEncryptedStateCookie(req, res, { email, stateToken });
+    updateEncryptedStateCookie(req, res, { email });
 
     trackMetric('OktaValidatePasswordToken::Success');
 
@@ -189,7 +189,6 @@ export const checkTokenInOkta = async (
           pageData: {
             browserName: getBrowserNameFromUserAgent(req.header('User-Agent')),
             email,
-            timeUntilTokenExpiry,
             fieldErrors,
           },
           globalMessage: {

--- a/src/server/lib/okta/api/authentication.ts
+++ b/src/server/lib/okta/api/authentication.ts
@@ -99,6 +99,7 @@ export const sendForgotPasswordEmail = async (
  * resetting a password or completing account activation).
  *
  * If valid, a state token is returned which can be used to complete the recovery transaction.
+ * This is a short-lived token with an expiry time of 5 minutes 30 seconds.
  *
  * @param {string} body.recoveryToken Recovery token that was distributed to the end user via out-of-band mechanism such as email
  *

--- a/src/shared/model/EncryptedState.ts
+++ b/src/shared/model/EncryptedState.ts
@@ -6,7 +6,6 @@ export interface EncryptedState {
   emailType?: EmailType;
   passwordSetOnWelcomePage?: boolean;
   status?: string;
-  stateToken?: string;
   signInRedirect?: boolean; // TODO: possibly rename for clarity
   queryParams?: PersistableQueryParams;
 }


### PR DESCRIPTION
## What does this change?

This resolves unintended behaviour on the page where a user types in a new password (`/reset-password/:recovery-token`), reached from a link in the reset password email.

**Previous behaviour**

1. The client loads the page, supplying a **recovery token** with a 60-minute expiry.
2. The server checks that the **recovery token** is valid and exchanges it with Okta for a **session token**, a short-lived token with a fixed expiry time of 5 minutes 30 seconds.
3. The server uses the **session token's** expiry time (as it does not have access to the **recovery token's** expiry time) to set a client-side timeout. After 5:30, the page is refreshed and the client is shown a 'token expired' page, even though the **recovery token** may not have expired - only the **session token**.
4. The user is confused and sad.

**New behaviour**

1. The client loads the page, supplying a **recovery token** with a 60-minute expiry.
2. The server checks that the **recovery token** is valid. If it's valid, it shows the page to let the user enter a new password. If it's invalid, it will show them the 'token expired' page.
3. _When the user submits the form_, the server again checks that the **recovery token** is valid and, if so, exchanges it with Okta for a **session token**. If it's invalid, it will send them to the 'token expired' page.
4. The server immediately uses this **session token** to change the user's password with Okta.
5. The user is happy, at least as far as changing their Guardian password goes!