### PR TITLE
Migrate change email logic from Identity Frontend to Gateway

### DIFF
--- a/cypress/integration/ete/change_email/change_email.2.cy.ts
+++ b/cypress/integration/ete/change_email/change_email.2.cy.ts
@@ -1,0 +1,38 @@
+import { randomMailosaurEmail } from '../../../support/commands/testUser';
+
+describe('Change email', () => {
+  it('change email flow successful', () => {
+    cy.createTestUser({
+      isUserEmailValidated: true,
+    }).then(({ cookies }) => {
+      // SC_GU_U is required for the cy.updateTestUser
+      const scGuU = cookies.find((cookie) => cookie.key === 'SC_GU_U');
+      if (!scGuU) throw new Error('SC_GU_U cookie not found');
+      cy.setCookie('SC_GU_U', scGuU?.value);
+
+      const timeRequestWasMade = new Date();
+
+      const newEmail = randomMailosaurEmail();
+
+      cy.updateTestUser({
+        primaryEmailAddress: newEmail,
+      });
+
+      cy.checkForEmailAndGetDetails(
+        newEmail,
+        timeRequestWasMade,
+        /change-email\/([^"]*)/,
+      ).then(({ token }) => {
+        cy.visit(`/change-email/${token}`);
+        cy.contains('Success! Your email address has been updated.');
+      });
+    });
+  });
+
+  it('change email flow unsuccessful', () => {
+    cy.visit(`/change-email/bad_token`);
+    cy.contains(
+      'The email change link you followed has expired or was invalid.',
+    );
+  });
+});

--- a/cypress/integration/mocked/change_email.5.cy.ts
+++ b/cypress/integration/mocked/change_email.5.cy.ts
@@ -1,0 +1,52 @@
+import { injectAndCheckAxe } from '../../support/cypress-axe';
+
+describe('Change email', () => {
+  beforeEach(() => {
+    cy.mockPurge();
+  });
+
+  context('a11y checks', () => {
+    it('Has no detectable a11y violations on change email complete page', () => {
+      cy.visit('/change-email/complete');
+      injectAndCheckAxe();
+    });
+
+    it('Has no detectable a11y violations on change email error page', () => {
+      cy.mockNext(500, {
+        status: 'error',
+        errors: [
+          {
+            message: 'Invalid token',
+          },
+        ],
+      });
+      cy.visit('/change-email/token');
+      injectAndCheckAxe();
+    });
+  });
+
+  context('change email flow', () => {
+    it('should be able to change email', () => {
+      cy.mockNext(200, {
+        status: 'ok',
+      });
+      cy.visit('/change-email/token');
+      cy.contains('Success! Your email address has been updated.');
+    });
+
+    it('should be able to handle a change email error', () => {
+      cy.mockNext(500, {
+        status: 'error',
+        errors: [
+          {
+            message: 'Invalid token',
+          },
+        ],
+      });
+      cy.visit('/change-email/token');
+      cy.contains(
+        'The email change link you followed has expired or was invalid.',
+      );
+    });
+  });
+});

--- a/src/client/pages/ChangeEmailComplete.stories.tsx
+++ b/src/client/pages/ChangeEmailComplete.stories.tsx
@@ -1,0 +1,18 @@
+/* eslint-disable functional/immutable-data */
+import React from 'react';
+import { Meta } from '@storybook/react';
+
+import { ChangeEmailComplete } from './ChangeEmailComplete';
+
+export default {
+  title: 'Pages/ChangeEmailComplete',
+  component: ChangeEmailComplete,
+  parameters: { layout: 'fullscreen' },
+} as Meta;
+
+export const Default = () => (
+  <ChangeEmailComplete accountManagementUrl="#" returnUrl="#" />
+);
+Default.story = {
+  name: 'with defaults',
+};

--- a/src/client/pages/ChangeEmailComplete.tsx
+++ b/src/client/pages/ChangeEmailComplete.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { ExternalLinkButton } from '@/client/components/ExternalLink';
+import { buttonStyles, MainLayout } from '@/client/layouts/Main';
+import { MainBodyText } from '@/client/components/MainBodyText';
+import { SvgArrowRightStraight } from '@guardian/source-react-components';
+
+type ChangeEmailCompleteProps = {
+  returnUrl?: string;
+  accountManagementUrl?: string;
+};
+
+export const ChangeEmailComplete = ({
+  returnUrl = 'https://www.theguardian.com',
+  accountManagementUrl = 'https://manage.theguardian.com',
+}: ChangeEmailCompleteProps) => {
+  return (
+    <MainLayout pageHeader="Email changed">
+      <MainBodyText noMargin>
+        Success! Your email address has been updated.
+      </MainBodyText>
+      <MainBodyText noMargin>
+        <ExternalLinkButton
+          css={buttonStyles({ halfWidth: true })}
+          href={`${accountManagementUrl}/account-settings`}
+          icon={<SvgArrowRightStraight />}
+          iconSide="right"
+        >
+          Back to account details
+        </ExternalLinkButton>
+      </MainBodyText>
+      <MainBodyText noMargin>
+        <ExternalLinkButton
+          priority="tertiary"
+          css={buttonStyles({ halfWidth: true })}
+          href={returnUrl}
+          icon={<SvgArrowRightStraight />}
+          iconSide="right"
+        >
+          Continue to the Guardian
+        </ExternalLinkButton>
+      </MainBodyText>
+    </MainLayout>
+  );
+};

--- a/src/client/pages/ChangeEmailCompletePage.tsx
+++ b/src/client/pages/ChangeEmailCompletePage.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import useClientState from '@/client/lib/hooks/useClientState';
+import { ChangeEmailComplete } from '@/client/pages/ChangeEmailComplete';
+
+export const ChangeEmailCompletePage = () => {
+  const clientState = useClientState();
+  const { pageData = {} } = clientState;
+  const { returnUrl, accountManagementUrl } = pageData;
+  return (
+    <ChangeEmailComplete
+      returnUrl={returnUrl}
+      accountManagementUrl={accountManagementUrl}
+    />
+  );
+};

--- a/src/client/pages/ChangeEmailError.stories.tsx
+++ b/src/client/pages/ChangeEmailError.stories.tsx
@@ -1,0 +1,16 @@
+/* eslint-disable functional/immutable-data */
+import React from 'react';
+import { Meta } from '@storybook/react';
+
+import { ChangeEmailError } from './ChangeEmailError';
+
+export default {
+  title: 'Pages/ChangeEmailError',
+  component: ChangeEmailError,
+  parameters: { layout: 'fullscreen' },
+} as Meta;
+
+export const Default = () => <ChangeEmailError accountManagementUrl="#" />;
+Default.story = {
+  name: 'with defaults',
+};

--- a/src/client/pages/ChangeEmailError.tsx
+++ b/src/client/pages/ChangeEmailError.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { ExternalLinkButton } from '@/client/components/ExternalLink';
+import { buttonStyles, MainLayout } from '@/client/layouts/Main';
+import { MainBodyText } from '@/client/components/MainBodyText';
+import { SvgArrowRightStraight } from '@guardian/source-react-components';
+
+type ChangeEmailErrorProps = {
+  accountManagementUrl?: string;
+};
+
+export const ChangeEmailError = ({
+  accountManagementUrl = 'https://manage.theguardian.com',
+}: ChangeEmailErrorProps) => {
+  return (
+    <MainLayout pageHeader="Email change failed">
+      <MainBodyText noMargin>
+        The email change link you followed has expired or was invalid. Please
+        return to your account details to try again.
+      </MainBodyText>
+      <MainBodyText noMargin>
+        <ExternalLinkButton
+          css={buttonStyles({ halfWidth: true })}
+          href={`${accountManagementUrl}/account-settings`}
+          icon={<SvgArrowRightStraight />}
+          iconSide="right"
+        >
+          Back to account details
+        </ExternalLinkButton>
+      </MainBodyText>
+    </MainLayout>
+  );
+};

--- a/src/client/pages/ChangeEmailErrorPage.tsx
+++ b/src/client/pages/ChangeEmailErrorPage.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import useClientState from '@/client/lib/hooks/useClientState';
+import { ChangeEmailError } from '@/client/pages/ChangeEmailError';
+
+export const ChangeEmailErrorPage = () => {
+  const clientState = useClientState();
+  const { pageData = {} } = clientState;
+  const { accountManagementUrl } = pageData;
+  return <ChangeEmailError accountManagementUrl={accountManagementUrl} />;
+};

--- a/src/client/routes.tsx
+++ b/src/client/routes.tsx
@@ -30,8 +30,10 @@ import { SetPasswordResendPage } from '@/client/pages/SetPasswordResendPage';
 import { SetPasswordSessionExpiredPage } from '@/client/pages/SetPasswordSessionExpiredPage';
 import { SetPasswordCompletePage } from '@/client/pages/SetPasswordCompletePage';
 import { MaintenancePage } from '@/client/pages/MaintenancePage';
-import { JobsTermsPage } from './pages/JobsTermsAcceptPage';
-import { SignedInAsPage } from './pages/SignedInAsPage';
+import { JobsTermsPage } from '@/client/pages/JobsTermsAcceptPage';
+import { SignedInAsPage } from '@/client/pages/SignedInAsPage';
+import { ChangeEmailCompletePage } from '@/client/pages/ChangeEmailCompletePage';
+import { ChangeEmailErrorPage } from '@/client/pages/ChangeEmailErrorPage';
 
 export type RoutingConfig = {
   clientState: ClientState;
@@ -161,6 +163,14 @@ const routes: Array<{
   {
     path: '/verify-email',
     element: <ResendEmailVerificationPage />,
+  },
+  {
+    path: '/change-email/complete',
+    element: <ChangeEmailCompletePage />,
+  },
+  {
+    path: '/change-email/error',
+    element: <ChangeEmailErrorPage />,
   },
   {
     path: '/magic-link',

--- a/src/server/lib/idapi/user.ts
+++ b/src/server/lib/idapi/user.ts
@@ -407,3 +407,24 @@ export const sendCreatePasswordEmail = async (
     return handleError(error as IDAPIError);
   }
 };
+
+export const changeEmail = async (
+  token: string,
+  ip: string,
+  request_id?: string,
+) => {
+  const options = APIPostOptions({
+    token,
+  });
+  try {
+    await idapiFetch({
+      path: '/user/change-email',
+      options: APIAddClientAccessToken(options, ip),
+    });
+  } catch (error) {
+    logger.error(`IDAPI Error change email '/user/change-email'`, error, {
+      request_id,
+    });
+    return handleError(error as IDAPIError);
+  }
+};

--- a/src/server/routes/changeEmail.ts
+++ b/src/server/routes/changeEmail.ts
@@ -1,0 +1,53 @@
+import { Request } from 'express';
+import { rateLimitedTypedRouter as router } from '@/server/lib/typedRoutes';
+import { ResponseWithRequestState } from '@/server/models/Express';
+import { renderer } from '@/server/lib/renderer';
+import { mergeRequestState } from '@/server/lib/requestState';
+import { getConfiguration } from '@/server/lib/getConfiguration';
+import { changeEmail } from '@/server/lib/idapi/user';
+import { handleAsyncErrors } from '@/server/lib/expressWrappers';
+import { logger } from '@/server/lib/serverSideLogger';
+
+const { accountManagementUrl } = getConfiguration();
+
+router.get(
+  '/change-email/complete',
+  (_: Request, res: ResponseWithRequestState) => {
+    const html = renderer('/change-email/complete', {
+      pageTitle: 'Change Email',
+      requestState: mergeRequestState(res.locals, {
+        pageData: {
+          accountManagementUrl,
+        },
+      }),
+    });
+    return res.type('html').send(html);
+  },
+);
+
+router.get(
+  '/change-email/:token',
+  handleAsyncErrors(async (req: Request, res: ResponseWithRequestState) => {
+    const { token } = req.params;
+
+    try {
+      await changeEmail(token, req.ip, res.locals.requestId);
+      return res.redirect(303, '/change-email/complete');
+    } catch (error) {
+      logger.error(`${req.method} ${req.originalUrl}  Error`, error, {
+        request_id: res.locals.requestId,
+      });
+      const html = renderer('/change-email/error', {
+        pageTitle: 'Change Email',
+        requestState: mergeRequestState(res.locals, {
+          pageData: {
+            accountManagementUrl,
+          },
+        }),
+      });
+      return res.type('html').send(html);
+    }
+  }),
+);
+
+export default router.router;

--- a/src/server/routes/index.ts
+++ b/src/server/routes/index.ts
@@ -16,6 +16,7 @@ import { default as maintenance } from './maintenance';
 import { default as oauth } from './oauth';
 import { default as emailTemplates } from './emailTemplates';
 import { default as agree } from './agree';
+import { default as changeEmail } from './changeEmail';
 
 const { okta } = getConfiguration();
 
@@ -61,6 +62,9 @@ uncachedRoutes.use(welcome);
 
 // terms and conditions routes
 uncachedRoutes.use(agree);
+
+// change email routes
+uncachedRoutes.use(changeEmail);
 
 // oauth callback routes
 if (okta.enabled) {

--- a/src/shared/model/ClientState.ts
+++ b/src/shared/model/ClientState.ts
@@ -34,6 +34,7 @@ export interface PageData {
   formError?: string;
   browserName?: string;
   isNativeApp?: IsNativeApp;
+  accountManagementUrl?: string;
 
   // token
   token?: string;

--- a/src/shared/model/PageTitle.ts
+++ b/src/shared/model/PageTitle.ts
@@ -24,7 +24,8 @@ export type PageTitle =
   | 'Newsletters'
   | 'Review'
   | 'Maintenance'
-  | 'Jobs';
+  | 'Jobs'
+  | 'Change Email';
 
 export type PasswordPageTitle = Extract<
   'Welcome' | 'Create Password' | 'Change Password',

--- a/src/shared/model/Routes.ts
+++ b/src/shared/model/Routes.ts
@@ -6,6 +6,9 @@ export type ConsentPath = 'communication' | 'newsletters' | 'data' | 'review';
  */
 export const ValidRoutePathsArray = [
   '/404',
+  '/change-email/:token',
+  '/change-email/complete',
+  '/change-email/error',
   '/consents',
   '/consents/:page',
   '/consents/communication',
@@ -70,6 +73,7 @@ export type ApiRoutePaths =
   | '/pwd-reset/user-for-token'
   | '/signin-token/token/:token'
   | '/unauth'
+  | '/user/change-email'
   | '/user/me'
   | '/user/me/consents'
   | '/user/me/group/:groupCode'


### PR DESCRIPTION
## What does this change?

Migrates the logic for the change email endpoints from Identity Frontend to Gateway. The copy for these pages were taken from the identity frontend equivalent pages.

We first create two new client pages:

`ChangeEmailComplete`

![Screenshot 2023-02-23 at 10 28 18](https://user-images.githubusercontent.com/13315440/220881646-d56d583e-0a92-4f5b-8913-a36f4a191d76.png)

`ChangeEmailError`

<img width="384" alt="Screenshot 2023-02-23 at 09 37 51" src="https://user-images.githubusercontent.com/13315440/220870697-26301e61-da9d-4d87-9bbe-742427b18086.png">

We then handle these on the following routes:

`GET /change-email/:token`
- Extracts the token from `req.params
- IDAPI `POST /user/change-email` with `token` in body
- On success redirect to `/change-email/complete`
- On failure render `ChangeEmailError` page

`GET /change-email/complete`
- Renders the `ChangeEmailComplete` page
- Replaces `/change-email-successful`
  - In convention with other pages in gateway
  - No redirect required as only logical way for user to get here would be through using a valid token

We also set up both `cypress-mocked` and `cypress-ete` tests to cover the flow.

## Tested
- [x] CODE

Test flow:
- Go to https://manage.code.dev-theguardian.com/account-settings
- Update email address
- Find email in new email address
- "Click to confirm"
- This should go to gateway now, with page looking like `ChangeEmailComplete`
- Failure case can be tested by using a fake token

## Notes

Merge VCL PR after this PR is deployed: https://github.com/guardian/identity-platform/pull/613