### PR TITLE
Always use Okta for social sign in

### DIFF
--- a/src/server/routes/signIn.ts
+++ b/src/server/routes/signIn.ts
@@ -486,15 +486,14 @@ const isValidSocialProvider = (provider: string): boolean =>
 router.get(
   '/signin/:social',
   handleAsyncErrors(async (req: Request, res: ResponseWithRequestState) => {
-    // todo can we use the login middleware here to stopped logged in users from accessing this endpoint?
-    const { useIdapi, returnUrl } = res.locals.queryParams;
+    const { returnUrl } = res.locals.queryParams;
     const socialIdp = req.params.social as SocialProvider;
 
     if (!isValidSocialProvider(socialIdp)) {
       return res.redirect(303, '/signin');
     }
 
-    if (okta.enabled && !useIdapi) {
+    if (okta.enabled) {
       // get the IDP id from the config
       const idp = okta.social[socialIdp];
 


### PR DESCRIPTION
## What does this change?

- Updates the `/signin/:social` to always use Okta if the switch is enabled, disregarding the `useIdapi` flag.
  - Social users behave the same whether in Okta or the legacy system, so there's no need to switch depending on the flag, and the only reason we'd want to turn it off is if we disable the Okta switch altogether
  - This should potentially stop all traffic going to our [legacy Identity Federation API](https://github.com/guardian/identity-federation-api)
  - This will allow us to determine if there is any traffic still going to that platform, and may allow us to turn it off sooner rather than later
  - We still get traffic using the `useIdapi` flag from some of the emails we still send from IDAPI. While none of them necessarily go to `/signin`, because the `useIdapi` flag is persistable (so persists between routes), it's possible to navigate to `/signin` and then click one of the social buttons theoretically