### PR TITLE
Reduce bundle size | Sentry optimisation and other imports

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -477,7 +477,7 @@ It's also used as [the Guardian Source Design System](https://theguardian.design
 Example of styling and adding it to a `p` tag using Emotion and Source:
 
 ```tsx
-import * as React from 'react';
+import React from 'react';
 import { css } from '@emotion/react';
 import { textSans, neutral } from '@guardian/source-foundations';
 

--- a/src/client/components/Nav.tsx
+++ b/src/client/components/Nav.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { css } from '@emotion/react';
 import {
   brandBackground,

--- a/src/client/components/SubHeader.tsx
+++ b/src/client/components/SubHeader.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { css } from '@emotion/react';
 import {
   neutral,

--- a/src/client/static/hydration.tsx
+++ b/src/client/static/hydration.tsx
@@ -7,8 +7,16 @@ import { RoutingConfig } from '@/client/routes';
 import { App } from '@/client/app';
 import { tests } from '@/shared/model/experiments/abTests';
 import { abSwitches } from '@/shared/model/experiments/abSwitches';
-import * as Sentry from '@sentry/browser';
-import { Integrations } from '@sentry/tracing';
+import {
+  BrowserClient,
+  Breadcrumbs,
+  Dedupe,
+  defaultStackParser,
+  getCurrentHub,
+  GlobalHandlers,
+  makeFetchTransport,
+  HttpContext,
+} from '@sentry/browser';
 
 type Props = {
   routingConfig: RoutingConfig;
@@ -23,16 +31,25 @@ export const hydrateApp = ({ routingConfig }: Props) => {
   } = clientState;
 
   if (dsn) {
-    Sentry.init({
+    const client = new BrowserClient({
       dsn,
-      integrations: [new Integrations.BrowserTracing()],
       environment: stage,
       release: `gateway@${build}`,
       // If you want to log something all the time, wrap your call to
       // Sentry in a new Transaction and set `sampled` to true.
       // An example of this is in clientSideLogger.ts
       sampleRate: 0.2,
+      transport: makeFetchTransport,
+      stackParser: defaultStackParser,
+      integrations: [
+        new Breadcrumbs(),
+        new GlobalHandlers(),
+        new Dedupe(),
+        new HttpContext(),
+      ],
     });
+
+    getCurrentHub().bindClient(client);
   }
 
   hydrate(

--- a/src/email/lib/send.ts
+++ b/src/email/lib/send.ts
@@ -1,4 +1,4 @@
-import * as AWS from 'aws-sdk';
+import { SESV2 } from 'aws-sdk';
 import { awsConfig } from '@/server/lib/awsConfig';
 
 // We need to adjust the SES timeouts to be longer than the standard AWS
@@ -13,7 +13,7 @@ const sesConfig = {
   },
 };
 
-const SESV2 = new AWS.SESV2(sesConfig);
+const ses = new SESV2(sesConfig);
 
 type Props = {
   html: string;
@@ -33,7 +33,7 @@ export const send = async ({
     return true;
   }
 
-  const params: AWS.SESV2.SendEmailRequest = {
+  const params: SESV2.SendEmailRequest = {
     Content: {
       Simple: {
         Body: {
@@ -55,7 +55,7 @@ export const send = async ({
     FromEmailAddress: 'registration-reply@theguardian.com',
   };
 
-  const result = await SESV2.sendEmail(params).promise();
+  const result = await ses.sendEmail(params).promise();
   if (!result?.MessageId) {
     return false;
   }

--- a/src/server/lib/awsConfig.ts
+++ b/src/server/lib/awsConfig.ts
@@ -1,14 +1,18 @@
-import * as AWS from 'aws-sdk';
+import {
+  ConfigurationOptions,
+  CredentialProviderChain,
+  SharedIniFileCredentials,
+} from 'aws-sdk';
 
 const AWS_REGION = 'eu-west-1';
 const PROFILE = 'identity';
 
-const CREDENTIAL_PROVIDER = new AWS.CredentialProviderChain([
-  () => new AWS.SharedIniFileCredentials({ profile: PROFILE }),
-  ...AWS.CredentialProviderChain.defaultProviders,
+const CREDENTIAL_PROVIDER = new CredentialProviderChain([
+  () => new SharedIniFileCredentials({ profile: PROFILE }),
+  ...CredentialProviderChain.defaultProviders,
 ]);
 
-export const awsConfig: AWS.ConfigurationOptions = {
+export const awsConfig: ConfigurationOptions = {
   region: AWS_REGION,
   credentialProvider: CREDENTIAL_PROVIDER,
   maxRetries: 0,

--- a/src/server/lib/trackMetric.ts
+++ b/src/server/lib/trackMetric.ts
@@ -1,7 +1,6 @@
-import * as AWS from 'aws-sdk';
+import { AWSError, CloudWatch } from 'aws-sdk';
 import { Metrics } from '@/server/models/Metrics';
 import { logger } from '@/server/lib/serverSideLogger';
-import { AWSError } from 'aws-sdk';
 import { getConfiguration } from '@/server/lib/getConfiguration';
 import { awsConfig } from '@/server/lib/awsConfig';
 
@@ -11,7 +10,7 @@ interface MetricDimensions {
   [name: string]: string;
 }
 
-const CloudWatch = new AWS.CloudWatch(awsConfig);
+const cloudwatch = new CloudWatch(awsConfig);
 
 const defaultDimensions = {
   Stage,
@@ -35,20 +34,21 @@ export const trackMetric = (
     ...dimensions,
   };
 
-  CloudWatch.putMetricData({
-    Namespace: 'Gateway',
-    MetricData: [
-      {
-        MetricName: metricName,
-        Dimensions: Object.entries(mergedDimensions).map(([Name, Value]) => ({
-          Name,
-          Value,
-        })),
-        Value: 1,
-        Unit: 'Count',
-      },
-    ],
-  })
+  cloudwatch
+    .putMetricData({
+      Namespace: 'Gateway',
+      MetricData: [
+        {
+          MetricName: metricName,
+          Dimensions: Object.entries(mergedDimensions).map(([Name, Value]) => ({
+            Name,
+            Value,
+          })),
+          Value: 1,
+          Unit: 'Count',
+        },
+      ],
+    })
     .promise()
     .catch((error: AWSError) => {
       if (error.code.includes('ExpiredToken') && Stage === 'DEV') {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,6 +9,7 @@ const Dotenv = require('dotenv-webpack');
 const TerserPlugin = require('terser-webpack-plugin');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
+const webpack = require('webpack');
 
 const mode =
   process.env.ENVIRONMENT === 'production' ? 'production' : 'development';
@@ -176,6 +177,11 @@ const browser = ({ isLegacy }) => {
     new AssetsPlugin({
       path: path.resolve(__dirname, 'build'),
       filename: `${isLegacy ? 'legacy.' : ''}webpack-assets.json`,
+    }),
+    // Reduce Sentry bundle size
+    new webpack.DefinePlugin({
+      __SENTRY_DEBUG__: false,
+      __SENTRY_TRACING__: false,
     }),
   ]
   


### PR DESCRIPTION
## What does this change?

### Sentry

Used https://docs.sentry.io/platforms/javascript/configuration/tree-shaking/ to optimise the tree shaking and reduce the
sentry bundle size.

| | Before | After | Difference |
| - | - | - | - |
| Modern | 112.34 kB (30.69 kB gzipped) | 62.96 kB (17.99 kB gzipped) | 49.38 kB (12.70 kB gzipped) |
| Legacy | 472.94 kB (119.07 kB gzipped) | 390.28 kb (101.09 kB gzipped) | 82.66 kB (17.98 kB gzipped) |

### Other changes

Avoid using `import * as X from 'Y'` syntax, which may help optimise other imports