### PR TITLE
Reduce bundle size | Remove `js-sha1` package

### DIFF
--- a/package.json
+++ b/package.json
@@ -148,7 +148,6 @@
     "express": "^4.18.2",
     "helmet": "^6.0.1",
     "ioredis": "^5.2.5",
-    "js-sha1": "^0.6.0",
     "mjml": "^4.13.0",
     "mjml-browser": "^4.13.0",
     "mjml-react": "^2.0.8",

--- a/src/client/pages/ChangePassword.tsx
+++ b/src/client/pages/ChangePassword.tsx
@@ -11,6 +11,7 @@ type Props = {
   email: string;
   fieldErrors: FieldError[];
   formError?: string;
+  browserName?: string;
 };
 
 export const ChangePassword = ({
@@ -20,6 +21,7 @@ export const ChangePassword = ({
   email,
   fieldErrors,
   formError,
+  browserName,
 }: Props) => (
   <MainLayout pageHeader={headerText}>
     <MainBodyText>
@@ -33,6 +35,7 @@ export const ChangePassword = ({
       autoComplete="new-password"
       formTrackingName="new-password"
       formError={formError}
+      browserName={browserName}
     />
   </MainLayout>
 );

--- a/src/client/pages/ChangePasswordPage.tsx
+++ b/src/client/pages/ChangePasswordPage.tsx
@@ -13,6 +13,7 @@ export const ChangePasswordPage = () => {
       timeUntilTokenExpiry,
       formError,
       token,
+      browserName,
     } = {},
     queryParams,
   } = clientState;
@@ -53,6 +54,7 @@ export const ChangePasswordPage = () => {
       )}
       email={email}
       fieldErrors={fieldErrors}
+      browserName={browserName}
     />
   );
 };

--- a/src/client/pages/SetPasswordPage.tsx
+++ b/src/client/pages/SetPasswordPage.tsx
@@ -14,6 +14,7 @@ export const SetPasswordPage = () => {
       timeUntilTokenExpiry,
       formError,
       token,
+      browserName,
     } = {},
     queryParams,
   } = clientState;
@@ -51,6 +52,7 @@ export const SetPasswordPage = () => {
       email={email}
       fieldErrors={fieldErrors}
       formError={formError}
+      browserName={browserName}
     />
   );
 };

--- a/src/client/pages/Welcome.tsx
+++ b/src/client/pages/Welcome.tsx
@@ -21,6 +21,7 @@ type Props = {
   fieldErrors: FieldError[];
   passwordSet?: boolean;
   isJobs?: boolean;
+  browserName?: string;
 };
 
 const linkButton = css`
@@ -47,6 +48,7 @@ export const Welcome = ({
   fieldErrors,
   passwordSet = false,
   isJobs = false,
+  browserName,
 }: Props) => {
   const autoRow = getAutoRow(1, passwordFormSpanDef);
   const {
@@ -92,6 +94,7 @@ export const Welcome = ({
           autoComplete="new-password"
           formTrackingName="welcome"
           onInvalid={() => setFormSubmitAttempted(true)}
+          browserName={browserName}
         >
           {isJobs && <NameInputField onGroupError={setGroupError} />}
         </PasswordForm>

--- a/src/client/pages/WelcomePage.tsx
+++ b/src/client/pages/WelcomePage.tsx
@@ -8,7 +8,13 @@ import { logger } from '@/client/lib/clientSideLogger';
 export const WelcomePage = () => {
   const clientState = useClientState();
   const {
-    pageData: { email, fieldErrors = [], timeUntilTokenExpiry, token } = {},
+    pageData: {
+      email,
+      fieldErrors = [],
+      timeUntilTokenExpiry,
+      token,
+      browserName,
+    } = {},
     queryParams,
   } = clientState;
   const { clientId } = queryParams;
@@ -45,6 +51,7 @@ export const WelcomePage = () => {
       email={email}
       fieldErrors={fieldErrors}
       isJobs={isJobs}
+      browserName={browserName}
     />
   );
 };

--- a/src/shared/modules.d.ts
+++ b/src/shared/modules.d.ts
@@ -1,1 +1,0 @@
-declare module 'js-sha1';

--- a/yarn.lock
+++ b/yarn.lock
@@ -12959,11 +12959,6 @@ js-sdsl@^4.1.4:
   resolved "https://registry.yarnpkg.com/js-sdsl/-/js-sdsl-4.1.4.tgz#78793c90f80e8430b7d8dc94515b6c77d98a26a6"
   integrity sha512-Y2/yD55y5jteOAmY50JbUZYwk3CP3wnLPEZnlR1w9oKhITrBEtAxwuWKebFf8hMrPMgbYwFoWK/lH2sBkErELw==
 
-js-sha1@^0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/js-sha1/-/js-sha1-0.6.0.tgz#adbee10f0e8e18aa07cdea807cf08e9183dbc7f9"
-  integrity sha512-01gwBFreYydzmU9BmZxpVk6svJJHrVxEN3IOiGl6VO93bVKYETJ0sIth6DASI6mIFdt7NmfX9UiByRzsYHGU9w==
-
 js-string-escape@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/js-string-escape/-/js-string-escape-1.0.1.tgz#e2625badbc0d67c7533e9edc1068c587ae4137ef"


### PR DESCRIPTION
## What does this change?

Removes the `js-sha1` package and replaces it with the browser `SubtleCrypto` API.

We add a `cryptoSubtleFeatureTest` to test if we should use this API. If we're able to use the API then we perform the breached checked as normal.

If the feature test fails either because the user is using Internet Explorer or the Web Crypto API is not supported, then we skip the breached check on the client side, and assume a valid password has been entered if between 8 - 72 characters.

The breached password check happens on the server side anyway, so if the user has entered a breached password on the client, we'll pick it up anyway on the server side and ask the user to change it should they be using an unsupported browser.

Tested support using Browserstack in IE11 and older chrome versions.

This saves around 6 kB (2 kB gzipped), and is more secure as it uses browser APIs rather than an npm package.