### PR TITLE
Okta | Fix reset password for user not found

### DIFF
--- a/cypress/integration/mocked/okta_send_reset_password.4.cy.ts
+++ b/cypress/integration/mocked/okta_send_reset_password.4.cy.ts
@@ -234,6 +234,22 @@ describe('Send password reset email in Okta', () => {
     });
   });
 
+  context('user not found', () => {
+    it('shows email sent page even when user not found', () => {
+      cy.visit('/reset-password?useOkta=true');
+      cy.get('input[name="email"]').type(email);
+      cy.mockNext(404, {
+        errorCode: 'E0000007',
+        errorSummary: 'User not found',
+        errorLink: 'E0000007',
+        errorId: 'errorId',
+        errorCauses: [],
+      });
+      cy.get('button[type="submit"]').click();
+      cy.contains('Check your email inbox');
+    });
+  });
+
   context('generic error handling', () => {
     it('shows a generic error when something goes wrong', () => {
       cy.visit('/reset-password?useOkta=true');

--- a/src/server/controllers/sendChangePasswordEmail.ts
+++ b/src/server/controllers/sendChangePasswordEmail.ts
@@ -252,6 +252,23 @@ const sendEmailInOkta = async (
       }),
     );
   } catch (error) {
+    // handle check for if the user is not found
+    // this is a special case because we don't want to send an email
+    // but we want to show the email sent page
+    // so the reset password page cannot be used for account enumeration
+    if (
+      isOktaError(error) &&
+      error.status === 404 &&
+      error.code === 'E0000007'
+    ) {
+      return res.redirect(
+        303,
+        addQueryParamsToPath('/reset-password/email-sent', state.queryParams, {
+          emailSentSuccess: true,
+        }),
+      );
+    }
+
     logger.error('Okta send reset password email failed', error, {
       request_id: res.locals.requestId,
     });


### PR DESCRIPTION
## What does this change?

In #1872 we fixed a bunch of errors for users in the non ACTIVE state for users going through the reset password flow, but a regression was introduced for users without an account requesting password reset.

In this case an error would be shown, rather than the email sent page. We want to show the email sent page for users without accounts too who go through the password reset flow to prevent this page from being used for account enumeration (checking if an account exists).

This PR fixes this by handling this case explicitly, and adds a cypress mocked test to check this behaviour.