### PR TITLE
Update Gateway to use ARM64 instance types in AWS

### DIFF
--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -238,7 +238,7 @@ Resources:
       AssociatePublicIpAddress: false
       ImageId: !Ref AMI
       IamInstanceProfile: !Ref InstanceProfile
-      InstanceType: t3.small
+      InstanceType: t4g.small
       SecurityGroups:
         - !Ref 'InstanceSecurityGroup'
         - !Ref 'SshAccessSecurityGroup'

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -9,7 +9,7 @@ deployments:
     parameters:
       cloudFormationStackName: gateway
       amiTags:
-        Recipe: gateway
+        Recipe: gateway-arm64
         AmigoStage: PROD
       templatePath: cloudformation.yaml
       amiEncrypted: true
@@ -30,6 +30,6 @@ deployments:
       cloudFormationStackName: gateway
       amiParametersToTags:
         AMI:
-          Recipe: gateway
+          Recipe: gateway-arm64
           AmigoStage: PROD
       amiEncrypted: true


### PR DESCRIPTION
## What does this change?

Updates gateway to use the `t4g.small` instance types, and an ARM64 based AMI.

## Tested
- [x] CODE

Deployed successfully.
Tested by deploying to CODE, ssh into the new instance and checking logs working, while performing actions on the CODE site, e.g. sign in, reset password, onboarding etc.
