### PR TITLE
Okta | Ophan | Fire ComponentEvent using componentEventParams

### DIFF
--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
     "@guardian/ab-core": "^2.0.0",
     "@guardian/ab-react": "^2.0.1",
     "@guardian/consent-management-platform": "^10.8.0",
-    "@guardian/libs": "^6.0.0",
+    "@guardian/libs": "^6.1.0",
     "@guardian/source-foundations": "^5.1.0",
     "@guardian/source-react-components": "^6.0.0",
     "@guardian/source-react-components-development-kitchen": "^2.0.0",

--- a/src/server/controllers/changePassword.ts
+++ b/src/server/controllers/changePassword.ts
@@ -32,6 +32,7 @@ import { checkTokenInOkta } from '@/server/controllers/checkPasswordToken';
 import { performAuthorizationCodeFlow } from '@/server/lib/okta/oauth';
 import { validateEmailAndPasswordSetSecurely } from '@/server/lib/okta/validateEmail';
 import { setupJobsUserInIDAPI, setupJobsUserInOkta } from '../lib/jobs';
+import { sendOphanComponentEventFromQueryParamsServer } from '../lib/ophan';
 
 const { okta } = getConfiguration();
 
@@ -226,7 +227,16 @@ const changePasswordInOkta = async (
         queryParams: undefined,
       });
 
-      // TODO: once sign out with Okta has been implemented, invalidate current sessions before kicking off code flow
+      // fire ophan component event if applicable
+      if (res.locals.queryParams.componentEventParams) {
+        sendOphanComponentEventFromQueryParamsServer(
+          res.locals.queryParams.componentEventParams,
+          'SIGN_IN',
+          'web',
+          res.locals.ophanConfig.consentUUID,
+        );
+      }
+
       return await performAuthorizationCodeFlow(req, res, {
         sessionToken,
         confirmationPagePath: successRedirectPath,

--- a/src/server/lib/__tests__/ophan.test.ts
+++ b/src/server/lib/__tests__/ophan.test.ts
@@ -1,0 +1,217 @@
+import {
+  getComponentType,
+  parseComponentEventParams,
+  generateOphanComponentEvent,
+  ComponentEventParams,
+} from '../ophan';
+
+// mock the server side logger
+jest.mock('@/server/lib/serverSideLogger');
+
+// mocked configuration
+jest.mock('@/server/lib/getConfiguration', () => ({
+  getConfiguration: () => ({
+    stage: 'DEV',
+    aws: {},
+  }),
+}));
+
+describe('ophan#parseComponentEventParams', () => {
+  test('it should parse component event params with all parameters', async () => {
+    const input =
+      'componentType=SIGN_IN_GATE&componentId=component_id&abTestName=main_test&abTestVariant=main_variant&browserId=321bca&visitId=123abc&viewId=987xyz';
+    const output = await parseComponentEventParams(input);
+    expect(output).toEqual({
+      abTestName: 'main_test',
+      abTestVariant: 'main_variant',
+      browserId: '321bca',
+      componentId: 'component_id',
+      componentType: 'SIGN_IN_GATE',
+      viewId: '987xyz',
+      visitId: '123abc',
+    });
+  });
+
+  test('it should parse component event params without optional parameters', async () => {
+    const input =
+      'componentType=SIGN_IN_GATE&componentId=component_id&viewId=987xyz';
+    const output = await parseComponentEventParams(input);
+    expect(output).toEqual({
+      componentId: 'component_id',
+      componentType: 'SIGN_IN_GATE',
+      viewId: '987xyz',
+    });
+  });
+
+  test('it should convert "undefined" string to "" empty string from parameters', async () => {
+    const input =
+      'componentType=SIGN_IN_GATE&componentId=component_id&abTestName=main_test&abTestVariant=main_variant&browserId=undefined&visitId=undefined&viewId=987xyz';
+    const output = await parseComponentEventParams(input);
+    expect(output).toEqual({
+      abTestName: 'main_test',
+      abTestVariant: 'main_variant',
+      componentId: 'component_id',
+      componentType: 'SIGN_IN_GATE',
+      viewId: '987xyz',
+      browserId: '',
+      visitId: '',
+    });
+  });
+
+  test('it should return undefined if unable to parse the query string', async () => {
+    const input = 'componentType=SIGN_IN_GATE&componentId=component_id';
+    const output = await parseComponentEventParams(input);
+    expect(output).toBeUndefined();
+  });
+
+  test('it should return undefined if the query string is empty', async () => {
+    const input = '';
+    const output = await parseComponentEventParams(input);
+    expect(output).toBeUndefined();
+  });
+
+  test('it should return undefined if the query string has unknown key', async () => {
+    const input =
+      'componentType=SIGN_IN_GATE&componentId=component_id&abTestName=main_test&abTestVariant=main_variant&browserId=321bca&visitId=123abc&viewId=987xyz&unknownKey=unknownValue';
+    const output = await parseComponentEventParams(input);
+    expect(output).toBeUndefined();
+  });
+});
+
+describe('ophan#getComponentType', () => {
+  test('it should convert "signingate" to "SIGN_IN_GATE"', () => {
+    expect(getComponentType('signingate')).toBe('SIGN_IN_GATE');
+  });
+
+  test('it should convert "identityauthentication" to "IDENTITY_AUTHENTICATION"', () => {
+    expect(getComponentType('identityauthentication')).toBe(
+      'IDENTITY_AUTHENTICATION',
+    );
+  });
+
+  test('it should return the same string if the component type is not "signingate" or "identityauthentication"', () => {
+    expect(getComponentType('NEWSLETTER_SUBSCRIPTION')).toBe(
+      'NEWSLETTER_SUBSCRIPTION',
+    );
+  });
+});
+
+describe('ophan#generateOphanComponentEvent', () => {
+  test('it should generate a valid ophan component event from componentEventParams, action, and value', () => {
+    const componentEventParams: ComponentEventParams = {
+      abTestName: 'main_test',
+      abTestVariant: 'main_variant',
+      browserId: '321bca',
+      componentId: 'component_id',
+      componentType: 'SIGN_IN_GATE',
+      viewId: '987xyz',
+      visitId: '123abc',
+    };
+
+    const output = generateOphanComponentEvent(
+      componentEventParams,
+      'SIGN_IN',
+      'a_value',
+    );
+    expect(output).toEqual({
+      abTest: {
+        name: 'main_test',
+        variant: 'main_variant',
+      },
+      action: 'SIGN_IN',
+      component: {
+        componentType: 'SIGN_IN_GATE',
+        id: 'component_id',
+      },
+      value: 'a_value',
+    });
+  });
+
+  test('it should generate a valid ophan component event from componentEventParams and action', () => {
+    const componentEventParams: ComponentEventParams = {
+      abTestName: 'main_test',
+      abTestVariant: 'main_variant',
+      browserId: '321bca',
+      componentId: 'component_id',
+      componentType: 'SIGN_IN_GATE',
+      viewId: '987xyz',
+      visitId: '123abc',
+    };
+
+    const output = generateOphanComponentEvent(componentEventParams, 'SIGN_IN');
+
+    expect(output).toEqual({
+      abTest: {
+        name: 'main_test',
+        variant: 'main_variant',
+      },
+      action: 'SIGN_IN',
+      component: {
+        componentType: 'SIGN_IN_GATE',
+        id: 'component_id',
+      },
+    });
+  });
+
+  test('it should not include ab test if ab test name missing', () => {
+    const componentEventParams: ComponentEventParams = {
+      abTestVariant: 'main_variant',
+      browserId: '321bca',
+      componentType: 'SIGN_IN_GATE',
+      componentId: 'component_id',
+      viewId: '987xyz',
+      visitId: '123abc',
+    };
+
+    const output = generateOphanComponentEvent(componentEventParams, 'SIGN_IN');
+
+    expect(output).toEqual({
+      action: 'SIGN_IN',
+      component: {
+        componentType: 'SIGN_IN_GATE',
+        id: 'component_id',
+      },
+    });
+  });
+
+  test('it should not include ab test if ab test variant missing', () => {
+    const componentEventParams: ComponentEventParams = {
+      abTestName: 'main_test',
+      browserId: '321bca',
+      componentType: 'SIGN_IN_GATE',
+      componentId: 'component_id',
+      viewId: '987xyz',
+      visitId: '123abc',
+    };
+
+    const output = generateOphanComponentEvent(componentEventParams, 'SIGN_IN');
+
+    expect(output).toEqual({
+      action: 'SIGN_IN',
+      component: {
+        componentType: 'SIGN_IN_GATE',
+        id: 'component_id',
+      },
+    });
+  });
+
+  test('it should not include ab test if ab test missing', () => {
+    const componentEventParams: ComponentEventParams = {
+      browserId: '321bca',
+      componentType: 'SIGN_IN_GATE',
+      componentId: 'component_id',
+      viewId: '987xyz',
+      visitId: '123abc',
+    };
+
+    const output = generateOphanComponentEvent(componentEventParams, 'SIGN_IN');
+
+    expect(output).toEqual({
+      action: 'SIGN_IN',
+      component: {
+        componentType: 'SIGN_IN_GATE',
+        id: 'component_id',
+      },
+    });
+  });
+});

--- a/src/server/lib/__tests__/ophan.test.ts
+++ b/src/server/lib/__tests__/ophan.test.ts
@@ -89,6 +89,16 @@ describe('ophan#getComponentType', () => {
     );
   });
 
+  test('it should convert "acquisitionsheader" to "ACQUISITIONS_HEADER"', () => {
+    expect(getComponentType('acquisitionsheader')).toBe('ACQUISITIONS_HEADER');
+  });
+
+  test('it should convert "acquisitionsengagementbanner" to "ACQUISITIONS_ENGAGEMENT_BANNER"', () => {
+    expect(getComponentType('acquisitionsengagementbanner')).toBe(
+      'ACQUISITIONS_ENGAGEMENT_BANNER',
+    );
+  });
+
   test('it should return the same string if the component type is not "signingate" or "identityauthentication"', () => {
     expect(getComponentType('NEWSLETTER_SUBSCRIPTION')).toBe(
       'NEWSLETTER_SUBSCRIPTION',

--- a/src/server/lib/ophan.ts
+++ b/src/server/lib/ophan.ts
@@ -2,17 +2,127 @@ import { OphanEvent, OphanInteraction } from '@/shared/model/ophan';
 import { fetch } from '@/server/lib/fetch';
 import { logger } from '@/server/lib/serverSideLogger';
 import timeoutSignal from 'timeout-signal';
-import { stringify } from 'query-string';
+import { stringify, parse } from 'query-string';
+import { z } from 'zod';
+import {
+  OphanAction,
+  OphanComponent,
+  OphanComponentEvent,
+  OphanComponentType,
+} from '@guardian/libs';
+import serialize from 'serialize-javascript';
 
 const ophanUrl = 'https://ophan.theguardian.com/img/2';
 
+// Component event params is the decoded version of the componentEventParams query parameter
+// defined in the TrackingQueryParams interface from src/shared/model/QueryParams.ts
+const componentEventParamsSchema = z
+  .object({
+    componentType: z.string(),
+    componentId: z.string(),
+    abTestName: z.string().optional(),
+    abTestVariant: z.string().optional(),
+    viewId: z.string(),
+    browserId: z.string().optional(),
+    visitId: z.string().optional(),
+  })
+  .strict();
+
+type ComponentEventParams = z.infer<typeof componentEventParamsSchema>;
+
+/**
+ * OphanConfig is the configuration for an Ophan event,
+ * for example the browser id (bwid), the consent UUID (consentUUID)
+ * and the page view id (viewId)
+ */
 export interface OphanConfig {
   bwid?: string;
   viewId?: string;
   consentUUID?: string;
 }
 
-export const record = (event: OphanEvent, config: OphanConfig = {}) => {
+/**
+ * Convert the componentEventParams query string to the
+ * ComponentEventParams type using zod, return undefined if
+ * unable to parse the query string
+ */
+const parseComponentEventParams = async (
+  componentEventParams: string,
+): Promise<ComponentEventParams | undefined> => {
+  try {
+    const parsedQuery = parse(componentEventParams.replace('undefined', ''));
+
+    const componentEventParamsParsed =
+      await componentEventParamsSchema.safeParseAsync(parsedQuery);
+
+    if (componentEventParamsParsed.success) {
+      return componentEventParamsParsed.data;
+    }
+  } catch (error) {
+    logger.warn(`Ophan: Error parsing componentEventParams`, error);
+  }
+
+  logger.warn(`Ophan: Failed to parse componentEventParams`);
+};
+
+/**
+ * In some cases in DCR and Frontend we send the component type
+ * as a lowercase string with no spaces, so we need to convert them
+ * to the correct case (upper snake case)
+ */
+const getComponentType = (componentType: string) => {
+  if (componentType === 'signingate') {
+    return 'SIGN_IN_GATE';
+  }
+  if (componentType === 'identityauthentication') {
+    return 'IDENTITY_AUTHENTICATION';
+  }
+  return componentType as OphanComponentType;
+};
+
+/**
+ * Generate the OphanComponentEvent object for the given componentEventParams
+ */
+const generateOphanComponentEvent = (
+  componentEventParams: ComponentEventParams,
+  action: OphanAction,
+  value?: string,
+): OphanComponentEvent => {
+  const componentType: OphanComponentType = getComponentType(
+    componentEventParams.componentType,
+  );
+
+  const component: OphanComponent = {
+    componentType,
+    id: componentEventParams.componentId,
+  };
+
+  // only include ab test object if both abTestName and abTestVariant are defined
+  const abTest =
+    componentEventParams.abTestName && componentEventParams.abTestVariant
+      ? {
+          name: componentEventParams.abTestName,
+          variant: componentEventParams.abTestVariant,
+        }
+      : undefined;
+
+  return {
+    component,
+    action,
+    abTest,
+    value,
+  };
+};
+
+/**
+ * @name record
+ * @description Record an event to Ophan
+ *
+ * @param event The event to send to ophan
+ * @param config The ophan configuration for this event
+ * @returns void - This is a fire and forget call so no need to wait for a response
+ */
+const record = (event: OphanEvent, config: OphanConfig = {}) => {
   const { bwid, consentUUID, viewId } = config;
 
   if (bwid && viewId) {
@@ -41,7 +151,56 @@ export const record = (event: OphanEvent, config: OphanConfig = {}) => {
   }
 };
 
+/**
+ * @name sendOphanInteractionEventServer
+ * @description Send an interaction event to Ophan from the server side
+ *
+ * @param interaction The interaction to send to ophan
+ * @param config The ophan configuration for this event
+ */
 export const sendOphanInteractionEventServer = (
   interaction: OphanInteraction,
   config?: OphanConfig,
 ) => record(interaction, config);
+
+/**
+ * @name sendOphanComponentEventFromQueryParamsServer
+ * @description Send a component event to Ophan from the server side using the componentEventParams query parameter passed in from the frontend
+ *
+ * @param componentEventParamsQuery The componentEventParams query parameter from the frontend
+ * @param action The OphanAction to send to ophan
+ * @param value The value of the component event to send to ophan
+ * @param consentUUID The user consent UUID from the consentUUID cookie
+ */
+export const sendOphanComponentEventFromQueryParamsServer = async (
+  componentEventParamsQuery: string,
+  action: OphanAction,
+  value?: string,
+  consentUUID?: string,
+) => {
+  const componentEventParams = await parseComponentEventParams(
+    componentEventParamsQuery,
+  );
+
+  if (componentEventParams) {
+    const componentEvent = generateOphanComponentEvent(
+      componentEventParams,
+      action,
+      value,
+    );
+
+    const config: OphanConfig = {
+      bwid: componentEventParams.browserId,
+      viewId: componentEventParams.viewId,
+      consentUUID,
+    };
+
+    logger.info(
+      `Ophan: Sending component event to Ophan: config ${serialize(
+        config,
+      )} componentEvent ${serialize(componentEvent)} `,
+    );
+
+    record(componentEvent, config);
+  }
+};

--- a/src/server/lib/ophan.ts
+++ b/src/server/lib/ophan.ts
@@ -78,6 +78,12 @@ export const getComponentType = (componentType: string) => {
   if (componentType === 'identityauthentication') {
     return 'IDENTITY_AUTHENTICATION';
   }
+  if (componentType === 'acquisitionsheader') {
+    return 'ACQUISITIONS_HEADER';
+  }
+  if (componentType === 'acquisitionsengagementbanner') {
+    return 'ACQUISITIONS_ENGAGEMENT_BANNER';
+  }
   return componentType as OphanComponentType;
 };
 

--- a/src/server/lib/ophan.ts
+++ b/src/server/lib/ophan.ts
@@ -28,7 +28,7 @@ const componentEventParamsSchema = z
   })
   .strict();
 
-type ComponentEventParams = z.infer<typeof componentEventParamsSchema>;
+export type ComponentEventParams = z.infer<typeof componentEventParamsSchema>;
 
 /**
  * OphanConfig is the configuration for an Ophan event,
@@ -46,11 +46,11 @@ export interface OphanConfig {
  * ComponentEventParams type using zod, return undefined if
  * unable to parse the query string
  */
-const parseComponentEventParams = async (
+export const parseComponentEventParams = async (
   componentEventParams: string,
 ): Promise<ComponentEventParams | undefined> => {
   try {
-    const parsedQuery = parse(componentEventParams.replace('undefined', ''));
+    const parsedQuery = parse(componentEventParams.replaceAll('undefined', ''));
 
     const componentEventParamsParsed =
       await componentEventParamsSchema.safeParseAsync(parsedQuery);
@@ -69,8 +69,9 @@ const parseComponentEventParams = async (
  * In some cases in DCR and Frontend we send the component type
  * as a lowercase string with no spaces, so we need to convert them
  * to the correct case (upper snake case)
+ * otherwise we just return the component type as is
  */
-const getComponentType = (componentType: string) => {
+export const getComponentType = (componentType: string) => {
   if (componentType === 'signingate') {
     return 'SIGN_IN_GATE';
   }
@@ -83,7 +84,7 @@ const getComponentType = (componentType: string) => {
 /**
  * Generate the OphanComponentEvent object for the given componentEventParams
  */
-const generateOphanComponentEvent = (
+export const generateOphanComponentEvent = (
   componentEventParams: ComponentEventParams,
   action: OphanAction,
   value?: string,

--- a/src/server/routes/register.ts
+++ b/src/server/routes/register.ts
@@ -34,6 +34,7 @@ import { getConfiguration } from '@/server/lib/getConfiguration';
 import { OktaError } from '@/server/models/okta/Error';
 import { causesInclude } from '@/server/lib/okta/api/errors';
 import { redirectIfLoggedIn } from '../lib/middleware/redirectIfLoggedIn';
+import { sendOphanComponentEventFromQueryParamsServer } from '../lib/ophan';
 
 const { okta } = getConfiguration();
 
@@ -270,6 +271,16 @@ const OktaRegistration = async (
   const { email = '' } = req.body;
   try {
     const user = await registerWithOkta(email);
+
+    // fire ophan component event if applicable
+    if (res.locals.queryParams.componentEventParams) {
+      sendOphanComponentEventFromQueryParamsServer(
+        res.locals.queryParams.componentEventParams,
+        'CREATE_ACCOUNT',
+        'web',
+        res.locals.ophanConfig.consentUUID,
+      );
+    }
 
     setEncryptedStateCookie(res, {
       email: user.profile.email,

--- a/src/shared/model/ophan.ts
+++ b/src/shared/model/ophan.ts
@@ -1,4 +1,4 @@
-import { OphanABEvent } from '@guardian/libs';
+import { OphanABEvent, OphanComponentEvent } from '@guardian/libs';
 
 export interface OphanInteraction {
   component: string;
@@ -11,4 +11,4 @@ export interface OphanBase {
   abTestRegister?: { [testId: string]: OphanABEvent };
 }
 
-export type OphanEvent = OphanBase | OphanInteraction;
+export type OphanEvent = OphanBase | OphanInteraction | OphanComponentEvent;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,13 +7,13 @@
     "noUnusedLocals": true,
     "outDir": "build",
     "strict": true,
-    "target": "ES2019",
+    "target": "ES2022",
     "types": ["@emotion/react", "jest", "@testing-library/jest-dom"],
     "baseUrl": "src",
     "paths": {
       "@/*": ["*"]
     },
-    "lib": ["ES2019", "DOM"]
+    "lib": ["ES2022", "DOM"]
   },
   "include": ["src"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2464,10 +2464,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-3.3.0.tgz#fa98c7b8216ab35b8cf3087cd9ba336958fac99a"
   integrity sha512-XB9o8qtDOg+KlPh1sjEr4u+Ai3RFTRr2riZ/HJpdlh8Cu4ZpYjCSGUZXSGkxp1CwFWT9sduANnsWSqZ97iBloQ==
 
-"@guardian/libs@^6.0.0":
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-6.0.0.tgz#7f5f6e5a9dcbe9bedb2d10afe5452f464b01045f"
-  integrity sha512-3FaV0d0eHFK4yBdxNR4fE2IdsuC3YqbXK9v8b9PEPOz+V6/sj0RfnM03i3k05k8BORb6GSu0PFy8sfprV18Jgw==
+"@guardian/libs@^6.1.0":
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-6.1.0.tgz#4fc63a988db93fb3554216256a24b22875122e0b"
+  integrity sha512-UpkM+EjkZLoDvTqFEpLaWjxbWsxtUd2w8qYrCa02eTMO3nwmuz/kygN3D4+nKhnl77qWSlLp5wyVJHJ7gP5mxw==
 
 "@guardian/node-riffraff-artifact@^0.3.2":
   version "0.3.2"


### PR DESCRIPTION
## What does this change?

We rely on end-to-end tracking from frontend/dcr through to the moment that we sign users in/create an account. We use ophan component events for this tracking. For example we track a user click from the Sign in Gate through to whether they signed in or created an account.

Previously we sent the `compoentEventParams` query param through gateway to IDAPI so that IDAPI would handle the call to ophan. However when moving to Okta, gateway needs to be able to handle this instead.

This PR sets up the `ComponentEventParams` type using `zod`, has a method to generate this object from the query param, and additional methods to send this to ophan.

We also send the ophan component events in the closest places to where IDAPI was sending them, i.e on account creation (`CREATE_ACCOUNT`) or sign in/session creation (`SIGN_IN`).

To facilitate some of the changes in this PR, we updated the ophan types in `@guardian/libs`: https://github.com/guardian/libs/pull/375

## Other changes

- Updates `tsconfig` to use `ES2022` so we can use new features!
 - In this PR I use `replaceAll` (from ES2021)
 - We can see from https://node.green/#ES2022 that versions of node >16.10 to <= 17.9.1 support all ES2022 features.
   - We're currently using 16.13 (might be worth updating to latest 16 LTS version in another PR)