### PR TITLE
Snyk | Add `SKIP_SBT` parameter to fix action

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -13,5 +13,6 @@ jobs:
       DEBUG: true
       ORG: guardian-identity
       SKIP_NODE: false
+      SKIP_SBT: true
     secrets:
       SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}


### PR DESCRIPTION
## What does this change?

This github action was failing as it could not find any scala or sbt files in this project. 

https://github.com/guardian/gateway/actions/runs/4342054892/jobs/7582406166

```
Error: No file in /home/runner/work/gateway/gateway matched to [**/*.sbt,**/project/build.properties,**/project/**.{scala,sbt}], make sure you have checked out the target repository
```

Adds the `SKIP_SBT` command to skip this check, as this is a typescript/node only project.

See https://github.com/guardian/gateway/actions/runs/4342315374 for fix
