### PR TITLE
Okta | Fix registration emails for users without password trying to register

### DIFF
--- a/cypress/integration/ete-okta/registration.cy.ts
+++ b/cypress/integration/ete-okta/registration.cy.ts
@@ -230,11 +230,11 @@ describe('Registration flow', () => {
             /set-password\/([^"]*)/,
           ).then(({ links, body, token }) => {
             expect(body).to.have.string('This account already exists');
-            expect(body).to.have.string('Sign in');
-            expect(body).to.have.string('Reset password');
-            expect(links.length).to.eq(3);
+
+            expect(body).to.have.string('Create password');
+            expect(links.length).to.eq(2);
             const setPasswordLink = links.find((s) =>
-              s.text?.includes('Reset password'),
+              s.text?.includes('Create password'),
             );
             expect(setPasswordLink?.href ?? '').to.have.string('useOkta=true');
             cy.visit(`/set-password/${token}`);
@@ -268,11 +268,10 @@ describe('Registration flow', () => {
               /set-password\/([^"]*)/,
             ).then(({ links, body, token }) => {
               expect(body).to.have.string('This account already exists');
-              expect(body).to.have.string('Sign in');
-              expect(body).to.have.string('Reset password');
-              expect(links.length).to.eq(3);
+              expect(body).to.have.string('Create password');
+              expect(links.length).to.eq(2);
               const setPasswordLink = links.find((s) =>
-                s.text?.includes('Reset password'),
+                s.text?.includes('Create password'),
               );
               expect(setPasswordLink?.href ?? '').to.have.string(
                 'useOkta=true',
@@ -463,11 +462,10 @@ describe('Registration flow', () => {
                 /set-password\/([^"]*)/,
               ).then(({ links, body, token }) => {
                 expect(body).to.have.string('This account already exists');
-                expect(body).to.have.string('Sign in');
-                expect(body).to.have.string('Reset password');
-                expect(links.length).to.eq(3);
+                expect(body).to.have.string('Create password');
+                expect(links.length).to.eq(2);
                 const setPasswordLink = links.find((s) =>
-                  s.text?.includes('Reset password'),
+                  s.text?.includes('Create password'),
                 );
                 expect(setPasswordLink?.href ?? '').to.have.string(
                   'useOkta=true',
@@ -513,11 +511,10 @@ describe('Registration flow', () => {
                   /set-password\/([^"]*)/,
                 ).then(({ links, body, token }) => {
                   expect(body).to.have.string('This account already exists');
-                  expect(body).to.have.string('Sign in');
-                  expect(body).to.have.string('Reset password');
-                  expect(links.length).to.eq(3);
+                  expect(body).to.have.string('Create password');
+                  expect(links.length).to.eq(2);
                   const setPasswordLink = links.find((s) =>
-                    s.text?.includes('Reset password'),
+                    s.text?.includes('Create password'),
                   );
                   expect(setPasswordLink?.href ?? '').to.have.string(
                     'useOkta=true',

--- a/src/email/templates/AccountWithoutPasswordExists/sendAccountWithoutPasswordExists.ts
+++ b/src/email/templates/AccountWithoutPasswordExists/sendAccountWithoutPasswordExists.ts
@@ -1,25 +1,32 @@
-import { render } from 'mjml-react';
 import { send } from '@/email/lib/send';
-
-import { AccountWithoutPasswordExists } from './AccountWithoutPasswordExists';
-import { AccountWithoutPasswordExistsText } from './AccountWithoutPasswordExistsText';
+import { generateUrl } from '@/email/lib/generateUrl';
+import { renderedAccountWithoutPasswordExists } from '../renderedTemplates';
 
 type Props = {
   to: string;
   subject?: string;
+  activationToken: string;
 };
-
-const plainText = AccountWithoutPasswordExistsText();
-
-const { html } = render(AccountWithoutPasswordExists());
 
 export const sendAccountWithoutPasswordExistsEmail = ({
   to,
   subject = 'Nearly there...',
+  activationToken,
 }: Props) => {
+  const setPasswordUrl = generateUrl({
+    path: 'set-password',
+    token: activationToken,
+  });
+
   return send({
-    html,
-    plainText,
+    html: renderedAccountWithoutPasswordExists.html.replace(
+      '$createPasswordLink',
+      setPasswordUrl,
+    ),
+    plainText: renderedAccountWithoutPasswordExists.plain.replace(
+      '$createPasswordLink',
+      setPasswordUrl,
+    ),
     subject,
     to,
   });

--- a/src/server/lib/__tests__/okta/register.test.ts
+++ b/src/server/lib/__tests__/okta/register.test.ts
@@ -14,6 +14,7 @@ import {
   TokenResponse,
 } from '@/server/models/okta/User';
 import { sendAccountExistsEmail } from '@/email/templates/AccountExists/sendAccountExistsEmail';
+import { sendAccountWithoutPasswordExistsEmail } from '@/email/templates/AccountWithoutPasswordExists/sendAccountWithoutPasswordExists';
 import { sendResetPasswordEmail } from '@/email/templates/ResetPassword/sendResetPasswordEmail';
 import { ErrorCause, OktaError } from '@/server/models/okta/Error';
 
@@ -34,6 +35,9 @@ jest.mock('@/server/lib/getConfiguration', () => ({
 // mocked Okta Users API
 jest.mock('@/server/lib/okta/api/users');
 jest.mock('@/email/templates/AccountExists/sendAccountExistsEmail');
+jest.mock(
+  '@/email/templates/AccountWithoutPasswordExists/sendAccountWithoutPasswordExists',
+);
 jest.mock('@/email/templates/ResetPassword/sendResetPasswordEmail');
 const mockedCreateOktaUser =
   mocked<(body: UserCreationRequest) => Promise<UserResponse>>(createUser);
@@ -53,6 +57,9 @@ const mockedDangerouslyResetPassword = mocked<
 const mockedSendAccountExistsEmail = mocked<
   (params: { to: string; activationToken: string }) => Promise<boolean>
 >(sendAccountExistsEmail);
+const mockedSendAccountWithoutPasswordExistsEmail = mocked<
+  (params: { to: string; activationToken: string }) => Promise<boolean>
+>(sendAccountWithoutPasswordExistsEmail);
 const mockedSendResetPasswordEmail = mocked<
   (params: { to: string; resetPasswordToken: string }) => Promise<boolean>
 >(sendResetPasswordEmail);
@@ -115,11 +122,13 @@ describe('okta#register', () => {
     mockedActivateOktaUser.mockReturnValueOnce(
       Promise.resolve({ token: 'sometoken' } as TokenResponse),
     );
-    mockedSendAccountExistsEmail.mockReturnValueOnce(Promise.resolve(true));
+    mockedSendAccountWithoutPasswordExistsEmail.mockReturnValueOnce(
+      Promise.resolve(true),
+    );
 
     await expect(register(email)).resolves.toEqual(user);
     expect(mockedActivateOktaUser).toHaveBeenCalled();
-    expect(mockedSendAccountExistsEmail).toHaveBeenCalled();
+    expect(mockedSendAccountWithoutPasswordExistsEmail).toHaveBeenCalled();
     // Make sure the function from the other branch of the switch isn't called
     expect(mockedReactivateOktaUser).not.toHaveBeenCalled();
   });
@@ -139,11 +148,13 @@ describe('okta#register', () => {
     mockedReactivateOktaUser.mockReturnValueOnce(
       Promise.resolve({ token: 'sometoken' } as TokenResponse),
     );
-    mockedSendAccountExistsEmail.mockReturnValueOnce(Promise.resolve(true));
+    mockedSendAccountWithoutPasswordExistsEmail.mockReturnValueOnce(
+      Promise.resolve(true),
+    );
 
     await expect(register(email)).resolves.toEqual(user);
     expect(mockedReactivateOktaUser).toHaveBeenCalled();
-    expect(mockedSendAccountExistsEmail).toHaveBeenCalled();
+    expect(mockedSendAccountWithoutPasswordExistsEmail).toHaveBeenCalled();
     // Make sure the function from the other branch of the switch isn't called
     expect(mockedActivateOktaUser).not.toHaveBeenCalled();
   });

--- a/src/server/routes/register.ts
+++ b/src/server/routes/register.ts
@@ -16,7 +16,7 @@ import {
 import { logger } from '@/server/lib/serverSideLogger';
 import {
   register as registerWithOkta,
-  resendRegistrationEmail,
+  sendRegistrationEmailByUserState,
 } from '@/server/lib/okta/register';
 import { renderer } from '@/server/lib/renderer';
 import { rateLimitedTypedRouter as router } from '@/server/lib/typedRoutes';
@@ -268,7 +268,6 @@ const OktaRegistration = async (
   res: ResponseWithRequestState,
 ) => {
   const { email = '' } = req.body;
-
   try {
     const user = await registerWithOkta(email);
 
@@ -328,7 +327,7 @@ const OktaResendEmail = async (req: Request, res: ResponseWithRequestState) => {
     const { email } = encryptedState ?? {};
 
     if (typeof email !== 'undefined') {
-      await resendRegistrationEmail(email);
+      await sendRegistrationEmailByUserState(email);
       trackMetric('OktaRegistrationResendEmail::Success');
       return res.redirect(
         303,

--- a/src/server/routes/welcome.ts
+++ b/src/server/routes/welcome.ts
@@ -14,7 +14,7 @@ import { addQueryParamsToPath } from '@/shared/lib/queryParams';
 import deepmerge from 'deepmerge';
 import { Request, Router } from 'express';
 import { setEncryptedStateCookie } from '../lib/encryptedStateCookie';
-import { resendRegistrationEmail } from '@/server/lib/okta/register';
+import { sendRegistrationEmailByUserState } from '@/server/lib/okta/register';
 import { trackMetric } from '@/server/lib/trackMetric';
 import { OktaError } from '@/server/models/okta/Error';
 import { GenericErrors } from '@/shared/model/Errors';
@@ -130,7 +130,7 @@ const OktaResendEmail = async (req: Request, res: ResponseWithRequestState) => {
     const { email } = req.body;
 
     if (typeof email !== 'undefined') {
-      await resendRegistrationEmail(email);
+      await sendRegistrationEmailByUserState(email);
 
       trackMetric('OktaWelcomeResendEmail::Success');
 


### PR DESCRIPTION
## What does this change?

- Fixes an issue where a user without a password tries to register (or resend an email after trying to register) where they would receive an email with a link to sign in (AccountExistsEmail), despite them not
having a password to do so.
  - This was fixed by sending the AccountExistsWithoutPasswordEmail instead, which doesn't have a sign in link.
- Refactors the registration with Okta code to share code between the register and resend functionality
