### PR TITLE
fix: remove `useOkta=true` from `.well-known/apple-app-site-association`

### DIFF
--- a/src/client/.well-known/apple-app-site-association
+++ b/src/client/.well-known/apple-app-site-association
@@ -9,11 +9,8 @@
         ],
         "components": [
           {
-            "/": "/welcome/?*",
-            "?": {
-              "useOkta": "true"
-            },
-            "comment": "Matches any URL whose path starts with /welcome/<randomString> and which has a query item with name 'useOkta' and a value of 'true'"
+            "/": "/welcome/*",
+            "comment": "Matches any URL whose path starts with /welcome/<randomString> where <randomString> is a token"
           },
           {
              "/": "/identity/fallback/*",


### PR DESCRIPTION
## What does this change?

As it says on the tin

Remove `useOkta=true` from `.well-known/apple-app-site-association`, so that the apps can intercept the registration links at the OS level without requiring the `useOkta=true` query parameter
