### PR TITLE
Add `isNativeApp` to `requestStateMiddleware`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,4 +11,3 @@ updates:
     directory: '/'
     schedule:
       interval: 'weekly'
-      

--- a/src/server/lib/middleware/redirectIfLoggedIn.ts
+++ b/src/server/lib/middleware/redirectIfLoggedIn.ts
@@ -10,7 +10,6 @@ import { IDAPIAuthStatus } from '@/shared/model/IDAPIAuth';
 import { clearIDAPICookies } from '../idapi/IDAPICookies';
 import { renderer } from '@/server/lib/renderer';
 import { mergeRequestState } from '../requestState';
-import { getApp } from '../okta/api/apps';
 
 const { okta, defaultReturnUri, baseUri } = getConfiguration();
 
@@ -58,14 +57,6 @@ export const redirectIfLoggedIn = async (
         returnUrl: signInLink,
       });
 
-      // we also need to know if the flow was initiated by a native app, hence we get the app info from the api
-      // and determine this based on the label, whether it contains "android" or "ios"
-      const isNativeApp =
-        !!state.queryParams.appClientId &&
-        /android|ios/i.test(
-          (await getApp(state.queryParams.appClientId)).label,
-        );
-
       // show the signed in as page
       const html = renderer('/signed-in-as', {
         requestState: mergeRequestState(state, {
@@ -73,7 +64,6 @@ export const redirectIfLoggedIn = async (
             email,
             continueLink,
             signOutLink,
-            isNativeApp,
           },
         }),
         pageTitle: 'Sign in',


### PR DESCRIPTION
## What does this change?

We need to be able to serve slight variations of pages or flows depending on if the user is initiating the OAuth from from a native application, i.e Android or iOS.

We can get this information from Okta, as the apps pass an `appClientId` query parameter which we can look up in Okta to see if it matches either an Android or iOS application.

This is added to the request state middleware, which we've had to convert to async/await as `getApp` is an asynchronous call. This is available in the `pageData` property in `ClientState` so that the client side is aware of this parameter.

We were already using this parameter as part of the `SignedInAs` page functionality #1968, which shows a good example of how this parameter can be used on the client side to show a different page.