### PR TITLE
Clear Okta cookie in IDAPI only controllers

### DIFF
--- a/src/server/controllers/changePassword.ts
+++ b/src/server/controllers/changePassword.ts
@@ -33,6 +33,7 @@ import { performAuthorizationCodeFlow } from '@/server/lib/okta/oauth';
 import { validateEmailAndPasswordSetSecurely } from '@/server/lib/okta/validateEmail';
 import { setupJobsUserInIDAPI, setupJobsUserInOkta } from '../lib/jobs';
 import { sendOphanComponentEventFromQueryParamsServer } from '../lib/ophan';
+import { clearOktaCookies } from '../routes/signOut';
 
 const { okta } = getConfiguration();
 
@@ -66,6 +67,10 @@ const changePasswordInIDAPI = async (
     );
 
     if (cookies) {
+      // because we are changing the password using idapi, and a new okta
+      // session will not be created, so we will need to clear the okta
+      // cookies to keep the sessions in sync
+      clearOktaCookies(res);
       setIDAPICookies(res, cookies);
     }
 

--- a/src/server/routes/signIn.ts
+++ b/src/server/routes/signIn.ts
@@ -194,6 +194,10 @@ const idapiSignInController = async (
       res.locals.requestId,
     );
 
+    // because we are signing in using idapi, and a new okta
+    // session will not be created, so we will need to clear the okta
+    // cookies to keep the sessions in sync
+    clearOktaCookies(res);
     setIDAPICookies(res, cookies);
 
     trackMetric('SignIn::Success');

--- a/src/server/routes/verifyEmail.ts
+++ b/src/server/routes/verifyEmail.ts
@@ -20,6 +20,7 @@ import { buildUrl } from '@/shared/lib/routeUtils';
 import deepmerge from 'deepmerge';
 import { Request, Router } from 'express';
 import handleRecaptcha from '@/server/lib/recaptcha';
+import { clearOktaCookies } from './signOut';
 
 const router = Router();
 
@@ -160,6 +161,10 @@ router.get(
     try {
       const cookies = await verifyEmail(token, req.ip, res.locals.requestId);
       trackMetric('EmailValidated::Success');
+      // because we are verifying the email using idapi, and a new okta
+      // session will not be created, so we will need to clear the okta
+      // cookies to keep the sessions in sync
+      clearOktaCookies(res);
       setIDAPICookies(res, cookies);
     } catch (error) {
       logger.error(`${req.method} ${req.originalUrl}  Error`, error, {


### PR DESCRIPTION
## What does this change?

When going live with MVP3 (releasing Okta sessions to production), there will still be some existing endpoints in Gateway still using IDAPI as the backend when using the `useIdapi=true` flag or otherwise, for example the welcome page for new guest users from contributions/subscriptions/support, reset password emails sent from the admin panel etc.

These endpoints all set new identity cookies, but have no awareness of a new Okta session, with no way to set one. So to be on the safe side in these cases we want to clear the Okta session should one exist, so that user sessions don't diverge.
