### PR TITLE
Okta OIE Prep | Migrate sessions to use the `/me` endpoint

### DIFF
--- a/cypress/integration/ete-okta/reauthenticate.4.cy.ts
+++ b/cypress/integration/ete-okta/reauthenticate.4.cy.ts
@@ -39,7 +39,7 @@ describe('Reauthenticate flow, Okta enabled', () => {
 					const sid = sidCookie?.value;
 					expect(sid).to.exist;
 					if (sid) {
-						cy.getCurrentOktaSession(sid).then((session) => {
+						cy.getCurrentOktaSession({ sid }).then((session) => {
 							expect(session.login).to.equal(emailAddress);
 						});
 					}
@@ -87,7 +87,7 @@ describe('Reauthenticate flow, Okta enabled', () => {
 									const sid = sidCookie?.value;
 									expect(sid).to.exist;
 									if (sid) {
-										cy.getCurrentOktaSession(sid).then((session) => {
+										cy.getCurrentOktaSession({ sid }).then((session) => {
 											expect(session.login).to.equal(emailAddressB);
 										});
 									}

--- a/cypress/integration/ete-okta/sign_in.1.cy.ts
+++ b/cypress/integration/ete-okta/sign_in.1.cy.ts
@@ -159,7 +159,9 @@ describe('Sign in flow, Okta enabled', () => {
 					// Get the current session data
 					cy.getCookie('sid').then((sidCookie) => {
 						// Close the user's current session in Okta
-						cy.closeCurrentOktaSession(sidCookie?.value).then(() => {
+						cy.closeCurrentOktaSession({
+							sid: sidCookie?.value,
+						}).then(() => {
 							// Refresh our user session
 							cy.visit(
 								`/signin/refresh?returnUrl=${encodeURIComponent(

--- a/cypress/integration/mocked/okta_register.3.cy.ts
+++ b/cypress/integration/mocked/okta_register.3.cy.ts
@@ -30,9 +30,8 @@ describe('Okta Register flow', () => {
 						id: '01a2bcdef3GHIJKLMNOP',
 						type: 'OKTA',
 					},
-					mfaActive: true,
 				},
-				'/api/v1/sessions/the_sid_cookie',
+				'/api/v1/sessions/me',
 			);
 
 			cy.mockPattern(204, {}, '/api/v1/users/userId/sessions');
@@ -73,7 +72,7 @@ describe('Okta Register flow', () => {
 		});
 
 		it('should redirect to /reauthenticate if the sid Okta session cookie is set, but invalid', () => {
-			cy.mockPattern(404, '/api/v1/sessions/the_sid_cookie');
+			cy.mockPattern(404, '/api/v1/sessions/me');
 
 			cy.mockPattern(204, {}, '/api/v1/users/userId/sessions');
 
@@ -110,9 +109,8 @@ describe('Okta Register flow', () => {
 						id: '01a2bcdef3GHIJKLMNOP',
 						type: 'OKTA',
 					},
-					mfaActive: true,
 				},
-				'/api/v1/sessions/the_sid_cookie',
+				'/api/v1/sessions/me',
 			);
 
 			cy.mockPattern(204, {}, '/api/v1/users/userId/sessions');
@@ -141,7 +139,7 @@ describe('Okta Register flow', () => {
 		});
 
 		it('should redirect to /reauthenticate if the sid Okta session cookie is set but invalid', () => {
-			cy.mockPattern(404, '/api/v1/sessions/the_sid_cookie');
+			cy.mockPattern(404, '/api/v1/sessions/me');
 
 			cy.mockPattern(204, {}, '/api/v1/users/userId/sessions');
 

--- a/cypress/integration/mocked/okta_sign_in.6.cy.ts
+++ b/cypress/integration/mocked/okta_sign_in.6.cy.ts
@@ -20,9 +20,8 @@ describe('Sign in flow', () => {
 						id: '01a2bcdef3GHIJKLMNOP',
 						type: 'OKTA',
 					},
-					mfaActive: true,
 				},
-				'/api/v1/sessions/the_sid_cookie',
+				'/api/v1/sessions/me',
 			);
 
 			cy.mockPattern(204, {}, '/api/v1/users/userId/sessions');
@@ -66,9 +65,8 @@ describe('Sign in flow', () => {
 						id: '01a2bcdef3GHIJKLMNOP',
 						type: 'OKTA',
 					},
-					mfaActive: true,
 				},
-				'/api/v1/sessions/the_sid_cookie',
+				'/api/v1/sessions/me',
 			);
 
 			cy.mockPattern(204, {}, '/api/v1/users/userId/sessions');

--- a/cypress/support/commands/testUser.ts
+++ b/cypress/support/commands/testUser.ts
@@ -496,14 +496,21 @@ export const findEmailValidatedOktaGroupId = () => {
 	}
 };
 
-export const getCurrentOktaSession = (sid: string) => {
+export const getCurrentOktaSession = ({
+	sid,
+	idx,
+}: {
+	sid?: string;
+	idx?: string;
+}) => {
 	try {
+		const Cookie = `${sid ? `sid=${sid};` : ''}${idx ? `idx=${idx};` : ''}`;
 		return cy
 			.request({
-				url: `${Cypress.env('OKTA_ORG_URL')}/api/v1/sessions/${sid}`,
+				url: `${Cypress.env('OKTA_ORG_URL')}/api/v1/sessions/me`,
 				method: 'GET',
 				headers: {
-					Authorization: `SSWS ${Cypress.env('OKTA_API_TOKEN')}`,
+					Cookie,
 				},
 				retryOnStatusCodeFailure: true,
 			})
@@ -516,14 +523,21 @@ export const getCurrentOktaSession = (sid: string) => {
 	}
 };
 
-export const closeCurrentOktaSession = (sid: string | undefined) => {
+export const closeCurrentOktaSession = ({
+	sid,
+	idx,
+}: {
+	sid?: string;
+	idx?: string;
+}) => {
 	try {
+		const Cookie = `${sid ? `sid=${sid};` : ''}${idx ? `idx=${idx};` : ''}`;
 		return cy
 			.request({
-				url: `${Cypress.env('OKTA_ORG_URL')}/api/v1/sessions/${sid}`,
+				url: `${Cypress.env('OKTA_ORG_URL')}/api/v1/sessions/me`,
 				method: 'DELETE',
 				headers: {
-					Authorization: `SSWS ${Cypress.env('OKTA_API_TOKEN')}`,
+					Cookie,
 				},
 				retryOnStatusCodeFailure: true,
 			})

--- a/src/server/lib/__tests__/okta/api/sessions.test.ts
+++ b/src/server/lib/__tests__/okta/api/sessions.test.ts
@@ -1,4 +1,4 @@
-import { getSession } from '@/server/lib/okta/api/sessions';
+import { getCurrentSession } from '@/server/lib/okta/api/sessions';
 import { OktaError } from '@/server/models/okta/Error';
 
 const sessionId = '123';
@@ -27,7 +27,7 @@ describe('okta#signOutUser', () => {
 		jest.clearAllMocks();
 	});
 
-	test('should sign out a user given a current valid session', async () => {
+	test('should sign out a user given a current valid session - Okta Identity Classic (`sid` cookie)', async () => {
 		const sessionData = {
 			id: '123',
 			login: 'email@example.com',
@@ -35,7 +35,6 @@ describe('okta#signOutUser', () => {
 			expiresAt: '2016-01-03T09:13:17.000Z',
 			status: 'ACTIVE',
 			lastPasswordVerification: '2016-01-03T07:02:00.000Z',
-			mfaActive: false,
 		};
 
 		json.mockResolvedValueOnce(sessionData);
@@ -43,7 +42,7 @@ describe('okta#signOutUser', () => {
 			Promise.resolve({ ok: true, status: 200, json } as Response),
 		);
 
-		const sessionResponse = await getSession(sessionId);
+		const sessionResponse = await getCurrentSession({ sid: sessionId });
 		expect(sessionResponse).toEqual(sessionData);
 	});
 
@@ -52,7 +51,68 @@ describe('okta#signOutUser', () => {
 			Promise.resolve({ ok: false, status: 404 } as Response),
 		);
 
-		await expect(getSession(sessionId)).rejects.toThrowError(
+		await expect(getCurrentSession({ sid: sessionId })).rejects.toThrowError(
+			new OktaError({ message: 'Could not parse Okta error response' }),
+		);
+	});
+
+	test('should sign out a user given a current valid session - Okta Identity Engine (`idx` cookie)', async () => {
+		const sessionData = {
+			id: '123',
+			login: 'email@example.com',
+			userId: '123',
+			expiresAt: '2016-01-03T09:13:17.000Z',
+			status: 'ACTIVE',
+			lastPasswordVerification: '2016-01-03T07:02:00.000Z',
+		};
+
+		json.mockResolvedValueOnce(sessionData);
+		mockedFetch.mockReturnValueOnce(
+			Promise.resolve({ ok: true, status: 200, json } as Response),
+		);
+
+		const sessionResponse = await getCurrentSession({ sid: sessionId });
+		expect(sessionResponse).toEqual(sessionData);
+	});
+
+	test('should throw an error after invalid session response from Okta', async () => {
+		mockedFetch.mockReturnValueOnce(
+			Promise.resolve({ ok: false, status: 404 } as Response),
+		);
+
+		await expect(getCurrentSession({ sid: sessionId })).rejects.toThrowError(
+			new OktaError({ message: 'Could not parse Okta error response' }),
+		);
+	});
+
+	test('should sign out a user given a current valid session - `idx` cookie & `sid` cookie', async () => {
+		const sessionData = {
+			id: '123',
+			login: 'email@example.com',
+			userId: '123',
+			expiresAt: '2016-01-03T09:13:17.000Z',
+			status: 'ACTIVE',
+			lastPasswordVerification: '2016-01-03T07:02:00.000Z',
+		};
+
+		json.mockResolvedValueOnce(sessionData);
+		mockedFetch.mockReturnValueOnce(
+			Promise.resolve({ ok: true, status: 200, json } as Response),
+		);
+
+		const sessionResponse = await getCurrentSession({
+			sid: sessionId,
+			idx: sessionId,
+		});
+		expect(sessionResponse).toEqual(sessionData);
+	});
+
+	test('should throw an error after invalid session response from Okta', async () => {
+		mockedFetch.mockReturnValueOnce(
+			Promise.resolve({ ok: false, status: 404 } as Response),
+		);
+
+		await expect(getCurrentSession({ sid: sessionId })).rejects.toThrowError(
 			new OktaError({ message: 'Could not parse Okta error response' }),
 		);
 	});

--- a/src/server/lib/okta/oauth.ts
+++ b/src/server/lib/okta/oauth.ts
@@ -8,7 +8,7 @@ import {
 	getOpenIdClient,
 	AuthorizationState,
 } from '@/server/lib/okta/openid-connect';
-import { closeSession } from './api/sessions';
+import { closeCurrentSession } from './api/sessions';
 
 /**
  * List of individual scopes that can be requested by gateway
@@ -116,10 +116,16 @@ export const performAuthorizationCodeFlow = async (
 	}: PerformAuthorizationCodeFlowOptions,
 ) => {
 	if (closeExistingSession) {
-		const oktaSessionCookieId: string | undefined = req.cookies.sid;
-		// clear existing okta session cookie if it exists
-		if (oktaSessionCookieId) {
-			await closeSession(oktaSessionCookieId);
+		// Okta Identity Engine session cookie is called `idx`
+		const oktaIdentityEngineSessionCookieId: string | undefined =
+			req.cookies.idx;
+		// Okta Classic session cookie is called `sid`
+		const oktaClassicSessionCookieId: string | undefined = req.cookies.sid; // clear existing okta session cookie if it exists
+		if (oktaIdentityEngineSessionCookieId || oktaClassicSessionCookieId) {
+			await closeCurrentSession({
+				idx: oktaIdentityEngineSessionCookieId,
+				sid: oktaClassicSessionCookieId,
+			});
 		}
 	}
 

--- a/src/server/models/okta/Session.ts
+++ b/src/server/models/okta/Session.ts
@@ -10,6 +10,5 @@ export const sessionSchema = z.object({
 	lastFactorVerification: z.string().nullable().optional(),
 	// amr: z.string(),
 	// idp: z.string(),
-	mfaActive: z.boolean(),
 });
 export type SessionResponse = z.infer<typeof sessionSchema>;

--- a/src/shared/model/Routes.ts
+++ b/src/shared/model/Routes.ts
@@ -116,6 +116,7 @@ export type OktaApiRoutePaths =
 	| '/api/v1/authn/credentials/reset_password'
 	| '/api/v1/authn/recovery/password'
 	| '/api/v1/authn/recovery/token'
+	| '/api/v1/sessions/me'
 	| '/api/v1/sessions/:sessionId'
 	| '/api/v1/users'
 	| '/api/v1/users/:id'


### PR DESCRIPTION
## What does this change?

tl;dr This PR fixes a blocker related to sessions within OIE. Safe to merge to CODE and PROD

Firstly, the use of the session ID cookie (`sid`) isn't supported in Identity Engine. The new `idx` cookie is used with Identity Engine.

Next, the Okta `/v1/sessions/{sessionid}` API has been deprecated, and doesn't support the `idx` cookie, only the only `sid` cookie. Okta recommends that we move away from using this API and use the [My Session Management endpoints](https://developer.okta.com/docs/api/openapi/okta-management/management/tag/Session/#tag/Session/operation/getCurrentSession) instead (`/v1/sessions/me` API endpoints).

All the related changes to the way sessions work in Okta after the upgrade are documented here: https://developer.okta.com/docs/guides/oie-upgrade-sessions-api/main/

From testing the behaviour in Okta dev, the following points were determined:
- `sid` cookie was used to create an `idx` cookie when going through oauth flow/sign in agin
- `sid` cookie is still set by okta on sign in/oauth, with expiry time set to when the session expires
- `idx` cookie also set by okta on sign in/oauth, but is only set as a session cookie, need to investigate further the implications of this
- The `/v1/sessions/me` API authenticates with a cookie, and not an Okta API token. It can be authenticated with the `sid` cookie, or the `idx` cookie, or both cookies provided at the same time
- This points to the outcome that the `sid` cookie should work alongside the `idx` cookie, i.e dual-running, and our code should be prepared so that we can use either one interchangeably or together, even post OIE migration

This PR replaces the `/v1/sessions/:sessionId` API methods (`getSession` and `closeSession`) with the `/v1/sessions/me` API (`getCurrentSession` and `closeCurrentSession`) which authenticates with either/both of the `sid`/`idx` cookies instead of the API token which the old endpoint was doing. Responses between the APIs are identical. Thankfully as we're running Okta and Gateway on the same domain, it makes reading cookies a breeze, so we just read the cookies from the request and forward them onto Okta. We also update Cypress to use these new endpoints too.

This is safe to deploy to CODE and PROD, as the `/v1/sessions/me` endpoint is fully compatible with non-OIE tenants, which we're currently using in CODE and PROD.

The Cypress tests currently don't use the `idx` cookie, as we usually run Cypress against the CODE environment, so when we do the Okta OIE upgrade in CODE, we can update the cypress tests once upgraded on CODE!

## Tested
- [x] DEV - Okta Identity Engine
- [x] CODE - Okta Classic 