### PR TITLE
Password field: do not disable form on submission with error

### DIFF
--- a/src/client/components/PasswordForm.tsx
+++ b/src/client/components/PasswordForm.tsx
@@ -338,14 +338,17 @@ export const PasswordForm = ({
         }
         if (isTooShort) {
           setError(PasswordFieldErrors.AT_LEAST_8);
-          e.preventDefault();
         } else if (isTooLong) {
           setError(PasswordFieldErrors.MAXIMUM_72);
-          e.preventDefault();
         } else if (isWeak) {
           setError(PasswordFieldErrors.COMMON_PASSWORD);
-          e.preventDefault();
         }
+        // If there are errors, don't submit the form and return here
+        if (isTooShort || isTooLong || isWeak) {
+          e.preventDefault();
+          return;
+        }
+        // If there are no errors, disable the form and submit it
         setIsFormDisabled(true);
       }}
       onFocus={(e) =>


### PR DESCRIPTION
## What does this change?

- Fixes a small bug in one of our password forms (the one for the `/welcome` route). After submitting a form with a validation error, the `onSubmit` function did not return and fell through to the statement which disabled the form. Now the submission stops when an error is encountered, and the form is not disabled, which allows the user to fix their input.