### PR TITLE
Show default weekly newsletter on Confirmation Page for trial

### DIFF
--- a/src/client/lib/consentsTracking.ts
+++ b/src/client/lib/consentsTracking.ts
@@ -1,4 +1,5 @@
 import { PageData } from '@/shared/model/ClientState';
+import { Newsletters } from '@/shared/model/Newsletter';
 import { sendOphanInteractionEvent } from './ophan';
 
 const trackInputElementInteraction = (
@@ -66,7 +67,8 @@ const newslettersFormSubmitOphanTracking = (
 
   // @AB_TEST: Default Weekly Newsletter Test: required for tracking
   inputElems.forEach((elem) => {
-    const defaultWeeklyNewsletter = elem.name === '6028';
+    const defaultWeeklyNewsletter =
+      elem.name === Newsletters.SATURDAY_ROUNDUP_TRIAL;
     if (defaultWeeklyNewsletter) {
       trackInputElementInteraction(
         elem,

--- a/src/client/pages/ConsentsNewslettersPage.tsx
+++ b/src/client/pages/ConsentsNewslettersPage.tsx
@@ -5,6 +5,7 @@ import { ConsentsNewsletters } from '@/client/pages/ConsentsNewsletters';
 import { ConsentsNewslettersAB } from '@/client/pages/ConsentsNewslettersAB';
 import { useAB } from '@guardian/ab-react';
 import { abDefaultWeeklyNewsletterTest } from '@/shared/model/experiments/tests/abDefaultWeeklyNewsletterTest';
+import { Newsletters } from '@/shared/model/Newsletter';
 
 export const ConsentsNewslettersPage = () => {
   const clientState = useClientState();
@@ -21,6 +22,11 @@ export const ConsentsNewslettersPage = () => {
   ];
 
   // @AB_TEST: Default Weekly Newsletter Test: START
+  const filteredConsents = consents.filter(
+    (consentType) =>
+      consentType.consent?.id !== Newsletters.SATURDAY_ROUNDUP_TRIAL,
+  );
+
   const ABTestAPI = useAB();
   const isInABTestVariant = ABTestAPI.isUserInVariant(
     abDefaultWeeklyNewsletterTest.id,
@@ -34,13 +40,13 @@ export const ConsentsNewslettersPage = () => {
   if (isInABTestVariant && hasCmpConsent && isInRegion) {
     return (
       <ConsentsNewslettersAB
-        consents={consents}
-        defaultOnboardingEmailId={'6028'}
+        consents={filteredConsents}
+        defaultOnboardingEmailId={Newsletters.SATURDAY_ROUNDUP_TRIAL}
         defaultOnboardingEmailConsentState={true}
       />
     );
   }
   // @AB_TEST: Default Weekly Newsletter Test: END
 
-  return <ConsentsNewsletters consents={consents} />;
+  return <ConsentsNewsletters consents={filteredConsents} />; // @AB_TEST: filtering out the Default Weekly Newsletter
 };

--- a/src/shared/lib/newsletter.ts
+++ b/src/shared/lib/newsletter.ts
@@ -30,6 +30,8 @@ export const NewsletterMap = new Map<GeoLocation | undefined, Newsletters[]>([
       Newsletters.DOWN_TO_EARTH,
       Newsletters.THE_LONG_READ,
       Newsletters.FIRST_EDITION_UK,
+      // @AB_TEST: Default Weekly Newsletter Test:
+      Newsletters.SATURDAY_ROUNDUP_TRIAL,
     ],
   ],
   [
@@ -38,6 +40,8 @@ export const NewsletterMap = new Map<GeoLocation | undefined, Newsletters[]>([
       Newsletters.DOWN_TO_EARTH,
       Newsletters.THE_LONG_READ,
       Newsletters.MORNING_BRIEFING_AU,
+      // @AB_TEST: Default Weekly Newsletter Test:
+      Newsletters.SATURDAY_ROUNDUP_TRIAL,
     ],
   ],
   [
@@ -46,6 +50,8 @@ export const NewsletterMap = new Map<GeoLocation | undefined, Newsletters[]>([
       Newsletters.DOWN_TO_EARTH,
       Newsletters.THE_LONG_READ,
       Newsletters.MORNING_BRIEFING_US,
+      // @AB_TEST: Default Weekly Newsletter Test:
+      Newsletters.SATURDAY_ROUNDUP_TRIAL,
     ],
   ],
 ]);

--- a/src/shared/model/Newsletter.ts
+++ b/src/shared/model/Newsletter.ts
@@ -18,6 +18,8 @@ export enum Newsletters {
   MORNING_BRIEFING_AU = '4148',
   MORNING_BRIEFING_US = '4300',
   THE_LONG_READ = '4165',
+  // @AB_TEST: Default Weekly Newsletter Test:
+  SATURDAY_ROUNDUP_TRIAL = '6028',
 }
 
 export const ALL_NEWSLETTER_IDS = Object.values(Newsletters);


### PR DESCRIPTION
## What does this change?

Addendum to #2105 

This PR ensures the Saturday Roundup newsletter shows up on the confirmation page at the end of the onboarding journey if a user has opted in. 

To achieve this, the newsletter is added to the Newsletter map for the three regions in the test, but filtered out from displaying on the newsletter page for both the test and non-test component. 

There should not be any need to filter out the newsletter from the Confirmation page component data, as only subscriber see the newsletters, and folks not in the test won't have been subscribed. 

## Images

<img width="541" alt="image" src="https://user-images.githubusercontent.com/32312712/213455724-afed737c-b2d7-4eac-b890-72749c964d9b.png">