### PR TITLE
UI changes when accessing Gateway from a native app client

### DIFF
--- a/cypress/integration/ete/registration/register.2.cy.ts
+++ b/cypress/integration/ete/registration/register.2.cy.ts
@@ -22,7 +22,7 @@ describe('Registration flow', () => {
         req.reply(200);
       });
       cy.visit('/signin?useIdapi=true');
-      cy.contains('This site is protected by reCAPTCHA and the Google')
+      cy.contains('This service is protected by reCAPTCHA and the Google')
         .contains('privacy policy')
         .click();
       cy.url().should('eq', googlePrivacyPolicyUrl);

--- a/cypress/integration/shared/sign_in.shared.ts
+++ b/cypress/integration/shared/sign_in.shared.ts
@@ -42,7 +42,7 @@ export const linksToTheGooglePrivacyPolicyPage = (isIdapi = false) => {
       });
       const visitUrl = isIdapi ? '/signin?useIdapi=true' : '/signin';
       cy.visit(visitUrl);
-      cy.contains('This site is protected by reCAPTCHA and the Google')
+      cy.contains('This service is protected by reCAPTCHA and the Google')
         .contains('privacy policy')
         .click();
       cy.url().should('eq', googlePrivacyPolicyUrl);

--- a/src/client/__tests__/MainForm.test.tsx
+++ b/src/client/__tests__/MainForm.test.tsx
@@ -53,7 +53,7 @@ test('terms and conditions not in the document when hasGuardianTerms is false', 
 test('does not render the reCAPTCHA terms and conditions when recaptchaSiteKey is undefined', async () => {
   const { queryByText } = setup();
   const terms = queryByText(
-    'This site is protected by reCAPTCHA and the Google',
+    'This service is protected by reCAPTCHA and the Google',
     { exact: false },
   );
   await waitFor(() => {
@@ -64,7 +64,7 @@ test('does not render the reCAPTCHA terms and conditions when recaptchaSiteKey i
 test('renders the reCAPTCHA terms and conditions when recaptchaSiteKey is defined', async () => {
   const { queryByText } = setup({ recaptchaSiteKey: 'invalid-key' });
   const terms = queryByText(
-    'This site is protected by reCAPTCHA and the Google',
+    'This service is protected by reCAPTCHA and the Google',
     { exact: false },
   );
   await waitFor(() => {

--- a/src/client/components/ConsentsHeader.tsx
+++ b/src/client/components/ConsentsHeader.tsx
@@ -3,15 +3,17 @@ import { GlobalError } from '@/client/components/GlobalError';
 import { GlobalSuccess } from '@/client/components/GlobalSuccess';
 import { Header } from '@/client/components/Header';
 import { DEFAULT_ERROR_LINK } from '@/client/lib/ErrorLink';
+import { IsNativeApp } from '@/shared/model/ClientState';
 
 type Props = {
   error?: string;
   success?: string;
+  isNativeApp?: IsNativeApp;
 };
 
-export const ConsentsHeader = ({ error, success }: Props) => (
+export const ConsentsHeader = ({ error, success, isNativeApp }: Props) => (
   <>
-    <Header />
+    <Header isNativeApp={isNativeApp} />
     {error && <GlobalError error={error} link={DEFAULT_ERROR_LINK} left />}
     {success && <GlobalSuccess success={success} />}
   </>

--- a/src/client/components/ConsentsSubHeader.tsx
+++ b/src/client/components/ConsentsSubHeader.tsx
@@ -14,6 +14,7 @@ import { AutoRow, gridRow } from '@/client/styles/Grid';
 import { greyBorderSides } from '@/client/styles/Consents';
 import { CONSENTS_PAGES_ARR } from '@/client/models/ConsentsPages';
 import { ErrorSummary } from '@guardian/source-react-components-development-kitchen';
+import { IsNativeApp } from '@/shared/model/ClientState';
 
 type Props = {
   autoRow: AutoRow;
@@ -21,6 +22,7 @@ type Props = {
   current?: string;
   errorMessage?: string;
   errorContext?: React.ReactNode;
+  isNativeApp?: IsNativeApp;
 };
 
 type PageStatus = 'active' | 'complete' | 'pending';
@@ -179,6 +181,7 @@ export const ConsentsSubHeader = ({
   current,
   errorContext,
   errorMessage,
+  isNativeApp,
 }: Props) => {
   const active = current
     ? (CONSENTS_PAGES_ARR as string[]).indexOf(current)
@@ -219,7 +222,7 @@ export const ConsentsSubHeader = ({
   return (
     <header data-cy="exclude-a11y-check">
       <div css={[gridRow, greyBorderSides]}>
-        {pageProgression}
+        {!isNativeApp && pageProgression}
         {errorMessage && (
           <ErrorSummary
             cssOverrides={[autoRow(), summaryStyles]}

--- a/src/client/components/Header.stories.tsx
+++ b/src/client/components/Header.stories.tsx
@@ -35,3 +35,9 @@ Mobile.parameters = {
 
 export const GeoGB = () => <Header />;
 GeoGB.storyName = 'with defaults';
+
+export const Jobs = () => <Header isJobs={true} />;
+Jobs.storyName = 'on Jobs';
+
+export const OnNativeApp = () => <Header isNativeApp={'android'} />;
+OnNativeApp.storyName = 'on native app';

--- a/src/client/components/Header.tsx
+++ b/src/client/components/Header.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
 import { css, SerializedStyles } from '@emotion/react';
-import { brand, from, space } from '@guardian/source-foundations';
+import { brand, from, space, neutral } from '@guardian/source-foundations';
 import { Logo } from '@guardian/source-react-components-development-kitchen';
+import { JobsLogo } from '@/client/components/JobsLogo';
 import { gridRow, manualRow, SpanDefinition } from '@/client/styles/Grid';
+import { IsNativeApp } from '@/shared/model/ClientState';
 
 const marginStyles = css`
   margin-top: ${space[5]}px;
@@ -47,22 +49,77 @@ const headerSpanDefinition: SpanDefinition = {
   },
 };
 
+const jobsHeaderStyles = css`
+  background-color: ${neutral[100]};
+  /* border */
+  border-bottom: 1px solid ${neutral[86]};
+`;
+
+const jobsHeaderMarginOverrides = css`
+  margin-top: initial;
+  margin-bottom: 2px;
+  margin-left: auto;
+  margin-right: auto;
+  ${from.mobileMedium} {
+    margin-top: initial;
+  }
+  ${from.tablet} {
+    margin-top: initial;
+  }
+  ${from.desktop} {
+    margin-top: initial;
+    margin-bottom: initial;
+  }
+`;
+
+const nativeAppMarginOverrides = css`
+  margin-top: ${space[1]}px;
+  margin-bottom: ${space[1]}px;
+  ${from.mobileMedium} {
+    margin-top: ${space[1]}px;
+  }
+  ${from.tablet} {
+    margin-top: ${space[1]}px;
+  }
+`;
+
 type Props = {
-  logoOverride?: React.ReactNode;
   cssOverrides?: SerializedStyles;
-  marginOverrides?: SerializedStyles;
+  isJobs?: boolean;
+  isNativeApp?: IsNativeApp;
+};
+
+const marginStyleOverrides = (isJobs: boolean, isNativeApp: IsNativeApp) => {
+  if (isJobs) {
+    return jobsHeaderMarginOverrides;
+  }
+  if (isNativeApp) {
+    return nativeAppMarginOverrides;
+  }
+  return undefined;
 };
 
 export const Header = ({
-  logoOverride,
   cssOverrides,
-  marginOverrides,
-}: Props) => (
-  <header id="top" css={[backgroundColor, cssOverrides]}>
-    <div css={[gridRow, marginStyles, marginOverrides]}>
-      <div css={[manualRow(1, headerSpanDefinition), headerGridRightToLeft]}>
-        {logoOverride ? logoOverride : <Logo />}
+  isJobs = false,
+  isNativeApp,
+}: Props) => {
+  return (
+    <header
+      id="top"
+      css={[
+        backgroundColor,
+        isJobs ? jobsHeaderStyles : undefined,
+        cssOverrides,
+      ]}
+    >
+      <div
+        css={[gridRow, marginStyles, marginStyleOverrides(isJobs, isNativeApp)]}
+      >
+        <div css={[manualRow(1, headerSpanDefinition), headerGridRightToLeft]}>
+          {isJobs ? <JobsLogo /> : <Logo />}
+        </div>
       </div>
-    </div>
-  </header>
-);
+    </header>
+  );
+};

--- a/src/client/components/Terms.tsx
+++ b/src/client/components/Terms.tsx
@@ -76,7 +76,7 @@ export const JobsTerms = () => (
 
 export const RecaptchaTerms = () => (
   <Text>
-    This site is protected by reCAPTCHA and the Google{' '}
+    This service is protected by reCAPTCHA and the Google{' '}
     <TermsLink href="https://policies.google.com/privacy">
       privacy policy
     </TermsLink>{' '}

--- a/src/client/layouts/ConsentsLayout.tsx
+++ b/src/client/layouts/ConsentsLayout.tsx
@@ -39,8 +39,10 @@ export const ConsentsLayout: FunctionComponent<ConsentsLayoutProps> = ({
 }) => {
   const autoRow = getAutoRow(1, gridItemColumnConsents);
   const clientState = useClientState();
-  const { globalMessage: { error: globalError, success: globalSuccess } = {} } =
-    clientState;
+  const {
+    globalMessage: { error: globalError, success: globalSuccess } = {},
+    pageData: { isNativeApp } = {},
+  } = clientState;
 
   return (
     <>
@@ -58,7 +60,7 @@ export const ConsentsLayout: FunctionComponent<ConsentsLayoutProps> = ({
         )}
         <div css={[spacer, gridRow, greyBorderSides]} />
       </main>
-      <Footer />
+      {!isNativeApp && <Footer />}
     </>
   );
 };

--- a/src/client/layouts/ConsentsLayout.tsx
+++ b/src/client/layouts/ConsentsLayout.tsx
@@ -46,7 +46,11 @@ export const ConsentsLayout: FunctionComponent<ConsentsLayoutProps> = ({
 
   return (
     <>
-      <ConsentsHeader error={globalError} success={globalSuccess} />
+      <ConsentsHeader
+        error={globalError}
+        success={globalSuccess}
+        isNativeApp={isNativeApp}
+      />
       <main css={mainStyles}>
         <ConsentsSubHeader
           autoRow={autoRow}
@@ -54,6 +58,7 @@ export const ConsentsLayout: FunctionComponent<ConsentsLayoutProps> = ({
           current={current}
           errorMessage={errorMessage}
           errorContext={errorContext}
+          isNativeApp={isNativeApp}
         />
         {children && (
           <section css={[gridRow, greyBorderSides]}>{children}</section>

--- a/src/client/layouts/Main.stories.tsx
+++ b/src/client/layouts/Main.stories.tsx
@@ -108,3 +108,11 @@ export const WithMultipleInputs = () => (
   </MainLayout>
 );
 WithMultipleInputs.storyName = 'with multiple inputs';
+
+export const OnNativeApp = () => (
+  <MainLayout pageHeader="Some page header">
+    <Paragraphs />
+    <MultipleInputFields />
+  </MainLayout>
+);
+OnNativeApp.storyName = 'on native app';

--- a/src/client/layouts/Main.tsx
+++ b/src/client/layouts/Main.tsx
@@ -15,7 +15,6 @@ import { gridRow, gridItem, SpanDefinition } from '@/client/styles/Grid';
 import { Header } from '@/client/components/Header';
 import { Footer } from '@/client/components/Footer';
 import useClientState from '@/client/lib/hooks/useClientState';
-import { JobsLogo } from '@/client/components/JobsLogo';
 import { Nav, TabType } from '@/client/components/Nav';
 import locations from '@/shared/lib/locations';
 
@@ -158,29 +157,6 @@ export const buttonStyles = ({
   `}
 `;
 
-const jobsHeaderStyles = css`
-  background-color: ${neutral[100]};
-  /* border */
-  border-bottom: 1px solid ${neutral[86]};
-`;
-
-const jobsHeaderMarginOverrides = css`
-  margin-top: initial;
-  margin-bottom: 2px;
-  margin-left: auto;
-  margin-right: auto;
-  ${from.mobileMedium} {
-    margin-top: initial;
-  }
-  ${from.tablet} {
-    margin-top: initial;
-  }
-  ${from.desktop} {
-    margin-top: initial;
-    margin-bottom: initial;
-  }
-`;
-
 export const MainLayout = ({
   children,
   pageHeader,
@@ -193,7 +169,10 @@ export const MainLayout = ({
   errorSmallMarginBottom,
 }: PropsWithChildren<MainLayoutProps>) => {
   const clientState = useClientState();
-  const { globalMessage: { error, success } = {} } = clientState;
+  const {
+    globalMessage: { error, success } = {},
+    pageData: { isNativeApp } = {},
+  } = clientState;
 
   const successMessage = successOverride || success;
   const errorMessage = errorOverride || error;
@@ -203,15 +182,7 @@ export const MainLayout = ({
 
   return (
     <>
-      {useJobsHeader ? (
-        <Header
-          cssOverrides={jobsHeaderStyles}
-          marginOverrides={jobsHeaderMarginOverrides}
-          logoOverride={<JobsLogo />}
-        />
-      ) : (
-        <Header />
-      )}
+      <Header isJobs={useJobsHeader} isNativeApp={isNativeApp} />
       {tabs && <Nav tabs={tabs} />}
       <main css={[mainStyles, gridRow]}>
         <section css={gridItem(gridSpanDefinition)}>

--- a/src/client/layouts/Main.tsx
+++ b/src/client/layouts/Main.tsx
@@ -210,7 +210,7 @@ export const MainLayout = ({
           <div css={bodyStyles(hasTitleOrSummary)}>{children}</div>
         </section>
       </main>
-      <Footer />
+      {!isNativeApp && <Footer />}
     </>
   );
 };

--- a/src/client/pages/SignedInAs.stories.tsx
+++ b/src/client/pages/SignedInAs.stories.tsx
@@ -18,6 +18,6 @@ export const NativeApp = () => (
     email="test@example.com"
     continueLink="#"
     signOutLink="#"
-    isNativeApp
+    isNativeApp="android"
   />
 );

--- a/src/client/pages/SignedInAs.tsx
+++ b/src/client/pages/SignedInAs.tsx
@@ -2,12 +2,13 @@ import React from 'react';
 import { buttonStyles, MainLayout } from '@/client/layouts/Main';
 import { MainBodyText } from '@/client/components/MainBodyText';
 import { Link, LinkButton } from '@guardian/source-react-components';
+import { IsNativeApp } from '@/shared/model/ClientState';
 
 interface Props {
   email: string;
   continueLink: string;
   signOutLink: string;
-  isNativeApp?: boolean;
+  isNativeApp?: IsNativeApp;
 }
 
 export const SignedInAs = ({
@@ -17,7 +18,7 @@ export const SignedInAs = ({
   isNativeApp,
 }: Props) => (
   <MainLayout
-    pageHeader={`Sign in to the Guardian${isNativeApp ? ' app' : ''}`}
+    pageHeader={`Sign in to the Guardian${!!isNativeApp ? ' app' : ''}`}
   >
     <MainBodyText noMargin>
       You are signed in with <br />

--- a/src/client/static/hydration.tsx
+++ b/src/client/static/hydration.tsx
@@ -10,11 +10,11 @@ import { abSwitches } from '@/shared/model/experiments/abSwitches';
 import * as Sentry from '@sentry/browser';
 import { Integrations } from '@sentry/tracing';
 
-export const hydrateApp = () => {
-  const routingConfig: RoutingConfig = JSON.parse(
-    document.getElementById('routingConfig')?.innerHTML ?? '{}',
-  );
+type Props = {
+  routingConfig: RoutingConfig;
+};
 
+export const hydrateApp = ({ routingConfig }: Props) => {
   const clientState = routingConfig.clientState;
 
   const {

--- a/src/client/static/index.tsx
+++ b/src/client/static/index.tsx
@@ -7,6 +7,7 @@ import {
   onConsentChange,
 } from '@guardian/consent-management-platform';
 import { getLocale } from '@guardian/libs';
+import { RoutingConfig } from '@/client/routes';
 
 // loading a js file without types, so ignore ts
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -28,22 +29,28 @@ const initGoogleAnalyticsWhenConsented = () => {
   });
 };
 
-hydrateApp();
+const routingConfig: RoutingConfig = JSON.parse(
+  document.getElementById('routingConfig')?.innerHTML ?? '{}',
+);
+
+hydrateApp({ routingConfig });
 
 // initalise ophan
 ophanInit();
 
 // load CMP
-if (window.Cypress) {
-  cmp.init({ country: 'GB' }); // CI hosted on GithubActions runs in US by default
-} else {
-  (async () => {
-    const country = await getLocale();
+if (!routingConfig.clientState.pageData?.isNativeApp) {
+  if (window.Cypress) {
+    cmp.init({ country: 'GB' }); // CI hosted on GithubActions runs in US by default
+  } else {
+    (async () => {
+      const country = await getLocale();
 
-    if (country) {
-      cmp.init({ country });
-    }
-  })();
+      if (country) {
+        cmp.init({ country });
+      }
+    })();
+  }
 }
 
 initGoogleAnalyticsWhenConsented();

--- a/src/shared/model/ClientState.ts
+++ b/src/shared/model/ClientState.ts
@@ -22,6 +22,8 @@ interface GlobalMessage {
   success?: string;
 }
 
+export type IsNativeApp = 'android' | 'ios' | undefined;
+
 export interface PageData {
   // general page data
   returnUrl?: string;
@@ -31,7 +33,7 @@ export interface PageData {
   fieldErrors?: Array<FieldError>;
   formError?: string;
   browserName?: string;
-  isNativeApp?: boolean;
+  isNativeApp?: IsNativeApp;
 
   // email sent pages specific
   emailType?: EmailType;


### PR DESCRIPTION
## What does this change?

The signin and registration flows from the native app will in future switch to a browser as part of the OAuth flow with Okta. To ensure a seamless experience and make the flow look more like the native app, we tweak parts of the design when the `appClientId` query parameter is one belonging to an iOS or Android client (i.e. the native apps).

To make this happen on the backend, we now read `appClientId` and check it with Okta. We then pass `isNativeApp` in `pageData` to the clientside pages. `isNativeApp` will either be `'ios'`, `'android'`, or `undefined` (not an app client).

On the frontend, we use this flag to make the following changes:

- Reduce the header margins
- Hide the progress bar on the consents/welcome flow as the native app user goes straight from the password setting page back to the app
- Change 'Sign in to the Guardian' to 'Sign in to the Guardian app' on the already-signed-in page
- Hide the footer entirely
- Never display the CMP banner

We also made the following changes to the general flow, for both desktop and native browsers:

- Change 'this site' to 'this service' in the T&Cs link

Some nice screenshots:

![Screen Shot 2022-10-18 at 16 18 31](https://user-images.githubusercontent.com/101555242/196474575-e3eaf2b4-bec5-4e31-8d1c-b5b4e375dd5b.png)
![Screen Shot 2022-10-18 at 16 18 03](https://user-images.githubusercontent.com/101555242/196474581-e5240b1d-3cdd-442d-9ff5-0b8c0544a280.png)
![Screen Shot 2022-10-18 at 16 17 28](https://user-images.githubusercontent.com/101555242/196474589-9b91e328-6013-458d-ab33-ea3df465d3d4.png)
![Screen Shot 2022-10-18 at 16 17 02](https://user-images.githubusercontent.com/101555242/196474593-9d74cd94-e995-4684-98b4-00ae2bfad9bf.png)
![Screen Shot 2022-10-18 at 16 16 54](https://user-images.githubusercontent.com/101555242/196474597-3ea2ce95-729c-4bc0-8781-a1cedffc3c22.png)
