### PR TITLE
Revert "Stop and remove default weekly newsletter test"

### DIFF
--- a/src/client/components/ConsentCardOnboardingEmails.stories.tsx
+++ b/src/client/components/ConsentCardOnboardingEmails.stories.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { ComponentMeta, ComponentStory } from '@storybook/react';
+
+import { ConsentCardOnboarding } from './ConsentCardOnboardingEmails';
+
+export default {
+  title: 'Components/ConsentCardOnboarding',
+  component: ConsentCardOnboarding,
+} as ComponentMeta<typeof ConsentCardOnboarding>;
+
+const Template: ComponentStory<typeof ConsentCardOnboarding> = ({
+  id = '4147',
+}) => <ConsentCardOnboarding id={id} />;
+
+export const Default = Template.bind({});
+Default.storyName = 'default';

--- a/src/client/components/ConsentCardOnboardingEmails.tsx
+++ b/src/client/components/ConsentCardOnboardingEmails.tsx
@@ -1,0 +1,78 @@
+import React, { FunctionComponent } from 'react';
+import { SerializedStyles, css } from '@emotion/react';
+import { space, neutral, from, textSans } from '@guardian/source-foundations';
+import { ToggleSwitchInput } from './ToggleSwitchInput';
+import { greyBorderTop, text } from '@/client/styles/Consents';
+import { topMargin } from '@/client/styles/Shared';
+
+const containerStyles = css`
+  display: flex;
+  flex-direction: column;
+  border: ${neutral[0]} 3px dashed;
+  border-radius: 12px;
+  margin-bottom: ${space[3]}px;
+  padding: ${space[2]}px;
+
+  ${from.tablet} {
+    padding: ${space[2]}px ${space[3]}px;
+    p {
+      padding-right: ${space[5]}px;
+    }
+  }
+
+  :not(:last-of-type) {
+    margin-bottom: ${space[5]}px;
+  }
+`;
+
+const toggleSwitchAlignment = css`
+  justify-content: space-between;
+  span {
+    align-self: flex-start;
+    margin-top: ${space[2]}px;
+  }
+`;
+
+const labelStyles = css`
+  ${textSans.small()}
+  font-weight: bold;
+  span {
+    margin-top: 2px !important;
+  }
+`;
+
+const switchRow = css`
+  border: 0;
+  padding: 0;
+  ${topMargin}
+`;
+
+interface ConsentCardOnboardingEmailProps {
+  id: string;
+  defaultChecked?: boolean;
+  cssOverrides?: SerializedStyles;
+}
+
+export const ConsentCardOnboarding: FunctionComponent<
+  ConsentCardOnboardingEmailProps
+> = ({ id, defaultChecked, cssOverrides }) => {
+  return (
+    <article css={[containerStyles, cssOverrides]}>
+      <p css={[text]}>
+        As a benefit of creating an account, you&apos;ll receive Saturday
+        Roundup for four weeks, an exclusive newsletter featuring highlights of
+        the last week from the Guardian and ways to support our journalism.
+      </p>
+      <fieldset css={[switchRow, greyBorderTop]}>
+        {/* Hidden input required to capture unsubscribe events */}
+        <input type="hidden" name={id} value="" key="hidden" />
+        <ToggleSwitchInput
+          id={id}
+          defaultChecked={defaultChecked}
+          label={'Receive Saturday Roundup'}
+          cssOverrides={[labelStyles, toggleSwitchAlignment]}
+        ></ToggleSwitchInput>
+      </fieldset>
+    </article>
+  );
+};

--- a/src/client/lib/consentsTracking.ts
+++ b/src/client/lib/consentsTracking.ts
@@ -1,4 +1,5 @@
 import { PageData } from '@/shared/model/ClientState';
+import { Newsletters } from '@/shared/model/Newsletter';
 import { sendOphanInteractionEvent } from './ophan';
 
 const trackInputElementInteraction = (
@@ -63,6 +64,19 @@ const newslettersFormSubmitOphanTracking = (
       }
     });
   }
+
+  // @AB_TEST: Default Weekly Newsletter Test: required for tracking
+  inputElems.forEach((elem) => {
+    const defaultWeeklyNewsletter =
+      elem.name === Newsletters.SATURDAY_ROUNDUP_TRIAL;
+    if (defaultWeeklyNewsletter) {
+      trackInputElementInteraction(
+        elem,
+        'newsletter',
+        'saturday-roundup-trial',
+      );
+    }
+  });
 };
 
 // handle generic form (direct to one of the two below based on page)

--- a/src/client/pages/ConsentsNewslettersAB.stories.tsx
+++ b/src/client/pages/ConsentsNewslettersAB.stories.tsx
@@ -1,0 +1,93 @@
+import React from 'react';
+import { ComponentMeta, ComponentStory } from '@storybook/react';
+
+import { ConsentsNewslettersAB } from './ConsentsNewslettersAB';
+
+export default {
+  title: 'Pages/ConsentsNewslettersAB',
+  component: ConsentsNewslettersAB,
+  parameters: {
+    layout: 'fullscreen',
+    clientState: { pageData: { previousPage: 'fake_page' } },
+  },
+} as ComponentMeta<typeof ConsentsNewslettersAB>;
+
+const Template: ComponentStory<typeof ConsentsNewslettersAB> = (props) => (
+  <ConsentsNewslettersAB {...props} />
+);
+
+const newsletters = [
+  {
+    id: '4147',
+    nameId: 'green-light',
+    description:
+      'Exclusive articles from our top environment correspondents and a round up of the planet’s most important stories of the week',
+    name: 'Down to Earth',
+    frequency: 'Weekly',
+  },
+  {
+    id: '4165',
+    nameId: 'the-long-read',
+    description:
+      'Lose yourself in a great story: from politics to psychology, food to technology, culture to crime',
+    name: 'The Long Read',
+    frequency: 'Weekly',
+  },
+  {
+    id: '9001',
+    nameId: 'over-nine-thousand',
+    description: '',
+    name: 'No image',
+    frequency: 'Monthly',
+  },
+];
+
+export const NoNewsletters = Template.bind({});
+NoNewsletters.args = { consents: [] };
+NoNewsletters.storyName = 'with no newsletters';
+
+export const SingleNewsletter = Template.bind({});
+SingleNewsletter.args = {
+  consents: [
+    {
+      type: 'newsletter',
+      consent: {
+        id: '4156',
+        nameId: 'n0',
+        description: 'Newsletter description',
+        name: 'Newsletter Name',
+        frequency: 'Weekly',
+      },
+    },
+  ],
+};
+SingleNewsletter.storyName = 'with a single newsletter';
+
+export const MultipleNewsletter = Template.bind({});
+MultipleNewsletter.args = {
+  consents: newsletters.map((newsletter) => ({
+    type: 'newsletter',
+    consent: newsletter,
+  })),
+};
+MultipleNewsletter.storyName = 'with multiple newsletters';
+
+export const NewslettersAndEvents = Template.bind({});
+NewslettersAndEvents.args = {
+  consents: [
+    ...newsletters.map((newsletter) => ({
+      type: 'newsletter' as const,
+      consent: newsletter,
+    })),
+    {
+      type: 'consent' as const,
+      consent: {
+        id: 'events',
+        name: 'Events & Masterclasses',
+        description:
+          'Receive weekly newsletters about our upcoming Live events and Masterclasses. Interact with leading minds and nourish your curiosity in our immersive online events, available worldwide.',
+      },
+    },
+  ],
+};
+NewslettersAndEvents.storyName = 'with newsletters and consent for events';

--- a/src/client/pages/ConsentsNewslettersAB.tsx
+++ b/src/client/pages/ConsentsNewslettersAB.tsx
@@ -1,0 +1,141 @@
+import React from 'react';
+import { css } from '@emotion/react';
+import {
+  brand,
+  from,
+  lifestyle,
+  news,
+  space,
+  neutral,
+} from '@guardian/source-foundations';
+import {
+  gridItem,
+  gridItemColumnConsents,
+  getAutoRow,
+  SpanDefinition,
+} from '@/client/styles/Grid';
+import { CONSENTS_PAGES } from '@/client/models/ConsentsPages';
+import { ConsentCardOnboarding } from '@/client/components/ConsentCardOnboardingEmails';
+import { ConsentCard } from '@/client/components/ConsentCard';
+import { ConsentsForm } from '@/client/components/ConsentsForm';
+import { ConsentsNavigation } from '@/client/components/ConsentsNavigation';
+import { ConsentsLayout } from '@/client/layouts/ConsentsLayout';
+import { Consent } from '@/shared/model/Consent';
+import { NewsLetter } from '@/shared/model/Newsletter';
+import {
+  NEWSLETTER_IMAGES,
+  NEWSLETTER_IMAGE_POSITIONS,
+} from '@/client/models/Newsletter';
+import { CONSENT_IMAGES } from '@/client/models/ConsentImages';
+import { h1, h1ResponsiveText } from '../styles/Consents';
+
+interface ConsentOption {
+  type: 'consent';
+  consent: Consent;
+}
+interface NewsletterOption {
+  type: 'newsletter';
+  consent: NewsLetter;
+}
+type NewsletterPageConsent = ConsentOption | NewsletterOption;
+
+type ConsentsNewslettersProps = {
+  consents: NewsletterPageConsent[];
+  defaultOnboardingEmailId: string;
+  defaultOnboardingEmailConsentState: boolean;
+};
+
+const idColor = (id: string) => {
+  if (/morning/.test(id)) {
+    return news[400];
+  }
+  if (id === 'the-long-read') {
+    return brand[400];
+  }
+  if (id === 'green-light') {
+    return news[400];
+  }
+  if (id === 'the-guide-staying-in') {
+    return lifestyle[400];
+  }
+  return brand[400];
+};
+
+const getNewsletterCardCss = (index: number) => {
+  const ITEMS_PER_ROW = 2;
+  const OFFSET = 4;
+  const row = Math.trunc(index / ITEMS_PER_ROW) + OFFSET;
+  const column = index % ITEMS_PER_ROW;
+
+  const gridDef: SpanDefinition = {
+    TABLET: { start: 2 + column * 5, span: 5 },
+    DESKTOP: { start: 2 + column * 5, span: 5 },
+    LEFT_COL: { start: 2 + column * 6, span: 6 },
+    WIDE: { start: 3 + column * 6, span: 6 },
+  };
+
+  return css`
+    ${gridItem(gridDef)}
+    -ms-grid-row: ${row};
+
+    margin-bottom: ${space[5]}px;
+
+    ${from.tablet} {
+      margin-bottom: ${space[6]}px;
+    }
+    ${from.desktop} {
+      margin-bottom: ${space[9]}px;
+    }
+  `;
+};
+
+export const ConsentsNewslettersAB = ({
+  consents,
+  defaultOnboardingEmailId,
+  defaultOnboardingEmailConsentState,
+}: ConsentsNewslettersProps) => {
+  const autoRow = getAutoRow(1, gridItemColumnConsents);
+
+  return (
+    <ConsentsLayout title="Newsletters" current={CONSENTS_PAGES.NEWSLETTERS}>
+      <ConsentsForm cssOverrides={autoRow()}>
+        <ConsentCardOnboarding
+          id={defaultOnboardingEmailId}
+          defaultChecked={defaultOnboardingEmailConsentState}
+        />
+        <h1 css={[h1, h1ResponsiveText, autoRow()]}>You might also like...</h1>
+        {consents.map(({ type, consent }, i) => {
+          const extraProps =
+            type === 'consent'
+              ? {
+                  id: consent.id,
+                  defaultChecked: !!consent.consented,
+                  highlightColor: neutral[46],
+                  imagePath: CONSENT_IMAGES[consent.id],
+                }
+              : {
+                  id: consent.id,
+                  defaultChecked: consent.subscribed,
+                  imagePath: NEWSLETTER_IMAGES[consent.id],
+                  imagePosition: NEWSLETTER_IMAGE_POSITIONS[consent.id],
+                  highlightColor: idColor(consent.nameId),
+                  frequency: consent.frequency,
+                  hiddenInput: true,
+                };
+
+          return (
+            <ConsentCard
+              key={consent.id}
+              title={consent.name}
+              description={consent.description || ''}
+              noTopBorderMobile
+              cssOverrides={getNewsletterCardCss(i)}
+              {...extraProps}
+            />
+          );
+        })}
+        <ConsentsNavigation />
+      </ConsentsForm>
+    </ConsentsLayout>
+  );
+};

--- a/src/client/pages/ConsentsNewslettersPage.tsx
+++ b/src/client/pages/ConsentsNewslettersPage.tsx
@@ -1,6 +1,11 @@
 import React from 'react';
 import useClientState from '@/client/lib/hooks/useClientState';
+import { useCmpConsent } from '@/client/lib/hooks/useCmpConsent';
 import { ConsentsNewsletters } from '@/client/pages/ConsentsNewsletters';
+import { ConsentsNewslettersAB } from '@/client/pages/ConsentsNewslettersAB';
+import { useAB } from '@guardian/ab-react';
+import { abDefaultWeeklyNewsletterTest } from '@/shared/model/experiments/tests/abDefaultWeeklyNewsletterTest';
+import { Newsletters } from '@/shared/model/Newsletter';
 
 export const ConsentsNewslettersPage = () => {
   const clientState = useClientState();
@@ -16,5 +21,32 @@ export const ConsentsNewslettersPage = () => {
     })),
   ];
 
-  return <ConsentsNewsletters consents={consents} />;
+  // @AB_TEST: Default Weekly Newsletter Test: START
+  const filteredConsents = consents.filter(
+    (consentType) =>
+      consentType.consent?.id !== Newsletters.SATURDAY_ROUNDUP_TRIAL,
+  );
+
+  const ABTestAPI = useAB();
+  const isInABTestVariant = ABTestAPI.isUserInVariant(
+    abDefaultWeeklyNewsletterTest.id,
+    abDefaultWeeklyNewsletterTest.variants[0].id,
+  );
+
+  const geolocation = pageData?.geolocation;
+  const isInRegion = geolocation && ['GB', 'US', 'AU'].includes(geolocation);
+  const hasCmpConsent = useCmpConsent();
+
+  if (isInABTestVariant && hasCmpConsent && isInRegion) {
+    return (
+      <ConsentsNewslettersAB
+        consents={filteredConsents}
+        defaultOnboardingEmailId={Newsletters.SATURDAY_ROUNDUP_TRIAL}
+        defaultOnboardingEmailConsentState={true}
+      />
+    );
+  }
+  // @AB_TEST: Default Weekly Newsletter Test: END
+
+  return <ConsentsNewsletters consents={filteredConsents} />; // @AB_TEST: filtering out the Default Weekly Newsletter
 };

--- a/src/shared/lib/newsletter.ts
+++ b/src/shared/lib/newsletter.ts
@@ -30,6 +30,8 @@ export const NewsletterMap = new Map<GeoLocation | undefined, Newsletters[]>([
       Newsletters.DOWN_TO_EARTH,
       Newsletters.THE_LONG_READ,
       Newsletters.FIRST_EDITION_UK,
+      // @AB_TEST: Default Weekly Newsletter Test:
+      Newsletters.SATURDAY_ROUNDUP_TRIAL,
     ],
   ],
   [
@@ -38,6 +40,8 @@ export const NewsletterMap = new Map<GeoLocation | undefined, Newsletters[]>([
       Newsletters.DOWN_TO_EARTH,
       Newsletters.THE_LONG_READ,
       Newsletters.MORNING_BRIEFING_AU,
+      // @AB_TEST: Default Weekly Newsletter Test:
+      Newsletters.SATURDAY_ROUNDUP_TRIAL,
     ],
   ],
   [
@@ -46,6 +50,8 @@ export const NewsletterMap = new Map<GeoLocation | undefined, Newsletters[]>([
       Newsletters.DOWN_TO_EARTH,
       Newsletters.THE_LONG_READ,
       Newsletters.MORNING_BRIEFING_US,
+      // @AB_TEST: Default Weekly Newsletter Test:
+      Newsletters.SATURDAY_ROUNDUP_TRIAL,
     ],
   ],
 ]);

--- a/src/shared/model/Newsletter.ts
+++ b/src/shared/model/Newsletter.ts
@@ -18,6 +18,8 @@ export enum Newsletters {
   MORNING_BRIEFING_AU = '4148',
   MORNING_BRIEFING_US = '4300',
   THE_LONG_READ = '4165',
+  // @AB_TEST: Default Weekly Newsletter Test:
+  SATURDAY_ROUNDUP_TRIAL = '6028',
 }
 
 export const ALL_NEWSLETTER_IDS = Object.values(Newsletters);

--- a/src/shared/model/experiments/abSwitches.ts
+++ b/src/shared/model/experiments/abSwitches.ts
@@ -1,3 +1,4 @@
 export const abSwitches = {
   abExampleTest: false,
+  abDefaultWeeklyNewsletterTest: false,
 };

--- a/src/shared/model/experiments/abTests.ts
+++ b/src/shared/model/experiments/abTests.ts
@@ -1,5 +1,6 @@
 import { AB, ABTest, Participations } from '@guardian/ab-core';
 import { abSwitches } from './abSwitches';
+import { abDefaultWeeklyNewsletterTest } from '@/shared/model/experiments/tests/abDefaultWeeklyNewsletterTest';
 
 interface ABTestConfiguration {
   abTestSwitches: Record<string, boolean>;
@@ -9,7 +10,7 @@ interface ABTestConfiguration {
 }
 
 // Add AB tests to run in this array
-export const tests: ABTest[] = [];
+export const tests: ABTest[] = [abDefaultWeeklyNewsletterTest];
 
 const getDefaultABTestConfiguration = (): ABTestConfiguration => ({
   abTestSwitches: abSwitches,

--- a/src/shared/model/experiments/tests/abDefaultWeeklyNewsletterTest.ts
+++ b/src/shared/model/experiments/tests/abDefaultWeeklyNewsletterTest.ts
@@ -1,0 +1,28 @@
+import { ABTest } from '@guardian/ab-core';
+
+export const abDefaultWeeklyNewsletterTest: ABTest = {
+  id: 'DefaultWeeklyNewsletterTest', // This ID must match the Server Side AB Test
+  start: '2023-01-04',
+  expiry: '2023-02-30', // Remember that the server side test expiry can be different
+  author: 'Personalisation',
+  description:
+    'How successful a default opt in newsletter could be in the registration onboarding journey',
+  audience: 0.1,
+  audienceOffset: 0,
+  successMeasure:
+    'An opt in rate of over 20% and an unsubscribe rate of under 4%',
+  audienceCriteria:
+    '10% of onboarding flow traffic over one week, limited to US, UK and AU',
+  idealOutcome:
+    'Success measure plus look at customer feedback, impact on deliverability and impact on supporter consent opt in as secondary measures',
+  showForSensitive: true, // Should this A/B test run on sensitive articles?
+  canRun: () => true, // Check for things like user or page sections
+  variants: [
+    {
+      id: 'variant', // toggle is on
+      test: (): string => {
+        return 'variant';
+      },
+    },
+  ],
+};


### PR DESCRIPTION
Reverts guardian/gateway#2129

Also changes the switch state to false

The Default Weekly Newsletter test was supposed to be rolled back at the end of the test, but Newsletters Team has requested it run for another week. 