### PR TITLE
Allow individual routes to be placed in "log only" mode.

### DIFF
--- a/docs/rate-limit/configuration.md
+++ b/docs/rate-limit/configuration.md
@@ -40,7 +40,8 @@ If the Redis connection fails, the server refuse to serve any requests until the
 
 ## Entry: `settings`
 
-An optional object which lets you enable some extra debug functionality
+An optional object which lets you enable some extra debug functionality.
+The `settings` configuration object is also available for individual routes, so you can override the global settings selectively on a route-by-route basis.
 
 - When `logOnly` is set to `true`, the rate limiter logic will still run, but the result will not be enforced. This is useful for when you want to try out some new configuration values but you don't want to actually apply them yet.
 - When `trackBucketCapacity` is set to `true`, it will log the global bucket capacity for every route periodically. This is used mainly for our dashboard so that we can keep track of any buckets at critically low values.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -37,7 +37,7 @@ FetchError: request to https://idapi.thegulocal.com/auth?format=cookies failed, 
 
 ### Rate Limiter
 
-We use a Redis backed rate-limiting implementation in Gateway to handle scenarios where we are experiencing a high level of traffic. To read more about the rate limiter implementation and how it is configured, please see the documentation: [TODO]
+We use a Redis backed rate-limiting implementation in Gateway to handle scenarios where we are experiencing a high level of traffic. To read more about the rate limiter implementation and how it is configured, please see [the documentation](./rate-limit/configuration.md).
 
 #### Quick configuration
 

--- a/src/server/lib/middleware/rateLimit.ts
+++ b/src/server/lib/middleware/rateLimit.ts
@@ -98,17 +98,17 @@ export const rateLimiterMiddleware = async (
     trackMetric(rateLimitHitMetric(ratelimitBucketTypeIfHit));
 
     // Don't rate limit users if we are configured to log only.
-    // Also check for whether this is overridden on a per-route level.
+    // Also check for whether this is overridden on a per-route level as well as generally.
     const logOnlyOverride = bucketConfiguration?.settings?.logOnly;
 
     if (logOnlyOverride === true) {
       return next();
     }
 
-    const isLogOnlyAndNotOverriden =
+    const isLogOnlyAndNotOverriddenAtTheRouteLevel =
       rateLimiter.settings?.logOnly === true && logOnlyOverride !== false;
 
-    if (isLogOnlyAndNotOverriden) {
+    if (isLogOnlyAndNotOverriddenAtTheRouteLevel) {
       return next();
     }
 

--- a/src/server/lib/rate-limit/configurationValidator.ts
+++ b/src/server/lib/rate-limit/configurationValidator.ts
@@ -9,21 +9,22 @@ export const bucketSchema = z
   })
   .strict();
 
+export const settingsConfigurationSchema = z
+  .object({
+    logOnly: z.boolean().optional(),
+    trackBucketCapacity: z.boolean().optional(),
+  })
+  .strict();
+
 export const routeBucketsConfigurationSchema = z
   .object({
     enabled: z.boolean().optional(),
+    settings: settingsConfigurationSchema.optional(),
     globalBucket: bucketSchema,
     accessTokenBucket: bucketSchema.optional(),
     ipBucket: bucketSchema.optional(),
     emailBucket: bucketSchema.optional(),
     oktaIdentifierBucket: bucketSchema.optional(),
-  })
-  .strict();
-
-export const settingsConfigurationSchema = z
-  .object({
-    logOnly: z.boolean().optional(),
-    trackBucketCapacity: z.boolean().optional(),
   })
   .strict();
 

--- a/src/server/lib/rate-limit/configurationValidator.ts
+++ b/src/server/lib/rate-limit/configurationValidator.ts
@@ -16,10 +16,16 @@ export const settingsConfigurationSchema = z
   })
   .strict();
 
+export const routeBucketSettingsConfigurationSchema = z
+  .object({
+    logOnly: z.boolean().optional(),
+  })
+  .strict();
+
 export const routeBucketsConfigurationSchema = z
   .object({
     enabled: z.boolean().optional(),
-    settings: settingsConfigurationSchema.optional(),
+    settings: routeBucketSettingsConfigurationSchema.optional(),
     globalBucket: bucketSchema,
     accessTokenBucket: bucketSchema.optional(),
     ipBucket: bucketSchema.optional(),


### PR DESCRIPTION
## What does this change?
We'll be using the log only mode soon once we start to issue Okta sessions to signed in dotcom users.

This PR aims to ease that process. Instead of having to put the whole limiter into log only mode, it allows us to selectively enable / disable it for specific routes. So in this scenario, we would only need to put `/signin/refresh` into log only mode, allowing the rate limiter to still be effective for all of the other routes we want to protect.

As an example, this configuration would look like this:

```json
{
  "enabled": true,
  "settings": {
    "logOnly": false,
    "trackBucketCapacity": false
  },
  "defaultBuckets": {
    "globalBucket": { "capacity": 500, "addTokenMs": 50 },
    "ipBucket": { "capacity": 100, "addTokenMs": 50 },
    "emailBucket": { "capacity": 100, "addTokenMs": 50 },
    "oktaIdentifierBucket": { "capacity": 100, "addTokenMs": 50 },
    "accessTokenBucket": { "capacity": 100, "addTokenMs": 50 }
  },
  "routeBuckets": {
    "/signin/refresh": {
      "settings": {
        "logOnly": true
      },
      "globalBucket": {
        "addTokenMs": 10,
        "capacity": 100
      }
    }
  }
}
```

## How to test

- [ ] Deploy to CODE and put a single route into log only mode. Check to see that it is not rate limited and logs are still captured.