### PR TITLE
Send ophan component_event for subscriptions

### DIFF
--- a/src/client/lib/ophan.ts
+++ b/src/client/lib/ophan.ts
@@ -1,4 +1,5 @@
 import { OphanEvent, OphanInteraction } from '@/shared/model/ophan';
+import { OphanComponentEvent } from '@guardian/libs';
 
 export const record = (event: OphanEvent) => {
   if (window.guardian?.ophan?.record) {
@@ -31,4 +32,10 @@ export const trackFormFocusBlur = (
       value: `${event.target.name}-input-${type}`,
     });
   }
+};
+
+export const sendOphanComponentEvent = (
+  componentEvent: OphanComponentEvent,
+): void => {
+  record(componentEvent);
 };

--- a/src/client/lib/ophan.ts
+++ b/src/client/lib/ophan.ts
@@ -36,6 +36,4 @@ export const trackFormFocusBlur = (
 
 export const sendOphanComponentEvent = (
   componentEvent: OphanComponentEvent,
-): void => {
-  record(componentEvent);
-};
+): void => record({ componentEvent });

--- a/src/client/pages/SubscriptionSuccessPage.tsx
+++ b/src/client/pages/SubscriptionSuccessPage.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import useClientState from '@/client/lib/hooks/useClientState';
 import { SubscriptionSuccess } from '@/client/pages/SubscriptionSuccess';
 import { SubscriptionAction } from '@/shared/lib/subscriptions';
@@ -13,15 +13,17 @@ export const SubscriptionSuccessPage = ({ action }: Props) => {
   const { pageData = {} } = clientState;
   const { returnUrl, accountManagementUrl, newsletterId } = pageData;
 
-  if (newsletterId) {
-    sendOphanComponentEvent({
-      action: 'SUBSCRIBE',
-      component: {
-        componentType: 'NEWSLETTER_SUBSCRIPTION',
-        id: newsletterId,
-      },
-    });
-  }
+  useEffect(() => {
+    if (newsletterId) {
+      sendOphanComponentEvent({
+        action: 'SUBSCRIBE',
+        component: {
+          componentType: 'NEWSLETTER_SUBSCRIPTION',
+          id: newsletterId,
+        },
+      });
+    }
+  }, [newsletterId]);
 
   return (
     <SubscriptionSuccess

--- a/src/client/pages/SubscriptionSuccessPage.tsx
+++ b/src/client/pages/SubscriptionSuccessPage.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import useClientState from '@/client/lib/hooks/useClientState';
 import { SubscriptionSuccess } from '@/client/pages/SubscriptionSuccess';
 import { SubscriptionAction } from '@/shared/lib/subscriptions';
+import { sendOphanComponentEvent } from '@/client/lib/ophan';
 
 interface Props {
   action: SubscriptionAction;
@@ -10,7 +11,18 @@ interface Props {
 export const SubscriptionSuccessPage = ({ action }: Props) => {
   const clientState = useClientState();
   const { pageData = {} } = clientState;
-  const { returnUrl, accountManagementUrl } = pageData;
+  const { returnUrl, accountManagementUrl, newsletterId } = pageData;
+
+  if (newsletterId) {
+    sendOphanComponentEvent({
+      action: 'SUBSCRIBE',
+      component: {
+        componentType: 'NEWSLETTER_SUBSCRIPTION',
+        id: newsletterId,
+      },
+    });
+  }
+
   return (
     <SubscriptionSuccess
       returnUrl={returnUrl}

--- a/src/server/lib/idapi/subscriptions.ts
+++ b/src/server/lib/idapi/subscriptions.ts
@@ -9,7 +9,7 @@ import { IdapiError } from '@/server/models/Error';
 import { SubscribeErrors, UnsubscribeErrors } from '@/shared/model/Errors';
 import { SubscriptionAction } from '@/shared/lib/subscriptions';
 
-type EmailType = 'newsletter' | 'marketing';
+export type EmailType = 'newsletter' | 'marketing';
 
 interface SubscriptionData {
   emailId: string;

--- a/src/server/lib/ophan.ts
+++ b/src/server/lib/ophan.ts
@@ -225,6 +225,6 @@ export const sendOphanComponentEventFromQueryParamsServer = async (
       { request_id },
     );
 
-    record(componentEvent, config);
+    record({ componentEvent }, config);
   }
 };

--- a/src/server/routes/subscriptions.ts
+++ b/src/server/routes/subscriptions.ts
@@ -17,11 +17,10 @@ import {
   SubscriptionAction,
   subscriptionActionName,
 } from '@/shared/lib/subscriptions';
-import { PageData } from '@/shared/model/ClientState';
 
 const { accountManagementUrl } = getConfiguration();
 
-const buildPageData = (emailType: EmailType, emailId: string): PageData => {
+const buildPageData = (emailType: EmailType, emailId: string) => {
   if (emailType === 'newsletter') {
     return {
       accountManagementUrl,

--- a/src/server/routes/subscriptions.ts
+++ b/src/server/routes/subscriptions.ts
@@ -6,6 +6,7 @@ import {
   isValidEmailType,
   parseSubscriptionData,
   makeSubscriptionRequest,
+  EmailType,
 } from '@/server/lib/idapi/subscriptions';
 import { renderer } from '@/server/lib/renderer';
 import { mergeRequestState } from '@/server/lib/requestState';
@@ -16,8 +17,21 @@ import {
   SubscriptionAction,
   subscriptionActionName,
 } from '@/shared/lib/subscriptions';
+import { PageData } from '@/shared/model/ClientState';
 
 const { accountManagementUrl } = getConfiguration();
+
+const buildPageData = (emailType: EmailType, emailId: string): PageData => {
+  if (emailType === 'newsletter') {
+    return {
+      accountManagementUrl,
+      newsletterId: emailId,
+    };
+  }
+  return {
+    accountManagementUrl,
+  };
+};
 
 const handler = (action: SubscriptionAction) =>
   handleAsyncErrors(async (req: Request, res: ResponseWithRequestState) => {
@@ -43,9 +57,7 @@ const handler = (action: SubscriptionAction) =>
 
       const html = renderer(`/${action}/success`, {
         requestState: mergeRequestState(res.locals, {
-          pageData: {
-            accountManagementUrl,
-          },
+          pageData: buildPageData(emailType, subscriptionData.emailId),
         }),
         pageTitle: `${subscriptionActionName(action)} Confirmation`,
       });

--- a/src/shared/model/ClientState.ts
+++ b/src/shared/model/ClientState.ts
@@ -61,6 +61,9 @@ export interface PageData {
   // signed in as page specific
   continueLink?: string;
   signOutLink?: string;
+
+  // subscription specific
+  newsletterId?: string;
 }
 
 export interface RecaptchaConfig {

--- a/src/shared/model/ophan.ts
+++ b/src/shared/model/ophan.ts
@@ -11,4 +11,7 @@ export interface OphanBase {
   abTestRegister?: { [testId: string]: OphanABEvent };
 }
 
-export type OphanEvent = OphanBase | OphanInteraction | OphanComponentEvent;
+export type OphanEvent =
+  | OphanBase
+  | OphanInteraction
+  | { componentEvent: OphanComponentEvent };


### PR DESCRIPTION
A [recent PR](https://github.com/guardian/gateway/pull/2261) enabled one-click subscribes, in addition to unsubscribes.

We'd like to track successful newsletter subscriptions in ophan. This PR changes the `SubscriptionSuccessPage` to send a component_event to ophan.

While working on this I noticed that the ophan model is slightly wrong in this repo - `componentEvent` data should be nested.

![Screenshot 2023-06-26 at 08 35 30](https://github.com/guardian/gateway/assets/1513454/cff35f7c-3476-4c91-a46c-f504584c76af)

