### PR TITLE
fix(@types/express): update and fix express types

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "@types/compression": "^1.7.2",
     "@types/cookie-parser": "^1.4.3",
     "@types/csurf": "^1.11.2",
-    "@types/express": "^4.17.15",
+    "@types/express": "^4.17.17",
     "@types/ioredis-mock": "^8.2.1",
     "@types/jest": "^29.4.0",
     "@types/mjml": "^4.7.0",

--- a/src/server/models/Express.ts
+++ b/src/server/models/Express.ts
@@ -35,9 +35,7 @@ export interface RequestState {
   requestId?: string;
 }
 
-export interface ResponseWithRequestState extends Response {
-  locals: RequestState;
-}
+export type ResponseWithRequestState = Response<unknown, RequestState>;
 
 export interface RequestWithTypedQuery extends Request {
   query: Record<keyof QueryParams, string | undefined>;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4666,10 +4666,10 @@
     "@types/qs" "*"
     "@types/range-parser" "*"
 
-"@types/express-serve-static-core@^4.17.31":
-  version "4.17.32"
-  resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.17.32.tgz#93dda387f5516af616d8d3f05f2c4c79d81e1b82"
-  integrity sha512-aI5h/VOkxOF2Z1saPy0Zsxs5avets/iaiAJYznQFm5By/pamU31xWKL//epiF4OfUA2qTOc9PV6tCUjhO8wlZA==
+"@types/express-serve-static-core@^4.17.33":
+  version "4.17.33"
+  resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.17.33.tgz#de35d30a9d637dc1450ad18dd583d75d5733d543"
+  integrity sha512-TPBqmR/HRYI3eC2E5hmiivIzv+bidAfXofM+sbonAGvyDhySGw9/PQZFt2BLOrjUUR++4eJVpx6KnLQK1Fk9tA==
   dependencies:
     "@types/node" "*"
     "@types/qs" "*"
@@ -4685,13 +4685,13 @@
     "@types/qs" "*"
     "@types/serve-static" "*"
 
-"@types/express@^4.17.15":
-  version "4.17.15"
-  resolved "https://registry.yarnpkg.com/@types/express/-/express-4.17.15.tgz#9290e983ec8b054b65a5abccb610411953d417ff"
-  integrity sha512-Yv0k4bXGOH+8a+7bELd2PqHQsuiANB+A8a4gnQrkRWzrkKlb6KHaVvyXhqs04sVW/OWlbPyYxRgYlIXLfrufMQ==
+"@types/express@^4.17.17":
+  version "4.17.17"
+  resolved "https://registry.yarnpkg.com/@types/express/-/express-4.17.17.tgz#01d5437f6ef9cfa8668e616e13c2f2ac9a491ae4"
+  integrity sha512-Q4FmmuLGBG58btUnfS1c1r/NQdlp3DMfGDGig8WhfpA2YRUtEkxAjkZb0yvplJGYdF1fsQ81iMDcH24sSCNC/Q==
   dependencies:
     "@types/body-parser" "*"
-    "@types/express-serve-static-core" "^4.17.31"
+    "@types/express-serve-static-core" "^4.17.33"
     "@types/qs" "*"
     "@types/serve-static" "*"
 


### PR DESCRIPTION
## What does this change?

There were some typing changes in express which caused things to break when we updated it, due to changes they'd made to their own types, which didn't affect functionality.

This updates the `ResponseWithRequestState` type to use the type generic instead of extending the `Response` object
