### PR TITLE
Okta | Jobs changes

### DIFF
--- a/cypress/integration/ete-okta/jobs_terms.4.cy.ts
+++ b/cypress/integration/ete-okta/jobs_terms.4.cy.ts
@@ -1,4 +1,26 @@
 describe('Jobs terms and conditions flow in Okta', () => {
+  context('Shows the terms and conditions page on Sign In', () => {
+    it('visits /agree/GRS after sign in if clientId=jobs parameter is set', () => {
+      cy.intercept('GET', 'https://jobs.theguardian.com/', (req) => {
+        req.reply(200);
+      });
+
+      cy.createTestUser({
+        isUserEmailValidated: true,
+      })?.then(({ emailAddress, finalPassword }) => {
+        const visitUrl =
+          '/signin?clientId=jobs&returnUrl=https%3A%2F%2Fjobs.theguardian.com%2F';
+        cy.visit(visitUrl);
+        cy.get('input[name=email]').type(emailAddress);
+        cy.get('input[name=password]').type(finalPassword);
+        cy.get('[data-cy="main-form-submit-button"]').click();
+        cy.url().should('include', '/agree/GRS');
+        cy.get('[data-cy="main-form-submit-button"]').click();
+        cy.url().should('include', 'https://jobs.theguardian.com/');
+      });
+    });
+  });
+
   context('Accepts Jobs terms and conditions and sets their name', () => {
     it('should redirect users with an invalid session cookie to reauthenticate', () => {
       // load the consents page as its on the same domain

--- a/src/server/routes/oauth.ts
+++ b/src/server/routes/oauth.ts
@@ -198,6 +198,18 @@ router.get(
       // track the success metric
       trackMetric('OAuthAuthorization::Success');
 
+      // redirect for jobs to show the jobs t&c page
+      // but not if confirmationPage is set (so that we can still show onboarding flow first)
+      // before redirecting to the jobs t&c page
+      if (
+        authState.queryParams.clientId === 'jobs' &&
+        !authState.confirmationPage
+      ) {
+        return res.redirect(
+          addQueryParamsToPath('/agree/GRS', authState.queryParams),
+        );
+      }
+
       // We only use to this option if the app does not provide a deep link with a custom scheme
       // This allows the native apps to complete the authorization code flow for the app.
       // the fromURI parameter is an undocumented feature from Okta that allows us to


### PR DESCRIPTION
## What does this change?

To make the Jobs migration easier, I investigated ways that I could make changes to the jobs flows to Gateway so that it was easier for Jobs to integrate with our changes.

Namely we wanted to facilitate the showing of the `/agree/GRS` page automatically if the user was coming from jobs, as well as setting the `clientId` and `returnUrl` parameters automatically.

The new jobs flow works in a similar way to the native apps flow, Jobs will try to perform the Authorization Code flow, if a session doesn't exist they'll be redirected to the Okta hosted login page, which we intercept and show our own sign in/registration page instead on Gateway.

The first change adds the old `clientId=jobs` query parameter at the point of intercept if the calling OAuth application is `jobs_site`, as well as the `returnUrl=` pointing to the jobs subdomain on the correct environment. These get passed through to Gateway.

On Gateway when a user gets an Okta session set, we look for the `clientId=jobs` query parameter, if this is the case then we redirect the user to `/agree/GRS`. This page already handles any checks that it needs to make, if a user is already a valid jobs user it will redirect them straight back to jobs, otherwise it will show the T&Cs page.

Since we need to complete the Authorization Code flow if initiated by the jobs site, we pass around the `fromURI` parameter, to `/agree/GRS` so that if this parameter exists, once the user accepts the T&Cs or is already a jobs user, they automatically complete the Authorization Code flow when we redirect them to the `fromURI`.

This allows us to keep the existing functionality as it is for production, but also adds a way that we can complete the Jobs flows directly in a purely OAuth2 world going forward in the future.

## Tested
- [x] CODE

## Related
https://github.com/guardian/identity-platform/pull/571
