### PR TITLE
Fix: Add query params to links missing params

### DIFF
--- a/src/client/pages/EmailSent.tsx
+++ b/src/client/pages/EmailSent.tsx
@@ -65,7 +65,10 @@ export const EmailSent = ({
       {changeEmailPage && (
         <MainBodyText>
           Wrong email address?{' '}
-          <Link href={changeEmailPage}>Change email address</Link>.
+          <Link href={`${changeEmailPage}${queryString}`}>
+            Change email address
+          </Link>
+          .
         </MainBodyText>
       )}
       {email && resendEmailAction && (
@@ -85,7 +88,9 @@ export const EmailSent = ({
                     </b>
                     <br />
                     Don’t have an account?{' '}
-                    <Link href={buildUrl('/register')}>Register for free</Link>
+                    <Link href={`${buildUrl('/register')}${queryString}`}>
+                      Register for free
+                    </Link>
                   </>
                 )}
               </>


### PR DESCRIPTION
## What does this change?

Some links on the `/email-sent` page didn't include any query parameters, which meant if a user clicked on any of those links then the query parameters would be removed.

This causes a problem on the Okta apps migration, where the query parameters being available are reliant for deeplinking to work. So if a user navigated away from the `/email-sent` page by using one of the links, and then submitted another form, we wouldn't know where to deeplink the user to.

This PR fixes this by attached the query params to these links, which was already being used on the page for the submit action on the "resend email" form functionality.