### PR TITLE
`SignedInAs` Page | Fix "Continue" link to refresh session instead of redirecting

### DIFF
--- a/cypress/integration/ete-okta/registration.2.cy.ts
+++ b/cypress/integration/ete-okta/registration.2.cy.ts
@@ -1109,7 +1109,12 @@ describe('Registration flow', () => {
             cy.contains(emailAddress);
             cy.contains('Continue')
               .should('have.attr', 'href')
-              .and('include', `https://${Cypress.env('BASE_URI')}/consents`);
+              .and(
+                'include',
+                `https://${Cypress.env(
+                  'BASE_URI',
+                )}/signin/refresh?returnUrl=https%3A%2F%2Fprofile.thegulocal.com%2Fconsents`,
+              );
             cy.contains('a', 'Sign in')
               .should('have.attr', 'href')
               .and('include', '/signout?returnUrl=');

--- a/cypress/integration/ete-okta/sign_in.1.cy.ts
+++ b/cypress/integration/ete-okta/sign_in.1.cy.ts
@@ -368,7 +368,12 @@ describe('Sign in flow, Okta enabled', () => {
             cy.contains(emailAddress);
             cy.contains('Continue')
               .should('have.attr', 'href')
-              .and('include', `https://${Cypress.env('BASE_URI')}/consents`);
+              .and(
+                'include',
+                `https://${Cypress.env(
+                  'BASE_URI',
+                )}/signin/refresh?returnUrl=https%3A%2F%2Fprofile.thegulocal.com%2Fconsents`,
+              );
             cy.contains('a', 'Sign in')
               .should('have.attr', 'href')
               .and('include', '/signout?returnUrl=');

--- a/cypress/integration/mocked/okta_register.3.cy.ts
+++ b/cypress/integration/mocked/okta_register.3.cy.ts
@@ -58,7 +58,11 @@ describe('Okta Register flow', () => {
       cy.contains('user@example.com');
       cy.contains('Continue')
         .should('have.attr', 'href')
-        .and('include', 'https://m.code.dev-theguardian.com');
+        .and('include', '/signin/refresh')
+        .and(
+          'include',
+          'returnUrl=https%3A%2F%2Fm.code.dev-theguardian.com%2F',
+        );
       cy.contains('a', 'Sign in')
         .should('have.attr', 'href')
         .and(
@@ -125,7 +129,8 @@ describe('Okta Register flow', () => {
       cy.contains('user@example.com');
       cy.contains('Continue')
         .should('have.attr', 'href')
-        .and('include', 'https://m.code.dev-theguardian.com');
+        .and('include', '/signin/refresh')
+        .and('include', 'returnUrl=https%3A%2F%2Fm.code.dev-theguardian.com');
       cy.contains('a', 'Sign in')
         .should('have.attr', 'href')
         .and(

--- a/cypress/integration/mocked/okta_sign_in.6.cy.ts
+++ b/cypress/integration/mocked/okta_sign_in.6.cy.ts
@@ -39,7 +39,8 @@ describe('Sign in flow', () => {
       cy.contains('user@example.com');
       cy.contains('Continue')
         .should('have.attr', 'href')
-        .and('include', 'https://m.code.dev-theguardian.com');
+        .and('include', '/signin/refresh')
+        .and('include', 'returnUrl=https%3A%2F%2Fm.code.dev-theguardian.com');
       cy.contains('a', 'Sign in')
         .should('have.attr', 'href')
         .and(

--- a/src/server/lib/middleware/redirectIfLoggedIn.ts
+++ b/src/server/lib/middleware/redirectIfLoggedIn.ts
@@ -39,9 +39,13 @@ export const redirectIfLoggedIn = async (
       const email = session.login;
 
       // determine the "Continue" button link, either "fromURI" if coming from Okta login page (and OAuth flow)
-      // or returnUrl if not
+      // or /signin/refresh if not (this will refresh their identity and okta session and redirect them back to the returnUrl)
       const continueLink =
-        state.queryParams.fromURI || state.queryParams.returnUrl;
+        state.queryParams.fromURI ||
+        `https://${baseUri}${addQueryParamsToPath(
+          '/signin/refresh',
+          state.queryParams,
+        )}`;
 
       // the "Sign in" link is used to log in as a different user, so we add the parameters we need to the link
       const signInLink = encodeURIComponent(


### PR DESCRIPTION
## What does this change?

There is currently a small bug/edge case where a user might have an Okta session, but not an Identity session, which means that they could get stuck into a login loop, as they'll be logged in on `profile.theguardian.com` which uses the Okta session, but not anywhere which hasn't migrated yet, e.g. Dotcom.

https://user-images.githubusercontent.com/13315440/197491280-4e9e6b8f-0322-4395-8d0c-d62e97d0247a.mov

To fix this, instead of redirecting straight to the `returnUrl` on the `SignedInAs` page, we instead take them to `/signin/refresh` which will refresh their Okta session cookie, and create new Identity cookies for the user, so that they remain "logged in".

https://user-images.githubusercontent.com/13315440/197494063-a353293b-cf8c-47f7-8be2-36f4284a9973.mov
