### PR TITLE
Upgrade @guardian/libs to the latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -132,7 +132,7 @@
     "@guardian/ab-core": "^2.0.0",
     "@guardian/ab-react": "^2.0.1",
     "@guardian/consent-management-platform": "^10.11.1",
-    "@guardian/libs": "^6.2.0",
+    "@guardian/libs": "^8.0.5",
     "@guardian/source-foundations": "^5.3.0",
     "@guardian/source-react-components": "^7.1.1",
     "@guardian/source-react-components-development-kitchen": "^3.1.10",

--- a/src/server/lib/__tests__/rate-limit/rateLimitMiddleware.test.ts
+++ b/src/server/lib/__tests__/rate-limit/rateLimitMiddleware.test.ts
@@ -5,7 +5,7 @@ import { RateLimiterConfiguration } from '@/server/lib/rate-limit';
 import { getServerInstance } from '../sharedConfig';
 
 // Override the default 5s max timeout for these tests because Supertest takes some time to run.
-jest.setTimeout(10000);
+jest.setTimeout(20000);
 
 describe('rate limiter middleware', () => {
   const loggerInfoMock = jest.fn();

--- a/yarn.lock
+++ b/yarn.lock
@@ -2670,15 +2670,15 @@
     "@typescript-eslint/eslint-plugin" "5.21.0"
     "@typescript-eslint/parser" "5.21.0"
 
-"@guardian/libs@^6.2.0":
-  version "6.2.0"
-  resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-6.2.0.tgz#db5a3d0a5abd3687563ed347b4a054c7e02319f1"
-  integrity sha512-8ppELyuQ52RTvqnukxICCU38ogBsboEtSqpeznWFytqxx8Zc8R5FKlf5g4KoDjxANWqpGv7RxIh+Gee8GSrDgQ==
-
 "@guardian/libs@^7.1.4":
   version "7.1.4"
   resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-7.1.4.tgz#f5de14f52a32cb677361d49157c94eb046a2b9a8"
   integrity sha512-r2AJk+4EakNLCLXHhUEqdYSjFhuq19k7tsQO5+53YZc6x6ADEXFNRVE/7EzbODgu5pVwk5SQ/rMuWsE7+5qdVQ==
+
+"@guardian/libs@^8.0.5":
+  version "8.0.5"
+  resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-8.0.5.tgz#b4c2a93f024322cda79a18bef5fbc0ee6f46922b"
+  integrity sha512-+1E2Okc9x306z+AjKOg52mlWm0Pzb3SCKmSdOqoVcnhXIm2SfF+ivAdnc3vPwZP6ltXDov4gYyNFxYCwbCESSA==
 
 "@guardian/node-riffraff-artifact@^0.3.2":
   version "0.3.2"


### PR DESCRIPTION
## What does this change?

We upgrade the `@guardian/libs` package to [^8.0.5](https://github.com/guardian/csnx/releases/tag/%40guardian%2Flibs%408.0.5)

As part of this upgrade one of our `react-testing-library` tests for MainForm started to fail. After looking into this issue, the problem was narrowed down to this change: https://github.com/guardian/libs/pull/390/files#diff-e66f30416e1d836f8f29281cd56fa1d9e3f1c9f7fd97b25a3019c8183006be9fR34 which I believe meant that that the mocked reCAPTCHA script was no longer inserted into the page properly due to `document.scripts[0]` being undefined until the `useRecaptcha` hook is loaded and subsequently evaluates the `loadScript` method. 

The fix was to ensure that we mock the script insertion for each test in a `beforeEach` method for every test. This should ensure that the script is in the page *before* the test begins, avoiding a circumstance where `document.scripts[0]` is undefined by the time `loadScript` is called.

There could be more at play here around how the test environment is bootstrapped, causing a possible race condition — but I didn't want to spend too much time digging into the why as the fix works as intended and isn't hacky.

This PR also includes a timeout bump for the supertest suite around the rate limiter because in some cases it runs slowly inside the GitHub actions environment — if this keeps getting slower and slower it'll need some deeper investigation most likely