### PR TITLE
Capture registration location for social registrations via onboarding flow

### DIFF
--- a/src/client/components/ConsentsForm.tsx
+++ b/src/client/components/ConsentsForm.tsx
@@ -5,6 +5,8 @@ import useClientState from '@/client/lib/hooks/useClientState';
 import { onboardingFormSubmitOphanTracking } from '@/client/lib/consentsTracking';
 import { CsrfFormField } from '@/client/components/CsrfFormField';
 import { buildUrlWithQueryParams } from '@/shared/lib/routeUtils';
+import { CmpConsentedStateHiddenInput } from '@/client/components/CmpConsentStateHiddenInput';
+import { useCmpConsent } from '@/client/lib/hooks/useCmpConsent';
 
 interface ConsentsFormProps {
   cssOverrides?: SerializedStyles;
@@ -15,6 +17,7 @@ export const ConsentsForm: React.FC<ConsentsFormProps> = ({
   children,
   cssOverrides,
 }) => {
+  const hasCmpConsent = useCmpConsent();
   const clientState = useClientState();
   const { pageData = {}, queryParams } = clientState;
   const { page = '' } = pageData;
@@ -33,6 +36,7 @@ export const ConsentsForm: React.FC<ConsentsFormProps> = ({
         );
       }}
     >
+      <CmpConsentedStateHiddenInput cmpConsentedState={hasCmpConsent} />
       <CsrfFormField />
       {children}
     </form>

--- a/src/server/lib/__tests__/updateRegistrationLocation.test.ts
+++ b/src/server/lib/__tests__/updateRegistrationLocation.test.ts
@@ -1,0 +1,88 @@
+import { Request } from 'express';
+import { mocked } from 'jest-mock';
+import { updateRegistrationLocationViaIDAPI } from '../updateRegistrationLocation';
+import { read, addRegistrationLocation } from '@/server/lib/idapi/user';
+import User from '@/shared/model/User';
+import { RegistrationLocation } from '@/server/models/okta/User';
+
+// mocked configuration
+jest.mock('@/server/lib/getConfiguration', () => ({
+  getConfiguration: () => ({}),
+}));
+
+// mocked logger
+jest.mock('@/server/lib/serverSideLogger', () => ({
+  logger: {
+    error: jest.fn(),
+  },
+}));
+
+const getFakeRequest = (
+  country: string | undefined,
+  consent: string | undefined,
+) => ({
+  cookies: {
+    GU_geo_country: country,
+  },
+  body: {
+    _cmpConsentedState: consent,
+  },
+});
+
+const user = (location: string | undefined) => {
+  return {
+    primaryEmailAddress: 'abc@gu.com',
+    privateFields: {
+      registrationLocation: location,
+    },
+  } as User;
+};
+
+jest.mock('@/server/lib/idapi/user');
+const mockedReadUser =
+  mocked<(ip: string, sc_gu_u: string) => Promise<User>>(read);
+const mockedAddRegistrationLocation = mocked<
+  (
+    registrationLocation: RegistrationLocation,
+    ip: string,
+    sc_gu_u: string,
+    request_id?: string,
+  ) => Promise<User>
+>(addRegistrationLocation);
+
+describe('updateRegistrationLocation', () => {
+  afterEach(() => jest.resetAllMocks());
+
+  test(`makes no idapi calls if registrationLocation undefined `, async () => {
+    await updateRegistrationLocationViaIDAPI(
+      'ip',
+      'cookie',
+      getFakeRequest(undefined, 'true') as Request,
+    );
+    expect(mockedReadUser).not.toBeCalled();
+    expect(mockedAddRegistrationLocation).not.toBeCalled();
+  });
+
+  test(`does not update location if user response already has location set `, async () => {
+    mockedReadUser.mockResolvedValue(user('Canada'));
+    await updateRegistrationLocationViaIDAPI(
+      'ip',
+      'cookie',
+      getFakeRequest('FR', 'true') as Request,
+    );
+
+    expect(mockedReadUser).toBeCalled();
+    expect(mockedAddRegistrationLocation).not.toBeCalled();
+  });
+
+  test(`updates location if user response does not have location set `, async () => {
+    mockedReadUser.mockResolvedValueOnce(user(''));
+    await updateRegistrationLocationViaIDAPI(
+      'ip',
+      'cookie',
+      getFakeRequest('FR', 'true') as Request,
+    );
+    expect(mockedReadUser).toBeCalled();
+    expect(mockedAddRegistrationLocation).toBeCalled();
+  });
+});

--- a/src/server/lib/updateRegistrationLocation.ts
+++ b/src/server/lib/updateRegistrationLocation.ts
@@ -1,0 +1,44 @@
+import { Request } from 'express';
+import { logger } from '@/server/lib/serverSideLogger';
+import { RegistrationLocation } from '@/server/models/okta/User';
+import { isStringBoolean } from '@/server/lib/isStringBoolean';
+import { getRegistrationLocation } from '@/server/lib/getRegistrationLocation';
+import {
+  read as readIdapiUser,
+  addRegistrationLocation,
+} from '@/server/lib/idapi/user';
+
+/**
+ * Until Gateway/Onboarding journey is migrated to Okta sessions, we don't have access to Okta User ID, only sg_gu_u cookie,
+ * so we need to add reg location via idapi (which updates Okta immediately). When Okta sessions are available, this should be refactored
+ * to use okta directly (Which is the source of truth for the user's registration location field)
+ */
+export const updateRegistrationLocationViaIDAPI = async (
+  ip: string,
+  sc_gu_u: string,
+  req: Request,
+) => {
+  const { _cmpConsentedState = false } = req.body;
+
+  const registrationLocation: RegistrationLocation | undefined =
+    getRegistrationLocation(req, isStringBoolean(_cmpConsentedState));
+
+  if (!!registrationLocation) {
+    try {
+      const user = await readIdapiUser(ip, sc_gu_u);
+      // don't update users who already have a location set
+      if (!!user.privateFields.registrationLocation) {
+        return;
+      }
+      await addRegistrationLocation(registrationLocation, ip, sc_gu_u);
+    } catch (error) {
+      logger.error(
+        `${req.method} ${req.originalUrl} Error updating registrationLocation via IDAPI`,
+        error,
+        {
+          request_id: req.get('x-request-id'),
+        },
+      );
+    }
+  }
+};

--- a/src/server/lib/updateRegistrationLocation.ts
+++ b/src/server/lib/updateRegistrationLocation.ts
@@ -23,22 +23,25 @@ export const updateRegistrationLocationViaIDAPI = async (
   const registrationLocation: RegistrationLocation | undefined =
     getRegistrationLocation(req, isStringBoolean(_cmpConsentedState));
 
-  if (!!registrationLocation) {
-    try {
-      const user = await readIdapiUser(ip, sc_gu_u);
-      // don't update users who already have a location set
-      if (!!user.privateFields.registrationLocation) {
-        return;
-      }
-      await addRegistrationLocation(registrationLocation, ip, sc_gu_u);
-    } catch (error) {
-      logger.error(
-        `${req.method} ${req.originalUrl} Error updating registrationLocation via IDAPI`,
-        error,
-        {
-          request_id: req.get('x-request-id'),
-        },
-      );
+  // don't update users if we can't derive location from request
+  if (!registrationLocation) {
+    return;
+  }
+
+  try {
+    const user = await readIdapiUser(ip, sc_gu_u);
+    // don't update users who already have a location set
+    if (!!user.privateFields.registrationLocation) {
+      return;
     }
+    await addRegistrationLocation(registrationLocation, ip, sc_gu_u);
+  } catch (error) {
+    logger.error(
+      `${req.method} ${req.originalUrl} Error updating registrationLocation via IDAPI`,
+      error,
+      {
+        request_id: req.get('x-request-id'),
+      },
+    );
   }
 };

--- a/src/server/routes/consents.ts
+++ b/src/server/routes/consents.ts
@@ -350,8 +350,9 @@ router.post(
       pageTitle = _pageTitle;
 
       // If on the first page, attempt to update location for consented users.
-      pageTitle == 'Stay in touch' &&
+      if (pageIndex === 0) {
         updateRegistrationLocationViaIDAPI(req.ip, sc_gu_u, req);
+      }
 
       if (update) {
         await update(req.ip, sc_gu_u, req.body, res.locals.requestId);

--- a/src/server/routes/consents.ts
+++ b/src/server/routes/consents.ts
@@ -42,13 +42,7 @@ import { ApiError } from '@/server/models/Error';
 import { ConsentPath, RoutePaths } from '@/shared/model/Routes';
 import { PageTitle } from '@/shared/model/PageTitle';
 import { mergeRequestState } from '@/server/lib/requestState';
-import { RegistrationLocation } from '@/server/models/okta/User';
-import { isStringBoolean } from '@/server/lib/isStringBoolean';
-import { getRegistrationLocation } from '@/server/lib/getRegistrationLocation';
-import {
-  read as readIdapiUser,
-  addRegistrationLocation,
-} from '@/server/lib/idapi/user';
+import { updateRegistrationLocationViaIDAPI } from '../lib/updateRegistrationLocation';
 
 interface ConsentPage {
   page: ConsentPath;
@@ -67,42 +61,6 @@ interface ConsentPage {
     request_id?: string,
   ) => Promise<void>;
 }
-
-/**
- * Until Gateway/Onboarding journey is migrated to Okta sessions, we don't have access to Okta User ID, only sg_gu_u cookie,
- * so we need to add reg location via idapi (which updates Okta immediately). When Okta sessions are available, this should be refactored
- * to use okta directly (Which is the source of truth for the user's registration location field)
- */
-// TODO write a test
-const updateRegistrationLocationViaIDAPI = async (
-  ip: string,
-  sc_gu_u: string,
-  req: Request,
-) => {
-  const { _cmpConsentedState = false } = req.body;
-
-  const registrationLocation: RegistrationLocation | undefined =
-    getRegistrationLocation(req, isStringBoolean(_cmpConsentedState));
-
-  if (!!registrationLocation) {
-    try {
-      const user = await readIdapiUser(ip, sc_gu_u);
-      // don't update users who already have a location set
-      if (user.privateFields.registrationLocation) {
-        return;
-      }
-      await addRegistrationLocation(registrationLocation, ip, sc_gu_u);
-    } catch (error) {
-      logger.error(
-        `${req.method} ${req.originalUrl} Error updating registrationLocation via IDAPI`,
-        error,
-        {
-          request_id: req.get('x-request-id'),
-        },
-      );
-    }
-  }
-};
 
 const getUserNewsletterSubscriptions = async (
   newslettersOnPage: string[],
@@ -367,6 +325,7 @@ router.get(
   }),
 );
 
+// On the first page ("Stay in touch") this POST will also post a registration_location update
 router.post(
   '/consents/:page',
   loginMiddleware,

--- a/src/shared/model/User.ts
+++ b/src/shared/model/User.ts
@@ -1,3 +1,5 @@
+import { RegistrationLocation } from '@/server/models/okta/User';
+
 export default interface User {
   consents: UserConsent[];
   primaryEmailAddress: string;
@@ -24,4 +26,5 @@ interface UserStatusFields {
 interface PrivateFields {
   firstName?: string;
   secondName?: string;
+  registrationLocation?: RegistrationLocation;
 }


### PR DESCRIPTION
## What does this change?

When a user clicks "next" on any of the onboarding flow pages, and additional hidden input field indicating CMP consent state of the client will be posted to the server. 

On the first page of the flow only ('Stay in touch' page) this will be used by the server to update in the background a new user's registration location if they are consented. 

A new server util has been added called `updateRegistrationLocation`:
- if a registration location can be inferred (cmp consented && available country sent on req header)
- call IDAPI to check if a user already has a location
- If not, post then new location to IDAPI (which then updates the value in Okta)

Note: Okta is the source of truth for the registration_location field, but until the onboarding flow is migrated to Okta sessions, we do not have the user info needed to update Okta directly. 


## Why?

We rolled out a new registration location field and autopopulate this value when a new user registers on web using email/password #1970.

We also want to capture registration location (for consented users) who register via social, but as the social sign in/registration flow is handled entirely by Okta and does not permit us to pass additional parameters (Eg. location) along the authorization flow, the new user onboarding flow is the only place where we can reliably capture this for social.

## Tested in CODE

- [x] a new user creates an account via FB. Their location is undefined in okta but correctly defined after they click continue on the onboarding stay in touch page. 
- [x] a new user creates an account via FB. They set a location in MMA. That location is unchanged after they go through the onboarding flow. 
- [x] a new user rejects cmp consents then creates an account via FB. Their location is undefined in okta and stays undefined once they complete the onboarding flow
- [x] a non-social user with cmp consent is updated of they don't have a location set. 

