### PR TITLE
Handle missing password for unvalidated user attempting to register

### DIFF
--- a/cypress/integration/mocked-okta/registerController.1.cy.ts
+++ b/cypress/integration/mocked-okta/registerController.1.cy.ts
@@ -36,7 +36,7 @@ userStatuses.forEach((status) => {
           break;
         case 'ACTIVE':
           specify(
-            "Then I should be shown the 'Check your email inbox' page",
+            "Then I should be shown the 'Check your email inbox' page if I have a validated email",
             () => {
               // Set the correct user status on the response
               const response = { ...userResponse.response, status };
@@ -57,6 +57,55 @@ userStatuses.forEach((status) => {
               verifyInRegularEmailSentPage();
             },
           );
+          specify(
+            "Then I should be shown the 'Check your email inbox' page if I don't have a validated email and don't have a password set",
+            () => {
+              // Set the correct user status on the response
+              const response = { ...userResponse.response, status };
+              cy.mockNext(userExistsError.code, userExistsError.response);
+              // This user response doesn't have a password credential
+              cy.mockNext(userResponse.code, response);
+              const userGroupsResponseWithoutEmailValidated =
+                userGroupsResponse.response.filter(
+                  (group) =>
+                    group.profile.name !== 'GuardianUser-EmailValidated',
+                );
+              cy.mockNext(
+                userGroupsResponse.code,
+                userGroupsResponseWithoutEmailValidated,
+              );
+              // dangerouslyResetPassword()
+              cy.mockNext(200, {
+                resetPasswordUrl:
+                  'https://example.com/reset_password/XE6wE17zmphl3KqAPFxO',
+              });
+              // validateRecoveryToken()
+              cy.mockNext(200, {
+                stateToken: 'sometoken',
+              });
+              // authenticationResetPassword()
+              cy.mockNext(200, {});
+              // from sendEmailToUnvalidatedUser() --> forgotPassword()
+              cy.mockNext(200, {
+                resetPasswordUrl:
+                  'https://example.com/signin/reset-password/XE6wE17zmphl3KqAPFxO',
+              });
+              cy.get('button[type=submit]').click();
+              verifyInRegularEmailSentPage();
+            },
+          );
+          specify(
+            "Then I should be shown the 'Check your email inbox' page if I don't have a validated email and do have a password set",
+            () => {
+              // Set the correct user status on the response
+              const response = { ...userResponse.response, status };
+              cy.mockNext(userExistsError.code, userExistsError.response);
+              cy.mockNext(userResponse.code, response);
+              cy.mockNext(userGroupsResponse.code, userGroupsResponse.response);
+              cy.get('button[type=submit]').click();
+              verifyInRegularEmailSentPage();
+            },
+          );
           //not sure if we need to do anything for the social case here. the only mocked response I can change is the user response
           //but it would be changing fields that no one looks at
           break;
@@ -70,7 +119,6 @@ userStatuses.forEach((status) => {
               const response = { ...userResponse.response, status };
               cy.mockNext(userExistsError.code, userExistsError.response);
               cy.mockNext(userResponse.code, response);
-              cy.mockNext(userGroupsResponse.code, userGroupsResponse.response);
               cy.mockNext(
                 successTokenResponse.code,
                 successTokenResponse.response,
@@ -90,7 +138,6 @@ userStatuses.forEach((status) => {
               const response = { ...userResponse.response, status };
               cy.mockNext(userExistsError.code, userExistsError.response);
               cy.mockNext(userResponse.code, response);
-              cy.mockNext(userGroupsResponse.code, userGroupsResponse.response);
               cy.mockNext(
                 resetPasswordResponse.code,
                 resetPasswordResponse.response,

--- a/cypress/integration/mocked-okta/resendEmailController.3.cy.ts
+++ b/cypress/integration/mocked-okta/resendEmailController.3.cy.ts
@@ -65,6 +65,55 @@ userStatuses.forEach((status) => {
               verifyInRegularEmailSentPage();
             },
           );
+          specify(
+            "Then I should be shown the 'Check your email inbox' page if I don't have a validated email and don't have a password set",
+            () => {
+              // Set the correct user status on the response
+              const response = { ...userResponse.response, status };
+              cy.mockNext(userExistsError.code, userExistsError.response);
+              // This user response doesn't have a password credential
+              cy.mockNext(userResponse.code, response);
+              const userGroupsResponseWithoutEmailValidated =
+                userGroupsResponse.response.filter(
+                  (group) =>
+                    group.profile.name !== 'GuardianUser-EmailValidated',
+                );
+              cy.mockNext(
+                userGroupsResponse.code,
+                userGroupsResponseWithoutEmailValidated,
+              );
+              // dangerouslyResetPassword()
+              cy.mockNext(200, {
+                resetPasswordUrl:
+                  'https://example.com/reset_password/XE6wE17zmphl3KqAPFxO',
+              });
+              // validateRecoveryToken()
+              cy.mockNext(200, {
+                stateToken: 'sometoken',
+              });
+              // authenticationResetPassword()
+              cy.mockNext(200, {});
+              // from sendEmailToUnvalidatedUser() --> forgotPassword()
+              cy.mockNext(200, {
+                resetPasswordUrl:
+                  'https://example.com/signin/reset-password/XE6wE17zmphl3KqAPFxO',
+              });
+              cy.get('button[type=submit]').click();
+              verifyInRegularEmailSentPage();
+            },
+          );
+          specify(
+            "Then I should be shown the 'Check your email inbox' page if I don't have a validated email and do have a password set",
+            () => {
+              // Set the correct user status on the response
+              const response = { ...userResponse.response, status };
+              cy.mockNext(userExistsError.code, userExistsError.response);
+              cy.mockNext(userResponse.code, response);
+              cy.mockNext(userGroupsResponse.code, userGroupsResponse.response);
+              cy.get('button[type=submit]').click();
+              verifyInRegularEmailSentPage();
+            },
+          );
           //i Think this is the same as register.. I don't know if I should add the modked social user here
           // when the execution doesn't check the credentials part of the response
           break;
@@ -78,7 +127,6 @@ userStatuses.forEach((status) => {
               const response = { ...userResponse.response, status };
               cy.mockNext(userExistsError.code, userExistsError.response);
               cy.mockNext(userResponse.code, response);
-              cy.mockNext(userGroupsResponse.code, userGroupsResponse.response);
               cy.mockNext(
                 successTokenResponse.code,
                 successTokenResponse.response,
@@ -98,7 +146,6 @@ userStatuses.forEach((status) => {
               const response = { ...userResponse.response, status };
               cy.mockNext(userExistsError.code, userExistsError.response);
               cy.mockNext(userResponse.code, response);
-              cy.mockNext(userGroupsResponse.code, userGroupsResponse.response);
               cy.mockNext(
                 resetPasswordResponse.code,
                 resetPasswordResponse.response,
@@ -173,7 +220,6 @@ userStatuses.forEach((status) => {
               const response = { ...userResponse.response, status };
               cy.mockNext(userExistsError.code, userExistsError.response);
               cy.mockNext(userResponse.code, response);
-              cy.mockNext(userGroupsResponse.code, userGroupsResponse.response);
               cy.mockNext(
                 successTokenResponse.code,
                 successTokenResponse.response,
@@ -193,7 +239,6 @@ userStatuses.forEach((status) => {
               const response = { ...userResponse.response, status };
               cy.mockNext(userExistsError.code, userExistsError.response);
               cy.mockNext(userResponse.code, response);
-              cy.mockNext(userGroupsResponse.code, userGroupsResponse.response);
               cy.mockNext(
                 resetPasswordResponse.code,
                 resetPasswordResponse.response,
@@ -257,7 +302,6 @@ userStatuses.forEach((status) => {
               const response = { ...userResponse.response, status };
               cy.mockNext(userExistsError.code, userExistsError.response);
               cy.mockNext(userResponse.code, response);
-              cy.mockNext(userGroupsResponse.code, userGroupsResponse.response);
               cy.mockNext(
                 successTokenResponse.code,
                 successTokenResponse.response,
@@ -277,7 +321,6 @@ userStatuses.forEach((status) => {
               const response = { ...userResponse.response, status };
               cy.mockNext(userExistsError.code, userExistsError.response);
               cy.mockNext(userResponse.code, response);
-              cy.mockNext(userGroupsResponse.code, userGroupsResponse.response);
               cy.mockNext(
                 resetPasswordResponse.code,
                 resetPasswordResponse.response,
@@ -341,7 +384,6 @@ userStatuses.forEach((status) => {
               const response = { ...userResponse.response, status };
               cy.mockNext(userExistsError.code, userExistsError.response);
               cy.mockNext(userResponse.code, response);
-              cy.mockNext(userGroupsResponse.code, userGroupsResponse.response);
               cy.mockNext(
                 successTokenResponse.code,
                 successTokenResponse.response,
@@ -363,7 +405,6 @@ userStatuses.forEach((status) => {
               const response = { ...userResponse.response, status };
               cy.mockNext(userExistsError.code, userExistsError.response);
               cy.mockNext(userResponse.code, response);
-              cy.mockNext(userGroupsResponse.code, userGroupsResponse.response);
               cy.mockNext(
                 resetPasswordResponse.code,
                 resetPasswordResponse.response,

--- a/docs/gateway-flows.md
+++ b/docs/gateway-flows.md
@@ -14,9 +14,20 @@ flowchart TD
 
 ```mermaid
 flowchart TD
-  A[GET /register] --> B[POST /register] --> OktaRegistration --> registerWithOkta --> setEncryptedStateCookieForOktaRegistration --> C[302 /register/email-sent]
+  A[GET /register] --> B[POST /register] --> OktaRegistration --> registerWithOkta --> redirectToEmailSent2[302 /register/email-sent]
   registerWithOkta --> createUser
   createUser --> catch --> sendRegistrationEmailByUserState
+  sendRegistrationEmailByUserState --> getUser
+  getUser --> userStatus{User status?}
+  userStatus -- ACTIVE --> emailValidated{Email validated?}
+  emailValidated -- Yes --> sendAccountExistsEmail --> redirectToEmailSent
+  emailValidated -- No --> hasPassword{Has password?}
+  hasPassword -- Yes --> sendEmailToUnvalidatedUser --> redirectToEmailSent
+  hasPassword -- No --> resetAndSetPassword[Reset and set placeholder password] --> sendEmailToUnvalidatedUser
+  userStatus -- STAGED --> activateUser --> sendAccountWithoutPasswordExistsEmail --> redirectToEmailSent
+  userStatus -- PROVISIONED --> reactivateUser --> sendAccountWithoutPasswordExistsEmail
+  userStatus -- RECOVERY/PASSWORD_EXPIRED --> dangerouslyResetPassword --> sendResetPasswordEmail --> redirectToEmailSent
+  redirectToEmailSent[302 /register/email-sent]
 ```
 
 ## Resend registration email


### PR DESCRIPTION
## What does this change?

[This PR](https://github.com/guardian/gateway/pull/1961) prevented users from being able to signin if they had an unvalidated email, and sent them a specific, new sort of email.

In implementing this, we failed to correctly handle a specific case:

```
Given I am an ACTIVE user
And given I have an unvalidated email
And given I don't have a password set
    When I attempt to register
        Then ???
```

This is an edge case scenario, possibly only for users who were imported into Okta from Identity, as `ACTIVE` users cannot have a missing password in regular Okta. This PR handles this state properly:

1. In `sendRegistrationEmailByUserState()`, it  moves the check for an unvalidated email into the `ACTIVE` user case, rather than checking for it before any of the status checks. This is because in all the other user states, we would want to send a regular reset password email instead of the special security one.
2. Inside that case, we check if the user has a password set before we attempt to generate a reset password token for them, as we can't generate a reset password token for a user without a password. If the user **doesn't** have a password, we use the same flow that we use in `sendChangePasswordEmail.ts` to:
    1. Dangerously reset their password, acquiring a reset password token and putting them into `RECOVERY` state
    2. Use that token to set a random placeholder password, returning them to `ACTIVE` state
    3. Finally, send the special security email now that the user has a password set.

```
Given I'm an ACTIVE user
   When I try to register
   Given I don't have a validated email
       Given I have a password set
           Then I should be sent an email with a reset password token
       Given I do NOT have a password set
           Then I should have my password dangerously reset, and then
           sent an email with a reset password token
   Given I have a validated email
       Then I should be sent an email with NO reset password token
   And my status should remain ACTIVE
```