### PR TITLE
Migrate consent token endpoint from Identity Frontend to Gateway

### DIFF
--- a/cypress/integration/ete/consent_token/consent_token.2.cy.ts
+++ b/cypress/integration/ete/consent_token/consent_token.2.cy.ts
@@ -1,0 +1,46 @@
+describe('Consent token flow', () => {
+  it('redirects to the success route when supplied a valid token by a logged in user', () => {
+    cy.createTestUser({
+      isUserEmailValidated: true,
+    }).then(({ emailAddress, cookies }) => {
+      // SC_GU_U is required for the cy.getTestUserDetails
+      const scGuU = cookies.find((cookie) => cookie.key === 'SC_GU_U');
+      if (!scGuU) throw new Error('SC_GU_U cookie not found');
+      cy.setCookie('SC_GU_U', scGuU?.value);
+      // SC_GU_LA is required for the cy.getTestUserDetails
+      const scGuLa = cookies.find((cookie) => cookie.key === 'SC_GU_LA');
+      if (!scGuLa) throw new Error('SC_GU_LA cookie not found');
+      cy.setCookie('SC_GU_LA', scGuLa?.value);
+      cy.sendConsentEmail({
+        emailAddress,
+        consents: ['jobs'],
+      }).then(() => {
+        const timeRequestWasMade = new Date();
+        cy.checkForEmailAndGetDetails(
+          emailAddress,
+          timeRequestWasMade,
+          /consent-token\/([^"]*)/,
+        ).then(({ token }) => {
+          cy.visit(`/consent-token/${token}`, {
+            failOnStatusCode: false,
+          });
+          // /consents/thank-you isn't hosted by Gateway so all we need to check
+          // is that the cy.visit() redirected successfully - this will show a 404 page.
+          cy.url().should(
+            'be.equal',
+            `https://${Cypress.env('BASE_URI')}/consents/thank-you`,
+          );
+        });
+      });
+    });
+  });
+
+  it('shows the email sent page when supplied an invalid token', () => {
+    const invalidToken = 'invalid-consent-token';
+    cy.visit(`/consent-token/${invalidToken}/accept`);
+    cy.contains('This link has expired.');
+    cy.get('button[type=submit]').click();
+    cy.url().should('include', '/consent-token/email-sent');
+    cy.contains('Check your email inbox');
+  });
+});

--- a/cypress/integration/mocked/consent_token.3.cy.ts
+++ b/cypress/integration/mocked/consent_token.3.cy.ts
@@ -1,0 +1,44 @@
+import { injectAndCheckAxe } from '../../support/cypress-axe';
+
+describe('Consent token accept flow', () => {
+  beforeEach(() => {
+    cy.mockPurge();
+  });
+
+  context('a11y checks', () => {
+    it('Has no detectable a11y violations on consent token expired page', () => {
+      cy.visit('/consent-token/abc123/accept');
+      injectAndCheckAxe();
+    });
+
+    it('Has no detectable a11y violations on consent token email sent page', () => {
+      cy.visit('/consent-token/abc123/accept');
+      cy.get('button[type=submit]').click();
+      injectAndCheckAxe();
+    });
+  });
+
+  context('consent token flow', () => {
+    // This test needs to be run mocked because we need to mock the
+    // expired token response from IDAPI.
+    it('shows the email sent page when supplied a valid, expired token', () => {
+      const expiredToken = 'expired-consent-token';
+      cy.mockNext(403, {
+        error: {
+          status: 'error',
+          errors: [
+            {
+              message: 'Token expired',
+              description: 'The link is no longer valid',
+            },
+          ],
+        },
+      });
+      cy.visit(`/consent-token/${expiredToken}/accept`);
+      cy.contains('This link has expired.');
+      cy.get('button[type=submit]').click();
+      cy.url().should('include', '/consent-token/email-sent');
+      cy.contains('Check your email inbox');
+    });
+  });
+});

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -35,6 +35,7 @@ import {
   closeCurrentOktaSession,
   subscribeToNewsletter,
   subscribeToMarketingConsent,
+  sendConsentEmail,
 } from './commands/testUser';
 
 Cypress.Commands.add('mockNext', mockNext);
@@ -75,3 +76,4 @@ Cypress.Commands.add(
   'subscribeToMarketingConsent',
   subscribeToMarketingConsent,
 );
+Cypress.Commands.add('sendConsentEmail', sendConsentEmail);

--- a/cypress/support/commands/testUser.ts
+++ b/cypress/support/commands/testUser.ts
@@ -27,6 +27,7 @@ declare global {
       closeCurrentOktaSession: typeof closeCurrentOktaSession;
       subscribeToNewsletter: typeof subscribeToNewsletter;
       subscribeToMarketingConsent: typeof subscribeToMarketingConsent;
+      sendConsentEmail: typeof sendConsentEmail;
     }
   }
 }
@@ -253,6 +254,42 @@ export const createTestUser = ({
   } catch (error) {
     throw new Error('Failed to create IDAPI test user: ' + error);
   }
+};
+
+export const sendConsentEmail = ({
+  emailAddress,
+  consents,
+  newsletters,
+}: {
+  emailAddress: string;
+  consents?: string[];
+  newsletters?: string[];
+}) => {
+  return cy.getCookie('SC_GU_U').then((cookie) => {
+    try {
+      return cy.request({
+        url: Cypress.env('IDAPI_BASE_URL') + '/consent-email',
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-GU-ID-Client-Access-Token': `Bearer ${Cypress.env(
+            'IDAPI_CLIENT_ACCESS_TOKEN',
+          )}`,
+          'X-GU-ID-FOWARDED-SC-GU-U': cookie?.value,
+        },
+        body: JSON.stringify([
+          {
+            email: emailAddress,
+            'set-consents': consents,
+            'set-lists': newsletters,
+          },
+        ]),
+        retryOnStatusCodeFailure: true,
+      });
+    } catch (error) {
+      throw new Error('Failed to send consents email: ' + error);
+    }
+  });
 };
 
 export const getTestOktaUser = (id: string) => {

--- a/src/client/pages/EmailSent.stories.tsx
+++ b/src/client/pages/EmailSent.stories.tsx
@@ -61,3 +61,10 @@ export const WithRecaptchaError = () => (
 WithRecaptchaError.story = {
   name: 'with reCAPTCHA error',
 };
+
+export const WithHelpText = () => (
+  <EmailSent changeEmailPage="/reset-password" showHelp={true} />
+);
+WithHelpText.story = {
+  name: 'with help text',
+};

--- a/src/client/pages/EmailSent.tsx
+++ b/src/client/pages/EmailSent.tsx
@@ -23,6 +23,7 @@ type Props = {
   recaptchaSiteKey?: string;
   formTrackingName?: string;
   formError?: string;
+  showHelp?: boolean;
 };
 
 export const EmailSent = ({
@@ -37,10 +38,12 @@ export const EmailSent = ({
   formTrackingName,
   children,
   formError,
+  showHelp,
 }: PropsWithChildren<Props>) => {
   const [recaptchaErrorMessage, setRecaptchaErrorMessage] = useState('');
   const [recaptchaErrorContext, setRecaptchaErrorContext] =
     useState<ReactNode>(null);
+  const showHelpBox = showHelp || (email && resendEmailAction);
   return (
     <MainLayout
       pageHeader="Check your email inbox"
@@ -110,20 +113,21 @@ export const EmailSent = ({
           >
             <EmailInput defaultValue={email} hidden hideLabel />
           </MainForm>
-          <MainBodyText cssOverrides={belowFormMarginTopSpacingStyle}>
-            If you are still having trouble, contact our customer service team
-            at{' '}
-            <ExternalLink
-              cssOverrides={css`
-                font-weight: 700;
-              `}
-              href="mailto:userhelp@theguardian.com"
-            >
-              userhelp@guardian.com
-            </ExternalLink>
-            .
-          </MainBodyText>
         </>
+      )}
+      {showHelpBox && (
+        <MainBodyText cssOverrides={belowFormMarginTopSpacingStyle}>
+          If you are still having trouble, contact our customer service team at{' '}
+          <ExternalLink
+            cssOverrides={css`
+              font-weight: 700;
+            `}
+            href="mailto:userhelp@theguardian.com"
+          >
+            userhelp@guardian.com
+          </ExternalLink>
+          .
+        </MainBodyText>
       )}
     </MainLayout>
   );

--- a/src/client/pages/EmailSentPage.tsx
+++ b/src/client/pages/EmailSentPage.tsx
@@ -6,9 +6,14 @@ import { buildQueryParamsString } from '@/shared/lib/queryParams';
 interface Props {
   noAccountInfo?: boolean;
   formTrackingName?: string;
+  showHelp?: boolean;
 }
 
-export const EmailSentPage = ({ noAccountInfo, formTrackingName }: Props) => {
+export const EmailSentPage = ({
+  noAccountInfo,
+  formTrackingName,
+  showHelp,
+}: Props) => {
   const clientState = useClientState();
   const {
     pageData = {},
@@ -37,6 +42,7 @@ export const EmailSentPage = ({ noAccountInfo, formTrackingName }: Props) => {
       noAccountInfo={noAccountInfo}
       recaptchaSiteKey={recaptchaSiteKey}
       formTrackingName={formTrackingName}
+      showHelp={showHelp}
     />
   );
 };

--- a/src/client/pages/ResendConsentEmail.stories.tsx
+++ b/src/client/pages/ResendConsentEmail.stories.tsx
@@ -1,0 +1,19 @@
+/* eslint-disable functional/immutable-data */
+import React from 'react';
+import { Meta } from '@storybook/react';
+
+import { ResendConsentEmail } from './ResendConsentEmail';
+
+export default {
+  title: 'Pages/ResendConsentEmail',
+  component: ResendConsentEmail,
+  parameters: { layout: 'fullscreen' },
+} as Meta;
+
+export const Default = () => (
+  <ResendConsentEmail
+    queryParams={{ returnUrl: 'https://theguardian.com' }}
+    token="sometoken"
+  />
+);
+Default.story = { name: 'with defaults' };

--- a/src/client/pages/ResendConsentEmail.tsx
+++ b/src/client/pages/ResendConsentEmail.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { MainBodyText } from '@/client/components/MainBodyText';
+import { MainLayout } from '@/client/layouts/Main';
+import { CsrfFormField } from '@/client/components/CsrfFormField';
+import { buildUrlWithQueryParams } from '@/shared/lib/routeUtils';
+import {
+  Button,
+  SvgArrowRightStraight,
+} from '@guardian/source-react-components';
+import { QueryParams } from '@/shared/model/QueryParams';
+
+interface Props {
+  token: string;
+  queryParams: QueryParams;
+}
+
+export const ResendConsentEmail = ({ token, queryParams }: Props) => {
+  return (
+    <MainLayout pageHeader="Link expired">
+      <MainBodyText>This link has expired.</MainBodyText>
+      <MainBodyText>To receive a new link, please click below.</MainBodyText>
+      <form
+        method="post"
+        action={buildUrlWithQueryParams(
+          '/consent-token/resend',
+          {},
+          queryParams,
+        )}
+      >
+        <CsrfFormField />
+        <input type="hidden" name="token" value={token} />
+        <Button type="submit" icon={<SvgArrowRightStraight />} iconSide="right">
+          Resend link
+        </Button>
+      </form>
+    </MainLayout>
+  );
+};

--- a/src/client/pages/ResendConsentEmailPage.tsx
+++ b/src/client/pages/ResendConsentEmailPage.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import useClientState from '@/client/lib/hooks/useClientState';
+import { ResendConsentEmail } from './ResendConsentEmail';
+
+export const ResendConsentEmailPage = () => {
+  const clientState = useClientState();
+  const { pageData: { token = '' } = {}, queryParams } = clientState;
+
+  return <ResendConsentEmail token={token} queryParams={queryParams} />;
+};

--- a/src/client/routes.tsx
+++ b/src/client/routes.tsx
@@ -36,6 +36,7 @@ import { ChangeEmailCompletePage } from '@/client/pages/ChangeEmailCompletePage'
 import { ChangeEmailErrorPage } from '@/client/pages/ChangeEmailErrorPage';
 import { UnsubscribeSuccessPage } from '@/client/pages/UnsubscribeSuccessPage';
 import { UnsubscribeErrorPage } from '@/client/pages/UnsubscribeErrorPage';
+import { ResendConsentEmailPage } from './pages/ResendConsentEmailPage';
 
 export type RoutingConfig = {
   clientState: ClientState;
@@ -201,6 +202,16 @@ const routes: Array<{
   {
     path: '/maintenance',
     element: <MaintenancePage />,
+  },
+  {
+    path: '/consent-token/error',
+    element: <ResendConsentEmailPage />,
+  },
+  {
+    path: '/consent-token/email-sent',
+    element: (
+      <EmailSentPage formTrackingName="consent-resend" showHelp={true} />
+    ),
   },
 ];
 

--- a/src/server/lib/idapi/consentToken.ts
+++ b/src/server/lib/idapi/consentToken.ts
@@ -1,0 +1,72 @@
+import {
+  APIAddClientAccessToken,
+  APIForwardSessionIdentifier,
+  APIPostOptions,
+  idapiFetch,
+} from '@/server/lib/IDAPIFetch';
+import { logger } from '@/server/lib/serverSideLogger';
+import { IdapiError } from '@/server/models/Error';
+import { IdapiErrorMessages } from '@/shared/model/Errors';
+
+const handleError = (): never => {
+  throw new IdapiError({
+    message: IdapiErrorMessages.INVALID_TOKEN,
+    status: 500,
+  });
+};
+
+export const validateConsentToken = async (
+  ip: string,
+  sc_gu_u: string,
+  token: string,
+  request_id?: string,
+) => {
+  const options = APIForwardSessionIdentifier(
+    APIAddClientAccessToken(APIPostOptions(), ip),
+    sc_gu_u,
+  );
+  try {
+    await idapiFetch({
+      path: '/consent-email/:token',
+      options,
+      tokenisationParam: { token },
+    });
+  } catch (error) {
+    logger.error(
+      `IDAPI Error validating consent token with route '/consent-email/:token'`,
+      error,
+      {
+        request_id,
+      },
+    );
+    return handleError();
+  }
+};
+
+export const resendConsentEmail = async (
+  ip: string,
+  sc_gu_u: string,
+  token: string,
+  request_id?: string,
+) => {
+  const options = APIForwardSessionIdentifier(
+    APIAddClientAccessToken(APIPostOptions(), ip),
+    sc_gu_u,
+  );
+  try {
+    await idapiFetch({
+      path: '/consent-email/resend/:token',
+      options,
+      tokenisationParam: { token },
+    });
+  } catch (error) {
+    logger.error(
+      `IDAPI Error resending consent email with route '/consent-email/resend/:token'`,
+      error,
+      {
+        request_id,
+      },
+    );
+    return handleError();
+  }
+};

--- a/src/server/routes/consentToken.ts
+++ b/src/server/routes/consentToken.ts
@@ -1,0 +1,75 @@
+import { Request } from 'express';
+import { ResponseWithRequestState } from '@/server/models/Express';
+import { renderer } from '@/server/lib/renderer';
+import { rateLimitedTypedRouter as router } from '@/server/lib/typedRoutes';
+import { handleAsyncErrors } from '@/server/lib/expressWrappers';
+import {
+  validateConsentToken,
+  resendConsentEmail,
+} from '@/server/lib/idapi/consentToken';
+import { mergeRequestState } from '@/server/lib/requestState';
+import { logger } from '@/server/lib/serverSideLogger';
+
+// This route is of this specific form because it's a direct copy of the legacy
+// route in identity-frontend, and emails sent by IDAPI contain this URL.
+// We can change the route after we've migrated the emails from IDAPI.
+router.get(
+  '/consent-token/:token/accept',
+  handleAsyncErrors(async (req: Request, res: ResponseWithRequestState) => {
+    const ip = req.ip;
+    const sc_gu_u = req.cookies.SC_GU_U;
+    const token = req.params.token;
+    try {
+      await validateConsentToken(ip, sc_gu_u, token, res.locals.requestId);
+      // Redirect to /consents/thank-you (a page managed by Frontend). This is
+      // to retain the legacy behaviour of the route from identity-frontend.
+      return res.redirect(303, '/consents/thank-you');
+    } catch (error) {
+      // On an error we assume the token is invalid and render a page
+      // where the user can request a new consent email.
+      const html = renderer('/consent-token/error', {
+        pageTitle: 'Resend Consent Email',
+        requestState: mergeRequestState(res.locals, {
+          pageData: {
+            token,
+          },
+        }),
+      });
+      return res.type('html').status(200).send(html);
+    }
+  }),
+);
+
+router.get(
+  '/consent-token/email-sent',
+  (_: Request, res: ResponseWithRequestState) => {
+    const html = renderer('/consent-token/email-sent', {
+      pageTitle: 'Check Your Inbox',
+      requestState: res.locals,
+    });
+    return res.type('html').status(200).send(html);
+  },
+);
+
+router.post(
+  '/consent-token/resend',
+  handleAsyncErrors(async (req: Request, res: ResponseWithRequestState) => {
+    // This is a pass-through route to IDAPI, which will send a new consent
+    // email to the user if the token matches. We don't need to do anything
+    // with the response here.
+    const { token } = req.body;
+    const ip = req.ip;
+    const sc_gu_u = req.cookies.SC_GU_U;
+    try {
+      await resendConsentEmail(ip, sc_gu_u, token, res.locals.requestId);
+    } catch (error) {
+      logger.error(`${req.method} ${req.originalUrl} Error`, error, {
+        request_id: res.locals.requestId,
+      });
+    } finally {
+      return res.redirect(303, '/consent-token/email-sent');
+    }
+  }),
+);
+
+export default router.router;

--- a/src/server/routes/index.ts
+++ b/src/server/routes/index.ts
@@ -18,6 +18,7 @@ import { default as emailTemplates } from './emailTemplates';
 import { default as agree } from './agree';
 import { default as changeEmail } from './changeEmail';
 import { default as unsubscribe } from './unsubscribe';
+import { default as consentToken } from './consentToken';
 
 const { okta } = getConfiguration();
 
@@ -74,6 +75,9 @@ uncachedRoutes.use(unsubscribe);
 if (okta.enabled) {
   uncachedRoutes.use(oauth);
 }
+
+// consent token routes
+uncachedRoutes.use(consentToken);
 
 // email template routes
 router.use(emailTemplates);

--- a/src/shared/model/PageTitle.ts
+++ b/src/shared/model/PageTitle.ts
@@ -15,6 +15,7 @@ export type PageTitle =
   | 'Change Password'
   | 'Resend Change Password Email'
   | 'Password Changed'
+  | 'Resend Consent Email'
   | 'Verify Email'
   | 'Welcome'
   | 'Resend Welcome Email'

--- a/src/shared/model/Routes.ts
+++ b/src/shared/model/Routes.ts
@@ -17,6 +17,10 @@ export const ValidRoutePathsArray = [
   '/consents/data',
   '/consents/review',
   '/email/:template',
+  '/consent-token/:token/accept',
+  '/consent-token/error',
+  '/consent-token/resend',
+  '/consent-token/email-sent',
   '/error',
   '/magic-link', //this is not being used until MVP4
   '/magic-link/email-sent', //this is not being used until MVP4
@@ -69,6 +73,8 @@ export type ApiRoutePaths =
   | '/auth/oauth-token'
   | '/auth/redirect'
   | '/consents'
+  | '/consent-email/:token'
+  | '/consent-email/resend/:token'
   | '/guest'
   | '/newsletters'
   | '/pwd-reset/reset-pwd-for-user'


### PR DESCRIPTION
## What does this change?

Migrates the 'confirm your subscription'/'confirm your communication preferences' journey from Identity Frontend to Gateway.

On the frontend, created a new page:

**Expired/invalid consent token** - `ResendConsentTokenPage`

<img width="372" alt="Screenshot 2023-02-23 at 11 35 10" src="https://user-images.githubusercontent.com/101555242/220894962-80498e47-23b3-409f-bc0b-dd3a576ac3f0.png">

And refactored the `EmailSent` page to show a user help text if a `showHelp` flag is present (previously, it would only show the help if specific conditions were met):

<img width="370" alt="Screenshot 2023-02-23 at 11 34 48" src="https://user-images.githubusercontent.com/101555242/220894824-ad48c08b-05e2-4096-8a1e-754743e4f958.png">

On the backend, added the following routes:

- `GET /consent-token/:token/accept`
  - Receives a token and validates it with IDAPI.
  - If the token is valid, redirects the user to an external page managed by Frontend: `/consents/thank-you`.
  - If the token is invalid, displays the new `ResendConsentTokenPage` with the token prefilled into the form, which POSTs to `/consent-token/resend`.

- `POST /consent-token/resend`
  - Receives a token in the post body.
  - Attempts to request IDAPI to resend the email for that token.
  - Whether the request succeeds or fails, redirects the user to `/consent-token/email-sent`.

- `GET /consent-token/email-sent`
  - Displays the `EmailSentPage` with the user help text shown, as above.
 
Also set up Cypress ETE tests to cover this journey.

## Testing

- [x] CODE
- [ ] PROD

1. In Postman or User Admin tool, `POST` to the IDAPI `/consent-email` endpoint with a JSON body of the form:
  ```
  {
      "email": "email@domain.com",
      "set-consents": ["jobs"],
     // OR
      "set-lists": ["morning-briefing"]
  }
  ```
2. The specified email address will receive an email with a link to click to confirm the new consents.
3. The link should point to the Gateway route `/consent-token/:token/accept`, which will then redirect the user to the Frontend route `/consents/thank-you`.
4. A direct query to `/consent-token/nonsense-token/accept` will display a 'link expired' page (again, all in Gateway) and clicking on the 'resend' button will redirect to the page `/consent-token/email-sent` (no email will be sent as the consent token is fake).

## Related PRs

After this PR is merged, we will want to merge in the Fastly VCL changes in https://github.com/guardian/identity-platform/pull/615.