### PR TITLE
`SC_GU_LA` cookie expiry fix

### DIFF
--- a/src/server/lib/idapi/IDAPICookies.ts
+++ b/src/server/lib/idapi/IDAPICookies.ts
@@ -37,9 +37,22 @@ export const setIDAPICookies = (
       }
     })
     .forEach(({ key, value, sessionCookie = false }) => {
+      const expires: Date | undefined = (() => {
+        if (key === 'SC_GU_LA') {
+          // have SC_GU_LA cookie expire in 30 mins, despite the fact that it is a session cookie
+          // this is to support the Native App logging in with an in-app browser, so the cookie
+          // isn't immediately deleted when the in app browser is closed
+          return new Date(Date.now() + 30 * 60 * 1000);
+        }
+        if (sessionCookie) {
+          return undefined;
+        }
+        return new Date(expiresAt);
+      })();
+
       res.cookie(key, value, {
         domain,
-        expires: sessionCookie ? undefined : new Date(expiresAt),
+        expires,
         httpOnly: !['GU_U', 'GU_SO'].includes(key), // unless GU_U/GU_SO cookie, set to true
         secure: isHttps && key !== 'GU_U', // unless GU_U cookie, set to isHttps (set to true, except in local dev)
         sameSite: 'lax',


### PR DESCRIPTION
## What does this change?

On native apps when a user logs in and completes the gateway authorization code flow on the `/oauth/authorization-code/callback` we redirect the user back to the app by completing the initial OAuth Auth Code flow initiated by the app by redirecting the browser to the `fromURI`. This functionality works as expected, and the user ends up back in the app, and the app is able to retrieve and use OAuth tokens.

In the `/oauth/authorization-code/callback` route, we also generate the existing Identity auth cookies, and add `Set-Cookie` headers to the redirect response to be able to set these cookies. When redirecting to a browser context this works as expected, these cookies are set, and the user is logged in on parts of the site which haven't yet migrated to Okta.

However the `SC_GU_LA` cookie, also called the "Last Authenticated" cookie, used to check if the user has authenticated within the last 30 mins, is set as a session cookie. This means that when the in-app browser is closed, this cookie is cleared. So when attempting to open an authenticated page, like Manage-my-account (MMA) within the 30 min period, it will still redirect the user to the `/reauthenticate` page asking users to enter their password/log in again.

This commit fixes this issue by setting the `SC_GU_LA` cookie with a 30 min expiry rather than as a session cookie, to prevent it from instantly being cleared, and thus allowing a user to visit pages like MMA within the 30 min period.

## Tested
- [x] Web CODE
- [x] Android
- [x] iOS