### PR TITLE
Filter consent/confirmation newsletters if AbDefaultWeeklyNewsletter switch is off

### DIFF
--- a/src/client/pages/ConsentsConfirmationPage.tsx
+++ b/src/client/pages/ConsentsConfirmationPage.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import useClientState from '@/client/lib/hooks/useClientState';
 import { ConsentsConfirmation } from '@/client/pages/ConsentsConfirmation';
 import { Consents } from '@/shared/model/Consent';
+import { abSwitches } from '@/shared/model/experiments/abSwitches';
+import { Newsletters } from '@/shared/model/Newsletter';
 
 export const ConsentsConfirmationPage = () => {
   const clientState = useClientState();
@@ -31,6 +33,16 @@ export const ConsentsConfirmationPage = () => {
 
   const subscribedNewsletters = newsletters.filter((n) => n.subscribed);
 
+  // @AB_TEST: Default Weekly Newsletter Test:
+  // When the switch is off, the trial newsletter will still show up on the confirmation page
+  // if an existing user who signed up during the trial manually navigates back to the /consents/confirmation page
+  // We need to filter for this until the AB Test Saturday Roundup is deleted including from the Newsletter Enum here: src/shared/model/Newsletter.ts
+  const filteredSubscribedNewsletters = abSwitches.abDefaultWeeklyNewsletterTest
+    ? subscribedNewsletters
+    : subscribedNewsletters.filter(
+        (n) => n.id !== Newsletters.SATURDAY_ROUNDUP_TRIAL,
+      );
+
   return (
     <ConsentsConfirmation
       error={error}
@@ -39,7 +51,7 @@ export const ConsentsConfirmationPage = () => {
       optedIntoProfiling={optedIntoProfiling}
       optedIntoPersonalisedAdvertising={optedIntoPersonalisedAdvertising}
       productConsents={productConsents}
-      subscribedNewsletters={subscribedNewsletters}
+      subscribedNewsletters={filteredSubscribedNewsletters}
     />
   );
 };


### PR DESCRIPTION
Until the default weekly newsletter is cancelled, it will continue to be returned as a user subscription in newsletter api responses. 

Gateway actively chooses which newsletters from that response to show via the[ Newsletter Enum in the model](https://github.com/guardian/gateway/blob/cc92cfed16ba59d406cee38056217828ba0e21c7/src/shared/model/Newsletter.ts#L22).  While the AbDfaultWeeklyNewsletterTtest switch is OFF but the AbTest code is still in the codebase/Enum, we need to filter out the newsletter from the Confirmation page. 

Otherwise there is a small edge case where one of the ~1000 people in the trial who signed up for SaturdayRoundUp when registering, manually navigates back to the onboarding pages and see 'Saturday Roundup' in the confirmation page but not the Newsletters page. 

This will not be an anymore issue when the Saturday Roundup test code is deleted from Gateway in the next couple weeks.  

<img width="339" alt="image" src="https://user-images.githubusercontent.com/32312712/217847084-ca76dae3-ce3b-421c-8adc-811ea332de0d.png">



## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
