### PR TITLE
chore(deps): update `@guardian/ab-*` packages to v3.x.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,8 +120,8 @@
   },
   "dependencies": {
     "@emotion/react": "^11.10.5",
-    "@guardian/ab-core": "^2.0.1",
-    "@guardian/ab-react": "^2.0.1",
+    "@guardian/ab-core": "^3.1.0",
+    "@guardian/ab-react": "^3.0.0",
     "@guardian/consent-management-platform": "^11.0.0",
     "@guardian/libs": "^13.1.0",
     "@guardian/source-foundations": "^9.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1748,15 +1748,15 @@
   resolved "https://registry.yarnpkg.com/@gar/promisify/-/promisify-1.1.2.tgz#30aa825f11d438671d585bd44e7fd564535fc210"
   integrity sha512-82cpyJyKRoQoRi+14ibCeGPu0CwypgtBAdBhq1WfvagpCZNKqwXbKwXllYSMG91DhmG4jt9gN8eP6lGOtozuaw==
 
-"@guardian/ab-core@^2.0.1":
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/@guardian/ab-core/-/ab-core-2.0.1.tgz#acff2ddf887fdba792f6dafa1acfc10149e0946a"
-  integrity sha512-5P1aOrKSvo6sde7+c+IiD+Mh2a9p33zaTMJl6n/I0s8gtVS16cOi9NH3fNjfMjTqUkbo8/o0RcSy91xwsauCow==
+"@guardian/ab-core@^3.1.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@guardian/ab-core/-/ab-core-3.1.0.tgz#8974bc0a0a25f6f47d946252cc410657801372b2"
+  integrity sha512-DGyDH1NrQEkyudUN2HlIb+BuEQNL4ftSG4DvDd+SPhcqCKH/41k2JMnchVM4KTO6ctHTw7D3AD9POhr+3Xm/YA==
 
-"@guardian/ab-react@^2.0.1":
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/@guardian/ab-react/-/ab-react-2.0.1.tgz#f018898de584c8e70a48e69ec9e499e08f512cc5"
-  integrity sha512-iOKbIxoLwRMv2eHddxL5l9mNBy/B9QaOOJgA3VUdo/jH5cUVzbF6W8yYDGcZJTolIVhSu5GPR8fitsOoup6Vww==
+"@guardian/ab-react@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@guardian/ab-react/-/ab-react-3.0.0.tgz#5ba61b1f4c63d2d45064ac47b6c345bc19e5f9dc"
+  integrity sha512-VzARrFaePHSJnbrHOVJOsgO4ocDwO6ktMdnqS83+PJXBQbiG0AGAPnAD1E4TkOp5YAhTKTOP6LpX6sI9AOuajw==
 
 "@guardian/consent-management-platform@^11.0.0":
   version "11.0.0"


### PR DESCRIPTION
## What does this change?

Updates `@guardian/ab-core` and `@guardian/ab-react` packages to v3, which we previously weren't able to do specifically in https://github.com/guardian/gateway/pull/2147