### PR TITLE
Migrate `robots.txt` from Identity Frontend

### DIFF
--- a/src/server/routes/core.ts
+++ b/src/server/routes/core.ts
@@ -30,4 +30,12 @@ router.get('/healthcheck', (_, res: Response) => {
   res.status(200).send('200 OK');
 });
 
+router.use('/robots.txt', (_, res: Response) => {
+  res.type('text/plain');
+  res.send(`User-agent: *
+Disallow: /user/
+Disallow: /signin?*returnUrl=https://discussion.theguardian.com/comment-permalink/
+`);
+});
+
 export default router;


### PR DESCRIPTION
## What does this change?

Migrates the `robots.txt` file from Identity Frontend to Gateway

https://github.com/guardian/identity-frontend/blob/main/public/robots.txt

VCL Changes to follow