### PR TITLE
Fix missing Janus creds error in Dev mode

### DIFF
--- a/src/server/lib/serverSideLogger.ts
+++ b/src/server/lib/serverSideLogger.ts
@@ -59,7 +59,10 @@ class KinesisTransport extends Transport {
 					})
 					.catch((error: unknown) => {
 						if (error instanceof Error) {
-							if (error.name === 'ExpiredTokenException' && stage === 'DEV') {
+							if (
+								error.name === 'CredentialsProviderError' &&
+								stage === 'DEV'
+							) {
 								console.log(error.message);
 								console.warn(
 									'AWS Credentials Expired. Have you added `Identity` Janus credentials?',

--- a/src/server/lib/trackMetric.ts
+++ b/src/server/lib/trackMetric.ts
@@ -59,7 +59,7 @@ export const trackMetric = (
 		)
 		.catch((error: unknown) => {
 			if (error instanceof Error) {
-				if (error.name === 'ExpiredTokenException' && Stage === 'DEV') {
+				if (error.name === 'CredentialsProviderError' && Stage === 'DEV') {
 					logger.warn(error.message);
 					logger.warn(
 						'AWS Credentials Expired. Have you added `Identity` Janus credentials?',


### PR DESCRIPTION
## What does this change?
Ensures the DEV error message about missing AWS janus credentials is printed. 

