### PR TITLE
Allow resend from /welcome/* after error

### DIFF
--- a/src/server/routes/welcome.ts
+++ b/src/server/routes/welcome.ts
@@ -131,8 +131,8 @@ router.post(
 );
 
 const OktaResendEmail = async (req: Request, res: ResponseWithRequestState) => {
+  const { email } = req.body;
   try {
-    const { email } = req.body;
     const state = res.locals;
 
     if (typeof email !== 'undefined') {
@@ -168,6 +168,11 @@ const OktaResendEmail = async (req: Request, res: ResponseWithRequestState) => {
       requestState: deepmerge(res.locals, {
         globalMessage: {
           error: GenericErrors.DEFAULT,
+        },
+        pageData: {
+          email,
+          resendEmailAction: '/welcome/resend',
+          changeEmailPage: '/welcome/resend',
         },
       }),
     });


### PR DESCRIPTION
## What does this change?

If a user attempts to submit the form on `/welcome/expired` or `/welcome/resend`, and Gateway responds with an error, the `/welcome/email-sent` page displays a user-facing error message but no option to resend the email. 

![image](https://user-images.githubusercontent.com/101555242/213420781-2d7ccc9c-8ee2-45f9-b279-510dd02cf5ce.png)

This is because we don't pass the email address into the `catch` branch which displays the error page, which this PR does:

<img width="987" alt="Screenshot 2023-01-19 at 10 43 45" src="https://user-images.githubusercontent.com/101555242/213422065-6282da29-089d-418b-8e70-f4460412beae.png">



