### PR TITLE
Okta | Reset password flows for non-`ACTIVE` Okta user states

### DIFF
--- a/.github/workflows/cypress-mocked.yml
+++ b/.github/workflows/cypress-mocked.yml
@@ -85,6 +85,7 @@ jobs:
           NODE_TLS_REJECT_UNAUTHORIZED: 0
           # Used to tell Gateway server we're running in Cypress
           RUNNING_IN_CYPRESS: true
+          RUNNING_IN_CYPRESS_MOCKED: true
         with:
           build: yarn build
           start: yarn start, yarn mock-server

--- a/cypress-mocked.sh
+++ b/cypress-mocked.sh
@@ -30,6 +30,7 @@ CI_ENV=${CI_ENV%?}
 
 # Used to tell Gateway server we're running in Cypress
 RUNNING_IN_CYPRESS=true
+RUNNING_IN_CYPRESS_MOCKED=true
 
 if [ -z ${NODE_EXTRA_CA_CERTS+x} ]; then
   echo "NODE_EXTRA_CA_CERTS is unset in your bash config, see setup docs on how to set this."

--- a/cypress/integration/ete-okta/reset_password.cy.ts
+++ b/cypress/integration/ete-okta/reset_password.cy.ts
@@ -1,4 +1,12 @@
+import { Status } from '../../../src/server/models/okta/User';
 import { randomPassword } from '../../support/commands/testUser';
+
+const breachCheck = () => {
+  cy.intercept({
+    method: 'GET',
+    url: 'https://api.pwnedpasswords.com/range/*',
+  }).as('breachCheck');
+};
 
 describe('Password reset flow in Okta', () => {
   context('Account exists', () => {
@@ -15,11 +23,7 @@ describe('Password reset flow in Okta', () => {
       const appClientId = 'appClientId1';
       const fromURI = 'fromURI1';
 
-      cy.intercept({
-        method: 'GET',
-        url: 'https://api.pwnedpasswords.com/range/*',
-      }).as('breachCheck');
-
+      breachCheck();
       cy.createTestUser({
         isUserEmailValidated: true,
       })?.then(({ emailAddress }) => {
@@ -77,11 +81,7 @@ describe('Password reset flow in Okta', () => {
       const encodedReturnUrl =
         'https%3A%2F%2Fm.code.dev-theguardian.com%2Ftravel%2F2019%2Fdec%2F18%2Ffood-culture-tour-bethlehem-palestine-east-jerusalem-photo-essay';
 
-      cy.intercept({
-        method: 'GET',
-        url: 'https://api.pwnedpasswords.com/range/*',
-      }).as('breachCheck');
-
+      breachCheck();
       cy.createTestUser({
         isUserEmailValidated: true,
       })?.then(({ emailAddress }) => {
@@ -143,11 +143,7 @@ describe('Password reset flow in Okta', () => {
       const appClientId1 = 'appClientId1';
       const fromURI1 = 'fromURI1';
 
-      cy.intercept({
-        method: 'GET',
-        url: 'https://api.pwnedpasswords.com/range/*',
-      }).as('breachCheck');
-
+      breachCheck();
       cy.createTestUser({
         isUserEmailValidated: true,
       })?.then(({ emailAddress }) => {
@@ -186,6 +182,218 @@ describe('Password reset flow in Okta', () => {
             .and('match', new RegExp(fromURI2))
             .and('not.match', new RegExp(appClientId1))
             .and('not.match', new RegExp(fromURI1));
+        });
+      });
+    });
+  });
+
+  context('STAGED user', () => {
+    it("changes the reader's password", () => {
+      breachCheck();
+      cy.createTestUser({ isGuestUser: true })?.then(({ emailAddress }) => {
+        cy.getTestOktaUser(emailAddress).then((oktaUser) => {
+          expect(oktaUser.status).to.eq(Status.STAGED);
+
+          cy.visit('/reset-password?useOkta=true');
+          const timeRequestWasMade = new Date();
+
+          cy.get('input[name=email]').type(emailAddress);
+          cy.get('button[type="submit"]').click();
+
+          cy.contains('Check your email inbox');
+          cy.contains(emailAddress);
+          cy.contains('Resend email');
+          cy.contains('Change email address');
+
+          cy.checkForEmailAndGetDetails(
+            emailAddress,
+            timeRequestWasMade,
+            /set-password\/([^"]*)/,
+          ).then(({ links, body, token }) => {
+            expect(body).to.have.string('Welcome back');
+
+            expect(body).to.have.string('Create password');
+            expect(links.length).to.eq(2);
+            const setPasswordLink = links.find((s) =>
+              s.text?.includes('Create password'),
+            );
+            expect(setPasswordLink?.href ?? '').to.have.string('useOkta=true');
+            cy.visit(`/set-password/${token}`);
+            cy.contains('Create password');
+            cy.contains(emailAddress);
+
+            cy.get('input[name=password]').type(randomPassword());
+
+            cy.wait('@breachCheck');
+            cy.get('[data-cy="main-form-submit-button"]')
+              .click()
+              .should('be.disabled');
+            cy.contains('Password created');
+            cy.contains(emailAddress.toLowerCase());
+          });
+        });
+      });
+    });
+  });
+
+  context('PROVISIONED user', () => {
+    it("changes the reader's password", () => {
+      breachCheck();
+      cy.createTestUser({ isGuestUser: true })?.then(({ emailAddress }) => {
+        cy.activateTestOktaUser(emailAddress).then(() => {
+          cy.getTestOktaUser(emailAddress).then((oktaUser) => {
+            expect(oktaUser.status).to.eq(Status.PROVISIONED);
+
+            cy.visit('/reset-password?useOkta=true');
+            const timeRequestWasMade = new Date();
+
+            cy.get('input[name=email]').type(emailAddress);
+            cy.get('button[type="submit"]').click();
+
+            cy.contains('Check your email inbox');
+            cy.contains(emailAddress);
+            cy.contains('Resend email');
+            cy.contains('Change email address');
+
+            cy.checkForEmailAndGetDetails(
+              emailAddress,
+              timeRequestWasMade,
+              /set-password\/([^"]*)/,
+            ).then(({ links, body, token }) => {
+              expect(body).to.have.string('Welcome back');
+
+              expect(body).to.have.string('Create password');
+              expect(links.length).to.eq(2);
+              const setPasswordLink = links.find((s) =>
+                s.text?.includes('Create password'),
+              );
+              expect(setPasswordLink?.href ?? '').to.have.string(
+                'useOkta=true',
+              );
+              cy.visit(`/set-password/${token}`);
+              cy.contains('Create password');
+              cy.contains(emailAddress);
+
+              cy.get('input[name=password]').type(randomPassword());
+
+              cy.wait('@breachCheck');
+              cy.get('[data-cy="main-form-submit-button"]')
+                .click()
+                .should('be.disabled');
+              cy.contains('Password created');
+              cy.contains(emailAddress.toLowerCase());
+            });
+          });
+        });
+      });
+    });
+  });
+
+  context('RECOVERY user', () => {
+    it("changes the reader's password", () => {
+      breachCheck();
+      cy.createTestUser({ isGuestUser: false })?.then(({ emailAddress }) => {
+        cy.resetOktaUserPassword(emailAddress).then(() => {
+          cy.getTestOktaUser(emailAddress).then((oktaUser) => {
+            expect(oktaUser.status).to.eq(Status.RECOVERY);
+
+            cy.visit('/reset-password?useOkta=true');
+            const timeRequestWasMade = new Date();
+
+            cy.get('input[name=email]').type(emailAddress);
+            cy.get('button[type="submit"]').click();
+
+            cy.contains('Check your email inbox');
+            cy.contains(emailAddress);
+            cy.contains('Resend email');
+            cy.contains('Change email address');
+
+            cy.checkForEmailAndGetDetails(
+              emailAddress,
+              timeRequestWasMade,
+              /set-password\/([^"]*)/,
+            ).then(({ links, body, token }) => {
+              expect(body).to.have.string('Password reset');
+              expect(body).to.have.string('Reset password');
+              expect(links.length).to.eq(2);
+              const resetPasswordLink = links.find((s) =>
+                s.text?.includes('Reset password'),
+              );
+              expect(resetPasswordLink?.href ?? '').to.have.string(
+                'useOkta=true',
+              );
+              expect(resetPasswordLink?.href ?? '').to.have.string(
+                'reset-password',
+              );
+              cy.visit(`/reset-password/${token}`);
+              cy.contains('Reset password');
+              cy.contains(emailAddress);
+
+              cy.get('input[name=password]').type(randomPassword());
+
+              cy.wait('@breachCheck');
+              cy.get('[data-cy="main-form-submit-button"]')
+                .click()
+                .should('be.disabled');
+              cy.contains('Password updated');
+              cy.contains(emailAddress.toLowerCase());
+            });
+          });
+        });
+      });
+    });
+  });
+
+  context('PASSWORD_EXPIRED user', () => {
+    it("changes the reader's password", () => {
+      breachCheck();
+      cy.createTestUser({ isGuestUser: false })?.then(({ emailAddress }) => {
+        cy.expireOktaUserPassword(emailAddress).then(() => {
+          cy.getTestOktaUser(emailAddress).then((oktaUser) => {
+            expect(oktaUser.status).to.eq(Status.PASSWORD_EXPIRED);
+
+            cy.visit('/reset-password?useOkta=true');
+            const timeRequestWasMade = new Date();
+
+            cy.get('input[name=email]').type(emailAddress);
+            cy.get('button[type="submit"]').click();
+
+            cy.contains('Check your email inbox');
+            cy.contains(emailAddress);
+            cy.contains('Resend email');
+            cy.contains('Change email address');
+
+            cy.checkForEmailAndGetDetails(
+              emailAddress,
+              timeRequestWasMade,
+              /set-password\/([^"]*)/,
+            ).then(({ links, body, token }) => {
+              expect(body).to.have.string('Password reset');
+              expect(body).to.have.string('Reset password');
+              expect(links.length).to.eq(2);
+              const resetPasswordLink = links.find((s) =>
+                s.text?.includes('Reset password'),
+              );
+              expect(resetPasswordLink?.href ?? '').to.have.string(
+                'useOkta=true',
+              );
+              expect(resetPasswordLink?.href ?? '').to.have.string(
+                'reset-password',
+              );
+              cy.visit(`/reset-password/${token}`);
+              cy.contains('Reset password');
+              cy.contains(emailAddress);
+
+              cy.get('input[name=password]').type(randomPassword());
+
+              cy.wait('@breachCheck');
+              cy.get('[data-cy="main-form-submit-button"]')
+                .click()
+                .should('be.disabled');
+              cy.contains('Password updated');
+              cy.contains(emailAddress.toLowerCase());
+            });
+          });
         });
       });
     });

--- a/cypress/integration/mocked/okta_send_reset_password.cy.ts
+++ b/cypress/integration/mocked/okta_send_reset_password.cy.ts
@@ -1,14 +1,108 @@
+import { UserResponse } from '../../../src/server/models/okta/User';
+
 describe('Send password reset email in Okta', () => {
   const email = 'mrtest@theguardian.com';
+
+  const mockUserActiveWithPassword: UserResponse = {
+    id: 'test',
+    status: 'ACTIVE',
+    profile: {
+      login: 'mrtest@theguardian.com',
+      email: 'mrtest@theguardian.com',
+    },
+    credentials: {
+      password: {},
+      provider: {
+        type: 'OKTA',
+        name: 'OKTA',
+      },
+    },
+  };
+
+  const mockUserActiveWithoutPassword: UserResponse = {
+    id: 'test',
+    status: 'ACTIVE',
+    profile: {
+      login: 'mrtest@theguardian.com',
+      email: 'mrtest@theguardian.com',
+    },
+    credentials: {
+      provider: {
+        type: 'OKTA',
+        name: 'OKTA',
+      },
+    },
+  };
+
+  const mockUserStaged: UserResponse = {
+    id: 'test',
+    status: 'STAGED',
+    profile: {
+      login: 'mrtest@theguardian.com',
+      email: 'mrtest@theguardian.com',
+    },
+    credentials: {
+      provider: {
+        type: 'OKTA',
+        name: 'OKTA',
+      },
+    },
+  };
+
+  const mockUserProvisioned: UserResponse = {
+    id: 'test',
+    status: 'PROVISIONED',
+    profile: {
+      login: 'mrtest@theguardian.com',
+      email: 'mrtest@theguardian.com',
+    },
+    credentials: {
+      provider: {
+        type: 'OKTA',
+        name: 'OKTA',
+      },
+    },
+  };
+
+  const mockUserRecovery: UserResponse = {
+    id: 'test',
+    status: 'RECOVERY',
+    profile: {
+      login: 'mrtest@theguardian.com',
+      email: 'mrtest@theguardian.com',
+    },
+    credentials: {
+      provider: {
+        type: 'OKTA',
+        name: 'OKTA',
+      },
+    },
+  };
+
+  const mockUserPasswordExpired: UserResponse = {
+    id: 'test',
+    status: 'PASSWORD_EXPIRED',
+    profile: {
+      login: 'mrtest@theguardian.com',
+      email: 'mrtest@theguardian.com',
+    },
+    credentials: {
+      provider: {
+        type: 'OKTA',
+        name: 'OKTA',
+      },
+    },
+  };
 
   beforeEach(() => {
     cy.mockPurge();
   });
 
-  context('send reset password email', () => {
+  context('send reset password email for ACTIVE user', () => {
     it('shows email sent page when successful', () => {
       cy.visit('/reset-password?useOkta=true');
       cy.get('input[name="email"]').type(email);
+      cy.mockNext(200, mockUserActiveWithPassword);
       cy.mockNext(200, {
         status: 'RECOVERY_CHALLENGE',
         factorResult: 'WAITING',
@@ -18,10 +112,133 @@ describe('Send password reset email in Okta', () => {
       cy.get('button[type="submit"]').click();
       cy.contains('Check your email inbox');
     });
+  });
 
+  context('send reset password email for ACTIVE user without password', () => {
+    it('shows email sent page when successful', () => {
+      cy.visit('/reset-password?useOkta=true');
+      cy.get('input[name="email"]').type(email);
+      cy.mockNext(200, mockUserActiveWithoutPassword);
+      cy.mockNext(403, {
+        errorCode: 'E0000006',
+        errorSummary:
+          'You do not have permission to perform the requested action',
+        errorLink: 'E0000006',
+        errorId: 'errorId',
+        errorCauses: [],
+      });
+      cy.mockNext(200, {
+        resetPasswordUrl: `https://${Cypress.env(
+          'BASE_URI',
+        )}/reset_password/token_token_token_to`,
+      });
+      cy.mockNext(200, {
+        stateToken: 'stateToken',
+        expiresAt: new Date(Date.now() + 1800000 /* 30min */),
+        status: 'SUCCESS',
+        _embedded: {
+          user: {
+            id: '12345',
+            passwordChanged: new Date().toISOString(),
+            profile: {
+              login: email,
+              firstName: null,
+              lastName: null,
+            },
+          },
+        },
+      });
+      cy.mockNext(200, {
+        expiresAt: new Date(Date.now() + 1800000 /* 30min */),
+        status: 'SUCCESS',
+        sessionToken: 'aValidSessionToken',
+        _embedded: {
+          user: {
+            id: '12345',
+            passwordChanged: new Date().toISOString(),
+            profile: {
+              login: email,
+              firstName: null,
+              lastName: null,
+              locale: 'en_US',
+              timeZone: 'America/Los_Angeles',
+            },
+          },
+        },
+      });
+      cy.mockNext(200, mockUserActiveWithoutPassword);
+      cy.mockNext(200, {
+        status: 'RECOVERY_CHALLENGE',
+        factorResult: 'WAITING',
+        factorType: 'EMAIL',
+        recoveryType: 'PASSWORD',
+      });
+      cy.get('button[type="submit"]').click();
+      cy.contains('Check your email inbox');
+    });
+  });
+
+  context('send create password email for STAGED user', () => {
+    it('shows email sent page when successful', () => {
+      cy.visit('/reset-password?useOkta=true');
+      cy.get('input[name="email"]').type(email);
+      cy.mockNext(200, mockUserStaged);
+      cy.mockNext(200, {
+        activationToken: `token_token_token_to`,
+      });
+      cy.get('button[type="submit"]').click();
+      cy.contains('Check your email inbox');
+    });
+  });
+
+  context('send create password email for PROVISIONED user', () => {
+    it('shows email sent page when successful', () => {
+      cy.visit('/reset-password?useOkta=true');
+      cy.get('input[name="email"]').type(email);
+      cy.mockNext(200, mockUserProvisioned);
+      cy.mockNext(200, {
+        activationToken: `token_token_token_to`,
+      });
+      cy.get('button[type="submit"]').click();
+      cy.contains('Check your email inbox');
+    });
+  });
+
+  context('send reset password email for RECOVERY user', () => {
+    it('shows email sent page when successful', () => {
+      cy.visit('/reset-password?useOkta=true');
+      cy.get('input[name="email"]').type(email);
+      cy.mockNext(200, mockUserRecovery);
+      cy.mockNext(200, {
+        resetPasswordUrl: `https://${Cypress.env(
+          'BASE_URI',
+        )}/reset_password/token_token_token_to`,
+      });
+      cy.get('button[type="submit"]').click();
+      cy.contains('Check your email inbox');
+    });
+  });
+
+  context('send reset password email for PASSWORD_EXPIRED user', () => {
+    it('shows email sent page when successful', () => {
+      cy.visit('/reset-password?useOkta=true');
+      cy.get('input[name="email"]').type(email);
+      cy.mockNext(200, mockUserPasswordExpired);
+      cy.mockNext(200, {
+        resetPasswordUrl: `https://${Cypress.env(
+          'BASE_URI',
+        )}/reset_password/token_token_token_to`,
+      });
+      cy.get('button[type="submit"]').click();
+      cy.contains('Check your email inbox');
+    });
+  });
+
+  context('generic error handling', () => {
     it('shows a generic error when something goes wrong', () => {
       cy.visit('/reset-password?useOkta=true');
       cy.get('input[name="email"]').type(email);
+      cy.mockNext(200, mockUserActiveWithPassword);
       cy.mockNext(403, {
         errorCode: 'E0000006',
         errorSummary:

--- a/src/email/lib/send.ts
+++ b/src/email/lib/send.ts
@@ -28,6 +28,11 @@ export const send = async ({
   subject,
   to,
 }: Props): Promise<boolean> => {
+  // used to mock email send in cypress mocked tests
+  if (process.env.RUNNING_IN_CYPRESS_MOCKED === 'true') {
+    return true;
+  }
+
   const params: AWS.SESV2.SendEmailRequest = {
     Content: {
       Simple: {

--- a/src/email/templates/CreatePassword/sendCreatePasswordEmail.ts
+++ b/src/email/templates/CreatePassword/sendCreatePasswordEmail.ts
@@ -1,24 +1,32 @@
-import { render } from 'mjml-react';
 import { send } from '@/email/lib/send';
-
-import { CreatePassword } from './CreatePassword';
-import { CreatePasswordText } from './CreatePasswordText';
+import { generateUrl } from '@/email/lib/generateUrl';
+import { renderedCreatePassword } from '../renderedTemplates';
 
 type Props = {
   to: string;
   subject?: string;
+  setPasswordToken: string;
 };
 
-const plainText = CreatePasswordText();
-const { html } = render(CreatePassword());
-
-export const sendNoAccountEmail = ({
+export const sendCreatePasswordEmail = ({
   to,
   subject = 'Nearly there...',
+  setPasswordToken,
 }: Props) => {
+  const setPasswordUrl = generateUrl({
+    path: 'reset-password',
+    token: setPasswordToken,
+  });
+
   return send({
-    html,
-    plainText,
+    html: renderedCreatePassword.html.replace(
+      '$createPasswordLink',
+      setPasswordUrl,
+    ),
+    plainText: renderedCreatePassword.plain.replace(
+      '$createPasswordLink',
+      setPasswordUrl,
+    ),
     subject,
     to,
   });


### PR DESCRIPTION
## What does this change?

During MVP3 testing it was discovered that the reset password flow was unable to handle non-`ACTIVE` Okta user states, and would either send a "Ignore this email" (Forgot password denied template in Okta), or cause an error to be thrown.

This PR adds the following functionality to the reset password flow for the following user states

- `STAGED` - Send create password email, with activation token, which will set a password and activate their account.
- `PROVISIONED` - Send create password email, with activation token, which will set a password and activate their account.
- `RECOVERY` - Send forgot password email, with recovery token, which will reset a password and put then into the ACTIVE state
- `PASSWORD_EXPIRED` - Send forgot password email, with recovery token, which will reset a password and put then into the ACTIVE state

Cypress mocked and end to end tests are added to cover these scenarios

## Other changes

- Add `RUNNING_IN_CYPRESS_MOCKED` flag to mocked tests, so we don't attempt to send an email through AWS SES, and just mock that it was sent successfully