### PR TITLE
Set the `encryptedStateCookie` to `lax`

### DIFF
--- a/src/server/lib/encryptedStateCookie.ts
+++ b/src/server/lib/encryptedStateCookie.ts
@@ -12,7 +12,7 @@ const encryptedStateCookieOptions: CookieOptions = {
   httpOnly: true,
   secure: !baseUri.includes('localhost'),
   signed: !baseUri.includes('localhost'),
-  sameSite: 'strict',
+  sameSite: 'lax',
 };
 
 export const setEncryptedStateCookie = (


### PR DESCRIPTION
## What does this change?
We would like to persist the `encryptedStateCookie` as the user continues their registration journey via the "Continue" link in our confirmation email.

By setting the cookie `same-site` attribute to `lax` instead of `strict`, we allow the cookie to persist when referred from a third party site. This ensures that the essential functionality that it provides—preserving query parameters among other things—remains intact once we have launched Okta.