### PR TITLE
Generate JSON schema for rate limiter configuration file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,14 +52,11 @@ cypress/videos
 # Cypress screenshots
 cypress/screenshots
 
-# vscode settings
-.vscode/settings.json
-
 # Rate limiter configuration
 .ratelimit.json
 
 # Rate limiter JSON schema (generated on install)
-ratelimit.schema.json
+.ratelimit.schema.json
 
 # Mac OS finder app metadata
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -58,5 +58,8 @@ cypress/screenshots
 # Rate limiter configuration
 .ratelimit.json
 
+# Rate limiter JSON schema (generated on install)
+ratelimit.schema.json
+
 # Mac OS finder app metadata
 .DS_Store

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,4 @@
 webpack.config.js
 webpack.development.js
 build
+.ratelimit.schema.json

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+  "json.schemas": [
+    {
+      "fileMatch": [".ratelimit.json", ".ratelimit.example.json"],
+      "url": "./.ratelimit.schema.json"
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "prepare": "husky install",
     "clear:cache": "rm -rf ./node_modules/.cache",
     "ts-prune": "ts-prune -i .stories.tsx",
-    "gen:ratelimit:schema": "TS_NODE_COMPILER_OPTIONS='{\"module\":\"commonjs\"}' yarn ts-node --transpileOnly ./scripts/generate-rate-limit-schema.ts | tail -n+2 | tee ./ratelimit.schema.json"
+    "gen:ratelimit:schema": "yarn ts-node --transpileOnly ./scripts/generate-rate-limit-schema.ts",
+    "postinstall": "yarn gen:ratelimit:schema"
   },
   "devDependencies": {
     "@babel/core": "^7.18.9",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "prettier:fix": "prettier . --write",
     "prepare": "husky install",
     "clear:cache": "rm -rf ./node_modules/.cache",
-    "ts-prune": "ts-prune -i .stories.tsx"
+    "ts-prune": "ts-prune -i .stories.tsx",
+    "gen:ratelimit:schema": "TS_NODE_COMPILER_OPTIONS='{\"module\":\"commonjs\"}' yarn ts-node --transpileOnly ./scripts/generate-rate-limit-schema.ts | tail -n+2 | tee ./ratelimit.schema.json"
   },
   "devDependencies": {
     "@babel/core": "^7.18.9",
@@ -112,6 +113,7 @@
     "stmux": "^1.8.4",
     "terser-webpack-plugin": "^5.3.3",
     "ts-jest": "^28.0.7",
+    "ts-node": "^10.9.1",
     "ts-prune": "^0.10.3",
     "typescript": "^4.7.4",
     "wait-on": "^6.0.1",
@@ -120,7 +122,8 @@
     "webpack-cli": "^4.10.0",
     "webpack-merge": "^5.8.0",
     "webpack-node-externals": "^3.0.0",
-    "whatwg-fetch": "^3.6.2"
+    "whatwg-fetch": "^3.6.2",
+    "zod-to-json-schema": "^3.17.1"
   },
   "dependencies": {
     "@babel/runtime": "^7.18.9",

--- a/scripts/generate-rate-limit-schema.ts
+++ b/scripts/generate-rate-limit-schema.ts
@@ -1,11 +1,18 @@
+import { writeFileSync } from 'node:fs';
 import zodToJsonSchema from 'zod-to-json-schema';
 import { rateLimiterConfigurationSchema } from '../src/server/lib/rate-limit/configurationValidator';
 
+process.stdout.write('✨  Generating rate limit configuration schema  ✨\n');
+
+// Generate a JSON schema for the rate limiter configuration.
 const jsonSchema = zodToJsonSchema(
   rateLimiterConfigurationSchema,
   'rateLimiterConfigurationSchema',
 );
 
-// Output the JSON schema for the rate limiter configuration.
-// We use this for autocompletion when editing the rate limit configuration file.
-process.stdout.write(JSON.stringify(jsonSchema) + '\n');
+// Write the pretty printed JSON schema to .ratelimit.schema.json.
+// We use this for autocompletion when editing the rate limit configuration file (and example).
+writeFileSync(
+  '.ratelimit.schema.json',
+  JSON.stringify(jsonSchema, null, 2) + '\n',
+);

--- a/scripts/generate-rate-limit-schema.ts
+++ b/scripts/generate-rate-limit-schema.ts
@@ -1,0 +1,11 @@
+import zodToJsonSchema from 'zod-to-json-schema';
+import { rateLimiterConfigurationSchema } from '../src/server/lib/rate-limit/configurationValidator';
+
+const jsonSchema = zodToJsonSchema(
+  rateLimiterConfigurationSchema,
+  'rateLimiterConfigurationSchema',
+);
+
+// Output the JSON schema for the rate limiter configuration.
+// We use this for autocompletion when editing the rate limit configuration file.
+process.stdout.write(JSON.stringify(jsonSchema) + '\n');

--- a/src/server/lib/rate-limit/configurationValidator.ts
+++ b/src/server/lib/rate-limit/configurationValidator.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { ValidRoutePathsArray } from '@/shared/model/Routes';
+import { ValidRoutePathsArray } from '../../../shared/model/Routes';
 
 export const bucketSchema = z
   .object({

--- a/yarn.lock
+++ b/yarn.lock
@@ -2243,6 +2243,13 @@
   resolved "https://registry.yarnpkg.com/@colors/colors/-/colors-1.5.0.tgz#bb504579c1cae923e6576a4f5da43d25f97bdbd9"
   integrity sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==
 
+"@cspotcode/source-map-support@^0.8.0":
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz#00629c35a688e05a88b1cda684fb9d5e73f000a1"
+  integrity sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==
+  dependencies:
+    "@jridgewell/trace-mapping" "0.3.9"
+
 "@cypress/request@^2.88.10":
   version "2.88.10"
   resolved "https://registry.yarnpkg.com/@cypress/request/-/request-2.88.10.tgz#b66d76b07f860d3a4b8d7a0604d020c662752cce"
@@ -2827,6 +2834,14 @@
   version "1.4.11"
   resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.11.tgz#771a1d8d744eeb71b6adb35808e1a6c7b9b8c8ec"
   integrity sha512-Fg32GrJo61m+VqYSdRSjRXMjQ06j8YIYfcTqndLYVAaHmroZHLJZCydsWBOTDqXS2v+mjxohBWEMfg97GXmYQg==
+
+"@jridgewell/trace-mapping@0.3.9":
+  version "0.3.9"
+  resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz#6534fd5933a53ba7cbf3a17615e273a0d1273ff9"
+  integrity sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==
+  dependencies:
+    "@jridgewell/resolve-uri" "^3.0.3"
+    "@jridgewell/sourcemap-codec" "^1.4.10"
 
 "@jridgewell/trace-mapping@^0.3.0":
   version "0.3.4"
@@ -4052,6 +4067,26 @@
     mkdirp "^1.0.4"
     path-browserify "^1.0.1"
 
+"@tsconfig/node10@^1.0.7":
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node10/-/node10-1.0.9.tgz#df4907fc07a886922637b15e02d4cebc4c0021b2"
+  integrity sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==
+
+"@tsconfig/node12@^1.0.7":
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node12/-/node12-1.0.11.tgz#ee3def1f27d9ed66dac6e46a295cffb0152e058d"
+  integrity sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==
+
+"@tsconfig/node14@^1.0.0":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node14/-/node14-1.0.3.tgz#e4386316284f00b98435bf40f72f75a09dabf6c1"
+  integrity sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==
+
+"@tsconfig/node16@^1.0.2":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node16/-/node16-1.0.3.tgz#472eaab5f15c1ffdd7f8628bd4c4f753995ec79e"
+  integrity sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==
+
 "@types/aria-query@^4.2.0":
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/@types/aria-query/-/aria-query-4.2.2.tgz#ed4e0ad92306a704f9fb132a0cfcf77486dbe2bc"
@@ -5249,6 +5284,11 @@ acorn-walk@^7.0.0, acorn-walk@^7.1.1, acorn-walk@^7.2.0:
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-7.2.0.tgz#0de889a601203909b0fbe07b8938dc21d2e967bc"
   integrity sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==
 
+acorn-walk@^8.1.1:
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.2.0.tgz#741210f2e2426454508853a2f44d0ab83b7f69c1"
+  integrity sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==
+
 acorn@^6.4.1:
   version "6.4.2"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.4.2.tgz#35866fd710528e92de10cf06016498e47e39e1e6"
@@ -5515,6 +5555,11 @@ are-we-there-yet@^2.0.0:
   dependencies:
     delegates "^1.0.0"
     readable-stream "^3.6.0"
+
+arg@^4.1.0:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/arg/-/arg-4.1.3.tgz#269fc7ad5b8e42cb63c896d5666017261c144089"
+  integrity sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==
 
 argparse@^1.0.7:
   version "1.0.10"
@@ -7515,6 +7560,11 @@ create-hmac@^1.1.0, create-hmac@^1.1.4, create-hmac@^1.1.7:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
+create-require@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
+  integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
+
 cross-spawn@^5.0.1:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
@@ -8082,6 +8132,11 @@ diff-sequences@^28.1.1:
   version "28.1.1"
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-28.1.1.tgz#9989dc731266dc2903457a70e996f3a041913ac6"
   integrity sha512-FU0iFaH/E23a+a718l8Qa/19bF9p06kgE0KipMOMadwa3SjnaElKzPaUC0vnibs6/B/9ni97s61mcejk8W1fQw==
+
+diff@^4.0.1:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
+  integrity sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==
 
 diffie-hellman@^5.0.0:
   version "5.0.3"
@@ -12672,7 +12727,7 @@ make-dir@^3.0.0, make-dir@^3.0.2, make-dir@^3.1.0:
   dependencies:
     semver "^6.0.0"
 
-make-error@1.x:
+make-error@1.x, make-error@^1.1.1:
   version "1.3.6"
   resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.6.tgz#2eb2e37ea9b67c4891f684a1394799af484cf7a2"
   integrity sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==
@@ -17143,6 +17198,25 @@ ts-morph@^13.0.1:
     "@ts-morph/common" "~0.12.3"
     code-block-writer "^11.0.0"
 
+ts-node@^10.9.1:
+  version "10.9.1"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-10.9.1.tgz#e73de9102958af9e1f0b168a6ff320e25adcff4b"
+  integrity sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==
+  dependencies:
+    "@cspotcode/source-map-support" "^0.8.0"
+    "@tsconfig/node10" "^1.0.7"
+    "@tsconfig/node12" "^1.0.7"
+    "@tsconfig/node14" "^1.0.0"
+    "@tsconfig/node16" "^1.0.2"
+    acorn "^8.4.1"
+    acorn-walk "^8.1.1"
+    arg "^4.1.0"
+    create-require "^1.1.0"
+    diff "^4.0.1"
+    make-error "^1.1.1"
+    v8-compile-cache-lib "^3.0.1"
+    yn "3.1.1"
+
 ts-pnp@^1.1.6:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/ts-pnp/-/ts-pnp-1.2.0.tgz#a500ad084b0798f1c3071af391e65912c86bca92"
@@ -17637,6 +17711,11 @@ uuid@^8.3.0, uuid@^8.3.2:
   version "8.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
+
+v8-compile-cache-lib@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz#6336e8d71965cb3d35a1bbb7868445a7c05264bf"
+  integrity sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==
 
 v8-compile-cache@^2.0.3:
   version "2.3.0"
@@ -18375,6 +18454,11 @@ yauzl@^2.10.0, yauzl@^2.4.2:
     buffer-crc32 "~0.2.3"
     fd-slicer "~1.1.0"
 
+yn@3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/yn/-/yn-3.1.1.tgz#1e87401a09d767c1d5eab26a6e4c185182d2eb50"
+  integrity sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==
+
 yocto-queue@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
@@ -18388,6 +18472,11 @@ zip-stream@^2.1.2:
     archiver-utils "^2.1.0"
     compress-commons "^2.1.1"
     readable-stream "^3.4.0"
+
+zod-to-json-schema@^3.17.1:
+  version "3.17.1"
+  resolved "https://registry.yarnpkg.com/zod-to-json-schema/-/zod-to-json-schema-3.17.1.tgz#681cb645837e0af71852f9b3e1033b419c145cdf"
+  integrity sha512-h1WLfvkdwM6lcRt5q09ytNh2OKcU13vY9D0FetN/7Erdd7lVraIiMkEnObg3KELm5EQlMqvi0r5nzMa0EA+8qw==
 
 zod@^3.17.10:
   version "3.17.10"


### PR DESCRIPTION
## What does this change?
We use the `zod-to-json-schema` module to generate a JSON schema on the `postinstall` hook of the project. This will help us write the configuration; giving us intellisense code completion on `.ratelimit.json` and `.ratelimit.example.json` as well as increased confidence that we are writing a valid configuration file.

This file is called `.ratelimit.schema.json` and is not tracked by version control, because it will be liable to change as the rate limiter configuration schema is modified over time.

The command `yarn gen:ratelimit:schema` creates the schema file, by running the `zodToJsonSchema` method on the rate limiter configuration schema using `ts-node` to transpile the typescript files.

## Demonstration
https://user-images.githubusercontent.com/1771189/182916733-5653dc64-2f8d-4d3d-95b0-e93b85b5b1f0.mov

### Notes
* The import path to the Routes file was changed to: `../../../shared/model/Routes` from a `@/*` path alias because of the way that module resolution works in `ts-node`.