### PR TITLE
Reduce bundle size | Remove `query-string`

### DIFF
--- a/cypress/integration/ete-okta/reauthenticate.4.cy.ts
+++ b/cypress/integration/ete-okta/reauthenticate.4.cy.ts
@@ -1,11 +1,11 @@
-import { stringify } from 'query-string';
-
 describe('Reauthenticate flow, Okta enabled', () => {
   beforeEach(() => {
     // Disable redirect to /signin/success by default
     cy.setCookie(
       'GU_ran_experiments',
-      stringify({ OptInPromptPostSignIn: Date.now() }),
+      new URLSearchParams({
+        OptInPromptPostSignIn: Date.now().toString(),
+      }).toString(),
     );
   });
   it('keeps User A signed in when User A attempts to reauthenticate', () => {

--- a/cypress/integration/ete-okta/registration.2.cy.ts
+++ b/cypress/integration/ete-okta/registration.2.cy.ts
@@ -3,7 +3,6 @@ import {
   randomPassword,
 } from '../../support/commands/testUser';
 import { Status } from '../../../src/server/models/okta/User';
-import { stringify } from 'query-string';
 
 describe('Registration flow', () => {
   context('Registering with Okta', () => {
@@ -1237,7 +1236,9 @@ describe('Registration flow', () => {
       // Disable redirect to /signin/success by default
       cy.setCookie(
         'GU_ran_experiments',
-        stringify({ OptInPromptPostSignIn: Date.now() }),
+        new URLSearchParams({
+          OptInPromptPostSignIn: Date.now().toString(),
+        }).toString(),
       );
       // Intercept the external redirect page.
       // We just want to check that the redirect happens, not that the page loads.

--- a/cypress/integration/ete-okta/sign_out.2.cy.ts
+++ b/cypress/integration/ete-okta/sign_out.2.cy.ts
@@ -1,5 +1,3 @@
-import { stringify } from 'query-string';
-
 describe('Sign out flow', () => {
   context('Signs a user out', () => {
     it('Removes Okta cookies and dotcom cookies when signing out', () => {
@@ -9,7 +7,9 @@ describe('Sign out flow', () => {
         // Disable redirect to /signin/success by default
         cy.setCookie(
           'GU_ran_experiments',
-          stringify({ OptInPromptPostSignIn: Date.now() }),
+          new URLSearchParams({
+            OptInPromptPostSignIn: Date.now().toString(),
+          }).toString(),
         );
 
         // load the consents page as its on the same domain

--- a/cypress/integration/ete/sign_out/sign_out.3.cy.ts
+++ b/cypress/integration/ete/sign_out/sign_out.3.cy.ts
@@ -1,5 +1,3 @@
-import { stringify } from 'query-string';
-
 describe('Sign out flow', () => {
   const DotComCookies = [
     'gu_user_features_expiry',
@@ -16,7 +14,9 @@ describe('Sign out flow', () => {
         // Disable redirect to /signin/success by default
         cy.setCookie(
           'GU_ran_experiments',
-          stringify({ OptInPromptPostSignIn: Date.now() }),
+          new URLSearchParams({
+            OptInPromptPostSignIn: Date.now().toString(),
+          }).toString(),
         );
         // load the consents page as its on the same domain
         const postSignInReturnUrl = `https://${Cypress.env(

--- a/cypress/integration/mocked/sign_in.2.cy.ts
+++ b/cypress/integration/mocked/sign_in.2.cy.ts
@@ -1,5 +1,3 @@
-import { stringify } from 'query-string';
-
 import { injectAndCheckAxe } from '../../support/cypress-axe';
 import { allConsents, CONSENTS_ENDPOINT } from '../../support/idapi/consent';
 import {
@@ -259,7 +257,9 @@ describe('Sign in flow', () => {
     it('unless experiment already viewed', () => {
       cy.setCookie(
         'GU_ran_experiments',
-        stringify({ OptInPromptPostSignIn: Date.now() }),
+        new URLSearchParams({
+          OptInPromptPostSignIn: Date.now().toString(),
+        }).toString(),
       );
       signIn();
       cy.url().should('include', defaultReturnUrl);

--- a/cypress/integration/mocked/welcome.4.cy.ts
+++ b/cypress/integration/mocked/welcome.4.cy.ts
@@ -9,7 +9,6 @@ import {
   verifiedUserWithNoConsent,
   USER_ENDPOINT,
 } from '../../support/idapi/user';
-import * as qs from 'query-string';
 import CommunicationsPage from '../../support/pages/onboarding/communications_page';
 
 describe('Welcome and set password page', () => {
@@ -142,7 +141,7 @@ describe('Welcome and set password page', () => {
       const returnUrl = encodeURIComponent(
         `https://www.theguardian.com/science/grrlscientist/2012/aug/07/3`,
       );
-      const query = qs.stringify({ returnUrl });
+      const query = new URLSearchParams({ returnUrl }).toString();
 
       cy.mockNext(200, checkTokenSuccessResponse());
       cy.intercept({
@@ -173,7 +172,7 @@ describe('Welcome and set password page', () => {
         `https://www.theguardian.com/science/grrlscientist/2012/aug/07/3`,
       );
       const clientId = 'jobs';
-      const query = qs.stringify({ returnUrl, clientId });
+      const query = new URLSearchParams({ returnUrl, clientId }).toString();
 
       cy.mockNext(200, checkTokenSuccessResponse());
       cy.intercept({

--- a/cypress/integration/shared/sign_in.shared.ts
+++ b/cypress/integration/shared/sign_in.shared.ts
@@ -1,5 +1,3 @@
-import { stringify } from 'query-string';
-
 const returnUrl =
   'https://www.theguardian.com/world/2013/jun/09/edward-snowden-nsa-whistleblower-surveillance';
 
@@ -7,7 +5,9 @@ export const beforeEach = () => {
   // Disable redirect to /signin/success by default
   cy.setCookie(
     'GU_ran_experiments',
-    stringify({ OptInPromptPostSignIn: Date.now() }),
+    new URLSearchParams({
+      OptInPromptPostSignIn: Date.now().toString(),
+    }).toString(),
   );
 };
 

--- a/cypress/support/pages/onboarding/onboarding_page.ts
+++ b/cypress/support/pages/onboarding/onboarding_page.ts
@@ -1,5 +1,3 @@
-import * as qs from 'query-string';
-
 class Onboarding {
   static URL = '/consents';
 
@@ -31,7 +29,7 @@ class Onboarding {
   }
 
   static gotoFlowStart({ failOnStatusCode = true, query = {} } = {}) {
-    const querystring = qs.stringify(query);
+    const querystring = new URLSearchParams(query).toString();
 
     cy.visit(`${Onboarding.URL}${querystring ? `?${querystring}` : ''}`, {
       failOnStatusCode,

--- a/cypress/support/pages/verify_email.ts
+++ b/cypress/support/pages/verify_email.ts
@@ -1,5 +1,3 @@
-import * as qs from 'query-string';
-
 class VerifyEmail {
   static URL = '/verify-email';
 
@@ -16,7 +14,7 @@ class VerifyEmail {
   };
 
   goto(token: string, { failOnStatusCode = true, query = {} } = {}) {
-    const querystring = qs.stringify(query);
+    const querystring = new URLSearchParams(query).toString();
 
     cy.visit(
       `${VerifyEmail.URL}${token ? `/${token}` : ''}${

--- a/package.json
+++ b/package.json
@@ -154,7 +154,6 @@
     "ms": "^2.1.3",
     "openid-client": "^5.3.2",
     "ophan-tracker-js": "^1.4.0",
-    "query-string": "^7.1.3",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "serialize-javascript": "^6.0.1",

--- a/scripts/okta/okta-login.html
+++ b/scripts/okta/okta-login.html
@@ -9,7 +9,7 @@
       href="https://static.guim.co.uk/images/favicon-32x32.ico"
     />
     <title>The Guardian | Login</title>
-    <script src="https://polyfill.io/v3/polyfill.min.js?features=String.prototype.startsWith%2CURLSearchParams"></script>
+    <script src="https://assets.guim.co.uk/polyfill.io/v3/polyfill.min.js?features=es2015%2Ces2016%2Ces2017%2Ces2018%2Ces2019%2Ces2020%2Ces2021%2Ces2022%2Cfetch%2CglobalThis%2CURLSearchParams"></script>
   </head>
   <body>
     {{{OktaUtil}}}

--- a/src/server/lib/__tests__/getABForcedVariants.test.ts
+++ b/src/server/lib/__tests__/getABForcedVariants.test.ts
@@ -1,19 +1,15 @@
 import { Request } from 'express';
 import { getABForcedVariants } from '@/server/lib/getABForcedVariants';
 
-const fakeRequest = (queryParameters?: string[]) => ({
-  url: `https://guardian.com${
-    queryParameters && '?' + queryParameters.join('&')
-  }`,
-});
-
 describe('getABForcedVariants', () => {
   describe('when there are variants', () => {
     it('returns the variants stripped of their ab- prefix', () => {
-      const request = fakeRequest([
-        'ab-test1=testparameter1',
-        'ab-test2=testparameter2',
-      ]) as unknown as Request;
+      const request = {
+        query: {
+          'ab-test1': 'testparameter1',
+          'ab-test2': 'testparameter2',
+        },
+      } as unknown as Request;
       const expected = {
         test1: {
           variant: 'testparameter1',
@@ -28,10 +24,11 @@ describe('getABForcedVariants', () => {
   });
   describe('when there are multiple variants of the same key', () => {
     it('only uses the latest query in the string', () => {
-      const request = fakeRequest([
-        'ab-test3=testparameter3',
-        'ab-test3=testparameter4',
-      ]) as unknown as Request;
+      const request = {
+        query: {
+          'ab-test3': ['testparameter3', 'testparameter4'],
+        },
+      } as unknown as Request;
       const expected = {
         test3: {
           variant: 'testparameter4',
@@ -43,7 +40,7 @@ describe('getABForcedVariants', () => {
   });
   describe('when there are no variants', () => {
     it('returns an empty varients object', () => {
-      const request = fakeRequest() as unknown as Request;
+      const request = { query: {} } as unknown as Request;
       const expected = {};
       const output = getABForcedVariants(request);
       expect(output).toStrictEqual(expected);

--- a/src/server/lib/experiments.ts
+++ b/src/server/lib/experiments.ts
@@ -1,5 +1,4 @@
 import { Request } from 'express';
-import { parse, stringify } from 'query-string';
 import ms from 'ms';
 import { getConfiguration } from '@/server/lib/getConfiguration';
 
@@ -13,7 +12,7 @@ const getRanExperiments = (req: Request) => {
 
   if (!ranExperimentsValue) return {};
 
-  return parse(ranExperimentsValue);
+  return Object.fromEntries(new URLSearchParams(ranExperimentsValue));
 };
 
 export const hasExperimentRun = (req: Request, experimentId: string) => {
@@ -41,7 +40,7 @@ export const setExperimentRan = (
     const { [experimentId]: omit, ...otherExperiments } = ranExperiments;
     newExperiments = otherExperiments;
   }
-  const newValue = stringify(newExperiments);
+  const newValue = new URLSearchParams(newExperiments).toString();
   res.cookie(RAN_EXPERIMENTS_COOKIE_NAME, newValue, {
     httpOnly: true,
     maxAge: ms('1yr'),

--- a/src/server/lib/getABForcedVariants.ts
+++ b/src/server/lib/getABForcedVariants.ts
@@ -1,4 +1,3 @@
-import qs from 'query-string';
 import { Request } from 'express';
 import { Participations } from '@guardian/ab-core';
 
@@ -7,8 +6,7 @@ const TEST_PREFIX = 'ab-';
 // get forced test variants
 // need to be in { [key: string]: { variant: string } }; type (Participations)
 export const getABForcedVariants = (req: Request): Participations => {
-  const query = qs.parseUrl(req.url).query;
-  const forcedTestVariants = Object.entries(query)
+  const forcedTestVariants = Object.entries(req.query)
     .filter(([key]) => key.startsWith(TEST_PREFIX))
     .map(([key, value]) => {
       const v = Array.isArray(value) ? value[value.length - 1] : value;

--- a/src/server/lib/renderer.tsx
+++ b/src/server/lib/renderer.tsx
@@ -149,7 +149,7 @@ export const renderer: <P extends RoutePaths>(
         <title>${pageTitle} | The Guardian</title>
         <script>window.gaUID = "${gaUID.id}"</script>
 
-        <script src="https://assets.guim.co.uk/polyfill.io/v3/polyfill.min.js?features=es2015%2Ces2016%2Ces2017%2Ces2018%2Ces2019%2Ces2020%2Ces2021%2Ces2022%2Cfetch%2CglobalThis" defer></script>
+        <script src="https://assets.guim.co.uk/polyfill.io/v3/polyfill.min.js?features=es2015%2Ces2016%2Ces2017%2Ces2018%2Ces2019%2Ces2020%2Ces2021%2Ces2022%2Cfetch%2CglobalThis%2CURLSearchParams" defer></script>
         ${scriptTags}
 
         <script id="routingConfig" type="application/json">${serialize(

--- a/src/shared/__tests__/queryParams.test.ts
+++ b/src/shared/__tests__/queryParams.test.ts
@@ -1,6 +1,7 @@
 import {
   addQueryParamsToPath,
   getPersistableQueryParams,
+  removeEmptyKeysFromObjectAndConvertValuesToString,
 } from '@/shared/lib/queryParams';
 import {
   QueryParams,
@@ -86,7 +87,60 @@ describe('addQueryParamsToPath', () => {
     const output = addQueryParamsToPath('/newsletters', input, inputOverride);
 
     expect(output).toEqual(
-      '/newsletters?clientId=jobs&componentEventParams=componentEventParams&csrfError=true&encryptedEmail=an%20encrypted%20email&recaptchaError=true&ref=ref&refViewId=refViewId&returnUrl=returnUrl',
+      '/newsletters?clientId=jobs&componentEventParams=componentEventParams&csrfError=true&encryptedEmail=an+encrypted+email&recaptchaError=true&ref=ref&refViewId=refViewId&returnUrl=returnUrl',
     );
+  });
+
+  it('removes undefined or empty string values from the querystring', () => {
+    const input: QueryParams = {
+      returnUrl: 'returnUrl',
+      clientId: 'jobs',
+      csrfError: true,
+      recaptchaError: true,
+      emailVerified: true,
+      encryptedEmail: 'encryptedEmail',
+      error: 'error',
+      ref: undefined,
+      refViewId: '',
+      componentEventParams: 'componentEventParams',
+      useIdapi: undefined,
+    };
+
+    const output = addQueryParamsToPath('/newsletters', input);
+
+    expect(output).toEqual(
+      '/newsletters?clientId=jobs&componentEventParams=componentEventParams&returnUrl=returnUrl',
+    );
+  });
+});
+
+describe('removeEmptyKeysFromObjectAndConvertValuesToString', () => {
+  it('removes undefined or empty string values from the object', () => {
+    const input: QueryParams = {
+      returnUrl: 'returnUrl',
+      clientId: 'jobs',
+      csrfError: true,
+      recaptchaError: true,
+      emailVerified: true,
+      encryptedEmail: 'encryptedEmail',
+      error: 'error',
+      ref: undefined,
+      refViewId: '',
+      componentEventParams: 'componentEventParams',
+      useIdapi: undefined,
+    };
+
+    const output = removeEmptyKeysFromObjectAndConvertValuesToString(input);
+
+    expect(output).toEqual({
+      returnUrl: 'returnUrl',
+      clientId: 'jobs',
+      csrfError: 'true',
+      recaptchaError: 'true',
+      emailVerified: 'true',
+      encryptedEmail: 'encryptedEmail',
+      error: 'error',
+      componentEventParams: 'componentEventParams',
+    });
   });
 });

--- a/src/shared/lib/queryParams.ts
+++ b/src/shared/lib/queryParams.ts
@@ -1,10 +1,30 @@
-import { stringify } from 'query-string';
 import {
   QueryParams,
   PersistableQueryParams,
 } from '@/shared/model/QueryParams';
 import { IdApiQueryParams } from '../model/IdapiQueryParams';
 import { AllRoutes } from '../model/Routes';
+
+/**
+ * function to remove undefined, null, and empty string values from an object
+ * and covert the values to strings so they can be used in a query string using
+ * the URLSearchParams object
+ * @param obj Object to remove empty keys from
+ * @returns Object with empty keys removed and values converted to strings
+ */
+export const removeEmptyKeysFromObjectAndConvertValuesToString = (
+  obj: Record<string, unknown>,
+) => {
+  const newObj: Record<string, string> = {};
+  Object.keys(obj).forEach((key) => {
+    const asStr = obj[key]?.toString();
+    if (asStr) {
+      // eslint-disable-next-line functional/immutable-data
+      newObj[key] = asStr;
+    }
+  });
+  return newObj;
+};
 
 /**
  * @param params QueryParams object with all query parameters
@@ -74,14 +94,17 @@ export const addQueryParamsToUntypedPath = (
   overrides?: Partial<QueryParams>,
 ): string => {
   const divider = path.includes('?') ? '&' : '?';
-  const queryString = stringify(
-    { ...getPersistableQueryParams(params), ...overrides },
-    {
-      skipNull: true,
-      skipEmptyString: true,
-    },
+  const searchParams = new URLSearchParams(
+    removeEmptyKeysFromObjectAndConvertValuesToString({
+      ...getPersistableQueryParams(params),
+      ...overrides,
+    }),
   );
-  return `${path}${divider}${queryString}`;
+
+  // eslint-disable-next-line functional/immutable-data
+  searchParams.sort();
+
+  return `${path}${divider}${searchParams.toString()}`;
 };
 
 /**
@@ -100,14 +123,16 @@ export const addApiQueryParamsToPath = (
   overrides?: Partial<QueryParams>,
 ): string => {
   const divider = path.includes('?') ? '&' : '?';
-  const queryString = stringify(
-    { ...params, ...overrides },
-    {
-      skipNull: true,
-      skipEmptyString: true,
-    },
+  const searchParams = new URLSearchParams(
+    removeEmptyKeysFromObjectAndConvertValuesToString({
+      ...params,
+      ...overrides,
+    }),
   );
-  return `${path}${divider}${queryString}`;
+  // eslint-disable-next-line functional/immutable-data
+  searchParams.sort();
+
+  return `${path}${divider}${searchParams.toString()}`;
 };
 
 /**
@@ -115,7 +140,7 @@ export const addApiQueryParamsToPath = (
  * @param params QueryParams - any query params to be added to the path
  * @param overrides Any query parameter overrides
  * @returns string
- * buildQueryParamsString is for building a Gateway compatabile query string
+ * buildQueryParamsString is for building a Gateway compatible query string
  * These parameters are are filtered, so only allowed parameters can be added.
  */
 
@@ -123,12 +148,15 @@ export const buildQueryParamsString = (
   params: QueryParams,
   overrides?: Partial<QueryParams>,
 ): string => {
-  const queryString = stringify(
-    { ...getPersistableQueryParams(params), ...overrides },
-    {
-      skipNull: true,
-      skipEmptyString: true,
-    },
+  const searchParams = new URLSearchParams(
+    removeEmptyKeysFromObjectAndConvertValuesToString({
+      ...getPersistableQueryParams(params),
+      ...overrides,
+    }),
   );
-  return `?${queryString}`;
+
+  // eslint-disable-next-line functional/immutable-data
+  searchParams.sort();
+
+  return `?${searchParams.toString()}`;
 };

--- a/src/shared/model/OktaQueryParams.ts
+++ b/src/shared/model/OktaQueryParams.ts
@@ -1,4 +1,4 @@
-import { StringifiableRecord } from 'query-string';
+import { StringifiableRecord } from './QueryParams';
 
 /**
  * OktaQueryParams are query parameters

--- a/src/shared/model/QueryParams.ts
+++ b/src/shared/model/QueryParams.ts
@@ -1,5 +1,11 @@
-import { StringifiableRecord } from 'query-string';
 import { ValidClientId } from '../lib/clientId';
+
+export type Stringifiable = string | boolean | number | null | undefined;
+
+export type StringifiableRecord = Record<
+  string,
+  Stringifiable | readonly Stringifiable[]
+>;
 
 export interface TrackingQueryParams {
   // this is the url of the referring page

--- a/yarn.lock
+++ b/yarn.lock
@@ -8552,7 +8552,7 @@ decimal.js@^10.4.2:
   resolved "https://registry.yarnpkg.com/decimal.js/-/decimal.js-10.4.3.tgz#1044092884d245d1b7f65725fa4ad4c6f781cc23"
   integrity sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA==
 
-decode-uri-component@^0.2.0, decode-uri-component@^0.2.2:
+decode-uri-component@^0.2.0:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.2.tgz#e69dbe25d37941171dd540e024c444cd5188e1e9"
   integrity sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==
@@ -10270,11 +10270,6 @@ fill-range@^7.0.1:
   integrity sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==
   dependencies:
     to-regex-range "^5.0.1"
-
-filter-obj@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/filter-obj/-/filter-obj-1.1.0.tgz#9b311112bc6c6127a16e016c6c5d7f19e0805c5b"
-  integrity sha1-mzERErxsYSehbgFsbF1/GeCAXFs=
 
 finalhandler@1.2.0:
   version "1.2.0"
@@ -16055,16 +16050,6 @@ query-string@^5.0.1:
     object-assign "^4.1.0"
     strict-uri-encode "^1.0.0"
 
-query-string@^7.1.3:
-  version "7.1.3"
-  resolved "https://registry.yarnpkg.com/query-string/-/query-string-7.1.3.tgz#a1cf90e994abb113a325804a972d98276fe02328"
-  integrity sha512-hh2WYhq4fi8+b+/2Kg9CEge4fDPvHS534aOOvOZeQ3+Vf2mCFsaFBYj0i+iXcAq6I9Vzp5fjMFBlONvayDC1qg==
-  dependencies:
-    decode-uri-component "^0.2.2"
-    filter-obj "^1.1.0"
-    split-on-first "^1.0.0"
-    strict-uri-encode "^2.0.0"
-
 querystring-es3@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/querystring-es3/-/querystring-es3-0.2.1.tgz#9ec61f79049875707d69414596fd907a4d711e73"
@@ -17427,11 +17412,6 @@ spdx-license-ids@^3.0.0:
   resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.11.tgz#50c0d8c40a14ec1bf449bae69a0ea4685a9d9f95"
   integrity sha512-Ctl2BrFiM0X3MANYgj3CkygxhRmr9mi6xhejbdO960nF6EDJApTYpn0BQnDKlnNBULKiCN1n3w9EBkHK8ZWg+g==
 
-split-on-first@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/split-on-first/-/split-on-first-1.1.0.tgz#f610afeee3b12bce1d0c30425e76398b78249a5f"
-  integrity sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==
-
 split-string@^3.0.1, split-string@^3.0.2:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/split-string/-/split-string-3.1.0.tgz#7cb09dda3a86585705c64b39a6466038682e8fe2"
@@ -17642,11 +17622,6 @@ strict-uri-encode@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz#279b225df1d582b1f54e65addd4352e18faa0713"
   integrity sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=
-
-strict-uri-encode@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz#b9c7330c7042862f6b142dc274bbcc5866ce3546"
-  integrity sha1-ucczDHBChi9rFC3CdLvMWGbONUY=
 
 string-length@^4.0.1:
   version "4.0.2"


### PR DESCRIPTION
## What does this change?

Removes the `query-string` package and replaces it with the browser `URLSearchParams` API.

Polyfill `URLSearchParams` for browsers that don't support the API.

Add additional methods and update tests to make sure this functionality remains identitcal to how we use it.

This saves a small amount in our bundle size, as well as removes the need for the dependency directly (which is causing problems to upgrade as it's moved to pure ESM).

Approx 6 kB (2 KB gzipped) in both the modern and legacy bundle.

Also updates the polyfill.io package so that it matches between the `renderer.tsx` (used by gateway pages) and the `okta-login.html` used for the intercept of the Okta hosted sign in page, so that the features match between the two.
