### PR TITLE
MVP2 | Add metrics for determining user state on sign in

### DIFF
--- a/src/server/models/Metrics.ts
+++ b/src/server/models/Metrics.ts
@@ -48,7 +48,10 @@ type UnconditionalMetrics =
   | 'LoginMiddlewareNotRecent'
   | 'LoginMiddlewareNotSignedIn'
   | 'LoginMiddlewareUnverified'
-  | `${RateLimitMetrics}GatewayRateLimitHit`;
+  | `${RateLimitMetrics}GatewayRateLimitHit`
+  | `User-${'EmailValidated' | 'EmailNotValidated'}-${
+      | 'WeakPassword'
+      | 'StrongPassword'}`;
 
 // Combine all the metrics above together into a type
 export type Metrics =


### PR DESCRIPTION
## What does this change?

As part of MVP2 we want to know the number of users who specifically when signing in have validated emails, but weak passwords. This information will enable us to weigh in on whether the functionality to address this needs to be put in place now or whether we can carry on with weak passwords in Okta.

To help with this this PR looks at all 4 possible states the user can be in and adds an AWS metric on the state that the user is in.

The 4 states are:

1. User has Email Validated and has a strong password
2. User has Email Validated and has a weak password
3. User has not Email Validated and has a strong password
4. User has not Email Validated and has a weak password

This maps to the following 4 metrics respectively:

1. `User-EmailValidated-StrongPassword`
2. `User-EmailValidated-WeakPassword`
3. `User-EmailNotValidated-StrongPassword`
4. `User-EmailNotValidated-WeakPassword`

This PR only adds the metrics for these states, and doesn't take any actions based on the state.

For each sign in with Okta, we get the user groups, check if the user is in the `GuardianUser-EmailValidated` group, as well as checking their password against the breached passwords API.

We don't log/track the user's email or password, nor would we ever want to do this!