### PR TITLE
Increase Default Weekly Newsletter test audience to 35%

### DIFF
--- a/src/shared/model/experiments/tests/abDefaultWeeklyNewsletterTest.ts
+++ b/src/shared/model/experiments/tests/abDefaultWeeklyNewsletterTest.ts
@@ -7,12 +7,12 @@ export const abDefaultWeeklyNewsletterTest: ABTest = {
   author: 'Personalisation',
   description:
     'How successful a default opt in newsletter could be in the registration onboarding journey',
-  audience: 0.2,
+  audience: 0.35,
   audienceOffset: 0,
   successMeasure:
     'An email open rate of over 20% and an unsubscribe rate of under 4%',
   audienceCriteria:
-    '20% of onboarding flow traffic over one week, limited to US, UK and AU',
+    '35% of onboarding flow traffic over one week, limited to US, UK and AU',
   idealOutcome:
     'Success measure plus look at customer feedback, impact on deliverability and impact on supporter consent opt in as secondary measures',
   showForSensitive: true, // Should this A/B test run on sensitive articles?


### PR DESCRIPTION
## What does this change?

Increases the audience % of the Default Weekly Newsletter test audience to 35%

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
