### PR TITLE
Switch on abDefaultWeeklyNewsletterTest

### DIFF
--- a/src/shared/model/experiments/abSwitches.ts
+++ b/src/shared/model/experiments/abSwitches.ts
@@ -1,4 +1,4 @@
 export const abSwitches = {
   abExampleTest: false,
-  abDefaultWeeklyNewsletterTest: false,
+  abDefaultWeeklyNewsletterTest: true,
 };

--- a/src/shared/model/experiments/tests/abDefaultWeeklyNewsletterTest.ts
+++ b/src/shared/model/experiments/tests/abDefaultWeeklyNewsletterTest.ts
@@ -7,12 +7,12 @@ export const abDefaultWeeklyNewsletterTest: ABTest = {
   author: 'Personalisation',
   description:
     'How successful a default opt in newsletter could be in the registration onboarding journey',
-  audience: 0.1,
+  audience: 0.2,
   audienceOffset: 0,
   successMeasure:
-    'An opt in rate of over 20% and an unsubscribe rate of under 4%',
+    'An email open rate of over 20% and an unsubscribe rate of under 4%',
   audienceCriteria:
-    '10% of onboarding flow traffic over one week, limited to US, UK and AU',
+    '20% of onboarding flow traffic over one week, limited to US, UK and AU',
   idealOutcome:
     'Success measure plus look at customer feedback, impact on deliverability and impact on supporter consent opt in as secondary measures',
   showForSensitive: true, // Should this A/B test run on sensitive articles?


### PR DESCRIPTION
## What does this change?
Switches on the DefaultWeeklyNewsletterTest in #2145 

Increases audience segmentation to: 20%

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
