### PR TITLE
Update Authorization Server and cookie exchange scope

### DIFF
--- a/src/server/lib/okta/oauth.ts
+++ b/src/server/lib/okta/oauth.ts
@@ -75,9 +75,9 @@ export const performAuthorizationCodeFlow = async (
     // we send the generated stateParam as the state parameter
     state: authState.stateParam,
     // any scopes, by default the 'openid' scope is required
-    // the idapi_token_cookie_exchange scope is checked on IDAPI to return
+    // the `guardian.identity-api.cookies.create.self.secure scope` is checked on IDAPI to return
     // idapi cookies on authentication
-    scope: 'openid idapi_token_cookie_exchange',
+    scope: 'openid guardian.identity-api.cookies.create.self.secure',
     // the redirect_uri is the url that we'll redirect the user to after
     redirect_uri: ProfileOpenIdClientRedirectUris.WEB,
     // the identity provider if doing social login


### PR DESCRIPTION
## What does this change?

While this PR is a one line change to use the new scope for the cookie exchange (`guardian.identity-api.cookies.create.self.secure`), this PR mainly serves as a distinction to the configuration changes we're making to the Authorization Server we use in gateway.

The config for CODE and PROD will be updated to use the main Guardian Authorization Server for OAuth instead of using the Gateway custom one, as we're moving to use a single authorization server for internal guardian applications.

The scope name change reflects the way we've standardised the format of our scopes.

## Testing and deployment steps

- [x] Update Authorization Server ID in CODE
- [x] Deploy and test CODE - Authentication works successfully in CODE, make sure to deploy IDAPI changes to CODE too.
- [x] Update Authorization Server ID in PROD
- [ ] Merge PR in PROD and deploy
- [ ] Test PROD - Authentication works successfully in PROD
- [x] Update DEV config files in S3
- [ ] PR to remove legacy code in IDAPI
- [ ] PR to remove terraform configuration of Gateway authorization server