### PR TITLE
Fix | Input/Email related issues

### DIFF
--- a/src/client/__tests__/EmailInput.test.tsx
+++ b/src/client/__tests__/EmailInput.test.tsx
@@ -20,9 +20,8 @@ const setup = () => {
 
 test('errors with nothing submitted', async () => {
   const { emailInput, queryByText } = setup();
-  // Input text and blur to trigger error
-  fireEvent.change(emailInput, { target: { value: '' } });
-  fireEvent.blur(emailInput);
+  // Input empty text to trigger error
+  fireEvent.input(emailInput, { target: { value: '' } });
   expect(emailInput.value).toEqual('');
 
   // Check error message

--- a/src/client/pages/Registration.tsx
+++ b/src/client/pages/Registration.tsx
@@ -63,7 +63,7 @@ export const Registration = ({
         disableOnSubmit
         formErrorMessageFromParent={formError}
       >
-        <EmailInput defaultValue={email} />
+        <EmailInput defaultValue={email} autoComplete="off" />
         <CmpConsentedStateHiddenInput cmpConsentedState={hasCmpConsent} />
       </MainForm>
     </MainLayout>

--- a/src/email/lib/send.ts
+++ b/src/email/lib/send.ts
@@ -52,7 +52,7 @@ export const send = async ({
     Destination: {
       ToAddresses: [to],
     },
-    FromEmailAddress: 'registration-reply@theguardian.com',
+    FromEmailAddress: 'The Guardian <registration-reply@theguardian.com>',
   };
 
   const result = await ses.sendEmail(params).promise();


### PR DESCRIPTION
## What does this change?

Worth going through this PR commit by commit when reviewing.

- Add `The Guardian` to the `FromEmailAddress` in email sending from AWS SES https://github.com/guardian/gateway/pull/2125/commits/f1ca64c9cc66e02567e5de7bfeb741ebde00f238
- Fix input validation to only transition validity state on if the input is not empty, and on change/on input when the user stops typing https://github.com/guardian/gateway/pull/2125/commits/45a3570ca6786070584ad189a89941aa8fac47ff
- Allow for custom `autocomplete` values in the `EmailInput` component, as we don't want to autofill the email field on the registration page https://github.com/guardian/gateway/pull/2125/commits/b30b2d11798a57c228714a8c7caadcea8e65111f


https://user-images.githubusercontent.com/13315440/214252346-0609383b-5d9f-4203-973a-65c0f008d5f9.mov

