### PR TITLE
Increase threshold on 5xx alarm

### DIFF
--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -554,7 +554,7 @@ Resources:
       InsufficientDataActions:
         - !Ref 'TopicSendEmail'
       ComparisonOperator: GreaterThanOrEqualToThreshold
-      Threshold: 3
+      Threshold: 15
       EvaluationPeriods: 5
       TreatMissingData: notBreaching
       Metrics:


### PR DESCRIPTION
## What does this change?

The 5xx alarm has been going off quite a lot recently, and it seems like it's due to a downstream issue with braze. For now I'm increasing the threshold to 15 to see if it hopefully helps with the spam.

![Screenshot 2023-07-24 at 12 15 35](https://github.com/guardian/gateway/assets/13315440/154c96c2-42ef-4078-941c-e49b10fe98dd)
![Screenshot 2023-07-24 at 12 14 05](https://github.com/guardian/gateway/assets/13315440/ef730d57-f6a0-4821-afda-9c1ae401ee36)
