### PR TITLE
WIP idapiAPIFetch with base url override to allow fetching PROD /newsletters info

### DIFF
--- a/src/server/lib/IDAPIFetch.ts
+++ b/src/server/lib/IDAPIFetch.ts
@@ -1,11 +1,11 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 import { getConfiguration } from '@/server/lib/getConfiguration';
-import { joinUrl } from '@guardian/libs';
+import { addApiQueryParamsToPath } from '@/shared/lib/queryParams';
 import { buildUrl, ExtractRouteParams } from '@/shared/lib/routeUtils';
 import { IdApiQueryParams } from '@/shared/model/IdapiQueryParams';
-import { addApiQueryParamsToPath } from '@/shared/lib/queryParams';
 import { ApiRoutePaths } from '@/shared/model/Routes';
+import { joinUrl } from '@guardian/libs';
 
 const { idapiBaseUrl, idapiClientAccessToken, stage, baseUri } =
 	getConfiguration();
@@ -156,3 +156,5 @@ export const APIOptionSelect = ({
 };
 
 export const idapiFetch = APIFetch(idapiBaseUrl);
+export const idapiFetchWithBaseUrlOverride = (idapiBaseUrlOverride?: string) =>
+	APIFetch(idapiBaseUrlOverride ?? idapiBaseUrl);

--- a/src/server/lib/idapi/newsletters.ts
+++ b/src/server/lib/idapi/newsletters.ts
@@ -1,13 +1,14 @@
 import {
-	idapiFetch,
 	APIGetOptions,
-	APIPatchOptions,
 	APIOptionSelect,
+	APIPatchOptions,
+	idapiFetch,
+	idapiFetchWithBaseUrlOverride,
 } from '@/server/lib/IDAPIFetch';
-import { NewslettersErrors } from '@/shared/model/Errors';
-import { NewsLetter, NewsletterPatch } from '@/shared/model/Newsletter';
 import { logger } from '@/server/lib/serverSideLogger';
 import { IdapiError } from '@/server/models/Error';
+import { NewslettersErrors } from '@/shared/model/Errors';
+import { NewsLetter, NewsletterPatch } from '@/shared/model/Newsletter';
 
 interface NewsletterAPIResponse {
 	id: string;
@@ -38,11 +39,15 @@ export const read = async (request_id?: string): Promise<NewsLetter[]> => {
 	const options = APIGetOptions();
 	try {
 		return (
-			(await idapiFetch({
-				path: '/newsletters',
-				options,
-			})) as NewsletterAPIResponse[]
-		).map(responseToEntity);
+			// NOTE: All newsletters are not consistently available in CODE, so for testing purposes
+			// you can override the base URL here to point to PROD, eg. await idapiFetchWithBaseUrlOverride('https://idapi.theguardian.com')({...
+			(
+				(await idapiFetchWithBaseUrlOverride()({
+					path: '/newsletters',
+					options,
+				})) as NewsletterAPIResponse[]
+			).map(responseToEntity)
+		);
 	} catch (error) {
 		logger.error(`IDAPI Error newsletters read '/newsletters'`, error, {
 			request_id,


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

We've had some annoyances testing newsletter updates because the CODE newsletter data is not uptodate and does not always match PROD data. This means we cannot correctly render newsletter data on the client when pointing to code, so we can actually see changes as they will appear in PROD before deploying to PROD. This might make engineers uncomfortable.

I thought one solution would be to allow for the allNewsletters read hitting idapi /newsletters endpoint to override the base url and manually point to prod - for testing purposes. See the WIP commit. 

However, this gets an access denied 403 message so maybe not a  viable solution 

Newsletters team has indicated updating the CODE newsltter information is a non-option, as the sequential id numbers are already off, so I suspect there may be more drift over time. 

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
