### PR TITLE
Okta | Fix welcome resend and register resend for user not found

### DIFF
--- a/cypress/integration/ete-okta/registration.2.cy.ts
+++ b/cypress/integration/ete-okta/registration.2.cy.ts
@@ -680,4 +680,293 @@ describe('Registration flow', () => {
       });
     },
   );
+
+  context('Welcome Page - Resend (Link expired)', () => {
+    it('send an email for user with no existing account', () => {
+      const encodedReturnUrl =
+        'https%3A%2F%2Fm.code.dev-theguardian.com%2Ftravel%2F2019%2Fdec%2F18%2Ffood-culture-tour-bethlehem-palestine-east-jerusalem-photo-essay';
+      const unregisteredEmail = randomMailosaurEmail();
+
+      cy.visit(`/welcome/resend?returnUrl=${encodedReturnUrl}&useOkta=true`);
+
+      const timeRequestWasMade = new Date();
+      cy.get('input[name=email]').type(unregisteredEmail);
+      cy.get('[data-cy="main-form-submit-button"]').click();
+
+      cy.contains('Check your email inbox');
+      cy.contains(unregisteredEmail);
+      cy.contains('Resend email');
+      cy.contains('Change email address');
+
+      cy.checkForEmailAndGetDetails(
+        unregisteredEmail,
+        timeRequestWasMade,
+        /welcome\/([^"]*)/,
+      ).then(({ body, token }) => {
+        expect(body).to.have.string('Complete registration');
+        cy.visit(`/welcome/${token}`);
+        cy.contains('Save and continue');
+
+        cy.get('form')
+          .should('have.attr', 'action')
+          .and('match', new RegExp(encodedReturnUrl));
+
+        //we are reloading here to make sure the params are persisted even on page refresh
+        cy.reload();
+
+        cy.get('input[name="password"]').type(randomPassword());
+        cy.get('button[type="submit"]').click();
+        cy.url().should('contain', encodedReturnUrl);
+      });
+    });
+
+    it('should resend a STAGED user a set password email with an Okta activation token', () => {
+      cy.createTestUser({ isGuestUser: true })?.then(({ emailAddress }) => {
+        cy.getTestOktaUser(emailAddress).then((oktaUser) => {
+          expect(oktaUser.status).to.eq(Status.STAGED);
+
+          cy.visit('/welcome/resend?useOkta=true');
+
+          let timeRequestWasMade = new Date();
+
+          cy.get('input[name=email]').type(emailAddress);
+          cy.get('[data-cy="main-form-submit-button"]').click();
+
+          cy.contains('Check your email inbox');
+          cy.contains(emailAddress);
+          cy.contains('Resend email');
+          cy.contains('Change email address');
+
+          // Wait for the first email to arrive...
+          cy.checkForEmailAndGetDetails(
+            emailAddress,
+            timeRequestWasMade,
+            /set-password\/([^"]*)/,
+          ).then(() => {
+            timeRequestWasMade = new Date();
+
+            cy.get('[data-cy="main-form-submit-button"]').click();
+
+            // ...before waiting for the second email to arrive
+            cy.checkForEmailAndGetDetails(
+              emailAddress,
+              timeRequestWasMade,
+              /set-password\/([^"]*)/,
+            ).then(({ links, body, token }) => {
+              expect(body).to.have.string('This account already exists');
+              expect(body).to.have.string('Create password');
+              expect(links.length).to.eq(2);
+              const setPasswordLink = links.find((s) =>
+                s.text?.includes('Create password'),
+              );
+              expect(setPasswordLink?.href ?? '').to.have.string(
+                'useOkta=true',
+              );
+              cy.visit(`/set-password/${token}`);
+              cy.contains('Create password');
+              cy.contains(emailAddress);
+            });
+          });
+        });
+      });
+    });
+    it('should resend a PROVISIONED user a set password email with an Okta activation token', () => {
+      cy.createTestUser({ isGuestUser: true })?.then(({ emailAddress }) => {
+        cy.activateTestOktaUser(emailAddress).then(() => {
+          cy.getTestOktaUser(emailAddress).then((oktaUser) => {
+            expect(oktaUser.status).to.eq(Status.PROVISIONED);
+
+            cy.visit('/welcome/resend?useOkta=true');
+
+            let timeRequestWasMade = new Date();
+
+            cy.get('input[name=email]').type(emailAddress);
+            cy.get('[data-cy="main-form-submit-button"]').click();
+
+            cy.contains('Check your email inbox');
+            cy.contains(emailAddress);
+            cy.contains('Resend email');
+            cy.contains('Change email address');
+
+            cy.checkForEmailAndGetDetails(
+              emailAddress,
+              timeRequestWasMade,
+              /set-password\/([^"]*)/,
+            ).then(() => {
+              timeRequestWasMade = new Date();
+              cy.get('[data-cy="main-form-submit-button"]').click();
+
+              cy.checkForEmailAndGetDetails(
+                emailAddress,
+                timeRequestWasMade,
+                /set-password\/([^"]*)/,
+              ).then(({ links, body, token }) => {
+                expect(body).to.have.string('This account already exists');
+                expect(body).to.have.string('Create password');
+                expect(links.length).to.eq(2);
+                const setPasswordLink = links.find((s) =>
+                  s.text?.includes('Create password'),
+                );
+                expect(setPasswordLink?.href ?? '').to.have.string(
+                  'useOkta=true',
+                );
+                cy.visit(`/set-password/${token}`);
+                cy.contains('Create password');
+                cy.contains(emailAddress);
+              });
+            });
+          });
+        });
+      });
+    });
+    it('should send an ACTIVE user a reset password email with no activation token', () => {
+      cy.createTestUser({ isGuestUser: false })?.then(({ emailAddress }) => {
+        cy.getTestOktaUser(emailAddress).then((oktaUser) => {
+          expect(oktaUser.status).to.eq(Status.ACTIVE);
+
+          cy.visit('/welcome/resend?useOkta=true');
+          let timeRequestWasMade = new Date();
+
+          cy.get('input[name=email]').type(emailAddress);
+          cy.get('[data-cy="main-form-submit-button"]').click();
+
+          cy.contains('Check your email inbox');
+          cy.contains(emailAddress);
+          cy.contains('Resend email');
+          cy.contains('Change email address');
+
+          cy.checkForEmailAndGetDetails(emailAddress, timeRequestWasMade).then(
+            () => {
+              timeRequestWasMade = new Date();
+              cy.get('[data-cy="main-form-submit-button"]').click();
+
+              cy.checkForEmailAndGetDetails(
+                emailAddress,
+                timeRequestWasMade,
+              ).then(({ links, body }) => {
+                expect(body).to.have.string('This account already exists');
+                expect(body).to.have.string('Sign in');
+                expect(body).to.have.string('Reset password');
+                expect(links.length).to.eq(3);
+                const resetPasswordLink = links.find((s) =>
+                  s.text?.includes('Reset password'),
+                );
+                expect(resetPasswordLink?.href ?? '').to.have.string(
+                  'useOkta=true',
+                );
+                expect(resetPasswordLink?.href ?? '').to.have.string(
+                  'reset-password',
+                );
+                cy.visit(`/reset-password?useOkta=true`);
+                cy.contains('Forgot password');
+                cy.contains('Reset password');
+              });
+            },
+          );
+        });
+      });
+    });
+    it('should send a RECOVERY user a reset password email with an Okta activation token', () => {
+      cy.createTestUser({ isGuestUser: false })?.then(({ emailAddress }) => {
+        cy.resetOktaUserPassword(emailAddress).then(() => {
+          cy.getTestOktaUser(emailAddress).then((oktaUser) => {
+            expect(oktaUser.status).to.eq(Status.RECOVERY);
+
+            cy.visit('/welcome/resend?useOkta=true');
+            let timeRequestWasMade = new Date();
+
+            cy.get('input[name=email]').type(emailAddress);
+            cy.get('[data-cy="main-form-submit-button"]').click();
+
+            cy.contains('Check your email inbox');
+            cy.contains(emailAddress);
+            cy.contains('Resend email');
+            cy.contains('Change email address');
+
+            cy.checkForEmailAndGetDetails(
+              emailAddress,
+              timeRequestWasMade,
+              /set-password\/([^"]*)/,
+            ).then(() => {
+              timeRequestWasMade = new Date();
+              cy.get('[data-cy="main-form-submit-button"]').click();
+
+              cy.checkForEmailAndGetDetails(
+                emailAddress,
+                timeRequestWasMade,
+                /set-password\/([^"]*)/,
+              ).then(({ links, body, token }) => {
+                expect(body).to.have.string('Password reset');
+                expect(body).to.have.string('Reset password');
+                expect(links.length).to.eq(2);
+                const resetPasswordLink = links.find((s) =>
+                  s.text?.includes('Reset password'),
+                );
+                expect(resetPasswordLink?.href ?? '').to.have.string(
+                  'useOkta=true',
+                );
+                expect(resetPasswordLink?.href ?? '').to.have.string(
+                  'reset-password',
+                );
+                cy.visit(`/reset-password/${token}`);
+                cy.contains('Reset password');
+                cy.contains(emailAddress);
+              });
+            });
+          });
+        });
+      });
+    });
+    it('should send a PASSWORD_EXPIRED user a reset password email with an Okta activation token', () => {
+      cy.createTestUser({ isGuestUser: false })?.then(({ emailAddress }) => {
+        cy.expireOktaUserPassword(emailAddress).then(() => {
+          cy.getTestOktaUser(emailAddress).then((oktaUser) => {
+            expect(oktaUser.status).to.eq(Status.PASSWORD_EXPIRED);
+
+            cy.visit('/welcome/resend?useOkta=true');
+            let timeRequestWasMade = new Date();
+
+            cy.get('input[name=email]').type(emailAddress);
+            cy.get('[data-cy="main-form-submit-button"]').click();
+
+            cy.contains('Check your email inbox');
+            cy.contains(emailAddress);
+            cy.contains('Resend email');
+            cy.contains('Change email address');
+
+            cy.checkForEmailAndGetDetails(
+              emailAddress,
+              timeRequestWasMade,
+              /set-password\/([^"]*)/,
+            ).then(() => {
+              timeRequestWasMade = new Date();
+              cy.get('[data-cy="main-form-submit-button"]').click();
+
+              cy.checkForEmailAndGetDetails(
+                emailAddress,
+                timeRequestWasMade,
+                /set-password\/([^"]*)/,
+              ).then(({ links, body, token }) => {
+                expect(body).to.have.string('Password reset');
+                expect(body).to.have.string('Reset password');
+                expect(links.length).to.eq(2);
+                const resetPasswordLink = links.find((s) =>
+                  s.text?.includes('Reset password'),
+                );
+                expect(resetPasswordLink?.href ?? '').to.have.string(
+                  'useOkta=true',
+                );
+                expect(resetPasswordLink?.href ?? '').to.have.string(
+                  'reset-password',
+                );
+                cy.visit(`/reset-password/${token}`);
+                cy.contains('Reset password');
+                cy.contains(emailAddress);
+              });
+            });
+          });
+        });
+      });
+    });
+  });
 });

--- a/src/server/lib/okta/register.ts
+++ b/src/server/lib/okta/register.ts
@@ -31,7 +31,7 @@ const { okta } = getConfiguration();
  * @param email
  * @returns {Promise<UserResponse>} Promise that resolves to the user object
  */
-export const sendRegistrationEmailByUserState = async (
+const sendRegistrationEmailByUserState = async (
   email: string,
 ): Promise<UserResponse> => {
   const user = await getUser(email);

--- a/src/server/routes/register.ts
+++ b/src/server/routes/register.ts
@@ -14,10 +14,7 @@ import {
   UserType,
 } from '@/server/lib/idapi/user';
 import { logger } from '@/server/lib/serverSideLogger';
-import {
-  register as registerWithOkta,
-  sendRegistrationEmailByUserState,
-} from '@/server/lib/okta/register';
+import { register as registerWithOkta } from '@/server/lib/okta/register';
 import { renderer } from '@/server/lib/renderer';
 import { rateLimitedTypedRouter as router } from '@/server/lib/typedRoutes';
 import { trackMetric } from '@/server/lib/trackMetric';
@@ -33,8 +30,9 @@ import deepmerge from 'deepmerge';
 import { getConfiguration } from '@/server/lib/getConfiguration';
 import { OktaError } from '@/server/models/okta/Error';
 import { causesInclude } from '@/server/lib/okta/api/errors';
-import { redirectIfLoggedIn } from '../lib/middleware/redirectIfLoggedIn';
-import { sendOphanComponentEventFromQueryParamsServer } from '../lib/ophan';
+import { redirectIfLoggedIn } from '@/server/lib/middleware/redirectIfLoggedIn';
+import { sendOphanComponentEventFromQueryParamsServer } from '@/server/lib/ophan';
+import { UserResponse } from '@/server/models/okta/User';
 
 const { okta } = getConfiguration();
 
@@ -279,6 +277,21 @@ router.post(
   }),
 );
 
+export const setEncryptedStateCookieForOktaRegistration = (
+  res: ResponseWithRequestState,
+  user: UserResponse,
+) => {
+  setEncryptedStateCookie(res, {
+    email: user.profile.email,
+    status: user.status,
+    // We set queryParams here to allow state to be persisted as part of the registration flow,
+    // because we are unable to pass these query parameters via the email activation link in Okta email templates
+    queryParams: getPersistableQueryParamsWithoutOktaParams(
+      res.locals.queryParams,
+    ),
+  });
+};
+
 const OktaRegistration = async (
   req: Request,
   res: ResponseWithRequestState,
@@ -298,15 +311,7 @@ const OktaRegistration = async (
       );
     }
 
-    setEncryptedStateCookie(res, {
-      email: user.profile.email,
-      status: user.status,
-      // We set queryParams here to allow state to be persisted as part of the registration flow,
-      // because we are unable to pass these query parameters via the email activation link in Okta email templates
-      queryParams: getPersistableQueryParamsWithoutOktaParams(
-        res.locals.queryParams,
-      ),
-    });
+    setEncryptedStateCookieForOktaRegistration(res, user);
 
     trackMetric('OktaRegistration::Success');
 
@@ -356,8 +361,12 @@ const OktaResendEmail = async (req: Request, res: ResponseWithRequestState) => {
     const { email } = encryptedState ?? {};
 
     if (typeof email !== 'undefined') {
-      await sendRegistrationEmailByUserState(email);
+      const user = await registerWithOkta(email);
+
       trackMetric('OktaRegistrationResendEmail::Success');
+
+      setEncryptedStateCookieForOktaRegistration(res, user);
+
       return res.redirect(
         303,
         addQueryParamsToPath('/register/email-sent', res.locals.queryParams, {


### PR DESCRIPTION
## What does this change?

If on the welcome link expired page (and the register email sent page resend functionality) a user entered an email for an account that doesn't exist in Okta the following error would occur:

https://user-images.githubusercontent.com/13315440/182950596-320cd3c1-1e7d-45bd-8399-acb6836f8de6.mov

This PR fixes this issue by utilising the same functionality as the register page for this form, i.e use the same controller as register on the welcome link expired page.

https://user-images.githubusercontent.com/13315440/183031991-a927366a-c5d9-4fbb-a235-02635379c90e.mov

Also added a bunch of tests for this welcome link expired page.
