### PR TITLE
Disable the submit button on all forms on submit

### DIFF
--- a/cypress/integration/mocked/okta_sign_in.6.cy.ts
+++ b/cypress/integration/mocked/okta_sign_in.6.cy.ts
@@ -260,7 +260,6 @@ describe('Sign in flow', () => {
         },
       ]);
 
-      cy.get('[data-cy=sign-in-button]').click();
       // we can't actually check the authorization code flow
       // so intercept the request and redirect to the default return URL
       cy.intercept(

--- a/cypress/integration/mocked/welcome.4.cy.ts
+++ b/cypress/integration/mocked/welcome.4.cy.ts
@@ -282,6 +282,7 @@ describe('Welcome and set password page', () => {
       cy.get('button[type="submit"]').click();
 
       cy.mockNext(200);
+      cy.contains('Check your email inbox');
       cy.get('button[type="submit"]').click();
       cy.contains('Check your email inbox');
     });

--- a/src/client/pages/EmailSent.tsx
+++ b/src/client/pages/EmailSent.tsx
@@ -96,6 +96,7 @@ export const EmailSent = ({
             setRecaptchaErrorContext={setRecaptchaErrorContext}
             setRecaptchaErrorMessage={setRecaptchaErrorMessage}
             formTrackingName={formTrackingName}
+            disableOnSubmit
           >
             <EmailInput defaultValue={email} hidden hideLabel />
           </MainForm>

--- a/src/client/pages/JobsTermsAccept.tsx
+++ b/src/client/pages/JobsTermsAccept.tsx
@@ -124,6 +124,7 @@ export const JobsTermsAccept: React.FC<JobsTermsAcceptProps> = ({
             hasJobsTerms={false}
             formAction={submitUrl}
             onInvalid={() => setFormSubmitAttempted(true)}
+            disableOnSubmit
           >
             <NameInputField
               onGroupError={setGroupError}
@@ -159,6 +160,7 @@ export const JobsTermsAccept: React.FC<JobsTermsAcceptProps> = ({
             hasJobsTerms={true}
             formAction={submitUrl}
             onInvalid={() => setFormSubmitAttempted(true)}
+            disableOnSubmit
           >
             <NameInputField
               onGroupError={setGroupError}

--- a/src/client/pages/ResendEmailVerification.tsx
+++ b/src/client/pages/ResendEmailVerification.tsx
@@ -67,6 +67,7 @@ const LoggedIn = ({
           recaptchaSiteKey={recaptchaSiteKey}
           setRecaptchaErrorMessage={setRecaptchaErrorMessage}
           setRecaptchaErrorContext={setRecaptchaErrorContext}
+          disableOnSubmit
         >
           <EmailInput defaultValue={email} hidden hideLabel />
         </MainForm>

--- a/src/client/pages/ResetPassword.tsx
+++ b/src/client/pages/ResetPassword.tsx
@@ -66,6 +66,7 @@ export const ResetPassword = ({
         setRecaptchaErrorMessage={setRecaptchaErrorMessage}
         setRecaptchaErrorContext={setRecaptchaErrorContext}
         formTrackingName={formPageTrackingName}
+        disableOnSubmit
       >
         <EmailInput label={emailInputLabel} defaultValue={email} />
       </MainForm>


### PR DESCRIPTION
## What does this change?

To avoid multiple requests being made on the sign in and register pages on submit, we disable the submit button client side when the user submits the form.

This should prevent multiple emails being sent, as well as reducing calls to our backend APIs.

This functionality was already included in the `MainForm` component, and has been ported to the `SignIn` and `Registration` components.

In another PR we should ideally migrate the `SignIn` and `Registration` components to just use the `MainForm` component too, there's already a `// TODO` in the code mentioning this.

I've also added the `disableOnSubmit` prop to other components using the `MainForm` which didn't have this enabled already, and will send an email, e.g. the reset password page, and the email sent pages.


https://user-images.githubusercontent.com/13315440/182625513-e3722416-ca1a-432c-8c6b-d371b652c7e9.mov

