### PR TITLE
Okta/OAuth | Fix SSO for Native Apps

### DIFF
--- a/src/server/routes/oauth.ts
+++ b/src/server/routes/oauth.ts
@@ -246,7 +246,13 @@ router.get(
       // the fromURI parameter is an undocumented feature from Okta that allows us to
       // rejoin the authorization code flow after we have set a session cookie on our own platform
       if (authState.queryParams.fromURI) {
-        return res.redirect(303, authState.queryParams.fromURI);
+        return res.redirect(
+          303,
+          addQueryParamsToPath(
+            '/oauth/authorization-code/complete',
+            authState.queryParams,
+          ),
+        );
       }
 
       // fallback option for apps
@@ -310,6 +316,22 @@ router.get(
       return redirectForGenericError(req, res);
     }
   }),
+);
+
+/**
+ * This is a route used to redirect the user to should they have a fromURI parameter,
+ * this is only so that we're able to set any cookies in the browser we need to before
+ * redirecting the user back to fromURI parameter, usually a native app.
+ */
+router.get(
+  '/oauth/authorization-code/complete',
+  (_: Request, res: ResponseWithRequestState) => {
+    const { queryParams } = res.locals;
+    if (queryParams.fromURI) {
+      return res.redirect(303, queryParams.fromURI);
+    }
+    return res.redirect(303, '/signin');
+  },
 );
 
 export default router.router;

--- a/src/shared/model/Routes.ts
+++ b/src/shared/model/Routes.ts
@@ -17,6 +17,7 @@ export const ValidRoutePathsArray = [
   '/magic-link/email-sent', //this is not being used until MVP4
   '/maintenance',
   '/oauth/authorization-code/callback',
+  '/oauth/authorization-code/complete',
   '/register',
   '/register/email-sent',
   '/register/email-sent/resend',


### PR DESCRIPTION
## What does this change?

On native apps when a user logs in and completes the gateway authorization code flow on the `/oauth/authorization-code/callback` we redirect the user back to the app by completing the initial OAuth Auth Code flow initiated by the app by redirecting the browser to the `fromURI`.

This functionality works as expected, and the user ends up back in the app, and the app is able to retrieve and use OAuth tokens.

However in the `/oauth/authorization-code/callback` route, we also generate the existing Identity auth cookies, and add `Set-Cookie` headers to the redirect response to be able to set these cookies. When redirecting to a browser context this works as expected, these cookies are set, and the user is logged in on parts of the site which haven't yet migrated to Okta. 

But when we redirect to a native app url, there is no browser context for these cookies to be set in. This means that if a user then opens their mobile browser, it will look like that they're not logged in, despite being logged in on `profile.theguardian.com` (using the `sid` cookie which was set on sign in/set password), and the app (using Oauth tokens), as the Identity auth cookies are missing.

To fix this we need to first redirect the user to a browser based route for the browser to set the Identity auth cookies, before redirecting the user onwards to the app.

This was done by creating a new route called `/oauth/authorization-code/complete`. This route simply redirects the user to the `fromURI` should that exist, or the `/signin` page if it does not. By having this route here, we add an additional navigation for the browser before going back to the app, which allows us to use `Set-Cookie` from the `/oauth/authorization-code/callback` route, as before going back to the app there is a browser request for the browser to set the cookies in.

This was tested on CODE and also by the apps team who verified that the functionality was now working.