### PR TITLE
Launch Default Onboarding Newsletter AB Test

### DIFF
--- a/src/client/components/ConsentCardOnboardingEmails.stories.tsx
+++ b/src/client/components/ConsentCardOnboardingEmails.stories.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { ComponentMeta, ComponentStory } from '@storybook/react';
+
+import { ConsentCardOnboarding } from './ConsentCardOnboardingEmails';
+
+export default {
+  title: 'Components/ConsentCardOnboarding',
+  component: ConsentCardOnboarding,
+} as ComponentMeta<typeof ConsentCardOnboarding>;
+
+const Template: ComponentStory<typeof ConsentCardOnboarding> = ({
+  id = '4147',
+}) => <ConsentCardOnboarding id={id} />;
+
+export const Default = Template.bind({});
+Default.storyName = 'default';

--- a/src/client/components/ConsentCardOnboardingEmails.tsx
+++ b/src/client/components/ConsentCardOnboardingEmails.tsx
@@ -1,0 +1,79 @@
+import React, { FunctionComponent } from 'react';
+import { SerializedStyles, css } from '@emotion/react';
+import { space, neutral, from, textSans } from '@guardian/source-foundations';
+import { ToggleSwitchInput } from './ToggleSwitchInput';
+import { greyBorderTop, text } from '@/client/styles/Consents';
+import { topMargin } from '@/client/styles/Shared';
+
+const containerStyles = css`
+  display: flex;
+  flex-direction: column;
+  border: ${neutral[0]} 3px dashed;
+  border-radius: 12px;
+  margin-bottom: ${space[3]}px;
+  padding: ${space[2]}px;
+
+  ${from.tablet} {
+    padding: ${space[2]}px ${space[3]}px;
+    p {
+      padding-right: ${space[5]}px;
+    }
+  }
+
+  :not(:last-of-type) {
+    margin-bottom: ${space[5]}px;
+  }
+`;
+
+const toggleSwitchAlignment = css`
+  justify-content: space-between;
+  span {
+    align-self: flex-start;
+    margin-top: ${space[2]}px;
+  }
+`;
+
+const labelStyles = css`
+  ${textSans.small()}
+  font-weight: bold;
+  span {
+    margin-top: 2px !important;
+  }
+`;
+
+const switchRow = css`
+  border: 0;
+  padding: 0;
+  ${topMargin}
+`;
+
+interface ConsentCardProps {
+  id: string;
+  defaultChecked?: boolean;
+  cssOverrides?: SerializedStyles;
+}
+
+export const ConsentCardOnboarding: FunctionComponent<ConsentCardProps> = ({
+  id,
+  defaultChecked,
+  cssOverrides,
+}) => {
+  return (
+    <article css={[containerStyles, cssOverrides]}>
+      <p css={[text]}>
+        As a benefit of creating an account, you&apos;ll receive Saturday
+        Roundup, an exclusive newsletter free for four weeks, featuring
+        highlights of the last week from the Guardian and ways to support our
+        journalism.
+      </p>
+      <fieldset css={[switchRow, greyBorderTop]}>
+        <ToggleSwitchInput
+          id={id}
+          defaultChecked={defaultChecked}
+          label={'Receive Saturday Roundup'}
+          cssOverrides={[labelStyles, toggleSwitchAlignment]}
+        ></ToggleSwitchInput>
+      </fieldset>
+    </article>
+  );
+};

--- a/src/client/components/ConsentCardOnboardingEmails.tsx
+++ b/src/client/components/ConsentCardOnboardingEmails.tsx
@@ -47,17 +47,15 @@ const switchRow = css`
   ${topMargin}
 `;
 
-interface ConsentCardProps {
+interface ConsentCardOnboardingEmailProps {
   id: string;
   defaultChecked?: boolean;
   cssOverrides?: SerializedStyles;
 }
 
-export const ConsentCardOnboarding: FunctionComponent<ConsentCardProps> = ({
-  id,
-  defaultChecked,
-  cssOverrides,
-}) => {
+export const ConsentCardOnboarding: FunctionComponent<
+  ConsentCardOnboardingEmailProps
+> = ({ id, defaultChecked, cssOverrides }) => {
   return (
     <article css={[containerStyles, cssOverrides]}>
       <p css={[text]}>
@@ -67,6 +65,8 @@ export const ConsentCardOnboarding: FunctionComponent<ConsentCardProps> = ({
         journalism.
       </p>
       <fieldset css={[switchRow, greyBorderTop]}>
+        {/* Hidden input required to capture unsubscribe events */}
+        <input type="hidden" name={id} value="" key="hidden" />
         <ToggleSwitchInput
           id={id}
           defaultChecked={defaultChecked}

--- a/src/client/components/ConsentsSubHeader.tsx
+++ b/src/client/components/ConsentsSubHeader.tsx
@@ -37,7 +37,7 @@ const CIRCLE_RADIUS = CIRCLE_DIAMETER / 2;
 
 const h1 = css`
   margin: ${space[6]}px 0 ${space[6]}px;
-  ${headline.small({ fontWeight: 'bold' })}};
+  ${headline.small({ fontWeight: 'bold' })};
 `;
 
 // For some reason this media query only applies if we use a separate style

--- a/src/client/components/ConsentsSubHeader.tsx
+++ b/src/client/components/ConsentsSubHeader.tsx
@@ -7,11 +7,14 @@ import {
   from,
   until,
   textSans,
-  headline,
   visuallyHidden,
 } from '@guardian/source-foundations';
 import { AutoRow, gridRow } from '@/client/styles/Grid';
-import { greyBorderSides } from '@/client/styles/Consents';
+import {
+  greyBorderSides,
+  h1,
+  h1ResponsiveText,
+} from '@/client/styles/Consents';
 import { CONSENTS_PAGES_ARR } from '@/client/models/ConsentsPages';
 import { ErrorSummary } from '@guardian/source-react-components-development-kitchen';
 import { IsNativeApp } from '@/shared/model/ClientState';
@@ -34,22 +37,6 @@ const PENDING_BORDER_SIZE = 1;
 const PENDING_COLOR = neutral[60];
 const CIRCLE_DIAMETER = 12;
 const CIRCLE_RADIUS = CIRCLE_DIAMETER / 2;
-
-const h1 = css`
-  margin: ${space[6]}px 0 ${space[6]}px;
-  ${headline.small({ fontWeight: 'bold' })};
-`;
-
-// For some reason this media query only applies if we use a separate style
-const h1ResponsiveText = css`
-  ${from.tablet} {
-    font-size: 32px;
-  }
-
-  ${from.desktop} {
-    margin-top: 30px;
-  }
-`;
 
 const ol = (active: number) => {
   const progressSections = CONSENTS_PAGES_COUNT - 1;

--- a/src/client/lib/consentsTracking.ts
+++ b/src/client/lib/consentsTracking.ts
@@ -63,6 +63,18 @@ const newslettersFormSubmitOphanTracking = (
       }
     });
   }
+
+  // @AB_TEST: Default Weekly Newsletter Test: required for tracking
+  inputElems.forEach((elem) => {
+    const defaultWeeklyNewsletter = elem.name === '6028';
+    if (defaultWeeklyNewsletter) {
+      trackInputElementInteraction(
+        elem,
+        'newsletter',
+        'saturday-roundup-trial',
+      );
+    }
+  });
 };
 
 // handle generic form (direct to one of the two below based on page)

--- a/src/client/pages/ConsentsNewslettersAB.stories.tsx
+++ b/src/client/pages/ConsentsNewslettersAB.stories.tsx
@@ -1,0 +1,93 @@
+import React from 'react';
+import { ComponentMeta, ComponentStory } from '@storybook/react';
+
+import { ConsentsNewslettersAB } from './ConsentsNewslettersAB';
+
+export default {
+  title: 'Pages/ConsentsNewslettersAB',
+  component: ConsentsNewslettersAB,
+  parameters: {
+    layout: 'fullscreen',
+    clientState: { pageData: { previousPage: 'fake_page' } },
+  },
+} as ComponentMeta<typeof ConsentsNewslettersAB>;
+
+const Template: ComponentStory<typeof ConsentsNewslettersAB> = (props) => (
+  <ConsentsNewslettersAB {...props} />
+);
+
+const newsletters = [
+  {
+    id: '4147',
+    nameId: 'green-light',
+    description:
+      'Exclusive articles from our top environment correspondents and a round up of the planet’s most important stories of the week',
+    name: 'Down to Earth',
+    frequency: 'Weekly',
+  },
+  {
+    id: '4165',
+    nameId: 'the-long-read',
+    description:
+      'Lose yourself in a great story: from politics to psychology, food to technology, culture to crime',
+    name: 'The Long Read',
+    frequency: 'Weekly',
+  },
+  {
+    id: '9001',
+    nameId: 'over-nine-thousand',
+    description: '',
+    name: 'No image',
+    frequency: 'Monthly',
+  },
+];
+
+export const NoNewsletters = Template.bind({});
+NoNewsletters.args = { consents: [] };
+NoNewsletters.storyName = 'with no newsletters';
+
+export const SingleNewsletter = Template.bind({});
+SingleNewsletter.args = {
+  consents: [
+    {
+      type: 'newsletter',
+      consent: {
+        id: '4156',
+        nameId: 'n0',
+        description: 'Newsletter description',
+        name: 'Newsletter Name',
+        frequency: 'Weekly',
+      },
+    },
+  ],
+};
+SingleNewsletter.storyName = 'with a single newsletter';
+
+export const MultipleNewsletter = Template.bind({});
+MultipleNewsletter.args = {
+  consents: newsletters.map((newsletter) => ({
+    type: 'newsletter',
+    consent: newsletter,
+  })),
+};
+MultipleNewsletter.storyName = 'with multiple newsletters';
+
+export const NewslettersAndEvents = Template.bind({});
+NewslettersAndEvents.args = {
+  consents: [
+    ...newsletters.map((newsletter) => ({
+      type: 'newsletter' as const,
+      consent: newsletter,
+    })),
+    {
+      type: 'consent' as const,
+      consent: {
+        id: 'events',
+        name: 'Events & Masterclasses',
+        description:
+          'Receive weekly newsletters about our upcoming Live events and Masterclasses. Interact with leading minds and nourish your curiosity in our immersive online events, available worldwide.',
+      },
+    },
+  ],
+};
+NewslettersAndEvents.storyName = 'with newsletters and consent for events';

--- a/src/client/pages/ConsentsNewslettersAB.tsx
+++ b/src/client/pages/ConsentsNewslettersAB.tsx
@@ -41,6 +41,7 @@ type NewsletterPageConsent = ConsentOption | NewsletterOption;
 
 type ConsentsNewslettersProps = {
   consents: NewsletterPageConsent[];
+  defaultOnboardingEmailConsentState: boolean;
 };
 
 const idColor = (id: string) => {
@@ -89,13 +90,17 @@ const getNewsletterCardCss = (index: number) => {
 
 export const ConsentsNewslettersAB = ({
   consents,
+  defaultOnboardingEmailConsentState,
 }: ConsentsNewslettersProps) => {
   const autoRow = getAutoRow(1, gridItemColumnConsents);
 
   return (
     <ConsentsLayout title="Newsletters" current={CONSENTS_PAGES.NEWSLETTERS}>
       <ConsentsForm cssOverrides={autoRow()}>
-        <ConsentCardOnboarding id={'fixme'} />
+        <ConsentCardOnboarding
+          id={'fixme'}
+          defaultChecked={defaultOnboardingEmailConsentState}
+        />
         <h1 css={[h1, h1ResponsiveText, autoRow()]}>You might also like...</h1>
         {consents.map(({ type, consent }, i) => {
           const extraProps =

--- a/src/client/pages/ConsentsNewslettersAB.tsx
+++ b/src/client/pages/ConsentsNewslettersAB.tsx
@@ -41,6 +41,7 @@ type NewsletterPageConsent = ConsentOption | NewsletterOption;
 
 type ConsentsNewslettersProps = {
   consents: NewsletterPageConsent[];
+  defaultOnboardingEmailId: string;
   defaultOnboardingEmailConsentState: boolean;
 };
 
@@ -90,6 +91,7 @@ const getNewsletterCardCss = (index: number) => {
 
 export const ConsentsNewslettersAB = ({
   consents,
+  defaultOnboardingEmailId,
   defaultOnboardingEmailConsentState,
 }: ConsentsNewslettersProps) => {
   const autoRow = getAutoRow(1, gridItemColumnConsents);
@@ -98,7 +100,7 @@ export const ConsentsNewslettersAB = ({
     <ConsentsLayout title="Newsletters" current={CONSENTS_PAGES.NEWSLETTERS}>
       <ConsentsForm cssOverrides={autoRow()}>
         <ConsentCardOnboarding
-          id={'fixme'}
+          id={defaultOnboardingEmailId}
           defaultChecked={defaultOnboardingEmailConsentState}
         />
         <h1 css={[h1, h1ResponsiveText, autoRow()]}>You might also like...</h1>

--- a/src/client/pages/ConsentsNewslettersAB.tsx
+++ b/src/client/pages/ConsentsNewslettersAB.tsx
@@ -1,0 +1,134 @@
+import React from 'react';
+import { css } from '@emotion/react';
+import {
+  brand,
+  from,
+  lifestyle,
+  news,
+  space,
+  neutral,
+} from '@guardian/source-foundations';
+import {
+  gridItem,
+  gridItemColumnConsents,
+  getAutoRow,
+  SpanDefinition,
+} from '@/client/styles/Grid';
+import { CONSENTS_PAGES } from '@/client/models/ConsentsPages';
+import { ConsentCardOnboarding } from '@/client/components/ConsentCardOnboardingEmails';
+import { ConsentCard } from '@/client/components/ConsentCard';
+import { ConsentsForm } from '@/client/components/ConsentsForm';
+import { ConsentsNavigation } from '@/client/components/ConsentsNavigation';
+import { ConsentsLayout } from '@/client/layouts/ConsentsLayout';
+import { Consent } from '@/shared/model/Consent';
+import { NewsLetter } from '@/shared/model/Newsletter';
+import {
+  NEWSLETTER_IMAGES,
+  NEWSLETTER_IMAGE_POSITIONS,
+} from '@/client/models/Newsletter';
+import { CONSENT_IMAGES } from '@/client/models/ConsentImages';
+import { h1, h1ResponsiveText } from '../styles/Consents';
+
+interface ConsentOption {
+  type: 'consent';
+  consent: Consent;
+}
+interface NewsletterOption {
+  type: 'newsletter';
+  consent: NewsLetter;
+}
+type NewsletterPageConsent = ConsentOption | NewsletterOption;
+
+type ConsentsNewslettersProps = {
+  consents: NewsletterPageConsent[];
+};
+
+const idColor = (id: string) => {
+  if (/morning/.test(id)) {
+    return news[400];
+  }
+  if (id === 'the-long-read') {
+    return brand[400];
+  }
+  if (id === 'green-light') {
+    return news[400];
+  }
+  if (id === 'the-guide-staying-in') {
+    return lifestyle[400];
+  }
+  return brand[400];
+};
+
+const getNewsletterCardCss = (index: number) => {
+  const ITEMS_PER_ROW = 2;
+  const OFFSET = 4;
+  const row = Math.trunc(index / ITEMS_PER_ROW) + OFFSET;
+  const column = index % ITEMS_PER_ROW;
+
+  const gridDef: SpanDefinition = {
+    TABLET: { start: 2 + column * 5, span: 5 },
+    DESKTOP: { start: 2 + column * 5, span: 5 },
+    LEFT_COL: { start: 2 + column * 6, span: 6 },
+    WIDE: { start: 3 + column * 6, span: 6 },
+  };
+
+  return css`
+    ${gridItem(gridDef)}
+    -ms-grid-row: ${row};
+
+    margin-bottom: ${space[5]}px;
+
+    ${from.tablet} {
+      margin-bottom: ${space[6]}px;
+    }
+    ${from.desktop} {
+      margin-bottom: ${space[9]}px;
+    }
+  `;
+};
+
+export const ConsentsNewslettersAB = ({
+  consents,
+}: ConsentsNewslettersProps) => {
+  const autoRow = getAutoRow(1, gridItemColumnConsents);
+
+  return (
+    <ConsentsLayout title="Newsletters" current={CONSENTS_PAGES.NEWSLETTERS}>
+      <ConsentsForm cssOverrides={autoRow()}>
+        <ConsentCardOnboarding id={'fixme'} />
+        <h1 css={[h1, h1ResponsiveText, autoRow()]}>You might also like...</h1>
+        {consents.map(({ type, consent }, i) => {
+          const extraProps =
+            type === 'consent'
+              ? {
+                  id: consent.id,
+                  defaultChecked: !!consent.consented,
+                  highlightColor: neutral[46],
+                  imagePath: CONSENT_IMAGES[consent.id],
+                }
+              : {
+                  id: consent.id,
+                  defaultChecked: consent.subscribed,
+                  imagePath: NEWSLETTER_IMAGES[consent.id],
+                  imagePosition: NEWSLETTER_IMAGE_POSITIONS[consent.id],
+                  highlightColor: idColor(consent.nameId),
+                  frequency: consent.frequency,
+                  hiddenInput: true,
+                };
+
+          return (
+            <ConsentCard
+              key={consent.id}
+              title={consent.name}
+              description={consent.description || ''}
+              noTopBorderMobile
+              cssOverrides={getNewsletterCardCss(i)}
+              {...extraProps}
+            />
+          );
+        })}
+        <ConsentsNavigation />
+      </ConsentsForm>
+    </ConsentsLayout>
+  );
+};

--- a/src/client/pages/ConsentsNewslettersPage.tsx
+++ b/src/client/pages/ConsentsNewslettersPage.tsx
@@ -33,7 +33,7 @@ export const ConsentsNewslettersPage = () => {
     return (
       <ConsentsNewslettersAB
         consents={consents}
-        defaultOnboardingEmailId={'fixme'}
+        defaultOnboardingEmailId={'6028'}
         defaultOnboardingEmailConsentState={true}
       />
     );

--- a/src/client/pages/ConsentsNewslettersPage.tsx
+++ b/src/client/pages/ConsentsNewslettersPage.tsx
@@ -21,23 +21,22 @@ export const ConsentsNewslettersPage = () => {
 
   // @AB_TEST: Default Weekly Newsletter Test: START
   const ABTestAPI = useAB();
-  const isInABTest = ABTestAPI.runnableTest(abDefaultWeeklyNewsletterTest);
+  const isInABTestVariant = ABTestAPI.isUserInVariant(
+    abDefaultWeeklyNewsletterTest.id,
+    abDefaultWeeklyNewsletterTest.variants[0].id,
+  );
 
-  switch (isInABTest?.variantToRun.id) {
-    case 'control-off':
-      return (
-        <ConsentsNewslettersAB
-          consents={consents}
-          defaultOnboardingEmailConsentState={false}
-        />
-      );
-    case 'variant-on':
-      return (
-        <ConsentsNewslettersAB
-          consents={consents}
-          defaultOnboardingEmailConsentState={true}
-        />
-      );
+  const geolocation = pageData?.geolocation;
+  const isInRegion = geolocation && ['GB', 'US', 'AU'].includes(geolocation);
+
+  if (isInABTestVariant && isInRegion) {
+    return (
+      <ConsentsNewslettersAB
+        consents={consents}
+        defaultOnboardingEmailId={'fixme'}
+        defaultOnboardingEmailConsentState={true}
+      />
+    );
   }
   // @AB_TEST: Default Weekly Newsletter Test: END
 

--- a/src/client/pages/ConsentsNewslettersPage.tsx
+++ b/src/client/pages/ConsentsNewslettersPage.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import useClientState from '@/client/lib/hooks/useClientState';
+import { useCmpConsent } from '@/client/lib/hooks/useCmpConsent';
 import { ConsentsNewsletters } from '@/client/pages/ConsentsNewsletters';
 import { ConsentsNewslettersAB } from '@/client/pages/ConsentsNewslettersAB';
 import { useAB } from '@guardian/ab-react';
@@ -28,8 +29,9 @@ export const ConsentsNewslettersPage = () => {
 
   const geolocation = pageData?.geolocation;
   const isInRegion = geolocation && ['GB', 'US', 'AU'].includes(geolocation);
+  const hasCmpConsent = useCmpConsent();
 
-  if (isInABTestVariant && isInRegion) {
+  if (isInABTestVariant && hasCmpConsent && isInRegion) {
     return (
       <ConsentsNewslettersAB
         consents={consents}

--- a/src/client/pages/ConsentsNewslettersPage.tsx
+++ b/src/client/pages/ConsentsNewslettersPage.tsx
@@ -1,6 +1,9 @@
 import React from 'react';
 import useClientState from '@/client/lib/hooks/useClientState';
 import { ConsentsNewsletters } from '@/client/pages/ConsentsNewsletters';
+import { ConsentsNewslettersAB } from '@/client/pages/ConsentsNewslettersAB';
+import { useAB } from '@guardian/ab-react';
+import { abDefaultWeeklyNewsletterTest } from '@/shared/model/experiments/tests/abDefaultWeeklyNewsletterTest';
 
 export const ConsentsNewslettersPage = () => {
   const clientState = useClientState();
@@ -15,6 +18,28 @@ export const ConsentsNewslettersPage = () => {
       consent,
     })),
   ];
+
+  // @AB_TEST: Default Weekly Newsletter Test: START
+  const ABTestAPI = useAB();
+  const isInABTest = ABTestAPI.runnableTest(abDefaultWeeklyNewsletterTest);
+
+  switch (isInABTest?.variantToRun.id) {
+    case 'control-off':
+      return (
+        <ConsentsNewslettersAB
+          consents={consents}
+          defaultOnboardingEmailConsentState={false}
+        />
+      );
+    case 'variant-on':
+      return (
+        <ConsentsNewslettersAB
+          consents={consents}
+          defaultOnboardingEmailConsentState={true}
+        />
+      );
+  }
+  // @AB_TEST: Default Weekly Newsletter Test: END
 
   return <ConsentsNewsletters consents={consents} />;
 };

--- a/src/client/styles/Consents.ts
+++ b/src/client/styles/Consents.ts
@@ -56,3 +56,19 @@ export const controls = css`
     padding-bottom: ${space[24]}px;
   }
 `;
+
+export const h1 = css`
+  margin: ${space[6]}px 0 ${space[6]}px;
+  ${headline.small({ fontWeight: 'bold' })};
+`;
+
+// For some reason this media query only applies if we use a separate style
+export const h1ResponsiveText = css`
+  ${from.tablet} {
+    font-size: 32px;
+  }
+
+  ${from.desktop} {
+    margin-top: 30px;
+  }
+`;

--- a/src/shared/model/experiments/abSwitches.ts
+++ b/src/shared/model/experiments/abSwitches.ts
@@ -1,3 +1,4 @@
 export const abSwitches = {
   abExampleTest: false,
+  abDefaultWeeklyNewsletterTest: false,
 };

--- a/src/shared/model/experiments/abTests.ts
+++ b/src/shared/model/experiments/abTests.ts
@@ -1,5 +1,6 @@
 import { AB, ABTest, Participations } from '@guardian/ab-core';
 import { abSwitches } from './abSwitches';
+import { abDefaultWeeklyNewsletterTest } from '@/shared/model/experiments/tests/abDefaultWeeklyNewsletterTest';
 
 interface ABTestConfiguration {
   abTestSwitches: Record<string, boolean>;
@@ -9,7 +10,7 @@ interface ABTestConfiguration {
 }
 
 // Add AB tests to run in this array
-export const tests: ABTest[] = [];
+export const tests: ABTest[] = [abDefaultWeeklyNewsletterTest];
 
 const getDefaultABTestConfiguration = (): ABTestConfiguration => ({
   abTestSwitches: abSwitches,

--- a/src/shared/model/experiments/tests/abDefaultWeeklyNewsletterTest.ts
+++ b/src/shared/model/experiments/tests/abDefaultWeeklyNewsletterTest.ts
@@ -1,0 +1,28 @@
+import { ABTest } from '@guardian/ab-core';
+
+export const abDefaultWeeklyNewsletterTest: ABTest = {
+  id: 'DefaultWeeklyNewsletterTest', // This ID must match the Server Side AB Test
+  start: '2023-01-04',
+  expiry: '2023-02-30', // Remember that the server side test expiry can be different
+  author: 'Personalisation',
+  description:
+    'How successful a default opt in newsletter could be in the registration onboarding journey',
+  audience: 0.1,
+  audienceOffset: 0,
+  successMeasure:
+    'An opt in rate of over 20% and an unsubscribe rate of under 4%',
+  audienceCriteria:
+    '10% of onboarding flow traffic over one week, limited to US, UK and AU',
+  idealOutcome:
+    'Success measure plus look at customer feedback, impact on deliverability and impact on supporter consent opt in as secondary measures',
+  showForSensitive: true, // Should this A/B test run on sensitive articles?
+  canRun: () => true, // Check for things like user or page sections
+  variants: [
+    {
+      id: 'variant', // toggle is on
+      test: (): string => {
+        return 'variant';
+      },
+    },
+  ],
+};


### PR DESCRIPTION
## What does this change?

Sets up an AB test on the Consents/Newsletters page

The test displays a toggle above the newsletter cards with the option to sign up for one month's work of a weekly editorial newsletter. 

Variant -> the toggle switch is is defaulted 'ON' and will only show to browsers in US, UK, or AU/ 

[Trello Card](https://trello.com/c/9nx3eCDD/50-default-weekly-newsletter-email-trial)
[Figma designs](https://www.figma.com/file/MqzpmAIfQ4A2oTmsiLfCWV/Onboarding-journey-Tests?node-id=2478%3A26294&t=HgpdDuqjxC8JlRrW-0)
*Note:* this PR does not include the design changes to the newsletter consent card component on the Figma link

#### TODO

- [x] Audience numbers confirmation
- [x] Add CMP consent check
- [x] Copy and newsletter id (still being prepared by newsletters team)
- [x] MMA update - https://github.com/guardian/manage-frontend/pull/950


## Images

<img width="320" alt="image" src="https://user-images.githubusercontent.com/32312712/211829029-661746ee-2970-4353-93d4-a5299f60156b.png">

<img width="696" alt="image" src="https://user-images.githubusercontent.com/32312712/211828626-baf6bee6-3e32-468b-a4ba-0d88585c4a61.png">


<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

