### PR TITLE
Only track subscribe events

### DIFF
--- a/src/client/pages/SubscriptionSuccessPage.tsx
+++ b/src/client/pages/SubscriptionSuccessPage.tsx
@@ -14,7 +14,7 @@ export const SubscriptionSuccessPage = ({ action }: Props) => {
   const { returnUrl, accountManagementUrl, newsletterId } = pageData;
 
   useEffect(() => {
-    if (newsletterId) {
+    if (action === 'subscribe' && newsletterId) {
       sendOphanComponentEvent({
         action: 'SUBSCRIBE',
         component: {
@@ -23,7 +23,7 @@ export const SubscriptionSuccessPage = ({ action }: Props) => {
         },
       });
     }
-  }, [newsletterId]);
+  }, [action, newsletterId]);
 
   return (
     <SubscriptionSuccess


### PR DESCRIPTION
A [previous PR](https://github.com/guardian/gateway/pull/2296) added component_event tracking for newsletter subscriptions.
It should only track subscribes, not unsubscribes. This PR fixes that.