### PR TITLE
Fix getting newsletter pillar colours

### DIFF
--- a/src/client/models/Newsletter.ts
+++ b/src/client/models/Newsletter.ts
@@ -1,5 +1,7 @@
 import { Newsletters } from '@/shared/model/Newsletter';
-import { brand, lifestyle, news } from '@guardian/source-foundations';
+import { palette } from '@guardian/source-foundations';
+
+const { brand, news, lifestyle } = palette;
 
 import {
   DOWN_TO_EARTH_IMAGE,

--- a/src/client/pages/ConsentsNewsletters.tsx
+++ b/src/client/pages/ConsentsNewsletters.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { css } from '@emotion/react';
-import { brand, from, space, neutral } from '@guardian/source-foundations';
+import { palette, from, space } from '@guardian/source-foundations';
 import {
   gridItem,
   gridItemColumnConsents,
@@ -36,7 +36,8 @@ type ConsentsNewslettersProps = {
   consents: NewsletterPageConsent[];
 };
 
-const getPillarColorById = (id: string) => NEWSLETTER_COLOURS[id] || brand[400];
+const getPillarColorById = (id: string) =>
+  NEWSLETTER_COLOURS[id] || palette.brand[400];
 
 const getNewsletterCardCss = (index: number) => {
   const ITEMS_PER_ROW = 2;
@@ -93,7 +94,7 @@ export const ConsentsNewsletters = ({ consents }: ConsentsNewslettersProps) => {
               ? {
                   id: consent.id,
                   defaultChecked: !!consent.consented,
-                  highlightColor: neutral[46],
+                  highlightColor: palette.neutral[46],
                   imagePath: CONSENT_IMAGES[consent.id],
                 }
               : {

--- a/src/client/pages/ConsentsNewslettersAB.tsx
+++ b/src/client/pages/ConsentsNewslettersAB.tsx
@@ -1,13 +1,6 @@
 import React from 'react';
 import { css } from '@emotion/react';
-import {
-  brand,
-  from,
-  lifestyle,
-  news,
-  space,
-  neutral,
-} from '@guardian/source-foundations';
+import { from, palette, space } from '@guardian/source-foundations';
 import {
   gridItem,
   gridItemColumnConsents,
@@ -23,6 +16,7 @@ import { ConsentsLayout } from '@/client/layouts/ConsentsLayout';
 import { Consent } from '@/shared/model/Consent';
 import { NewsLetter } from '@/shared/model/Newsletter';
 import {
+  NEWSLETTER_COLOURS,
   NEWSLETTER_IMAGES,
   NEWSLETTER_IMAGE_POSITIONS,
 } from '@/client/models/Newsletter';
@@ -45,21 +39,8 @@ type ConsentsNewslettersProps = {
   defaultOnboardingEmailConsentState: boolean;
 };
 
-const idColor = (id: string) => {
-  if (/morning/.test(id)) {
-    return news[400];
-  }
-  if (id === 'the-long-read') {
-    return brand[400];
-  }
-  if (id === 'green-light') {
-    return news[400];
-  }
-  if (id === 'the-guide-staying-in') {
-    return lifestyle[400];
-  }
-  return brand[400];
-};
+const getPillarColorById = (id: string) =>
+  NEWSLETTER_COLOURS[id] || palette.brand[400];
 
 const getNewsletterCardCss = (index: number) => {
   const ITEMS_PER_ROW = 2;
@@ -110,7 +91,7 @@ export const ConsentsNewslettersAB = ({
               ? {
                   id: consent.id,
                   defaultChecked: !!consent.consented,
-                  highlightColor: neutral[46],
+                  highlightColor: palette.neutral[46],
                   imagePath: CONSENT_IMAGES[consent.id],
                 }
               : {
@@ -118,7 +99,7 @@ export const ConsentsNewslettersAB = ({
                   defaultChecked: consent.subscribed,
                   imagePath: NEWSLETTER_IMAGES[consent.id],
                   imagePosition: NEWSLETTER_IMAGE_POSITIONS[consent.id],
-                  highlightColor: idColor(consent.nameId),
+                  highlightColor: getPillarColorById(consent.id),
                   frequency: consent.frequency,
                   hiddenInput: true,
                 };


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Updates the newletters colours to use the non-deprecated Source object. 
Uses a utility function to get newsletter pillar colours instead of hard coded. This had been acctidently during an AB test reversion so putting it back in. 


## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
