### PR TITLE
Group dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,10 @@ updates:
     directory: '/'
     schedule:
       interval: 'weekly'
+    groups:
+      all:
+        patterns:
+          - '*'
     open-pull-requests-limit: 10
     labels:
       - 'dependencies'


### PR DESCRIPTION
As we tend to bump all the dependencies in one go once a week we might as well group them together in a single PR.

There might be some logical subgroups that we want to use instead but this seemed like a sensible first iteration.

See https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups
