### PR TITLE
Replace express-recaptcha with custom reCAPTCHA middleware

### DIFF
--- a/package.json
+++ b/package.json
@@ -148,7 +148,6 @@
     "csurf": "^1.11.0",
     "deepmerge": "^4.2.2",
     "express": "^4.18.2",
-    "express-recaptcha": "^5.1.0",
     "hal-types": "^1.8.0",
     "helmet": "^6.0.0",
     "ioredis": "^5.2.3",

--- a/src/server/lib/recaptcha.ts
+++ b/src/server/lib/recaptcha.ts
@@ -46,10 +46,6 @@ const handleRecaptcha = async (
   _: Response,
   next: NextFunction,
 ): Promise<void> => {
-  // Skip the reCAPTCHA check if we're running in a test environment
-  if (process.env.RUNNING_IN_CYPRESS === 'true') {
-    return next();
-  }
   const recaptchaToken = req.body['g-recaptcha-response'];
   // If the recaptcha response is missing entirely, throw an error which will be shown to the user.
   if (!recaptchaToken) {

--- a/src/server/lib/recaptcha.ts
+++ b/src/server/lib/recaptcha.ts
@@ -46,6 +46,10 @@ const handleRecaptcha = async (
   _: Response,
   next: NextFunction,
 ): Promise<void> => {
+  // Skip the reCAPTCHA check if we're running in a test environment
+  if (process.env.RUNNING_IN_CYPRESS === 'true') {
+    return next();
+  }
   const recaptchaToken = req.body['g-recaptcha-response'];
   // If the recaptcha response is missing entirely, throw an error which will be shown to the user.
   if (!recaptchaToken) {

--- a/src/shared/lib/featureSwitches.ts
+++ b/src/shared/lib/featureSwitches.ts
@@ -13,8 +13,6 @@ interface FeatureSwitches {
     CODE: boolean;
     PROD: boolean;
   };
-  // reCAPTCHA is disabled in the DEV stage by default.
-  recaptchaEnabledDev: boolean;
 }
 
 export const featureSwitches: FeatureSwitches = {
@@ -24,5 +22,4 @@ export const featureSwitches: FeatureSwitches = {
     CODE: true,
     PROD: true,
   },
-  recaptchaEnabledDev: false,
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -9450,11 +9450,6 @@ expect@^29.2.0:
     jest-message-util "^29.2.0"
     jest-util "^29.2.0"
 
-express-recaptcha@^5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/express-recaptcha/-/express-recaptcha-5.1.0.tgz#e7aa67f85597ec4b90d68db540586f7205c46e7e"
-  integrity sha512-L9BSaHbwVzEAf38LNnFwEbk4qpX1LiD1z8viBGYBuxyBWWVKMgBrKDb1mNLq6uSxubJzZbyIz+0ldgTSXfxsvQ==
-
 express@^4.17.1:
   version "4.17.2"
   resolved "https://registry.yarnpkg.com/express/-/express-4.17.2.tgz#c18369f265297319beed4e5558753cc8c1364cb3"


### PR DESCRIPTION
## What does this change?

We have been using the NPM module [express-recaptcha](https://www.npmjs.com/package/express-recaptcha) exclusively to handle validation of  our V2 reCAPTCHA on the serverside. express-recaptcha is quite a large module with a lot of features - it handles reCAPTCHA V2 and V3; and links into rendering engines to display the reCAPTCHA clientside code as well as dealing with reCAPTCHAs on the backend.

We've previously encountered a problem where, on development environments, the express-recaptcha middleware would run the Express route handler for a route multiple times, causing 'headers cannot be sent' errors and in one case (cc. @vlbee) activating an Okta user multiple times in local dev.

This PR removes express-recaptcha entirely, and sets up a new, much simpler middleware, which simply follows Google's instructions for validating a reCAPTCHA token. This allows us to use only basic tools to accomplish this task and doesn't involve a complex external library. It also solves the multiple route handler calls problem in dev environments, which means we might be able to locally test reCAPTCHA in future if we ever feel the need.

Obligatory xkcd:

![](https://imgs.xkcd.com/comics/reinvent_the_wheel_2x.png)