### PR TITLE
Shift loading spinner to the right

### DIFF
--- a/src/client/pages/Registration.tsx
+++ b/src/client/pages/Registration.tsx
@@ -174,6 +174,7 @@ export const Registration = ({
             isLoading={isFormDisabled}
             disabled={isFormDisabled}
             aria-disabled={isFormDisabled}
+            iconSide="right"
           >
             Register
           </Button>

--- a/src/client/pages/SignIn.tsx
+++ b/src/client/pages/SignIn.tsx
@@ -272,6 +272,7 @@ export const SignIn = ({
             isLoading={isFormDisabled}
             disabled={isFormDisabled}
             aria-disabled={isFormDisabled}
+            iconSide="right"
           >
             Sign in
           </Button>


### PR DESCRIPTION
## What does this change?
The existing loading spinner on the reset password page was aligned to the right. When the spinners were added to the registration and sign in page, they were aligned to the left.

This PR changes the two spinners on the left so they are aligned to the right for consistency.

## How to test
Are the spinners for sign in and registration aligned to the right?
