### PR TITLE
Okta | Show onboarding flow for new social users

### DIFF
--- a/src/server/lib/okta/api/groups.ts
+++ b/src/server/lib/okta/api/groups.ts
@@ -1,0 +1,96 @@
+import { Group, groupSchema } from '@/server/models/okta/Group';
+import { buildUrl } from '@/shared/lib/routeUtils';
+import { getConfiguration } from '@/server/lib/getConfiguration';
+import { joinUrl } from '@guardian/libs';
+import { defaultHeaders, authorizationHeader } from './headers';
+import { z } from 'zod';
+import { OktaError } from '@/server/models/okta/Error';
+import { handleErrorResponse } from './errors';
+import { handleVoidResponse } from './responses';
+
+const { okta } = getConfiguration();
+
+/**
+ * Okta's Groups API
+ * https://developer.okta.com/docs/reference/api/groups
+ */
+
+/**
+ * @name getGroupByName
+ * @description Get a group configured within Okta by name
+ *
+ * Uses GroupNameCache map to memoize as to cache the response, as the group config is unlikely to change
+ *
+ * https://developer.okta.com/docs/reference/api/groups/#find-groups
+ *
+ * @returns {Promise<Group | undefined>}
+ */
+const GroupNameCache = new Map<string, Group>();
+export const getGroupByName = async (
+  name: string,
+): Promise<Group | undefined> => {
+  if (GroupNameCache.has(name)) {
+    return Promise.resolve(GroupNameCache.get(name) as Group);
+  }
+
+  const path = `${buildUrl(`/api/v1/groups`)}?q=${name}`;
+
+  const groups = await fetch(joinUrl(okta.orgUrl, path), {
+    headers: { ...defaultHeaders, ...authorizationHeader() },
+  }).then(handleGroupsResponse);
+
+  const group = groups.find((group) => group.profile.name === name);
+
+  if (group) {
+    GroupNameCache.set(name, group);
+  }
+
+  return group;
+};
+
+/**
+ * @name removeUserFromGroup
+ * @description Remove a user from a group
+ *
+ * https://developer.okta.com/docs/reference/api/groups/#remove-user-from-group
+ *
+ * @param userId {string} - The user Okta ID
+ * @param groupId {string} - The group Okta ID
+ */
+export const removeUserFromGroup = async (
+  userId: string,
+  groupId: string,
+): Promise<void> => {
+  const path = buildUrl(`/api/v1/groups/:groupId/users/:userId`, {
+    groupId,
+    userId,
+  });
+
+  await fetch(joinUrl(okta.orgUrl, path), {
+    method: 'DELETE',
+    headers: { ...defaultHeaders, ...authorizationHeader() },
+  }).then(handleVoidResponse);
+};
+
+/**
+ * @name handleGroupsResponse
+ * @description Handles the response from Okta's /users/:id/groups endpoint
+ * and converts it to an array of Group
+ * @param response fetch response object
+ * @returns Promise<Group[]>
+ */
+export const handleGroupsResponse = async (
+  response: Response,
+): Promise<Group[]> => {
+  if (response.ok) {
+    try {
+      return z.array(groupSchema).parse(await response.json());
+    } catch (error) {
+      throw new OktaError({
+        message: 'Could not parse Okta user group response',
+      });
+    }
+  } else {
+    return await handleErrorResponse(response);
+  }
+};

--- a/src/server/lib/okta/api/users.ts
+++ b/src/server/lib/okta/api/users.ts
@@ -17,8 +17,8 @@ import {
 import { handleVoidResponse } from '@/server/lib/okta/api/responses';
 import { OktaError } from '@/server/models/okta/Error';
 import { handleErrorResponse } from '@/server/lib/okta/api/errors';
-import { Group, groupSchema } from '@/server/models/okta/Group';
-import { z } from 'zod';
+import { Group } from '@/server/models/okta/Group';
+import { handleGroupsResponse } from '@/server/lib/okta/api/groups';
 
 const { okta } = getConfiguration();
 
@@ -300,27 +300,6 @@ const handleUserResponse = async (
     } catch (error) {
       throw new OktaError({
         message: 'Could not parse Okta user response',
-      });
-    }
-  } else {
-    return await handleErrorResponse(response);
-  }
-};
-
-/**
- * @name handleGroupsResponse
- * @description Handles the response from Okta's /users/:id/groups endpoint
- * and converts it to an array of Group
- * @param response fetch response object
- * @returns Promise<Group[]>
- */
-const handleGroupsResponse = async (response: Response): Promise<Group[]> => {
-  if (response.ok) {
-    try {
-      return z.array(groupSchema).parse(await response.json());
-    } catch (error) {
-      throw new OktaError({
-        message: 'Could not parse Okta user group response',
       });
     }
   } else {

--- a/src/shared/model/Routes.ts
+++ b/src/shared/model/Routes.ts
@@ -89,6 +89,8 @@ export type OktaApiRoutePaths =
   | '/api/v1/authn/credentials/reset_password'
   | '/api/v1/authn/recovery/password'
   | '/api/v1/authn/recovery/token'
+  | '/api/v1/groups'
+  | '/api/v1/groups/:groupId/users/:userId'
   | '/api/v1/sessions/:sessionId'
   | '/api/v1/users'
   | '/api/v1/users/:id'


### PR DESCRIPTION
## What does this change?

In Okta it is currently not possible to differentiate between new social users, and existing social users. This means that is was not possible to show social users the onboarding flow.

We realised however that is was possible to assign new social users to a particular Okta group for new social accounts with Okta's JIT user creation for social IDPs.

So this commit checks that the user is in the "GuardianUser-SocialShowOnboardingUser" on the authorization code callback method (after session is set). If the user is in the group, then show the onboarding flow, and then remove them from the group so that they're not shown it again.

## Release order

This PR should be merged in to main before https://github.com/guardian/identity-platform/pull/591 so that users aren't assigned to the group before they're able to use it.

## Tested
- [ ] CODE