### PR TITLE
Change CSRF error message from field to form error

### DIFF
--- a/src/client/pages/ResendPasswordPage.tsx
+++ b/src/client/pages/ResendPasswordPage.tsx
@@ -7,7 +7,7 @@ import { logger } from '@/client/lib/clientSideLogger';
 export const ResendPasswordPage = () => {
   const clientState = useClientState();
   const {
-    pageData: { email = '' } = {},
+    pageData: { email = '', formError } = {},
     queryParams,
     recaptchaConfig,
   } = clientState;
@@ -38,6 +38,7 @@ export const ResendPasswordPage = () => {
       showRecentEmailSummary
       recaptchaSiteKey={recaptchaSiteKey}
       formPageTrackingName="reset-password-link-expired"
+      formError={formError}
     >
       <MainBodyText>This link has expired.</MainBodyText>
       <MainBodyText>

--- a/src/client/pages/ResetPasswordSessionExpiredPage.tsx
+++ b/src/client/pages/ResetPasswordSessionExpiredPage.tsx
@@ -7,7 +7,7 @@ import { logger } from '@/client/lib/clientSideLogger';
 export const ResetPasswordSessionExpiredPage = () => {
   const clientState = useClientState();
   const {
-    pageData: { email = '' } = {},
+    pageData: { email = '', formError } = {},
     queryParams,
     recaptchaConfig,
   } = clientState;
@@ -30,6 +30,7 @@ export const ResetPasswordSessionExpiredPage = () => {
       emailInputLabel="Email address"
       recaptchaSiteKey={recaptchaSiteKey}
       formPageTrackingName="reset-password-session-expired"
+      formError={formError}
     >
       <MainBodyText>
         The link we sent you was valid for 60 minutes and it has now expired.

--- a/src/client/pages/SetPasswordResendPage.tsx
+++ b/src/client/pages/SetPasswordResendPage.tsx
@@ -7,7 +7,7 @@ import { buildUrl } from '@/shared/lib/routeUtils';
 export const SetPasswordResendPage = () => {
   const clientState = useClientState();
   const {
-    pageData: { email = '' } = {},
+    pageData: { email = '', formError } = {},
     queryParams,
     recaptchaConfig,
   } = clientState;
@@ -25,6 +25,7 @@ export const SetPasswordResendPage = () => {
       showRecentEmailSummary
       recaptchaSiteKey={recaptchaSiteKey}
       formPageTrackingName="set-password-link-expired"
+      formError={formError}
     >
       <MainBodyText>This link has expired.</MainBodyText>
       <MainBodyText>

--- a/src/client/pages/SetPasswordSessionExpiredPage.tsx
+++ b/src/client/pages/SetPasswordSessionExpiredPage.tsx
@@ -8,7 +8,7 @@ import { logger } from '@/client/lib/clientSideLogger';
 export const SetPasswordSessionExpiredPage = () => {
   const clientState = useClientState();
   const {
-    pageData: { email = '' } = {},
+    pageData: { email = '', formError } = {},
     queryParams,
     recaptchaConfig,
   } = clientState;
@@ -32,6 +32,7 @@ export const SetPasswordSessionExpiredPage = () => {
       emailInputLabel="Email address"
       recaptchaSiteKey={recaptchaSiteKey}
       formPageTrackingName="set-password-session-expired"
+      formError={formError}
     >
       <MainBodyText>
         The link we sent you was valid for 60 minutes and it has now expired.

--- a/src/client/pages/WelcomeResendPage.tsx
+++ b/src/client/pages/WelcomeResendPage.tsx
@@ -7,7 +7,7 @@ import { buildUrl } from '@/shared/lib/routeUtils';
 export const WelcomeResendPage = () => {
   const clientState = useClientState();
   const {
-    pageData: { email = '' } = {},
+    pageData: { email = '', formError } = {},
     queryParams,
     recaptchaConfig,
   } = clientState;
@@ -25,6 +25,7 @@ export const WelcomeResendPage = () => {
       showRecentEmailSummary
       recaptchaSiteKey={recaptchaSiteKey}
       formPageTrackingName="welcome-link-expired"
+      formError={formError}
     >
       <MainBodyText>This link has expired.</MainBodyText>
       <MainBodyText>

--- a/src/client/pages/WelcomeSessionExpiredPage.tsx
+++ b/src/client/pages/WelcomeSessionExpiredPage.tsx
@@ -9,7 +9,7 @@ import { logger } from '@/client/lib/clientSideLogger';
 export const WelcomeSessionExpiredPage = () => {
   const clientState = useClientState();
   const {
-    pageData: { email = '' } = {},
+    pageData: { email = '', formError } = {},
     queryParams,
     recaptchaConfig,
   } = clientState;
@@ -33,6 +33,7 @@ export const WelcomeSessionExpiredPage = () => {
       emailInputLabel="Email address"
       recaptchaSiteKey={recaptchaSiteKey}
       formPageTrackingName="welcome-session-expired"
+      formError={formError}
     >
       <MainBodyText>
         The link we sent you was valid for 60 minutes and it has now expired.

--- a/src/server/lib/renderer.tsx
+++ b/src/server/lib/renderer.tsx
@@ -1,4 +1,4 @@
-import { ClientState, FieldError } from '@/shared/model/ClientState';
+import { ClientState } from '@/shared/model/ClientState';
 import ReactDOMServer from 'react-dom/server';
 import React from 'react';
 import { StaticRouter } from 'react-router-dom/server';
@@ -84,20 +84,11 @@ const clientStateFromRequestStateLocals = ({
   // checking if csrf error exists in query params, and attaching it to the
   // forms field errors
   if (queryParams.csrfError) {
-    // global state page data will already exist at this point
-    // this is just a check to get typescript to compile
-    const fieldErrors: Array<FieldError> =
-      clientState.pageData?.fieldErrors ?? [];
-    // eslint-disable-next-line functional/immutable-data
-    fieldErrors.push({
-      field: 'csrf',
-      message: CsrfErrors.CSRF_ERROR,
-    });
     return {
       ...clientState,
       pageData: {
         ...clientState.pageData,
-        fieldErrors,
+        formError: CsrfErrors.CSRF_ERROR,
       },
     };
   }


### PR DESCRIPTION
## What does this change?

The CSRF error was previously displayed as a field error connected to an invisible CSRF field, which made the error message look weird. I've moved it into a form error.

| Before | After|
| ----- | ----- |
| <img width="240" alt="Screenshot 2022-10-18 at 10 44 41" src="https://user-images.githubusercontent.com/101555242/196396463-e62ffa01-04fa-4c56-b1c4-bec0ee1e5d22.png"> | <img width="240" alt="Screenshot 2022-10-18 at 10 41 14" src="https://user-images.githubusercontent.com/101555242/196396485-95967d1a-4a1f-4b5e-b4fb-45ea902abc23.png"> |
