### PR TITLE
Refactor Sign Out Cookie (`GU_SO` cookie)

### DIFF
--- a/src/server/routes/oauth.ts
+++ b/src/server/routes/oauth.ts
@@ -13,7 +13,10 @@ import { logger } from '@/server/lib/serverSideLogger';
 import { trackMetric } from '@/server/lib/trackMetric';
 import { handleAsyncErrors } from '@/server/lib/expressWrappers';
 import { exchangeAccessTokenForCookies } from '@/server/lib/idapi/auth';
-import { setIDAPICookies } from '@/server/lib/idapi/IDAPICookies';
+import {
+  clearSignOutCookie,
+  setIDAPICookies,
+} from '@/server/lib/idapi/IDAPICookies';
 import { FederationErrors, SignInErrors } from '@/shared/model/Errors';
 import { addQueryParamsToPath } from '@/shared/lib/queryParams';
 import postSignInController from '@/server/lib/postSignInController';
@@ -225,6 +228,9 @@ router.get(
           request_id: res.locals.requestId,
         });
       }
+
+      // clear the sign out cookie if it exists
+      clearSignOutCookie(res);
 
       // track the success metric
       trackMetric('OAuthAuthorization::Success');

--- a/src/server/routes/signIn.ts
+++ b/src/server/routes/signIn.ts
@@ -6,7 +6,10 @@ import { renderer } from '@/server/lib/renderer';
 import { ResponseWithRequestState } from '@/server/models/Express';
 import { trackMetric } from '@/server/lib/trackMetric';
 import { handleAsyncErrors } from '@/server/lib/expressWrappers';
-import { setIDAPICookies } from '@/server/lib/idapi/IDAPICookies';
+import {
+  clearSignOutCookie,
+  setIDAPICookies,
+} from '@/server/lib/idapi/IDAPICookies';
 import { getConfiguration } from '@/server/lib/getConfiguration';
 import { decrypt } from '@/server/lib/idapi/decryptToken';
 import {
@@ -294,6 +297,7 @@ const idapiSignInController = async (
     // cookies to keep the sessions in sync
     clearOktaCookies(res);
     setIDAPICookies(res, cookies);
+    clearSignOutCookie(res);
 
     trackMetric('SignIn::Success');
 


### PR DESCRIPTION
## What does this change?

In preparation for the Okta migration for web applications, we want to be able to tell when a user has signed out within the last 24 hours on a given device.

We do this by reusing the existing `GU_SO` cookie (signout cookie) which we previously got from Identity API which was set when a user signed out.

We now set this cookie from Gateway, avoiding the need for Identity API.

This cookie has a value which is the unix epoch time in seconds when the user signed out, and an expiry of 24 hours. It's also set as a non-HTTPOnly cookie so that it can be read in javascript applications.

This allows any applications when reading this cookie to assume that the user is currently signed out, and clear any tokens/user data required if it comes across this cookie.

This is initially part of the "spike" work to test the feasibility of the approach we decided, but if that goes well then this will rolled out.
