### PR TITLE
Email Template: Update footer link text and email address

### DIFF
--- a/src/email/components/Footer.tsx
+++ b/src/email/components/Footer.tsx
@@ -39,8 +39,8 @@ export const Footer = ({ mistakeParagraphComponent }: Props) => (
       <FooterText>
         If you have any queries about why you are receiving this email, please
         contact our customer service team at{' '}
-        <Link href="mailto:userhelp@theguardian.com">
-          userhelp@theguardian.com
+        <Link href="mailto:customer.help@theguardian.com">
+          customer.help@theguardian.com
         </Link>
         .
       </FooterText>

--- a/src/email/templates/CompleteRegistration/CompleteRegistration.tsx
+++ b/src/email/templates/CompleteRegistration/CompleteRegistration.tsx
@@ -18,9 +18,9 @@ export const CompleteRegistration = () => {
       <Footer
         mistakeParagraphComponent={
           <>
-            If you received this email by mistake, please delete it. You
-            won&apos;t be registered if you don&apos;t click the &lsquo;Complete
-            registration&rsquo; button above.
+            If you received this email by mistake, please delete it. Your
+            registration won&apos;t be complete if you don&apos;t click the
+            &lsquo;Complete registration&rsquo; button above.
           </>
         }
       />

--- a/src/email/templates/CompleteRegistration/CompleteRegistrationText.ts
+++ b/src/email/templates/CompleteRegistration/CompleteRegistrationText.ts
@@ -9,7 +9,7 @@ $activateLink
 
 The Guardian
 
-If you received this email by mistake, please delete it. You won’t be registered if you don't click the link above.
+If you received this email by mistake, please delete it. Your registration won't be complete if you don't click the link above.
 
 If you have any queries about this email please contact our customer services team at userhelp@theguardian.com
 


### PR DESCRIPTION
## What does this change?

### Change 1

Data privacy requested an update to the footer copy in the registration email:
`You won't be registered if you don't click the ‘Complete registration’ button above.`

Becomes:
`Your registration won't be complete if you don't click the ‘Complete registration’ button above.`

### Change 2

Also update the email address in the footer from:
`userhelp@theguardian.com`
To:
`customer.help@theguardian.com`

### Storybook

https://60929d168594f80039336501-lwamciiggw.chromatic.com/?path=/story/email-templates-completeregistration--default

![60929d168594f80039336501-lwamciiggw chromatic com_iframe html_args= id=email-templates-completeregistration--default viewMode=story(iPhone SE)](https://user-images.githubusercontent.com/13315440/235687249-a14524e5-aa8c-4f90-9679-b22421ffa5b6.png)
