### PR TITLE
RiffRaff - Use SSM lookup for artifact bucket

### DIFF
--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -71,6 +71,12 @@ Parameters:
   LoadBalancerLogsS3Bucket:
     Description: S3 Bucket to write ELB access logs to
     Type: String
+  IdentityArtifactBucket:
+    Description: S3 Bucket to read identity artifacts from
+    Type: String
+  IdentityConfigBucket:
+    Description: S3 Bucket to read identity config from
+    Type: String
 Mappings:
   StageVariables:
     CODE:
@@ -116,11 +122,11 @@ Resources:
               - Effect: Allow
                 Action: s3:GetObject
                 Resource:
-                  - !Sub arn:aws:s3:::identity-artifacts/${Stage}/${App}/*
+                  - !Sub arn:aws:s3:::${IdentityArtifactBucket}/${Stage}/${App}/*
               - Effect: Allow
                 Action: s3:GetObject
                 Resource:
-                  - !Sub arn:aws:s3:::identity-private-config/${Stage}/identity-gateway/*
+                  - !Sub arn:aws:s3:::${IdentityConfigBucket}/${Stage}/${App}/*
               - Effect: Allow
                 Action:
                   - kinesis:Describe*
@@ -244,14 +250,14 @@ Resources:
             mkdir /etc/gu
 
             # Get Riff Raff deployed artefact S3
-            aws s3 cp s3://identity-artifacts/${Stage}/${App}/${App}.zip /etc/gu
+            aws s3 cp s3://${IdentityArtifactBucket}/${Stage}/${App}/${App}.zip /etc/gu
             unzip -o /etc/gu/${App}.zip -d /etc/gu
 
             # Get Rate Limiter configuration file
             # Try multiple times to the config file. The s3 cp command can fail when called immediately on instance startup.
             while true; do
               if \
-                aws s3 cp s3://identity-private-config/${Stage}/identity-gateway/.ratelimit.json /etc/gu/.ratelimit.json
+                aws s3 cp s3://${IdentityConfigBucket}/${Stage}/${App}/.ratelimit.json /etc/gu/.ratelimit.json
                 then break
               fi
               sleep 1

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -20,7 +20,8 @@ deployments:
     dependencies:
       - gateway-cloudformation
     parameters:
-      bucket: identity-artifacts
+      bucketSsmLookup: true
+      bucketSsmKey: /account/services/identity.artifact.bucket
       prefixStack: false
   update-ami:
     type: ami-cloudformation-parameter


### PR DESCRIPTION
## What does this change?

Follows recommendations to not commit s3 bucket names into public repos.

https://github.com/guardian/riff-raff/pull/704

Unable to use the default `/account/services/artifact.bucket` ssm parameter as this was set already to a different bucket, so created a new parameter (`/account/services/identity.artifact.bucket`) to target the correct bucket.

Also updates our cloudformation to remove direct s3 bucket names and use parameters instead.

## Tested
- [x] CODE
