### PR TITLE
Persist cmpState in encryptedStateCookie

### DIFF
--- a/src/server/routes/consents.ts
+++ b/src/server/routes/consents.ts
@@ -43,6 +43,8 @@ import { ConsentPath, RoutePaths } from '@/shared/model/Routes';
 import { PageTitle } from '@/shared/model/PageTitle';
 import { mergeRequestState } from '@/server/lib/requestState';
 import { updateRegistrationLocationViaIDAPI } from '../lib/updateRegistrationLocation';
+import { updateEncryptedStateCookie } from '../lib/encryptedStateCookie';
+import { isStringBoolean } from '../lib/isStringBoolean';
 
 interface ConsentPage {
   page: ConsentPath;
@@ -333,6 +335,7 @@ router.post(
     let state = res.locals;
 
     const sc_gu_u = req.cookies.SC_GU_U;
+    const _cmpConsentedState = isStringBoolean(req.body._cmpConsentedState);
 
     const { page } = req.params;
     let status = 200;
@@ -364,6 +367,10 @@ router.post(
         `${consentPages[pageIndex + 1].path}`,
         state.queryParams,
       );
+
+      updateEncryptedStateCookie(req, res, {
+        cmpConsentedState: _cmpConsentedState,
+      });
 
       return res.redirect(303, url);
     } catch (error) {

--- a/src/shared/model/EncryptedState.ts
+++ b/src/shared/model/EncryptedState.ts
@@ -7,5 +7,6 @@ export interface EncryptedState {
   passwordSetOnWelcomePage?: boolean;
   status?: string;
   signInRedirect?: boolean; // TODO: possibly rename for clarity
+  cmpConsentedState?: boolean;
   queryParams?: PersistableQueryParams;
 }


### PR DESCRIPTION
## What does this change?

Adds the cmpState to the EncryptedState cookie and persists it the though the onboarding flow (Consent pages)

The cmpState is sent to the server on each POST /consents/:page request and added/updated in the EncryptedStateCookie at that point. 

We need to know the cmp state on the server in order to localise newsletters in #2119 (draft)


## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
