### PR TITLE
Switch order of social and email/password components on SignIn and Registration pages

### DIFF
--- a/cypress/integration/ete/registration/register.2.cy.ts
+++ b/cypress/integration/ete/registration/register.2.cy.ts
@@ -65,7 +65,7 @@ describe('Registration flow', () => {
         req.reply(200);
       });
       cy.visit('/signin?clientId=jobs&useIdapi=true');
-      cy.contains("Guardian's Jobs terms & conditions").click();
+      cy.contains('Guardian Jobs terms & conditions').click();
       cy.url().should('eq', guardianJobsTermsOfServiceUrl);
     });
 
@@ -79,7 +79,7 @@ describe('Registration flow', () => {
       });
       cy.visit('/signin?clientId=jobs&useIdapi=true');
       cy.contains('For information about how we use your data')
-        .contains("Guardian Jobs' privacy policy")
+        .contains('Guardian Jobs privacy policy')
         .click();
       cy.url().should('eq', guardianJobsPrivacyPolicyUrl);
     });

--- a/cypress/integration/shared/sign_in.shared.ts
+++ b/cypress/integration/shared/sign_in.shared.ts
@@ -107,7 +107,7 @@ export const linksToTheGuardianJobsTermsAndConditionsPageWhenJobsClientIdSet = (
         ? '/signin?clientId=jobs&useIdapi=true'
         : '/signin?clientId=jobs';
       cy.visit(visitUrl);
-      cy.contains("Guardian's Jobs terms & conditions").click();
+      cy.contains('Guardian Jobs terms & conditions').click();
       cy.url().should('eq', guardianJobsTermsOfServiceUrl);
     },
   ] as const;
@@ -131,7 +131,7 @@ export const linksToTheGuardianJobsPrivacyPolicyPageWhenJobsClientIdSet = (
         : '/signin?clientId=jobs';
       cy.visit(visitUrl);
       cy.contains('For information about how we use your data')
-        .contains("Guardian Jobs' privacy policy")
+        .contains('Guardian Jobs privacy policy')
         .click();
       cy.url().should('eq', guardianJobsPrivacyPolicyUrl);
     },

--- a/src/client/__tests__/Registration.test.tsx
+++ b/src/client/__tests__/Registration.test.tsx
@@ -1,0 +1,103 @@
+/**
+ * @jest-environment jsdom
+ */
+/** @jsx jsx */
+
+import { jsx } from '@emotion/react';
+import { render, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+import { Registration, RegistrationProps } from '../pages/Registration';
+
+const setup = (extraProps?: Partial<RegistrationProps>) =>
+  render(
+    <Registration
+      recaptchaSiteKey="6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI"
+      // oauthBaseUrl="https://oauth.theguardian.com/"
+      queryParams={{
+        returnUrl: 'https://www.theguardian.com/uk',
+      }}
+      email="test@test.com"
+      {...extraProps}
+    />,
+  );
+
+test('Default terms and conditions in document when clientId not set', async () => {
+  const { queryByText } = setup({
+    queryParams: {
+      returnUrl: 'https://www.theguardian.com/uk',
+    },
+  });
+
+  /**
+   * A helper function to check if the specified text appears in any tag in the document,
+   * including that tag's children.
+   */
+  const queryByTextContent = (text: string) => {
+    // Passing function to testing-library's `queryByText`
+    return queryByText((content, element) => {
+      const hasText = (element: Element | null) =>
+        element?.textContent === text;
+      const elementHasText = hasText(element);
+      const childrenDontHaveText = Array.from(element?.children || []).every(
+        (child) => !hasText(child),
+      );
+      return elementHasText && childrenDontHaveText;
+    });
+  };
+
+  const defaultTerms = queryByTextContent(
+    'By proceeding, you agree to our terms & conditions.',
+  );
+  const privacyPolicy = queryByTextContent(
+    'For information about how we use your data, see our privacy policy.',
+  );
+  const jobsTerms = queryByTextContent(
+    'By proceeding, you agree to our Guardian Jobs terms & conditions.',
+  );
+  await waitFor(() => {
+    expect(defaultTerms).toBeInTheDocument();
+    expect(privacyPolicy).toBeInTheDocument();
+    expect(jobsTerms).not.toBeInTheDocument();
+  });
+});
+
+test('Jobs terms and conditions in document when clientId equals "jobs"', async () => {
+  const { queryByText } = setup({
+    queryParams: {
+      returnUrl: 'https://www.theguardian.com/uk',
+      clientId: 'jobs',
+    },
+  });
+
+  /**
+   * A helper function to check if the specified text appears in any tag in the document,
+   * including that tag's children.
+   */
+  const queryByTextContent = (text: string) => {
+    // Passing function to testing-library's `queryByText`
+    return queryByText((content, element) => {
+      const hasText = (element: Element | null) =>
+        element?.textContent === text;
+      const elementHasText = hasText(element);
+      const childrenDontHaveText = Array.from(element?.children || []).every(
+        (child) => !hasText(child),
+      );
+      return elementHasText && childrenDontHaveText;
+    });
+  };
+
+  const defaultTerms = queryByTextContent(
+    'By proceeding, you agree to our terms & conditions',
+  );
+  const privacyPolicy = queryByTextContent(
+    'For information about how we use your data, see our Guardian Jobs privacy policy.',
+  );
+  const jobsTerms = queryByTextContent(
+    'By proceeding, you agree to our Guardian Jobs terms & conditions.',
+  );
+  await waitFor(() => {
+    expect(defaultTerms).not.toBeInTheDocument();
+    expect(privacyPolicy).toBeInTheDocument();
+    expect(jobsTerms).toBeInTheDocument();
+  });
+});

--- a/src/client/__tests__/SignIn.test.tsx
+++ b/src/client/__tests__/SignIn.test.tsx
@@ -1,0 +1,111 @@
+/**
+ * @jest-environment jsdom
+ */
+/** @jsx jsx */
+
+import { jsx } from '@emotion/react';
+import { render, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+import { SignIn, SignInProps } from '../pages/SignIn';
+
+const setup = (extraProps?: Partial<SignInProps>) =>
+  render(
+    <SignIn
+      recaptchaSiteKey="6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI"
+      isReauthenticate={false}
+      queryParams={{
+        returnUrl: 'https://www.theguardian.com/uk',
+      }}
+      {...extraProps}
+    />,
+  );
+
+test('Register button not shown when reauthenticate is set to true', async () => {
+  const { queryByText } = setup({ isReauthenticate: true });
+  await waitFor(() => {
+    // This may need to be made a bit more specific if we ever put the word
+    // 'Register' on the page but it works for the moment!
+    expect(queryByText('Register')).not.toBeInTheDocument();
+  });
+});
+
+test('Default terms and conditions in document when clientId not set', async () => {
+  const { queryByText } = setup({
+    queryParams: {
+      returnUrl: 'https://www.theguardian.com/uk',
+    },
+  });
+
+  /**
+   * A helper function to check if the specified text appears in any tag in the document,
+   * including that tag's children.
+   */
+  const queryByTextContent = (text: string) => {
+    // Passing function to testing-library's `queryByText`
+    return queryByText((content, element) => {
+      const hasText = (element: Element | null) =>
+        element?.textContent === text;
+      const elementHasText = hasText(element);
+      const childrenDontHaveText = Array.from(element?.children || []).every(
+        (child) => !hasText(child),
+      );
+      return elementHasText && childrenDontHaveText;
+    });
+  };
+
+  const defaultTerms = queryByTextContent(
+    'By proceeding, you agree to our terms & conditions.',
+  );
+  const privacyPolicy = queryByTextContent(
+    'For information about how we use your data, see our privacy policy.',
+  );
+  const jobsTerms = queryByTextContent(
+    'By proceeding, you agree to our Guardian Jobs terms & conditions.',
+  );
+  await waitFor(() => {
+    expect(defaultTerms).toBeInTheDocument();
+    expect(privacyPolicy).toBeInTheDocument();
+    expect(jobsTerms).not.toBeInTheDocument();
+  });
+});
+
+test('Jobs terms and conditions in document when clientId equals "jobs"', async () => {
+  const { queryByText } = setup({
+    queryParams: {
+      returnUrl: 'https://www.theguardian.com/uk',
+      clientId: 'jobs',
+    },
+  });
+
+  /**
+   * A helper function to check if the specified text appears in any tag in the document,
+   * including that tag's children.
+   */
+  const queryByTextContent = (text: string) => {
+    // Passing function to testing-library's `queryByText`
+    return queryByText((content, element) => {
+      const hasText = (element: Element | null) =>
+        element?.textContent === text;
+      const elementHasText = hasText(element);
+      const childrenDontHaveText = Array.from(element?.children || []).every(
+        (child) => !hasText(child),
+      );
+      return elementHasText && childrenDontHaveText;
+    });
+  };
+
+  const defaultTerms = queryByTextContent(
+    'By proceeding, you agree to our terms & conditions',
+  );
+  const privacyPolicy = queryByTextContent(
+    'For information about how we use your data, see our Guardian Jobs privacy policy.',
+  );
+  const jobsTerms = queryByTextContent(
+    'By proceeding, you agree to our Guardian Jobs terms & conditions.',
+  );
+  await waitFor(() => {
+    expect(defaultTerms).not.toBeInTheDocument();
+    expect(privacyPolicy).toBeInTheDocument();
+    expect(jobsTerms).toBeInTheDocument();
+  });
+});

--- a/src/client/components/MainForm.stories.tsx
+++ b/src/client/components/MainForm.stories.tsx
@@ -55,6 +55,18 @@ export const FormWithRecaptchaGuardianTerms = () => (
 );
 FormWithRecaptchaGuardianTerms.storyName = 'FormWithRecaptchaGuardianTerms';
 
+export const FormWithRecaptchaJobsTerms = () => (
+  <MainForm
+    formAction=""
+    submitButtonText="Send me a link"
+    recaptchaSiteKey="test"
+    hasJobsTerms
+  >
+    <EmailInput />
+  </MainForm>
+);
+FormWithRecaptchaJobsTerms.storyName = 'FormWithRecaptchaJobsTerms';
+
 export const TertiarySubmitButton = () => (
   <MainForm
     formAction=""

--- a/src/client/components/SocialButtons.tsx
+++ b/src/client/components/SocialButtons.tsx
@@ -12,22 +12,19 @@ import { buildUrlWithQueryParams } from '@/shared/lib/routeUtils';
 
 type SocialButtonProps = {
   queryParams: QueryParams;
+  marginTop?: boolean;
 };
 
-const containerStyles = css`
+const containerStyles = (marginTop = false) => css`
   display: flex;
   flex-direction: column;
   ${from.tablet} {
     flex-direction: row;
   }
   justify-content: center;
-  margin-top: ${space[5]}px;
+  margin-top: ${marginTop ? space[5] : 0}px;
   ${from.mobileMedium} {
-    margin-top: ${space[6]}px;
-  }
-  margin-bottom: 60px;
-  ${from.desktop} {
-    margin-bottom: ${space[24]}px;
+    margin-top: ${marginTop ? space[6] : 0}px;
   }
   width: 100%;
 `;
@@ -63,9 +60,12 @@ const Gap = () => (
   ></span>
 );
 
-export const SocialButtons = ({ queryParams }: SocialButtonProps) => {
+export const SocialButtons = ({
+  queryParams,
+  marginTop,
+}: SocialButtonProps) => {
   return (
-    <div css={containerStyles}>
+    <div css={containerStyles(marginTop)}>
       <LinkButton
         priority="tertiary"
         cssOverrides={[buttonOverrides, iconOverrides]}

--- a/src/client/components/Terms.stories.tsx
+++ b/src/client/components/Terms.stories.tsx
@@ -1,12 +1,27 @@
 import React from 'react';
 import { Meta } from '@storybook/react';
 
-import { Terms } from './Terms';
+import { GuardianTerms, JobsTerms, RecaptchaTerms } from './Terms';
 
 export default {
   title: 'Components/Terms',
-  component: Terms,
+  component: GuardianTerms,
 } as Meta;
 
-export const Default = () => <Terms />;
-Default.storyName = 'Default terms';
+export const Default = () => (
+  <>
+    <GuardianTerms />
+    <RecaptchaTerms />
+  </>
+);
+
+Default.storyName = 'Terms';
+
+export const Jobs = () => (
+  <>
+    <JobsTerms />
+    <RecaptchaTerms />
+  </>
+);
+
+Jobs.storyName = 'Jobs terms';

--- a/src/client/components/Terms.tsx
+++ b/src/client/components/Terms.tsx
@@ -1,7 +1,11 @@
 import React from 'react';
 import { css } from '@emotion/react';
-import { from, space, textSans } from '@guardian/source-foundations';
+import { space, textSans } from '@guardian/source-foundations';
 import { ExternalLink } from '@/client/components/ExternalLink';
+
+export const termsContainer = css`
+  margin-top: ${space[5]}px;]};
+`;
 
 const Text = ({ children }: { children: React.ReactNode }) => (
   <p
@@ -32,16 +36,6 @@ const TermsLink = ({
   </ExternalLink>
 );
 
-const terms = css`
-  margin-top: ${space[3]}px;
-  ${from.mobileMedium} {
-    margin-top: ${space[4]}px;
-  }
-  ${from.tablet} {
-    margin-top: ${space[3]}px;
-  }
-`;
-
 export const GuardianTerms = () => (
   <>
     <Text>
@@ -61,50 +55,23 @@ export const GuardianTerms = () => (
   </>
 );
 
-export const JobsStandaloneTerms = () => (
-  <div css={terms}>
+export const JobsTerms = () => (
+  <>
     <Text>
       By proceeding, you agree to our{' '}
       <TermsLink href="https://jobs.theguardian.com/terms-and-conditions/">
-        Guardian&#39;s Jobs terms &amp; conditions
+        Guardian Jobs terms &amp; conditions
       </TermsLink>
       .
     </Text>
     <Text>
       For information about how we use your data, see our{' '}
       <TermsLink href="https://jobs.theguardian.com/privacy-policy/">
-        Guardian Jobs&#39; privacy policy
+        Guardian Jobs privacy policy
       </TermsLink>
       .
     </Text>
-  </div>
-);
-
-const JobsTerms = () => (
-  <div css={terms}>
-    <Text>
-      By proceeding, you agree to our{' '}
-      <TermsLink href="https://www.theguardian.com/help/terms-of-service">
-        terms &amp; conditions
-      </TermsLink>{' '}
-      and{' '}
-      <TermsLink href="https://jobs.theguardian.com/terms-and-conditions/">
-        Guardian&#39;s Jobs terms &amp; conditions
-      </TermsLink>
-      .
-    </Text>
-    <Text>
-      For information about how we use your data, see our{' '}
-      <TermsLink href="https://www.theguardian.com/help/privacy-policy">
-        privacy policy
-      </TermsLink>{' '}
-      and{' '}
-      <TermsLink href="https://jobs.theguardian.com/privacy-policy/">
-        Guardian Jobs&#39; privacy policy
-      </TermsLink>
-      .
-    </Text>
-  </div>
+  </>
 );
 
 export const RecaptchaTerms = () => (
@@ -119,11 +86,4 @@ export const RecaptchaTerms = () => (
     </TermsLink>{' '}
     apply.
   </Text>
-);
-
-export const Terms = ({ isJobs = false }) => (
-  <div css={terms}>
-    {isJobs ? <JobsTerms /> : <GuardianTerms />}
-    <RecaptchaTerms />
-  </div>
 );

--- a/src/client/pages/Registration.stories.tsx
+++ b/src/client/pages/Registration.stories.tsx
@@ -44,3 +44,12 @@ export const InvalidRecaptcha = (args: RegistrationProps) => (
 InvalidRecaptcha.story = {
   name: 'with reCAPTCHA error',
 };
+
+export const WithJobs = (args: RegistrationProps) => (
+  <Registration
+    {...{ ...args, queryParams: { ...args.queryParams, clientId: 'jobs' } }}
+  />
+);
+WithJobs.story = {
+  name: 'with Jobs terms',
+};

--- a/src/client/pages/Registration.tsx
+++ b/src/client/pages/Registration.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, useState } from 'react';
+import React from 'react';
 import { QueryParams } from '@/shared/model/QueryParams';
 import { MainLayout } from '@/client/layouts/Main';
 import { MainForm } from '@/client/components/MainForm';
@@ -9,12 +9,20 @@ import { Divider } from '@guardian/source-react-components-development-kitchen';
 import { SocialButtons } from '@/client/components/SocialButtons';
 import { socialButtonDivider } from '@/client/styles/Shared';
 import { usePageLoadOphanInteraction } from '@/client/lib/hooks/usePageLoadOphanInteraction';
+import { GuardianTerms, JobsTerms, termsContainer } from '../components/Terms';
 
 export type RegistrationProps = {
   email?: string;
   recaptchaSiteKey: string;
   queryParams: QueryParams;
 };
+
+const RegistrationTerms = ({ isJobs }: { isJobs: boolean }) => (
+  <div css={termsContainer}>
+    {!isJobs && <GuardianTerms />}
+    {isJobs && <JobsTerms />}
+  </div>
+);
 
 export const Registration = ({
   email,
@@ -26,10 +34,6 @@ export const Registration = ({
   const { clientId } = queryParams;
   const isJobs = clientId === 'jobs';
 
-  const [recaptchaErrorMessage, setRecaptchaErrorMessage] = useState('');
-  const [recaptchaErrorContext, setRecaptchaErrorContext] =
-    useState<ReactNode>(null);
-
   usePageLoadOphanInteraction(formTrackingName);
 
   const tabs = generateSignInRegisterTabs({
@@ -38,33 +42,23 @@ export const Registration = ({
   });
 
   return (
-    <MainLayout
-      errorOverride={recaptchaErrorMessage}
-      errorContext={recaptchaErrorContext}
-      showErrorReportUrl={!!recaptchaErrorContext}
-      tabs={tabs}
-      errorSmallMarginBottom={!!recaptchaErrorMessage}
-    >
+    <MainLayout tabs={tabs}>
+      <RegistrationTerms isJobs={isJobs} />
+      <SocialButtons queryParams={queryParams} marginTop={true} />
+      <Divider
+        spaceAbove="loose"
+        displayText="or continue with"
+        cssOverrides={socialButtonDivider}
+      />
       <MainForm
         formAction={buildUrlWithQueryParams('/register', {}, queryParams)}
         submitButtonText="Register"
         recaptchaSiteKey={recaptchaSiteKey}
         formTrackingName={formTrackingName}
         disableOnSubmit
-        setRecaptchaErrorMessage={setRecaptchaErrorMessage}
-        setRecaptchaErrorContext={setRecaptchaErrorContext}
-        hasGuardianTerms={!isJobs}
-        hasJobsTerms={isJobs}
-        largeFormMarginTop={!recaptchaErrorMessage}
       >
         <EmailInput defaultValue={email} />
       </MainForm>
-      <Divider
-        spaceAbove="loose"
-        displayText="or continue with"
-        cssOverrides={socialButtonDivider}
-      />
-      <SocialButtons queryParams={queryParams} />
     </MainLayout>
   );
 };

--- a/src/client/pages/SignIn.stories.tsx
+++ b/src/client/pages/SignIn.stories.tsx
@@ -30,18 +30,18 @@ WithEmail.story = {
   name: 'with email',
 };
 
-export const WithSummaryError = (args: SignInProps) => (
+export const WithPageLevelError = (args: SignInProps) => (
   <SignIn error="This is an error" {...args} />
 );
-WithSummaryError.story = {
-  name: 'with summary error',
+WithPageLevelError.story = {
+  name: 'with page level error',
 };
 
-export const WithSummaryErrorAndEmail = (args: SignInProps) => (
+export const WithPageLevelErrorAndEmail = (args: SignInProps) => (
   <SignIn error="This is an error" email="test@example.com" {...args} />
 );
-WithSummaryErrorAndEmail.story = {
-  name: 'with summary error and email',
+WithPageLevelErrorAndEmail.story = {
+  name: 'with page level error and email',
 };
 
 export const SocialSigninBlocked = (args: SignInProps) => (
@@ -67,4 +67,24 @@ export const WithoutRegisterButton = (args: SignInProps) => (
 );
 WithoutRegisterButton.story = {
   name: 'without register button',
+};
+
+export const WithJobs = (args: SignInProps) => (
+  <SignIn
+    {...{ ...args, queryParams: { ...args.queryParams, clientId: 'jobs' } }}
+  />
+);
+WithJobs.story = {
+  name: 'with Jobs terms',
+};
+
+export const WithJobsAndSocialSigninBlocked = (args: SignInProps) => (
+  <SignIn
+    {...{ ...args, queryParams: { ...args.queryParams, clientId: 'jobs' } }}
+    error={SignInErrors.ACCOUNT_ALREADY_EXISTS}
+    email="someone@theguardian.com"
+  />
+);
+WithJobsAndSocialSigninBlocked.story = {
+  name: 'with Jobs terms and social sign-in blocked',
 };


### PR DESCRIPTION
## What does this change?

We're switching the order of the social login buttons the and email/password components on the `SignIn` and `Registration` pages. Previously the social buttons were at the bottom, now they'll be on top.

## Register page

|                          | **Before** | **After** |
|--------------------------|------------|-----------|
| First load | <img width="240" alt="register-before-first" src="https://user-images.githubusercontent.com/101555242/194894686-6219a38a-bbe1-4527-ba9b-fa54a793ebad.png"> | <img width="240" alt="register-after-first" src="https://user-images.githubusercontent.com/101555242/194894682-2cc205ef-8b65-4ef7-9e64-2772d4fe4619.png"> |
| With error | <img width="240" alt="register-before-error" src="https://user-images.githubusercontent.com/101555242/194894685-51102e59-499b-4193-bc6f-1032e8052906.png"> | <img width="240" alt="register-after-error" src="https://user-images.githubusercontent.com/101555242/194895034-4e211cd1-684b-4749-aded-3b81f5e64a33.png"> |

## Sign in page

|  | **Before** | **After** |
|---|---|---|
| First load | <img width="240" alt="siginin-before-first" src="https://user-images.githubusercontent.com/101555242/194894689-93551218-5a68-4116-8456-9748f7e1a508.png"> | <img width="240" alt="signin-after-first" src="https://user-images.githubusercontent.com/101555242/194894692-406c8980-2cf8-4b8e-bd02-8f891e271cce.png"> |
| With error | <img width="240" alt="signin-before-error" src="https://user-images.githubusercontent.com/101555242/194894699-9120d0ae-7585-4162-8a68-a7bc08de1089.png"> | <img width="240" alt="signin-after-error" src="https://user-images.githubusercontent.com/101555242/194894690-dd5297e2-07e7-43c2-ab4e-744a2e41a31b.png"> |
| Error, no social buttons | <img width="240" alt="signin-before-no-social" src="https://user-images.githubusercontent.com/101555242/194894702-78879c35-1794-4e29-af4a-4d9e48be4558.png"> | <img width="240" alt="signin-after-no-social" src="https://user-images.githubusercontent.com/101555242/194894694-c1edc2a2-4df3-4ddc-98c8-6e7475a9bf95.png"> |


As a side-effect of these changes, a couple of small changes have been made:

- Minor changes to margins across pages using the `MainForm` component. This is because the `MainForm` component had a large margin at the bottom, which presumably was only there to push the bottom of the page down, as there aren't any pages that (1) use `MainForm` and (2) have any elements _below_ the bottom of `MainForm`. I don't _think_ we need this, since it has no real purpose and simply pushes the page down further than its preset 900px minimum height.
- Also on the note of margins, I've standardised some mysterious margins that sat between the bottom of the `MainForm` inputs and the terms/reCAPTCHA texts. I believe they're now consistent!
- I've added tests to ensure T&Cs appear correctly on `SignIn` and `Registration`, as well as the vanilla `MainForm`. This is mostly for my own peace of mind as I had to refactor the logic for when the terms text appears. This is because I needed to split the terms text in two: the T&Cs and privacy policy text needs to appear **above the first interactable button on the page**, so the social buttons when those appear and the submit button otherwise; and the reCAPTCHA text has to always appear above the submit button.
- `MainForm` now handles reCAPTCHA (and, in future, any other submit-generated) errors in two ways. If it receives a setter function, it will pass the error up through the function to the parent component. If it doesn't receive a setter function, it will instead display the error at the top of the `MainForm` component itself. This is so the error associated with a set of email/password inputs, for instance a reCAPTCHA error, will appear directly above _those_ inputs, and not above the social buttons, at the top of `MainForm`'s parent component.
- So that the `MainForm` Storybook stories don't break, I've added in a check which doesn't display a reCAPTCHA error if the reCAPTCHA token is set to `"test"`. Otherwise, the stories would immediately show a reCAPTCHA error.
- I've removed an unused component in `Terms.tsx`, and reorganised the terms texts a little. I also fixed some grammatical mistakes after confirming with the PM.
- I've added a couple of useful Storybook stories and renamed a couple of others to better encapsulate our use cases.