### PR TITLE
Update Cypress tests for 60 minute token timeout emails

### DIFF
--- a/cypress/integration/ete/registration/register.cy.ts
+++ b/cypress/integration/ete/registration/register.cy.ts
@@ -209,7 +209,7 @@ describe('Registration flow', () => {
         expect(body).to.have.string('This account already exists');
         expect(body).to.have.string('Sign in');
         expect(body).to.have.string('Reset password');
-        expect(body).to.have.string('This link is only valid for 30 minutes.');
+        expect(body).to.have.string('This link is valid for 60 minutes.');
 
         expect(links.length).to.eq(3);
 
@@ -250,7 +250,7 @@ describe('Registration flow', () => {
         expect(body).to.have.string(
           'To continue to your account please click below to create a password.',
         );
-        expect(body).to.have.string('This link is only valid for 30 minutes.');
+        expect(body).to.have.string('This link is valid for 60 minutes.');
         expect(body).to.have.string('Create password');
 
         expect(links.length).to.eq(2);

--- a/cypress/integration/ete/registration/register_email_sent.cy.ts
+++ b/cypress/integration/ete/registration/register_email_sent.cy.ts
@@ -69,7 +69,7 @@ describe('Registration email sent page', () => {
         expect(body).to.have.string(
           'To continue to your account please click below to create a password.',
         );
-        expect(body).to.have.string('This link is only valid for 30 minutes.');
+        expect(body).to.have.string('This link is valid for 60 minutes.');
         expect(body).to.have.string('Create password');
       });
 
@@ -85,9 +85,7 @@ describe('Registration email sent page', () => {
           expect(body).to.have.string(
             'To continue to your account please click below to create a password.',
           );
-          expect(body).to.have.string(
-            'This link is only valid for 30 minutes.',
-          );
+          expect(body).to.have.string('This link is valid for 60 minutes.');
           expect(body).to.have.string('Create password');
         },
       );

--- a/cypress/integration/ete/reset_password/reset_password.cy.ts
+++ b/cypress/integration/ete/reset_password/reset_password.cy.ts
@@ -160,9 +160,7 @@ describe('Password set flow', () => {
           expect(body).to.have.string(
             'Please click below to create a password for your account.',
           );
-          expect(body).to.have.string(
-            'This link is only valid for 30 minutes.',
-          );
+          expect(body).to.have.string('This link is valid for 60 minutes.');
           expect(body).to.have.string('Create password');
         });
 
@@ -180,9 +178,7 @@ describe('Password set flow', () => {
           expect(body).to.have.string(
             'Please click below to create a password for your account.',
           );
-          expect(body).to.have.string(
-            'This link is only valid for 30 minutes.',
-          );
+          expect(body).to.have.string('This link is valid for 60 minutes.');
           expect(body).to.have.string('Create password');
 
           expect(links.length).to.eq(2);


### PR DESCRIPTION
## What does this change?
This pull request: https://github.com/guardian/identity/pull/2134 in IDAPI changes the timeout of our tokens to be 60 minutes, instead of 30 minutes as it was previously.

We change our Cypress tests here to make an assertion against the email content for the new 60 minutes copy to prevent our tests from failing once the change to IDAPI has been merged.

## How to test
Run our e2e tests against IDAPI with the referenced PR deployed. The tests should pass.
