### PR TITLE
Add metrics for identity-frontend migrated routes

### DIFF
--- a/src/server/models/Metrics.ts
+++ b/src/server/models/Metrics.ts
@@ -19,9 +19,13 @@ type RateLimitMetrics = BucketType;
 type ConditionalMetrics =
   | 'AccountVerification'
   | 'BreachedPasswordCheck'
+  | 'ChangeEmail'
+  | 'ConsentToken'
+  | 'ConsentTokenResend'
   | `${EmailMetrics}EmailSend`
   | 'EmailValidated'
   | `${'Get' | 'Post'}ConsentsPage-${string}`
+  | 'JobsGRSGroupAgree'
   | 'LoginMiddleware'
   | 'OAuthAuthorization'
   | 'OktaRegistration'
@@ -40,10 +44,10 @@ type ConditionalMetrics =
   | 'SendValidationEmail'
   | 'SignIn'
   | 'SignOut'
+  | 'Unsubscribe'
   | 'UpdatePassword'
   | 'RecaptchaMiddleware'
-  | 'ValidatePasswordToken'
-  | 'JobsGRSGroupAgree';
+  | 'ValidatePasswordToken';
 
 // Unconditional metrics that we want to track directly
 type UnconditionalMetrics =

--- a/src/server/routes/changeEmail.ts
+++ b/src/server/routes/changeEmail.ts
@@ -7,6 +7,7 @@ import { getConfiguration } from '@/server/lib/getConfiguration';
 import { changeEmail } from '@/server/lib/idapi/user';
 import { handleAsyncErrors } from '@/server/lib/expressWrappers';
 import { logger } from '@/server/lib/serverSideLogger';
+import { trackMetric } from '@/server/lib/trackMetric';
 
 const { accountManagementUrl } = getConfiguration();
 
@@ -32,11 +33,17 @@ router.get(
 
     try {
       await changeEmail(token, req.ip, res.locals.requestId);
+
+      trackMetric('ChangeEmail::Success');
+
       return res.redirect(303, '/change-email/complete');
     } catch (error) {
       logger.error(`${req.method} ${req.originalUrl}  Error`, error, {
         request_id: res.locals.requestId,
       });
+
+      trackMetric('ChangeEmail::Failure');
+
       const html = renderer('/change-email/error', {
         pageTitle: 'Change Email',
         requestState: mergeRequestState(res.locals, {

--- a/src/server/routes/unsubscribe.ts
+++ b/src/server/routes/unsubscribe.ts
@@ -11,6 +11,7 @@ import { renderer } from '@/server/lib/renderer';
 import { mergeRequestState } from '@/server/lib/requestState';
 import { getConfiguration } from '@/server/lib/getConfiguration';
 import { logger } from '@/server/lib/serverSideLogger';
+import { trackMetric } from '@/server/lib/trackMetric';
 
 const { accountManagementUrl } = getConfiguration();
 
@@ -34,6 +35,8 @@ router.get(
         res.locals.requestId,
       );
 
+      trackMetric('Unsubscribe::Success');
+
       const html = renderer('/unsubscribe/success', {
         requestState: mergeRequestState(res.locals, {
           pageData: {
@@ -48,6 +51,8 @@ router.get(
       logger.error(`${req.method} ${req.originalUrl}  Error`, error, {
         request_id: res.locals.requestId,
       });
+
+      trackMetric('Unsubscribe::Failure');
 
       const html = renderer('/unsubscribe/error', {
         requestState: mergeRequestState(res.locals, {


### PR DESCRIPTION
## What does this change?

Adds `Success` and `Failure` metrics for the following

- `ChangeEmail`
- `Unsubscribe`
- `ConsentToken`
- `ConsentTokenResend`

### Other chnges

- Sorts the `Metrics` type in alphabetical order.
- Adds missing `logger` for `/consent-token/:token/accept` route error