### PR TITLE
Forward user IP address in Okta API calls

### DIFF
--- a/src/server/controllers/checkPasswordToken.ts
+++ b/src/server/controllers/checkPasswordToken.ts
@@ -154,6 +154,7 @@ export const checkTokenInOkta = async (
     // return an error and we will show the link expired page.
     const { _embedded } = await validateTokenInOkta({
       recoveryToken: token,
+      ip: req.ip,
     });
     const email = _embedded?.user.profile.login;
 

--- a/src/server/lib/__tests__/deeplink/oktaRecoveryToken.test.ts
+++ b/src/server/lib/__tests__/deeplink/oktaRecoveryToken.test.ts
@@ -34,7 +34,8 @@ jest.mock('@/server/lib/serverSideLogger', () => ({
 }));
 
 jest.mock('@/server/lib/okta/api/apps');
-const mockedGetApp = mocked<(id: string) => Promise<AppResponse>>(getApp);
+const mockedGetApp =
+  mocked<(id: string, ip: string) => Promise<AppResponse>>(getApp);
 
 describe('extractOktaRecoveryToken', () => {
   it('should return the token when there is no prefix', () => {
@@ -72,9 +73,13 @@ describe('addAppPrefixToOktaRecoveryToken', () => {
     const token = 'token';
     const appClientId = undefined;
 
-    expect(await addAppPrefixToOktaRecoveryToken(token, appClientId)).toEqual(
-      token,
-    );
+    expect(
+      await addAppPrefixToOktaRecoveryToken({
+        token,
+        appClientId,
+        ip: '127.0.0.1',
+      }),
+    ).toEqual(token);
   });
 
   it('should return the token when there is no app prefix', async () => {
@@ -92,9 +97,13 @@ describe('addAppPrefixToOktaRecoveryToken', () => {
 
     mockedGetApp.mockResolvedValueOnce(app);
 
-    expect(await addAppPrefixToOktaRecoveryToken(token, appClientId)).toEqual(
-      token,
-    );
+    expect(
+      await addAppPrefixToOktaRecoveryToken({
+        token,
+        appClientId,
+        ip: '127.0.0.1',
+      }),
+    ).toEqual(token);
   });
 
   it('should return the token when there is an app prefix android live', async () => {
@@ -112,9 +121,13 @@ describe('addAppPrefixToOktaRecoveryToken', () => {
 
     mockedGetApp.mockResolvedValueOnce(app);
 
-    expect(await addAppPrefixToOktaRecoveryToken(token, appClientId)).toEqual(
-      `al_${token}`,
-    );
+    expect(
+      await addAppPrefixToOktaRecoveryToken({
+        token,
+        appClientId,
+        ip: '127.0.0.1',
+      }),
+    ).toEqual(`al_${token}`);
   });
 
   it('should return the token when there is an app prefix ios live', async () => {
@@ -132,9 +145,13 @@ describe('addAppPrefixToOktaRecoveryToken', () => {
 
     mockedGetApp.mockResolvedValueOnce(app);
 
-    expect(await addAppPrefixToOktaRecoveryToken(token, appClientId)).toEqual(
-      `il_${token}`,
-    );
+    expect(
+      await addAppPrefixToOktaRecoveryToken({
+        token,
+        appClientId,
+        ip: '127.0.0.1',
+      }),
+    ).toEqual(`il_${token}`);
   });
 
   it('should return the token if the appClientId is not found', async () => {
@@ -143,8 +160,12 @@ describe('addAppPrefixToOktaRecoveryToken', () => {
 
     mockedGetApp.mockRejectedValueOnce(new Error('App not found'));
 
-    expect(await addAppPrefixToOktaRecoveryToken(token, appClientId)).toEqual(
-      token,
-    );
+    expect(
+      await addAppPrefixToOktaRecoveryToken({
+        token,
+        appClientId,
+        ip: '127.0.0.1',
+      }),
+    ).toEqual(token);
   });
 });

--- a/src/server/lib/__tests__/okta/api/sessions.test.ts
+++ b/src/server/lib/__tests__/okta/api/sessions.test.ts
@@ -43,7 +43,7 @@ describe('okta#signOutUser', () => {
       Promise.resolve({ ok: true, status: 200, json } as Response),
     );
 
-    const sessionResponse = await getSession(sessionId);
+    const sessionResponse = await getSession(sessionId, '127.0.0.1');
     expect(sessionResponse).toEqual(sessionData);
   });
 
@@ -52,7 +52,7 @@ describe('okta#signOutUser', () => {
       Promise.resolve({ ok: false, status: 404 } as Response),
     );
 
-    await expect(getSession(sessionId)).rejects.toThrowError(
+    await expect(getSession(sessionId, '127.0.0.1')).rejects.toThrowError(
       new OktaError({ message: 'Could not parse Okta error response' }),
     );
   });

--- a/src/server/lib/__tests__/okta/api/users.test.ts
+++ b/src/server/lib/__tests__/okta/api/users.test.ts
@@ -66,7 +66,7 @@ describe('okta#createUser', () => {
       Promise.resolve({ ok: true, json } as Response),
     );
 
-    const response = await createUser(userCreationRequest(email));
+    const response = await createUser(userCreationRequest(email), '127.0.0.1');
     expect(response).toEqual(user);
   });
 
@@ -89,7 +89,9 @@ describe('okta#createUser', () => {
       Promise.resolve({ ok: false, status: 400, json } as Response),
     );
 
-    await expect(createUser(userCreationRequest(userId))).rejects.toThrowError(
+    await expect(
+      createUser(userCreationRequest(userId), '127.0.0.1'),
+    ).rejects.toThrowError(
       new OktaError({ message: 'Api validation failed: login' }),
     );
   });
@@ -117,7 +119,9 @@ describe('okta#createUser', () => {
       Promise.resolve({ ok: false, status: 400, json } as Response),
     );
 
-    await expect(createUser(userCreationRequest(userId))).rejects.toThrowError(
+    await expect(
+      createUser(userCreationRequest(userId), '127.0.0.1'),
+    ).rejects.toThrowError(
       new OktaError({ message: 'Api validation failed: login', causes }),
     );
   });
@@ -141,7 +145,9 @@ describe('okta#createUser', () => {
       Promise.resolve({ ok: false, status: 400, json } as Response),
     );
 
-    await expect(createUser(userCreationRequest(userId))).rejects.toThrowError(
+    await expect(
+      createUser(userCreationRequest(userId), '127.0.0.1'),
+    ).rejects.toThrowError(
       new OktaError({ message: 'Api validation failed: login', causes }),
     );
   });
@@ -165,7 +171,7 @@ describe('okta#fetchUser', () => {
       Promise.resolve({ ok: true, json } as Response),
     );
 
-    const response = await getUser(userId);
+    const response = await getUser(userId, '127.0.0.1');
     expect(response).toEqual(user);
   });
 
@@ -182,7 +188,7 @@ describe('okta#fetchUser', () => {
       Promise.resolve({ ok: false, status: 404, json } as Response),
     );
 
-    await expect(getUser(userId)).rejects.toThrowError(
+    await expect(getUser(userId, '127.0.0.1')).rejects.toThrowError(
       new OktaError({ message: 'Not found: Resource not found: 12345 (User)' }),
     );
   });
@@ -209,7 +215,7 @@ describe('okta#getUserGroups', () => {
       Promise.resolve({ ok: true, json } as Response),
     );
 
-    const response = await getUserGroups(userId);
+    const response = await getUserGroups(userId, '127.0.0.1');
     expect(response).toEqual(groups);
   });
 
@@ -226,7 +232,7 @@ describe('okta#getUserGroups', () => {
       Promise.resolve({ ok: false, status: 404, json } as Response),
     );
 
-    await expect(getUserGroups(userId)).rejects.toThrowError(
+    await expect(getUserGroups(userId, '127.0.0.1')).rejects.toThrowError(
       new OktaError({ message: 'Not found: Resource not found: 12345 (User)' }),
     );
   });
@@ -242,7 +248,9 @@ describe('okta#activateUser', () => {
       Promise.resolve({ ok: true, json } as Response),
     );
 
-    await expect(activateUser(userId, true)).resolves.toEqual(undefined);
+    await expect(
+      activateUser({ id: userId, sendEmail: true, ip: '127.0.0.1' }),
+    ).resolves.toEqual(undefined);
   });
 
   test('should throw an error when a user is already activated', async () => {
@@ -259,7 +267,9 @@ describe('okta#activateUser', () => {
       Promise.resolve({ ok: false, status: 403, json } as Response),
     );
 
-    await expect(activateUser(userId)).rejects.toThrowError(
+    await expect(
+      activateUser({ id: userId, ip: '127.0.0.1' }),
+    ).rejects.toThrowError(
       new OktaError({
         message: 'Activation failed because the user is already active',
       }),
@@ -277,7 +287,9 @@ describe('okta#reactivateUser', () => {
       Promise.resolve({ ok: true, json } as Response),
     );
 
-    await expect(reactivateUser(userId, true)).resolves.toEqual(undefined);
+    await expect(
+      reactivateUser({ id: userId, sendEmail: true, ip: '127.0.0.1' }),
+    ).resolves.toEqual(undefined);
   });
 
   test('throw a an error when a user cannot be reactivated', async () => {
@@ -295,7 +307,9 @@ describe('okta#reactivateUser', () => {
       Promise.resolve({ ok: false, status: 403, json } as Response),
     );
 
-    await expect(reactivateUser(userId)).rejects.toThrow(
+    await expect(
+      reactivateUser({ id: userId, ip: '127.0.0.1' }),
+    ).rejects.toThrow(
       new OktaError({
         message: "This operation is not allowed in the user's current status.",
       }),
@@ -311,7 +325,9 @@ describe('okta#clearUserSessions', () => {
   test('should clear user sessions', async () => {
     mockedFetch.mockReturnValueOnce(Promise.resolve({ ok: true } as Response));
 
-    await expect(clearUserSessions(userId)).resolves.toEqual(undefined);
+    await expect(
+      clearUserSessions({ id: userId, ip: '127.0.0.1' }),
+    ).resolves.toEqual(undefined);
   });
 
   test('should throw an error when a user session cannot be cleared', async () => {
@@ -328,7 +344,9 @@ describe('okta#clearUserSessions', () => {
       Promise.resolve({ ok: false, status: 404, json } as Response),
     );
 
-    await expect(clearUserSessions(userId)).rejects.toThrow(
+    await expect(
+      clearUserSessions({ id: userId, ip: '127.0.0.1' }),
+    ).rejects.toThrow(
       new OktaError({
         message: 'Not found: Resource not found: <userId> (User)',
       }),
@@ -351,7 +369,9 @@ describe('okta#dangerouslyResetPassword', () => {
       Promise.resolve({ ok: true, json } as Response),
     );
 
-    await expect(dangerouslyResetPassword(userId)).resolves.toEqual(token);
+    await expect(
+      dangerouslyResetPassword(userId, '127.0.0.1'),
+    ).resolves.toEqual(token);
   });
 
   test('handle unable to parse response', async () => {
@@ -365,7 +385,7 @@ describe('okta#dangerouslyResetPassword', () => {
       Promise.resolve({ ok: true, json } as Response),
     );
 
-    await expect(dangerouslyResetPassword(userId)).rejects.toThrow(
+    await expect(dangerouslyResetPassword(userId, '127.0.0.1')).rejects.toThrow(
       new OktaError({
         message: 'Could not parse Okta reset password url response',
       }),
@@ -386,7 +406,7 @@ describe('okta#dangerouslyResetPassword', () => {
       Promise.resolve({ ok: false, status: 404, json } as Response),
     );
 
-    await expect(dangerouslyResetPassword(userId)).rejects.toThrow(
+    await expect(dangerouslyResetPassword(userId, '127.0.0.1')).rejects.toThrow(
       new OktaError({
         message: 'Not found: Resource not found: <userId> (User)',
       }),
@@ -409,7 +429,7 @@ describe('okta#forgotPassword', () => {
       Promise.resolve({ ok: true, json } as Response),
     );
 
-    await expect(forgotPassword(userId)).resolves.toEqual(token);
+    await expect(forgotPassword(userId, '127.0.0.1')).resolves.toEqual(token);
   });
 
   test('handle unable to parse response', async () => {
@@ -423,7 +443,7 @@ describe('okta#forgotPassword', () => {
       Promise.resolve({ ok: true, json } as Response),
     );
 
-    await expect(forgotPassword(userId)).rejects.toThrow(
+    await expect(forgotPassword(userId, '127.0.0.1')).rejects.toThrow(
       new OktaError({
         message: 'Could not parse Okta reset password url response',
       }),
@@ -444,7 +464,7 @@ describe('okta#forgotPassword', () => {
       Promise.resolve({ ok: false, status: 404, json } as Response),
     );
 
-    await expect(forgotPassword(userId)).rejects.toThrow(
+    await expect(forgotPassword(userId, '127.0.0.1')).rejects.toThrow(
       new OktaError({
         message: 'Not found: Resource not found: <userId> (User)',
       }),
@@ -470,7 +490,7 @@ describe('okta#forgotPassword', () => {
       Promise.resolve({ ok: false, status: 403, json } as Response),
     );
 
-    await expect(forgotPassword(userId)).rejects.toThrow(
+    await expect(forgotPassword(userId, '127.0.0.1')).rejects.toThrow(
       new OktaError({
         message: 'Password reset failed',
       }),

--- a/src/server/lib/deeplink/oktaRecoveryToken.ts
+++ b/src/server/lib/deeplink/oktaRecoveryToken.ts
@@ -57,17 +57,23 @@ export const extractOktaRecoveryToken = (token: string): string => {
  * @returns string representing the recovery token with the app prefix
  *
  */
-export const addAppPrefixToOktaRecoveryToken = async (
-  token: string,
-  appClientId?: string,
-  request_id?: string,
-): Promise<string> => {
+export const addAppPrefixToOktaRecoveryToken = async ({
+  token,
+  ip,
+  appClientId,
+  request_id,
+}: {
+  token: string;
+  ip: string;
+  appClientId?: string;
+  request_id?: string;
+}): Promise<string> => {
   if (!appClientId) {
     return token;
   }
 
   try {
-    const app = await getApp(appClientId);
+    const app = await getApp(appClientId, ip);
 
     const label = app.label.toLowerCase();
 

--- a/src/server/lib/jobs.ts
+++ b/src/server/lib/jobs.ts
@@ -6,6 +6,7 @@ export const setupJobsUserInOkta = (
   firstName: string,
   lastName: string,
   id: string,
+  ip: string,
 ) => {
   if (firstName === '' || lastName === '') {
     throw new Error('Empty values not permitted for first or last name.');
@@ -19,13 +20,17 @@ export const setupJobsUserInOkta = (
   // When `isJobsUser` is set to true, Madgex will see that the user belongs to the GRS group
   // because we have made the `isJobsUser` flag the source of truth for this group membership
   // when IDAPI returns the user's groups, overriding the value stored in Postgres.
-  return updateUser(id, {
-    profile: {
-      isJobsUser: true,
-      firstName,
-      lastName,
+  return updateUser(
+    id,
+    {
+      profile: {
+        isJobsUser: true,
+        firstName,
+        lastName,
+      },
     },
-  });
+    ip,
+  );
 };
 
 export const setupJobsUserInIDAPI = async (

--- a/src/server/lib/middleware/redirectIfLoggedIn.ts
+++ b/src/server/lib/middleware/redirectIfLoggedIn.ts
@@ -33,7 +33,7 @@ export const redirectIfLoggedIn = async (
   if (okta.enabled && !useIdapi && oktaSessionCookieId) {
     try {
       // If they do and it's valid, get the session info
-      const session = await getSession(oktaSessionCookieId);
+      const session = await getSession(oktaSessionCookieId, req.ip);
 
       // pull the user email from the session, which we need to display
       const email = session.login;

--- a/src/server/lib/middleware/requestState.ts
+++ b/src/server/lib/middleware/requestState.ts
@@ -51,7 +51,7 @@ const getRequestState = async (
 
   try {
     if (!!queryParams.appClientId) {
-      const app = await getApp(queryParams.appClientId);
+      const app = await getApp(queryParams.appClientId, req.ip);
 
       const label = app.label.toLowerCase();
 

--- a/src/server/lib/okta/api/apps.ts
+++ b/src/server/lib/okta/api/apps.ts
@@ -24,7 +24,7 @@ const { okta } = getConfiguration();
  * @returns {Promise<AppResponse>}
  */
 const AppCache = new Map<string, AppResponse>();
-export const getApp = async (id: string): Promise<AppResponse> => {
+export const getApp = async (id: string, ip: string): Promise<AppResponse> => {
   if (AppCache.has(id)) {
     return Promise.resolve(AppCache.get(id) as AppResponse);
   }
@@ -32,7 +32,7 @@ export const getApp = async (id: string): Promise<AppResponse> => {
   const path = buildUrl(`/api/v1/apps/:id`, { id });
 
   const app = await fetch(joinUrl(okta.orgUrl, path), {
-    headers: { ...defaultHeaders, ...authorizationHeader() },
+    headers: { ...defaultHeaders(ip), ...authorizationHeader() },
   }).then(handleAppResponse);
 
   AppCache.set(id, app);

--- a/src/server/lib/okta/api/authentication.ts
+++ b/src/server/lib/okta/api/authentication.ts
@@ -45,12 +45,13 @@ const { okta } = getConfiguration();
  */
 export const authenticate = async (
   body: AuthenticationRequestParameters,
+  ip: string,
 ): Promise<AuthenticationTransaction> => {
   const path = buildUrl('/api/v1/authn');
   return await fetch(joinUrl(okta.orgUrl, path), {
     method: 'POST',
     body: JSON.stringify(body),
-    headers: defaultHeaders,
+    headers: defaultHeaders(ip),
   }).then(handleAuthenticationResponse);
 };
 
@@ -74,6 +75,7 @@ export const authenticate = async (
  */
 export const sendForgotPasswordEmail = async (
   username: string,
+  ip: string,
 ): Promise<void> => {
   const path = buildUrl('/api/v1/authn/recovery/password');
   const body = {
@@ -85,7 +87,7 @@ export const sendForgotPasswordEmail = async (
     body: JSON.stringify(body),
     // do not add authorization headers here as this turns the operation
     // into an administrator action and locks the user out of their account
-    headers: defaultHeaders,
+    headers: defaultHeaders(ip),
   }).then(handleVoidResponse);
 };
 
@@ -107,8 +109,10 @@ export const sendForgotPasswordEmail = async (
  */
 export const validateRecoveryToken = async ({
   recoveryToken,
+  ip,
 }: {
   recoveryToken: string;
+  ip: string;
 }): Promise<AuthenticationTransaction> => {
   const path = buildUrl('/api/v1/authn/recovery/token');
 
@@ -119,7 +123,7 @@ export const validateRecoveryToken = async ({
   return await fetch(joinUrl(okta.orgUrl, path), {
     method: 'POST',
     body: JSON.stringify(body),
-    headers: defaultHeaders,
+    headers: defaultHeaders(ip),
   }).then(handleAuthenticationResponse);
 };
 
@@ -142,10 +146,13 @@ export const validateRecoveryToken = async ({
  *
  * @returns Promise<AuthenticationTransaction>
  */
-export const resetPassword = async (body: {
-  stateToken: string;
-  newPassword: string;
-}): Promise<AuthenticationTransaction> => {
+export const resetPassword = async (
+  body: {
+    stateToken: string;
+    newPassword: string;
+  },
+  ip: string,
+): Promise<AuthenticationTransaction> => {
   const path = buildUrl('/api/v1/authn/credentials/reset_password');
 
   if (await isBreachedPassword(body.newPassword)) {
@@ -158,7 +165,7 @@ export const resetPassword = async (body: {
   return await fetch(joinUrl(okta.orgUrl, path), {
     method: 'POST',
     body: JSON.stringify(body),
-    headers: { ...defaultHeaders, ...authorizationHeader() },
+    headers: { ...defaultHeaders(ip), ...authorizationHeader() },
   }).then(handleAuthenticationResponse);
 };
 

--- a/src/server/lib/okta/api/headers.ts
+++ b/src/server/lib/okta/api/headers.ts
@@ -1,9 +1,10 @@
 import { getConfiguration } from '@/server/lib/getConfiguration';
 
-export const defaultHeaders = {
+export const defaultHeaders = (ip: string) => ({
   Accept: 'application/json',
   'Content-Type': 'application/json',
-};
+  'X-Forwarded-For': ip,
+});
 
 /**
  * AuthorizationHeader

--- a/src/server/lib/okta/api/sessions.ts
+++ b/src/server/lib/okta/api/sessions.ts
@@ -24,10 +24,11 @@ const { okta } = getConfiguration();
  */
 export const getSession = async (
   sessionId: string,
+  ip: string,
 ): Promise<SessionResponse> => {
   const path = buildUrl('/api/v1/sessions/:sessionId', { sessionId });
   return fetch(joinUrl(okta.orgUrl, path), {
-    headers: { ...defaultHeaders, ...authorizationHeader() },
+    headers: { ...defaultHeaders(ip), ...authorizationHeader() },
   }).then(handleSessionResponse);
 };
 
@@ -42,11 +43,14 @@ export const getSession = async (
  * @param sessionId Okta session ID
  * @returns Promise<boolean>
  */
-export const closeSession = async (sessionId: string): Promise<undefined> => {
+export const closeSession = async (
+  sessionId: string,
+  ip: string,
+): Promise<undefined> => {
   const path = buildUrl('/api/v1/sessions/:sessionId', { sessionId });
   const response = await fetch(joinUrl(okta.orgUrl, path), {
     method: 'DELETE',
-    headers: { ...defaultHeaders, ...authorizationHeader() },
+    headers: { ...defaultHeaders(ip), ...authorizationHeader() },
   });
 
   if (!(response.ok || response.status === 404)) {

--- a/src/server/lib/okta/api/users.ts
+++ b/src/server/lib/okta/api/users.ts
@@ -42,6 +42,7 @@ const { okta } = getConfiguration();
  */
 export const createUser = async (
   body: UserCreationRequest,
+  ip: string,
 ): Promise<UserResponse> => {
   // If 'activate' is true, Okta will peform the activation lifecycle operation
   // on the user, which in the case of a user without a password will send them
@@ -57,7 +58,7 @@ export const createUser = async (
   return await fetch(joinUrl(okta.orgUrl, path), {
     method: 'POST',
     body: JSON.stringify(body),
-    headers: { ...defaultHeaders, ...authorizationHeader() },
+    headers: { ...defaultHeaders(ip), ...authorizationHeader() },
   }).then(handleUserResponse);
 };
 
@@ -76,12 +77,13 @@ export const createUser = async (
 export const updateUser = async (
   id: string,
   body: UserUpdateRequest,
+  ip: string,
 ): Promise<UserResponse> => {
   const path = buildUrl('/api/v1/users/:id', { id });
   return await fetch(joinUrl(okta.orgUrl, path), {
     method: 'POST',
     body: JSON.stringify(body),
-    headers: { ...defaultHeaders, ...authorizationHeader() },
+    headers: { ...defaultHeaders(ip), ...authorizationHeader() },
   }).then(handleUserResponse);
 };
 
@@ -96,10 +98,13 @@ export const updateUser = async (
  * @returns Promise<UserResponse>
  */
 
-export const getUser = async (id: string): Promise<UserResponse> => {
+export const getUser = async (
+  id: string,
+  ip: string,
+): Promise<UserResponse> => {
   const path = buildUrl('/api/v1/users/:id', { id });
   return fetch(joinUrl(okta.orgUrl, path), {
-    headers: { ...defaultHeaders, ...authorizationHeader() },
+    headers: { ...defaultHeaders(ip), ...authorizationHeader() },
   }).then(handleUserResponse);
 };
 
@@ -114,10 +119,13 @@ export const getUser = async (id: string): Promise<UserResponse> => {
  * @returns Promise<Group[]>
  */
 
-export const getUserGroups = async (id: string): Promise<Group[]> => {
+export const getUserGroups = async (
+  id: string,
+  ip: string,
+): Promise<Group[]> => {
   const path = buildUrl('/api/v1/users/:id/groups', { id });
   return fetch(joinUrl(okta.orgUrl, path), {
-    headers: { ...defaultHeaders, ...authorizationHeader() },
+    headers: { ...defaultHeaders(ip), ...authorizationHeader() },
   }).then(handleGroupsResponse);
 };
 
@@ -145,10 +153,15 @@ export const getUserGroups = async (id: string): Promise<Group[]> => {
  *
  * @returns Promise<TokenResponse | void>
  */
-export const activateUser = async (
-  id: string,
+export const activateUser = async ({
+  id,
   sendEmail = false,
-): Promise<TokenResponse | void> => {
+  ip,
+}: {
+  id: string;
+  sendEmail?: boolean;
+  ip: string;
+}): Promise<TokenResponse | void> => {
   const path = buildApiUrlWithQueryParams(
     '/api/v1/users/:id/lifecycle/activate',
     { id },
@@ -156,7 +169,7 @@ export const activateUser = async (
   );
   return await fetch(joinUrl(okta.orgUrl, path), {
     method: 'POST',
-    headers: { ...defaultHeaders, ...authorizationHeader() },
+    headers: { ...defaultHeaders(ip), ...authorizationHeader() },
   }).then(async (response) => {
     return sendEmail
       ? await handleVoidResponse(response)
@@ -186,10 +199,16 @@ export const activateUser = async (
  *
  * @returns Promise<TokenResponse | void>
  */
-export const reactivateUser = async (
-  id: string,
+export const reactivateUser = async ({
+  id,
   sendEmail = false,
-): Promise<TokenResponse | void> => {
+  ip,
+}: {
+  id: string;
+
+  sendEmail?: boolean;
+  ip: string;
+}): Promise<TokenResponse | void> => {
   const path = buildApiUrlWithQueryParams(
     '/api/v1/users/:id/lifecycle/reactivate',
     { id },
@@ -197,7 +216,7 @@ export const reactivateUser = async (
   );
   return await fetch(joinUrl(okta.orgUrl, path), {
     method: 'POST',
-    headers: { ...defaultHeaders, ...authorizationHeader() },
+    headers: { ...defaultHeaders(ip), ...authorizationHeader() },
   }).then(async (response) => {
     return sendEmail
       ? await handleVoidResponse(response)
@@ -232,7 +251,10 @@ export const reactivateUser = async (
  * @param id Okta user Id
  * @returns Promise<string>
  */
-export const dangerouslyResetPassword = async (id: string): Promise<string> => {
+export const dangerouslyResetPassword = async (
+  id: string,
+  ip: string,
+): Promise<string> => {
   const path = buildApiUrlWithQueryParams(
     '/api/v1/users/:id/lifecycle/reset_password',
     { id },
@@ -240,7 +262,7 @@ export const dangerouslyResetPassword = async (id: string): Promise<string> => {
   );
   return await fetch(joinUrl(okta.orgUrl, path), {
     method: 'POST',
-    headers: { ...defaultHeaders, ...authorizationHeader() },
+    headers: { ...defaultHeaders(ip), ...authorizationHeader() },
   }).then(handleResetPasswordUrlResponse);
 };
 
@@ -256,10 +278,15 @@ export const dangerouslyResetPassword = async (id: string): Promise<string> => {
  * @param oauthTokens (optional, default: `true`) Revoke issued OpenID Connect and OAuth refresh and access tokens
  * @returns Promise<void>
  */
-export const clearUserSessions = async (
-  id: string,
+export const clearUserSessions = async ({
+  id,
   oauthTokens = true,
-): Promise<void> => {
+  ip,
+}: {
+  id: string;
+  oauthTokens?: boolean;
+  ip: string;
+}): Promise<void> => {
   const path = buildApiUrlWithQueryParams(
     '/api/v1/users/:id/sessions',
     { id },
@@ -269,7 +296,7 @@ export const clearUserSessions = async (
   );
   return await fetch(joinUrl(okta.orgUrl, path), {
     method: 'DELETE',
-    headers: { ...defaultHeaders, ...authorizationHeader() },
+    headers: { ...defaultHeaders(ip), ...authorizationHeader() },
   }).then(handleVoidResponse);
 };
 
@@ -285,7 +312,10 @@ export const clearUserSessions = async (
  * @param id Okta user Id
  * @returns Promise<string>
  */
-export const forgotPassword = async (id: string): Promise<string> => {
+export const forgotPassword = async (
+  id: string,
+  ip: string,
+): Promise<string> => {
   const path = buildApiUrlWithQueryParams(
     '/api/v1/users/:id/credentials/forgot_password',
     { id },
@@ -293,7 +323,7 @@ export const forgotPassword = async (id: string): Promise<string> => {
   );
   return await fetch(joinUrl(okta.orgUrl, path), {
     method: 'POST',
-    headers: { ...defaultHeaders, ...authorizationHeader() },
+    headers: { ...defaultHeaders(ip), ...authorizationHeader() },
   }).then(handleResetPasswordUrlResponse);
 };
 

--- a/src/server/lib/okta/dangerouslySetPlaceholderPassword.ts
+++ b/src/server/lib/okta/dangerouslySetPlaceholderPassword.ts
@@ -14,13 +14,17 @@ import { dangerouslyResetPassword } from './api/users';
  * After these operations, we can send the user a password reset email.
  * @param id The Okta user ID
  */
-const dangerouslySetPlaceholderPassword = async (id: string): Promise<void> => {
+const dangerouslySetPlaceholderPassword = async (
+  id: string,
+  ip: string,
+): Promise<void> => {
   try {
     // Generate an recoveryToken OTT and put user into RECOVERY state
-    const recoveryToken = await dangerouslyResetPassword(id);
+    const recoveryToken = await dangerouslyResetPassword(id, ip);
     // Validate the token
     const { stateToken } = await validateRecoveryToken({
       recoveryToken,
+      ip,
     });
     // Check if state token is defined
     if (!stateToken) {
@@ -30,10 +34,13 @@ const dangerouslySetPlaceholderPassword = async (id: string): Promise<void> => {
       });
     }
     // Set the placeholder password as a cryptographically secure UUID
-    await resetPassword({
-      stateToken,
-      newPassword: crypto.randomUUID(),
-    });
+    await resetPassword(
+      {
+        stateToken,
+        newPassword: crypto.randomUUID(),
+      },
+      ip,
+    );
   } catch (error) {
     logger.error(
       `dangerouslySetPlaceholderPassword failed: Error setting placeholder password for user ${id}`,

--- a/src/server/lib/okta/oauth.ts
+++ b/src/server/lib/okta/oauth.ts
@@ -46,7 +46,7 @@ export const performAuthorizationCodeFlow = async (
     const oktaSessionCookieId: string | undefined = req.cookies.sid;
     // clear existing okta session cookie if it exists
     if (oktaSessionCookieId) {
-      await closeSession(oktaSessionCookieId);
+      await closeSession(oktaSessionCookieId, req.ip);
     }
   }
 

--- a/src/server/lib/okta/validateEmail.ts
+++ b/src/server/lib/okta/validateEmail.ts
@@ -11,14 +11,19 @@ import { UserResponse } from '@/server/models/okta/User';
  */
 export const validateEmailAndPasswordSetSecurely = async (
   id: string,
+  ip: string,
 ): Promise<UserResponse> => {
   const timestamp = new Date().toISOString();
-  return await updateUser(id, {
-    profile: {
-      emailValidated: true,
-      lastEmailValidatedTimestamp: timestamp,
-      passwordSetSecurely: true,
-      lastPasswordSetSecurelyTimestamp: timestamp,
+  return await updateUser(
+    id,
+    {
+      profile: {
+        emailValidated: true,
+        lastEmailValidatedTimestamp: timestamp,
+        passwordSetSecurely: true,
+        lastPasswordSetSecurelyTimestamp: timestamp,
+      },
     },
-  });
+    ip,
+  );
 };

--- a/src/server/lib/unvalidatedEmail.ts
+++ b/src/server/lib/unvalidatedEmail.ts
@@ -8,6 +8,7 @@ type Props = {
   email: string;
   appClientId?: string;
   request_id?: string;
+  ip: string;
 };
 
 /**
@@ -24,8 +25,9 @@ export const sendEmailToUnvalidatedUser = async ({
   email,
   appClientId,
   request_id,
+  ip,
 }: Props): Promise<void> => {
-  const token = await forgotPassword(id);
+  const token = await forgotPassword(id, ip);
   if (!token) {
     throw new OktaError({
       message: `Unvalidated email sign-in failed: missing reset password token`,
@@ -33,11 +35,12 @@ export const sendEmailToUnvalidatedUser = async ({
   }
   const emailIsSent = await sendUnvalidatedEmailResetPasswordEmail({
     to: email,
-    resetPasswordToken: await addAppPrefixToOktaRecoveryToken(
+    resetPasswordToken: await addAppPrefixToOktaRecoveryToken({
       token,
       appClientId,
       request_id,
-    ),
+      ip,
+    }),
   });
   if (!emailIsSent) {
     throw new OktaError({

--- a/src/server/routes/agree.ts
+++ b/src/server/routes/agree.ts
@@ -104,8 +104,8 @@ const OktaAgreeGetController = async (
   }
 
   try {
-    const { userId } = await getSession(oktaSessionCookieId);
-    const { profile } = await getUser(userId);
+    const { userId } = await getSession(oktaSessionCookieId, req.ip);
+    const { profile } = await getUser(userId, req.ip);
     const { isJobsUser, firstName, lastName, email } = profile;
 
     const userFullNameSet = !!firstName && !!lastName;
@@ -180,8 +180,8 @@ router.post(
     try {
       if (okta.enabled && !useIdapi && oktaSessionCookieId) {
         // Get the id from Okta
-        const { userId } = await getSession(oktaSessionCookieId);
-        await setupJobsUserInOkta(firstName, secondName, userId);
+        const { userId } = await getSession(oktaSessionCookieId, req.ip);
+        await setupJobsUserInOkta(firstName, secondName, userId, req.ip);
         trackMetric('JobsGRSGroupAgree::Success');
       } else {
         await setupJobsUserInIDAPI(

--- a/src/server/routes/oauth.ts
+++ b/src/server/routes/oauth.ts
@@ -186,7 +186,7 @@ router.get(
           user_groups?.some((group) => group === 'GuardianUser-EmailValidated')
         ) {
           // updated the user profile emailValidated to true
-          await updateUser(sub, { profile: { emailValidated: true } });
+          await updateUser(sub, { profile: { emailValidated: true } }, req.ip);
 
           // since this is a new social user, we want to show the onboarding flow too
           // we use the `confirmationPage` flag to redirect the user to the onboarding page
@@ -263,7 +263,10 @@ router.get(
       if (authState.queryParams.appClientId) {
         try {
           // attempt to find the native app by the client id
-          const nativeApp = await getApp(authState.queryParams.appClientId);
+          const nativeApp = await getApp(
+            authState.queryParams.appClientId,
+            req.ip,
+          );
 
           // Check for fallback link if found
           if (nativeApp) {

--- a/src/server/routes/register.ts
+++ b/src/server/routes/register.ts
@@ -129,6 +129,7 @@ const OktaRegistration = async (
       registrationLocation,
       appClientId,
       request_id,
+      ip: req.ip,
     });
     // fire ophan component event if applicable
     if (res.locals.queryParams.componentEventParams) {
@@ -204,6 +205,8 @@ const OktaResendEmail = async (req: Request, res: ResponseWithRequestState) => {
       const user = await registerWithOkta({
         email,
         appClientId: queryParams?.appClientId,
+        ip: req.ip,
+        request_id: res.locals.requestId,
       });
       trackMetric('OktaRegistrationResendEmail::Success');
       setEncryptedStateCookieForOktaRegistration(res, user);

--- a/src/server/routes/signOut.ts
+++ b/src/server/routes/signOut.ts
@@ -122,8 +122,8 @@ const signOutFromOkta = async (
     const oktaSessionCookieId: string | undefined = req.cookies.sid;
 
     if (oktaSessionCookieId) {
-      const { userId } = await getSession(oktaSessionCookieId);
-      await clearUserSessions(userId);
+      const { userId } = await getSession(oktaSessionCookieId, req.ip);
+      await clearUserSessions({ id: userId, ip: req.ip });
       trackMetric('OktaSignOut::Success');
     }
   } catch (error) {

--- a/src/server/routes/welcome.ts
+++ b/src/server/routes/welcome.ts
@@ -140,6 +140,7 @@ const OktaResendEmail = async (req: Request, res: ResponseWithRequestState) => {
         email,
         appClientId: state.queryParams.appClientId,
         request_id: state.requestId,
+        ip: req.ip,
       });
 
       trackMetric('OktaWelcomeResendEmail::Success');


### PR DESCRIPTION
## What does this change?

Okta by default uses the public IP of the application as the client IP for requests to Okta APIs. However it supports the `X-Forwarded-For` header to forward the originating client's IP address.

This PR sets up all calls to Okta to use the user (client) ip (we get from express `req.ip`) instead of gateway's IP address.

This should help identifying problematic IP addresses in places like the system log and rate limits, and may also allow for better usage of okta's built in threat insight and analysis.

Documentation is available here: https://developer.okta.com/docs/reference/core-okta-api/#ip-address

## How to test

- Deploy to CODE
- Check that when you make requests, that your IP is showing up in the system log/rate limits
