### PR TITLE
Use Zod for our Okta interface | 🐙 ➡️ 🆉🅾🅳🤖 

### DIFF
--- a/cypress/integration/mocked-okta/registerController.1.cy.ts
+++ b/cypress/integration/mocked-okta/registerController.1.cy.ts
@@ -27,7 +27,7 @@ userStatuses.forEach((status) => {
             "Then I should be shown the 'Check your email inbox' page",
             () => {
               // Set the correct user status on the response
-              const response = { ...userResponse.response, status };
+              const response = { ...userResponse.response, status: 'STAGED' };
               cy.mockNext(userResponse.code, response);
               cy.get('button[type=submit]').click();
               verifyInRegularEmailSentPage();

--- a/cypress/integration/mocked-okta/resendEmailController.3.cy.ts
+++ b/cypress/integration/mocked-okta/resendEmailController.3.cy.ts
@@ -35,7 +35,7 @@ userStatuses.forEach((status) => {
             "Then I should be shown the 'Check your email inbox' page",
             () => {
               // Set the correct user status on the response
-              const response = { ...userResponse.response, status };
+              const response = { ...userResponse.response, status: 'STAGED' };
               cy.mockNext(userResponse.code, response);
               cy.get('[data-cy="main-form-submit-button"]').click();
               verifyInRegularEmailSentPage();
@@ -175,7 +175,7 @@ userStatuses.forEach((status) => {
             "Then I should be shown the 'Check your email inbox' page",
             () => {
               // Set the correct user status on the response
-              const response = { ...userResponse.response, status };
+              const response = { ...userResponse.response, status: 'STAGED' };
               cy.mockNext(userResponse.code, response);
               cy.get('[data-cy="main-form-submit-button"]').click();
               verifyInRegularEmailSentPage();
@@ -261,7 +261,7 @@ userStatuses.forEach((status) => {
             "Then I should be shown the 'Check your email inbox' page",
             () => {
               // Set the correct user status on the response
-              const response = { ...userResponse.response, status };
+              const response = { ...userResponse.response, status: 'STAGED' };
               cy.mockNext(userResponse.code, response);
               cy.get('[data-cy="main-form-submit-button"]').click();
               verifyInRegularEmailSentPage();
@@ -343,7 +343,7 @@ userStatuses.forEach((status) => {
             "Then I should be shown the 'Check your email inbox' page",
             () => {
               // Set the correct user status on the response
-              const response = { ...userResponse.response, status };
+              const response = { ...userResponse.response, status: 'STAGED' };
               cy.mockNext(userResponse.code, response);
               cy.get('[data-cy="main-form-submit-button"]').click();
               verifyInRegularEmailSentPage();

--- a/cypress/integration/mocked/okta_change_password.2.cy.ts
+++ b/cypress/integration/mocked/okta_change_password.2.cy.ts
@@ -91,6 +91,7 @@ describe('Change password in Okta', () => {
           email,
           isGuardianUser: true,
         },
+        credentials: {},
       });
     };
 

--- a/cypress/integration/mocked/okta_send_reset_password.4.cy.ts
+++ b/cypress/integration/mocked/okta_send_reset_password.4.cy.ts
@@ -188,6 +188,7 @@ describe('Send password reset email in Okta', () => {
       cy.get('input[name="email"]').type(email);
       cy.mockNext(200, mockUserStaged);
       cy.mockNext(200, {
+        activationUrl: `token_token_token_to`,
         activationToken: `token_token_token_to`,
       });
       cy.get('button[type="submit"]').click();
@@ -203,6 +204,7 @@ describe('Send password reset email in Okta', () => {
       cy.get('input[name="email"]').type(email);
       cy.mockNext(200, mockUserProvisioned);
       cy.mockNext(200, {
+        activationUrl: `token_token_token_to`,
         activationToken: `token_token_token_to`,
       });
       cy.get('button[type="submit"]').click();

--- a/package.json
+++ b/package.json
@@ -147,7 +147,6 @@
     "csurf": "^1.11.0",
     "deepmerge": "^4.2.2",
     "express": "^4.18.2",
-    "hal-types": "^1.8.0",
     "helmet": "^6.0.0",
     "ioredis": "^5.2.3",
     "js-sha1": "^0.6.0",

--- a/src/server/lib/__tests__/okta/api/users.test.ts
+++ b/src/server/lib/__tests__/okta/api/users.test.ts
@@ -12,7 +12,7 @@ import {
   getUserGroups,
 } from '@/server/lib/okta/api/users';
 import { OktaError } from '@/server/models/okta/Error';
-import { UserCreationRequest } from '@/server/models/okta/User';
+import { UserCreationRequest, UserResponse } from '@/server/models/okta/User';
 
 const userId = '12345';
 const email = 'test@test.com';
@@ -65,7 +65,8 @@ describe('okta#createUser', () => {
       id: userId,
       status: 'PROVISIONED',
       profile: { email: email, login: email, isGuardianUser: true },
-    };
+      credentials: {},
+    } as UserResponse;
 
     json.mockResolvedValueOnce(user);
     mockedFetch.mockReturnValueOnce(
@@ -163,7 +164,8 @@ describe('okta#fetchUser', () => {
       id: userId,
       status: 'ACTIVE',
       profile: { email: email, login: email, isGuardianUser: true },
-    };
+      credentials: {},
+    } as UserResponse;
 
     json.mockResolvedValueOnce(user);
     mockedFetch.mockReturnValueOnce(

--- a/src/server/lib/members-data-api/user-attributes.ts
+++ b/src/server/lib/members-data-api/user-attributes.ts
@@ -79,12 +79,7 @@ export const getUserAttributes = async (
       );
     }
 
-    const unparsed = await response.json();
-
-    const userAttributesResponse =
-      await userAttributesResponseSchema.parseAsync(unparsed);
-
-    return userAttributesResponse;
+    return userAttributesResponseSchema.parse(await response.json());
   } catch (error) {
     logger.error(`MDAPI Error getUserAttributes '/user-attributes/me'`, error, {
       request_id,

--- a/src/server/lib/okta/api/apps.ts
+++ b/src/server/lib/okta/api/apps.ts
@@ -1,5 +1,5 @@
 import { getConfiguration } from '@/server/lib/getConfiguration';
-import { AppResponse } from '@/server/models/okta/App';
+import { AppResponse, appResponseSchema } from '@/server/models/okta/App';
 import { OktaError } from '@/server/models/okta/Error';
 import { buildUrl } from '@/shared/lib/routeUtils';
 import { joinUrl } from '@guardian/libs';
@@ -45,14 +45,7 @@ export const getApp = async (id: string): Promise<AppResponse> => {
 const handleAppResponse = async (response: Response): Promise<AppResponse> => {
   if (response.ok) {
     try {
-      return await response.json().then((json) => {
-        const app = json as AppResponse;
-        return {
-          id: app.id,
-          label: app.label,
-          settings: app.settings,
-        };
-      });
+      return appResponseSchema.parse(await response.json());
     } catch (error) {
       throw new OktaError({
         message: 'Could not parse Okta app response',

--- a/src/server/lib/okta/api/authentication.ts
+++ b/src/server/lib/okta/api/authentication.ts
@@ -12,6 +12,7 @@ import { OktaError } from '@/server/models/okta/Error';
 import {
   AuthenticationRequestParameters,
   AuthenticationTransaction,
+  authenticationTransactionSchema,
 } from '@/server/models/okta/Authentication';
 import { handleVoidResponse } from '@/server/lib/okta/api/responses';
 import { isBreachedPassword } from '../../breachedPasswordCheck';
@@ -167,16 +168,7 @@ const handleAuthenticationResponse = async (
 ): Promise<AuthenticationTransaction> => {
   if (response.ok) {
     try {
-      return await response.json().then((json) => {
-        const token = json as AuthenticationTransaction;
-        return {
-          stateToken: token.stateToken,
-          sessionToken: token.sessionToken,
-          expiresAt: token.expiresAt,
-          _embedded: token._embedded,
-          status: token.status,
-        };
-      });
+      return authenticationTransactionSchema.parse(await response.json());
     } catch (error) {
       throw new OktaError({
         message: 'Could not parse Okta authentication transaction response',

--- a/src/server/lib/okta/api/errors.ts
+++ b/src/server/lib/okta/api/errors.ts
@@ -1,5 +1,6 @@
 import type { Response } from 'node-fetch';
 import {
+  errorResponseSchema,
   ErrorResponse,
   OktaError,
   ErrorCause,
@@ -9,16 +10,7 @@ const extractErrorResponse = async (
   response: Response,
 ): Promise<ErrorResponse> => {
   try {
-    return await response.json().then((json) => {
-      const error = json as ErrorResponse;
-      return {
-        errorCode: error.errorCode,
-        errorSummary: error.errorSummary,
-        errorLink: error.errorLink,
-        errorId: error.errorId,
-        errorCauses: error.errorCauses,
-      };
-    });
+    return errorResponseSchema.parse(await response.json());
   } catch (error) {
     throw new OktaError({
       message: 'Could not parse Okta error response',

--- a/src/server/lib/okta/api/sessions.ts
+++ b/src/server/lib/okta/api/sessions.ts
@@ -1,5 +1,5 @@
 import { OktaError } from '@/server/models/okta/Error';
-import { SessionResponse } from '@/server/models/okta/Session';
+import { SessionResponse, sessionSchema } from '@/server/models/okta/Session';
 import { buildUrl } from '@/shared/lib/routeUtils';
 import { joinUrl } from '@guardian/libs';
 import { getConfiguration } from '../../getConfiguration';
@@ -61,19 +61,7 @@ export const handleSessionResponse = async (
 ): Promise<SessionResponse> => {
   if (response.ok) {
     try {
-      return await response.json().then((json) => {
-        const session = json as SessionResponse;
-        return {
-          id: session.id,
-          login: session.login,
-          userId: session.userId,
-          expiresAt: session.expiresAt,
-          status: session.status,
-          lastPasswordVerification: session.lastPasswordVerification,
-          lastFactorVerification: session.lastFactorVerification,
-          mfaActive: session.mfaActive,
-        };
-      });
+      return sessionSchema.parse(await response.json());
     } catch (error) {
       throw new OktaError({
         message: 'Could not parse Okta session response',

--- a/src/server/lib/okta/api/users.ts
+++ b/src/server/lib/okta/api/users.ts
@@ -10,9 +10,10 @@ import {
   UserCreationRequest,
   UserResponse,
   UserUpdateRequest,
-  ActivationTokenResponse,
-  ResetPasswordUrlResponse,
   TokenResponse,
+  userResponseSchema,
+  activationTokenResponseSchema,
+  resetPasswordUrlResponseSchema,
 } from '@/server/models/okta/User';
 import { handleVoidResponse } from '@/server/lib/okta/api/responses';
 import { Response } from 'node-fetch';
@@ -297,24 +298,7 @@ const handleUserResponse = async (
 ): Promise<UserResponse> => {
   if (response.ok) {
     try {
-      return await response.json().then((json) => {
-        const user = json as UserResponse;
-        return {
-          id: user.id,
-          status: user.status,
-          profile: {
-            firstName: user.profile.firstName,
-            lastName: user.profile.lastName,
-            email: user.profile.email,
-            login: user.profile.login,
-            isGuardianUser: user.profile.isGuardianUser,
-            emailValidated: user.profile.emailValidated,
-            isJobsUser: user.profile.isJobsUser,
-            registrationLocation: user.profile.registrationLocation,
-          },
-          credentials: user.credentials,
-        };
-      });
+      return userResponseSchema.parse(await response.json());
     } catch (error) {
       throw new OktaError({
         message: 'Could not parse Okta user response',
@@ -359,12 +343,13 @@ const handleActivationTokenResponse = async (
 ): Promise<TokenResponse> => {
   if (response.ok) {
     try {
-      return await response.json().then((json) => {
-        const response = json as ActivationTokenResponse;
-        return {
-          token: response.activationToken,
-        };
-      });
+      const activationTokenResponse = activationTokenResponseSchema.parse(
+        await response.json(),
+      );
+
+      return {
+        token: activationTokenResponse.activationToken,
+      };
     } catch (error) {
       throw new OktaError({
         message: 'Could not parse Okta activation token response',
@@ -387,23 +372,24 @@ const handleResetPasswordUrlResponse = async (
 ): Promise<string> => {
   if (response.ok) {
     try {
-      return await response.json().then((json) => {
-        const { resetPasswordUrl } = json as ResetPasswordUrlResponse;
-        const url = new URL(resetPasswordUrl);
-        const token = url.pathname.split('/').at(-1);
+      const { resetPasswordUrl } = resetPasswordUrlResponseSchema.parse(
+        await response.json(),
+      );
 
-        // validate should exist, be length 20, and not equal to "signin" or "reset-password"
-        if (
-          token &&
-          token.length === 20 &&
-          token !== 'signin' &&
-          token !== 'reset-password'
-        ) {
-          return token;
-        } else {
-          throw new Error('Could not parse OTT from resetPasswordUrl');
-        }
-      });
+      const url = new URL(resetPasswordUrl);
+      const token = url.pathname.split('/').at(-1);
+
+      // validate should exist, be length 20, and not equal to "signin" or "reset-password"
+      if (
+        token &&
+        token.length === 20 &&
+        token !== 'signin' &&
+        token !== 'reset-password'
+      ) {
+        return token;
+      } else {
+        throw new Error('Could not parse OTT from resetPasswordUrl');
+      }
     } catch (error) {
       throw new OktaError({
         message: 'Could not parse Okta reset password url response',

--- a/src/server/lib/okta/api/users.ts
+++ b/src/server/lib/okta/api/users.ts
@@ -18,7 +18,8 @@ import { handleVoidResponse } from '@/server/lib/okta/api/responses';
 import { Response } from 'node-fetch';
 import { OktaError } from '@/server/models/okta/Error';
 import { handleErrorResponse } from '@/server/lib/okta/api/errors';
-import { Group } from '@/server/models/okta/Group';
+import { Group, groupSchema } from '@/server/models/okta/Group';
+import { z } from 'zod';
 
 const { okta } = getConfiguration();
 
@@ -334,16 +335,7 @@ const handleUserResponse = async (
 const handleGroupsResponse = async (response: Response): Promise<Group[]> => {
   if (response.ok) {
     try {
-      return await response.json().then((json) => {
-        const groups = json as Group[];
-        return groups.map((group) => ({
-          id: group.id,
-          profile: {
-            name: group.profile.name,
-            description: group.profile.description,
-          },
-        }));
-      });
+      return z.array(groupSchema).parse(await response.json());
     } catch (error) {
       throw new OktaError({
         message: 'Could not parse Okta user group response',

--- a/src/server/lib/okta/oauth.ts
+++ b/src/server/lib/okta/oauth.ts
@@ -35,7 +35,7 @@ export const performAuthorizationCodeFlow = async (
     closeExistingSession,
     doNotSetLastAccessCookie = false,
   }: {
-    sessionToken?: string;
+    sessionToken?: string | null;
     confirmationPagePath?: RoutePaths;
     idp?: string;
     closeExistingSession?: boolean;

--- a/src/server/models/okta/App.ts
+++ b/src/server/models/okta/App.ts
@@ -1,10 +1,13 @@
+import { z } from 'zod';
+
 // https://developer.okta.com/docs/reference/api/apps/#application-properties
-export interface AppResponse {
-  id: string;
-  label: string;
-  settings: {
-    oauthClient: {
-      redirect_uris: string[];
-    };
-  };
-}
+export const appResponseSchema = z.object({
+  id: z.string(),
+  label: z.string(),
+  settings: z.object({
+    oauthClient: z.object({
+      redirect_uris: z.array(z.string()),
+    }),
+  }),
+});
+export type AppResponse = z.infer<typeof appResponseSchema>;

--- a/src/server/models/okta/Authentication.ts
+++ b/src/server/models/okta/Authentication.ts
@@ -1,4 +1,17 @@
-import { HalLink } from 'hal-types';
+import { z } from 'zod';
+
+// https://github.com/badgateway/hal-types/blob/main/src/hal.ts#L7
+const halLinkSchema = z.object({
+  href: z.string(),
+  type: z.string().nullable().optional(),
+  templated: z.boolean().nullable().optional(),
+  title: z.string().nullable().optional(),
+  hreflang: z.string().nullable().optional(),
+  profile: z.string().nullable().optional(),
+  name: z.string().nullable().optional(),
+  deprecation: z.string().nullable().optional(),
+  hints: z.object({}).nullable().optional(),
+});
 
 /**
  * Okta's Authentication API models, see - https://developer.okta.com/docs/reference/api/authn/
@@ -31,60 +44,79 @@ enum AuthenticationFactorResult {
 }
 
 // https://developer.okta.com/docs/reference/api/authn/#links-object
-interface AuthenticationLinks {
-  next?: HalLink;
-  prev?: HalLink;
-  cancel?: HalLink;
-  skip?: HalLink;
-  resend?: HalLink;
-}
-
-// https://developer.okta.com/docs/reference/api/authn/#user-object
-interface AuthenticationEmbeddedUser {
-  id: string;
-  passwordChanged?: string;
-  profile: AuthenticationEmbeddedUserProfile;
-  recovery_question?: AuthenticationEmbeddedRecoveryQuestion;
-}
+const authenticationLinksSchema = z.object({
+  next: halLinkSchema.nullable().optional(),
+  prev: halLinkSchema.nullable().optional(),
+  cancel: halLinkSchema.nullable().optional(),
+  skip: halLinkSchema.nullable().optional(),
+  resend: halLinkSchema.nullable().optional(),
+});
 
 // https://developer.okta.com/docs/reference/api/authn/#user-profile-object
-interface AuthenticationEmbeddedUserProfile {
-  firstName: string;
-  secondName: string;
-  locale?: string;
-  login: string;
-  timeZone?: string;
-}
+const authenticationEmbeddedUserProfileSchema = z.object({
+  login: z.string(),
+  // okta says this is not nullable or optional, but there are some
+  // users in our system that do not have a firstName/lastName or it is null
+  firstName: z.string().nullable().optional(),
+  lastName: z.string().nullable().optional(),
+  locale: z.string().nullable().optional(),
+  timeZone: z.string().nullable().optional(),
+});
 
 // https://developer.okta.com/docs/reference/api/authn/#recovery-question-object
-interface AuthenticationEmbeddedRecoveryQuestion {
-  question: string;
-}
+const authenticationEmbeddedRecoveryQuestionSchema = z.object({
+  question: z.string(),
+});
+
+// https://developer.okta.com/docs/reference/api/authn/#user-object
+const authenticationEmbeddedUserSchema = z.object({
+  id: z.string(),
+  passwordChanged: z.string().nullable().optional(),
+  profile: authenticationEmbeddedUserProfileSchema,
+  recovery_question: authenticationEmbeddedRecoveryQuestionSchema
+    .nullable()
+    .optional(),
+});
 
 // https://developer.okta.com/docs/reference/api/authn/#authentication-transaction-object
-export interface AuthenticationTransaction {
-  _embedded?: {
-    user: AuthenticationEmbeddedUser;
-  };
-  _links?: AuthenticationLinks;
-  expiresAt?: string;
-  factorResult?: AuthenticationFactorResult;
-  sessionToken?: string;
-  stateToken?: string;
-  status?: AuthenticationTransactionState;
-}
+export const authenticationTransactionSchema = z.object({
+  _embedded: z
+    .object({
+      user: authenticationEmbeddedUserSchema,
+    })
+    .nullable()
+    .optional(),
+  _links: authenticationLinksSchema.nullable().optional(),
+  expiresAt: z.string().nullable().optional(),
+  factorResult: z.nativeEnum(AuthenticationFactorResult).nullable().optional(),
+  sessionToken: z.string().nullable().optional(),
+  stateToken: z.string().nullable().optional(),
+  status: z.nativeEnum(AuthenticationTransactionState).nullable().optional(),
+});
+export type AuthenticationTransaction = z.infer<
+  typeof authenticationTransactionSchema
+>;
 
 // https://developer.okta.com/docs/reference/api/authn/#request-parameters-for-primary-authentication
-export interface AuthenticationRequestParameters {
-  audience?: string;
-  context?: {
-    deviceToken?: string;
-  };
-  options?: {
-    multiOptionalFactorEnroll?: boolean;
-    warnBeforePasswordExpired?: boolean;
-  };
-  password?: string;
-  token?: string;
-  username?: string;
-}
+const authenticationRequestParametersSchema = z.object({
+  audience: z.string().nullable().optional(),
+  context: z
+    .object({
+      deviceToken: z.string().nullable().optional(),
+    })
+    .nullable()
+    .optional(),
+  options: z
+    .object({
+      multiOptionalFactorEnroll: z.boolean().nullable().optional(),
+      warnBeforePasswordExpired: z.boolean().nullable().optional(),
+    })
+    .nullable()
+    .optional(),
+  password: z.string().nullable().optional(),
+  token: z.string().nullable().optional(),
+  username: z.string().nullable().optional(),
+});
+export type AuthenticationRequestParameters = z.infer<
+  typeof authenticationRequestParametersSchema
+>;

--- a/src/server/models/okta/Error.ts
+++ b/src/server/models/okta/Error.ts
@@ -1,22 +1,26 @@
+import { z } from 'zod';
+
 /**
  * File related to Okta error codes and descriptions
  * Errors sourced from:
  * https://developer.okta.com/docs/reference/error-codes/
  */
+const errorCauseSchema = z.object({
+  errorSummary: z.string(),
+});
+export type ErrorCause = z.infer<typeof errorCauseSchema>;
 
-export interface ErrorResponse {
-  errorCode: string;
-  errorSummary: string;
-  errorLink: string;
-  errorId: string;
-  errorCauses: Array<ErrorCause>;
-}
+// convert ErrorResponse to zod schema
+export const errorResponseSchema = z.object({
+  errorCode: z.string(),
+  errorSummary: z.string(),
+  errorLink: z.string(),
+  errorId: z.string(),
+  errorCauses: z.array(errorCauseSchema).nullable().optional(),
+});
+export type ErrorResponse = z.infer<typeof errorResponseSchema>;
 
-export interface ErrorCause {
-  errorSummary: string;
-}
-
-export type ErrorName =
+type ErrorName =
   | 'ApiValidationError'
   | 'AuthenticationFailedError'
   | 'ResourceNotFoundError'
@@ -26,7 +30,7 @@ export type ErrorName =
   | 'PasswordPolicyViolationError'
   | 'OktaError';
 
-export const ErrorName = new Map<string, ErrorName>([
+const ErrorName = new Map<string, ErrorName>([
   ['E0000001', 'ApiValidationError'],
   ['E0000004', 'AuthenticationFailedError'],
   ['E0000007', 'ResourceNotFoundError'],
@@ -45,7 +49,7 @@ export class OktaError extends Error {
     message?: string;
     status?: number;
     code?: string;
-    causes?: Array<ErrorCause>;
+    causes?: Array<ErrorCause> | null;
   }) {
     super(error.message);
     this.name = (error.code && ErrorName.get(error.code)) || 'OktaError';

--- a/src/server/models/okta/Group.ts
+++ b/src/server/models/okta/Group.ts
@@ -1,8 +1,11 @@
+import { z } from 'zod';
+
 // https://developer.okta.com/docs/reference/api/groups/#group-attributes
-export interface Group {
-  id: string;
-  profile: {
-    name: string;
-    description?: string;
-  };
-}
+export const groupSchema = z.object({
+  id: z.string(),
+  profile: z.object({
+    name: z.string(),
+    description: z.string().nullable().optional(),
+  }),
+});
+export type Group = z.infer<typeof groupSchema>;

--- a/src/server/models/okta/Session.ts
+++ b/src/server/models/okta/Session.ts
@@ -1,14 +1,15 @@
+import { z } from 'zod';
 // Session object definition https://developer.okta.com/docs/reference/api/sessions/#session-properties
-
-export interface SessionResponse {
-  id: string;
-  login: string;
-  userId: string;
-  expiresAt: string;
-  status: 'ACTIVE' | 'MFA_REQUIRED' | 'MFA_ENROLL';
-  lastPasswordVerification: string;
-  lastFactorVerification: string;
-  // amr: string;
-  // idp: string;
-  mfaActive: boolean;
-}
+export const sessionSchema = z.object({
+  id: z.string(),
+  login: z.string(),
+  userId: z.string(),
+  expiresAt: z.string(),
+  status: z.enum(['ACTIVE', 'MFA_REQUIRED', 'MFA_ENROLL']),
+  lastPasswordVerification: z.string().nullable().optional(),
+  lastFactorVerification: z.string().nullable().optional(),
+  // amr: z.string(),
+  // idp: z.string(),
+  mfaActive: z.boolean(),
+});
+export type SessionResponse = z.infer<typeof sessionSchema>;

--- a/yarn.lock
+++ b/yarn.lock
@@ -10572,11 +10572,6 @@ growly@^1.3.0:
   resolved "https://registry.yarnpkg.com/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
   integrity sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=
 
-hal-types@^1.8.0:
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/hal-types/-/hal-types-1.8.0.tgz#c51f476c8734dbaa746d332a197a4f1778924015"
-  integrity sha512-CEOp6suUO3E67B2PfjDqJtmVTHDAL5pU9IggyYjwj+1hz7B47RE/2UM0YgijqZt9XcsZzbJN3kHGSsLKLTVOiA==
-
 handlebars@^4.7.7:
   version "4.7.7"
   resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.7.7.tgz#9ce33416aad02dbd6c8fafa8240d5d98004945a1"


### PR DESCRIPTION
## What does this change?

Updates all our types/models we use with Okta to be defined with [zod](https://github.com/colinhacks/zod) instead! Zod is a TypeScript-first schema declaration and validation library.

This has the benefit of still keeping the same types and type safety at compile time, but also being able to easily validate types at  run time too, e.g. responses from the Okta API.

We were already using Zod in this project, specifically in our rate limiter configuration thanks to @ob6160.

This PR updates all the Okta models and API responses to use Zod, and fixed any tests/issues that were encountered when doing this. Types for the Okta models were taken from the [Okta API documentation](https://developer.okta.com/docs/reference/core-okta-api/), and we've linked to them above the types and schema where appropriate for reference.

## Notes

Unlike TypeScript, Zod creates schemas of data structures which can be checked at both compile and runtime, unlike TS where type checking only happens at compile time.

In Zod you have to first define a schema which defines the structure, types, and validation e.g.

```ts
import { z } from 'zod';

const exampleSchema = z.object({
  keyA: z.string(),
  keyB: z.boolean().nullable().optional(),
  keyC: z.object({
    foo: z.enum(['bar', 'baz']),
  }).optional(),
});
```

You can then infer the typescript type by using `z.infer`:

```ts
type Example = z.infer<typeof exampleSchema>;

// equivalent to
interface Example {
  keyA: string;
  keyB?:  boolean | null;
  keyC?: {
    foo: 'bar' | 'baz';
  };
}
```

You can then use the schema to validate objects at runtime without having to resort to type guards or manual type checking

```ts
// old way
const isExample = (obj: unknown): obj is Example => {
  const maybeExample = obj as Example;
  return !!(maybeExample.keyA && typeOf maybeExample.keyA === 'string' && ... other checks);
};

// or

try { 
 const example = await response.json() as Example;
  // not checking the types at runtime here
  return {
    keyA: example.keyA,
    keyB: example.keyB,
    keyC: example.keyC,
  }
} catch (error) {
 console.error('failed to parse example', error);
}

// becomes simply
try {
  // this checks the types at runtime to make sure it's valid!
  return userResponseSchema.parse(await response.json());
} catch (error) {
 // handle parsing error
}
```