### PR TITLE
Remove redundant alarm

### DIFF
--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -536,56 +536,6 @@ Resources:
             Stat: Sum
             Unit: Count
           ReturnData: false
-  Alarm5XXHigh:
-    Type: AWS::CloudWatch::Alarm
-    Condition: IsProd
-    Properties:
-      ActionsEnabled: 'true'
-      AlarmName: !Sub '${App}-${Stage} high 5xx errors'
-      AlarmDescription: 'Server errors detected'
-      AlarmActions:
-        - !Ref 'TopicSendEmail'
-      OKActions:
-        - !Ref 'TopicSendEmail'
-      InsufficientDataActions:
-        - !Ref 'TopicSendEmail'
-      ComparisonOperator: GreaterThanOrEqualToThreshold
-      Threshold: 30
-      EvaluationPeriods: 1
-      TreatMissingData: notBreaching
-      Metrics:
-        - Id: total5XXCount
-          Expression: backend5XXCount + elb5XXCount
-          Label: 'Count of Backend AND ELB 5XX'
-        - Id: backend5XXCount
-          MetricStat:
-            Metric:
-              Namespace: AWS/ApplicationELB
-              MetricName: HTTPCode_Target_5XX_Count
-              Dimensions:
-                - Name: LoadBalancer
-                  Value: !GetAtt LoadBalancer.LoadBalancerFullName
-                - Name: TargetGroup
-                  Value: !GetAtt TargetGroup.TargetGroupFullName
-            Period: 60
-            Stat: Sum
-            Unit: Count
-          ReturnData: false
-        - Id: elb5XXCount
-          MetricStat:
-            Metric:
-              Namespace: AWS/ApplicationELB
-              MetricName: HTTPCode_ELB_5XX_Count
-              Dimensions:
-                - Name: LoadBalancer
-                  Value: !GetAtt LoadBalancer.LoadBalancerFullName
-            Period: 60
-            Stat: Sum
-            Unit: Count
-          ReturnData: false
-    DependsOn:
-      - TargetGroup
-      - LoadBalancer
   SigninInactivityAlarm:
     Type: AWS::CloudWatch::Alarm
     Condition: IsProd


### PR DESCRIPTION
As we also have an [alarm for sustained 5XX errors](https://github.com/guardian/gateway/blob/main/cloudformation.yaml#L492-L538), this one seems to be redundant.  
It's unlikely we would respond within 5 minutes in almost any circumstances.