### PR TITLE
Update Facebook not supported location

### DIFF
--- a/src/client/components/NoFacebookSupport.stories.tsx
+++ b/src/client/components/NoFacebookSupport.stories.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { Meta } from '@storybook/react';
+
+import { NoFacebookSupport } from './NoFacebookSupport';
+
+export default {
+  title: 'Components/NoFacebookSupport',
+  component: NoFacebookSupport,
+} as Meta;
+
+export const Default = () => {
+  return <NoFacebookSupport queryParams={{ returnUrl: '#' }} />;
+};
+Default.storyName = 'default';

--- a/src/client/components/NoFacebookSupport.tsx
+++ b/src/client/components/NoFacebookSupport.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { buildUrlWithQueryParams } from '@/shared/lib/routeUtils';
+import { Link } from '@guardian/source-react-components';
+import { sendOphanInteractionEvent } from '@/client/lib/ophan';
+import { MainBodyText } from '@/client/components/MainBodyText';
+import { QueryParams } from '@/shared/model/QueryParams';
+import { css } from '@emotion/react';
+import { space } from '@guardian/source-foundations';
+
+interface Props {
+  queryParams: QueryParams;
+}
+
+const fontStyles = css`
+  font-size: 14px;
+`;
+
+const styles = css`
+  margin-top: ${space[4]}px;
+`;
+
+export const NoFacebookSupport = ({ queryParams }: Props) => (
+  <MainBodyText
+    cssOverrides={css`
+      ${fontStyles};
+      ${styles};
+    `}
+    noMargin
+  >
+    <b>We no longer support authentication with Facebook.</b> Please sign in
+    above using the same email address as your Facebook account. If you
+    don&apos;t have a Guardian password, please{' '}
+    <Link
+      cssOverrides={fontStyles}
+      href={buildUrlWithQueryParams('/reset-password', {}, queryParams)}
+      onClick={() => {
+        sendOphanInteractionEvent({
+          component: 'facebook-password-reset-link',
+          value: 'click',
+        });
+      }}
+    >
+      reset your password
+    </Link>
+    .
+  </MainBodyText>
+);

--- a/src/client/components/SocialButtons.tsx
+++ b/src/client/components/SocialButtons.tsx
@@ -5,13 +5,10 @@ import {
   LinkButton,
   SvgGoogleBrand,
   SvgAppleBrand,
-  Link,
 } from '@guardian/source-react-components';
 import { QueryParams } from '@/shared/model/QueryParams';
 import { buildUrlWithQueryParams } from '@/shared/lib/routeUtils';
 import { IsNativeApp } from '@/shared/model/ClientState';
-import { MainBodyText } from './MainBodyText';
-import { sendOphanInteractionEvent } from '../lib/ophan';
 
 type SocialButtonsProps = {
   queryParams: QueryParams;
@@ -40,7 +37,6 @@ const containerStyles = (marginTop = false, isNativeApp: IsNativeApp) => css`
   ${from.mobileMedium} {
     margin-top: ${marginTop ? space[6] : 0}px;
   }
-  margin-bottom: ${space[4]}px;
   width: 100%;
 `;
 
@@ -148,37 +144,18 @@ export const SocialButtons = ({
 }: SocialButtonsProps) => {
   const buttonOrder = getButtonOrder(isNativeApp);
   return (
-    <>
-      <div css={containerStyles(marginTop, isNativeApp)}>
-        {buttonOrder.map((socialProvider, index) => (
-          <SocialButton
-            key={socialProvider}
-            label={socialProvider}
-            icon={socialButtonIcon(socialProvider)}
-            socialProvider={socialProvider}
-            queryParams={queryParams}
-            showGap={index < buttonOrder.length - 1}
-            isNativeApp={isNativeApp}
-          />
-        ))}
-      </div>
-      <MainBodyText noMargin>
-        <b>We no longer support authentication with Facebook.</b> Please sign in
-        below using your Facebook email. If you don&apos;t have or don&apos;t
-        know your password, please{' '}
-        <Link
-          href={buildUrlWithQueryParams('/reset-password', {}, queryParams)}
-          onClick={() => {
-            sendOphanInteractionEvent({
-              component: 'facebook-password-reset-link',
-              value: 'click',
-            });
-          }}
-        >
-          reset your password
-        </Link>
-        .
-      </MainBodyText>
-    </>
+    <div css={containerStyles(marginTop, isNativeApp)}>
+      {buttonOrder.map((socialProvider, index) => (
+        <SocialButton
+          key={socialProvider}
+          label={socialProvider}
+          icon={socialButtonIcon(socialProvider)}
+          socialProvider={socialProvider}
+          queryParams={queryParams}
+          showGap={index < buttonOrder.length - 1}
+          isNativeApp={isNativeApp}
+        />
+      ))}
+    </div>
   );
 };

--- a/src/client/pages/Registration.tsx
+++ b/src/client/pages/Registration.tsx
@@ -9,9 +9,14 @@ import { Divider } from '@guardian/source-react-components-development-kitchen';
 import { SocialButtons } from '@/client/components/SocialButtons';
 import { socialButtonDivider } from '@/client/styles/Shared';
 import { usePageLoadOphanInteraction } from '@/client/lib/hooks/usePageLoadOphanInteraction';
-import { GuardianTerms, JobsTerms, termsContainer } from '../components/Terms';
-import { CmpConsentedStateHiddenInput } from '../components/CmpConsentStateHiddenInput';
-import { useCmpConsent } from '../lib/hooks/useCmpConsent';
+import {
+  GuardianTerms,
+  JobsTerms,
+  termsContainer,
+} from '@/client/components/Terms';
+import { CmpConsentedStateHiddenInput } from '@/client/components/CmpConsentStateHiddenInput';
+import { useCmpConsent } from '@/client/lib/hooks/useCmpConsent';
+import { NoFacebookSupport } from '@/client/components/NoFacebookSupport';
 
 export type RegistrationProps = {
   email?: string;
@@ -66,6 +71,7 @@ export const Registration = ({
         <EmailInput defaultValue={email} autoComplete="off" />
         <CmpConsentedStateHiddenInput cmpConsentedState={hasCmpConsent} />
       </MainForm>
+      <NoFacebookSupport queryParams={queryParams} />
     </MainLayout>
   );
 };

--- a/src/client/pages/SignIn.tsx
+++ b/src/client/pages/SignIn.tsx
@@ -14,7 +14,12 @@ import { Link } from '@guardian/source-react-components';
 import { Divider } from '@guardian/source-react-components-development-kitchen';
 import { SocialButtons } from '@/client/components/SocialButtons';
 import { socialButtonDivider } from '@/client/styles/Shared';
-import { GuardianTerms, JobsTerms, termsContainer } from '../components/Terms';
+import {
+  GuardianTerms,
+  JobsTerms,
+  termsContainer,
+} from '@/client/components/Terms';
+import { NoFacebookSupport } from '@/client/components/NoFacebookSupport';
 
 export type SignInProps = {
   queryParams: QueryParams;
@@ -149,6 +154,7 @@ export const SignIn = ({
           </Link>
         </Links>
       </MainForm>
+      <NoFacebookSupport queryParams={queryParams} />
     </MainLayout>
   );
 };


### PR DESCRIPTION
## What does this change?

Updates the text indicating the removal of support for Facebook following feedback from product managers as to draw less attention to it, and be below the fold. Namely the following:

- Updates the copy
- Moves to below the sign in/registration form
- Makes the text smaller

Created a new `NoFacebookSupport` component to facilitate this which can easily be updated/removed when necessary.

## Storybook
`NoFacebookSupport` component - https://60929d168594f80039336501-kcmtenfcxm.chromatic.com/?path=/story/components-nofacebooksupport--default

`SignIn` page - https://60929d168594f80039336501-kcmtenfcxm.chromatic.com/?path=/story/pages-signin--default

`Registration` page - https://60929d168594f80039336501-kcmtenfcxm.chromatic.com/?path=/story/pages-registration--default

Old designs can be seen in https://github.com/guardian/gateway/pull/2185