### PR TITLE
Native app fow: change social CTA button labels and position

### DIFF
--- a/src/client/components/SocialButtons.stories.tsx
+++ b/src/client/components/SocialButtons.stories.tsx
@@ -33,3 +33,19 @@ Mobile.parameters = {
   },
   chromatic: { viewports: [320] },
 };
+
+export const NativeAppAndroid = () => (
+  <SocialButtons
+    queryParams={{ returnUrl: 'https://www.theguardian.com/uk/' }}
+    isNativeApp="android"
+  />
+);
+NativeAppAndroid.storyName = 'Android native app';
+
+export const NativeAppIos = () => (
+  <SocialButtons
+    queryParams={{ returnUrl: 'https://www.theguardian.com/uk/' }}
+    isNativeApp="ios"
+  />
+);
+NativeAppIos.storyName = 'iOS native app';


### PR DESCRIPTION
## What does this change?

**When accessing Gateway from a native app:**

- The social buttons now all say 'Continue with X' instead of just 'X' for the name of the social auth provider.
- Apple will show at the top and Google at the bottom on iOS; Google will show at the top and Apple at the bottom on Android.
- The buttons no longer collapse to a row on desktop widths; they stay stacked vertically.

On a regular flow, without native app being set, the buttons have not changed.

<img width="520" alt="Screenshot 2022-10-17 at 15 00 36" src="https://user-images.githubusercontent.com/101555242/196197396-963bb98c-c4ca-47ba-87c1-14ce92482e7d.png">
