### PR TITLE
Fix high latency alarm description

### DIFF
--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -464,7 +464,7 @@ Resources:
     Properties:
       AlarmName: !Sub '${App}-${Stage} high load balancer latency'
       AlarmDescription: !Sub
-        - 'Latency is greater than ${Threshold} seconds over ${Period} seconds for last ${EvaluationPeriods} periods'
+        - 'Latency is greater than ${Threshold} seconds over ${Period} seconds for last 5 periods'
         - Period: !FindInMap [StageVariables, !Ref 'Stage', LatencyAlarmPeriod]
           Threshold:
             !FindInMap [StageVariables, !Ref 'Stage', LatencyAlarmThreshold]


### PR DESCRIPTION
The PR #1998 failed to deploy because there is no value `EvaluationPeriods`, which was referred to in the alarm description.
Here, I've just hardcoded the value instead.
