### PR TITLE
Remove useOkta flag from /signin/refresh

### DIFF
--- a/src/server/routes/signIn.ts
+++ b/src/server/routes/signIn.ts
@@ -464,14 +464,14 @@ router.post(
 router.get(
   '/signin/refresh',
   handleAsyncErrors(async (req: Request, res: ResponseWithRequestState) => {
-    const { useOkta, returnUrl } = res.locals.queryParams;
+    const { returnUrl } = res.locals.queryParams;
     const oktaSessionCookieId: string | undefined = req.cookies.sid;
     const identitySessionCookie = req.cookies.SC_GU_U;
 
     const redirectUrl = returnUrl || defaultReturnUri;
 
     // Check if the user has an existing Okta session.
-    if (okta.enabled && useOkta && oktaSessionCookieId) {
+    if (okta.enabled && oktaSessionCookieId) {
       try {
         // If the user session is valid, we re-authenticate them, supplying
         // the SID cookie value to Okta.


### PR DESCRIPTION
We don't need this flag in this route as only Okta-enabled users would be using it anyway.