### PR TITLE
Okta Identity Engine |  Switch from `sid` cookie to `idx` cookie in tests and documentation

### DIFF
--- a/cypress/integration/ete-okta/jobs_terms.4.cy.ts
+++ b/cypress/integration/ete-okta/jobs_terms.4.cy.ts
@@ -30,6 +30,7 @@ describe('Jobs terms and conditions flow in Okta', () => {
 				'BASE_URI',
 			)}/agree/GRS?returnUrl=https://profile.thegulocal.com/signin?returnUrl=https%3A%2F%2Fm.code.dev-theguardian.com%2F`;
 			cy.setCookie('sid', 'invalid-cookie');
+			cy.setCookie('idx', 'invalid-cookie');
 			cy.visit(termsAcceptPageUrl);
 			cy.url().should(
 				'include',
@@ -175,6 +176,7 @@ describe('Jobs terms and conditions flow in Okta', () => {
 					cy.url().should('include', `/agree/GRS`);
 					// check session cookie is set
 					cy.getCookie('sid').should('exist');
+					cy.getCookie('idx').should('exist');
 					// check idapi cookies are set
 					cy.getCookie('SC_GU_U').should('exist');
 					cy.getCookie('SC_GU_LA').should('exist');

--- a/cypress/integration/ete-okta/reauthenticate.4.cy.ts
+++ b/cypress/integration/ete-okta/reauthenticate.4.cy.ts
@@ -35,11 +35,11 @@ describe('Reauthenticate flow, Okta enabled', () => {
 				cy.url().should('include', '/consents/data');
 
 				// Get the current session data
-				cy.getCookie('sid').then((sidCookie) => {
-					const sid = sidCookie?.value;
-					expect(sid).to.exist;
-					if (sid) {
-						cy.getCurrentOktaSession({ sid }).then((session) => {
+				cy.getCookie('idx').then((idxCookie) => {
+					const idx = idxCookie?.value;
+					expect(idx).to.exist;
+					if (idx) {
+						cy.getCurrentOktaSession({ idx }).then((session) => {
 							expect(session.login).to.equal(emailAddress);
 						});
 					}
@@ -83,11 +83,11 @@ describe('Reauthenticate flow, Okta enabled', () => {
 								cy.url().should('include', '/consents/data');
 
 								// Get the current session data
-								cy.getCookie('sid').then((sidCookie) => {
-									const sid = sidCookie?.value;
-									expect(sid).to.exist;
-									if (sid) {
-										cy.getCurrentOktaSession({ sid }).then((session) => {
+								cy.getCookie('idx').then((idxCookie) => {
+									const idx = idxCookie?.value;
+									expect(idx).to.exist;
+									if (idx) {
+										cy.getCurrentOktaSession({ idx }).then((session) => {
 											expect(session.login).to.equal(emailAddressB);
 										});
 									}

--- a/cypress/integration/ete-okta/registration_2.6.cy.ts
+++ b/cypress/integration/ete-okta/registration_2.6.cy.ts
@@ -617,8 +617,8 @@ describe('Registration flow - Split 2/2', () => {
 					cy.url().should('include', '/consents');
 
 					// Get the current session data
-					cy.getCookie('sid').then((originalSidCookie) => {
-						expect(originalSidCookie).to.exist;
+					cy.getCookie('idx').then((originalIdxCookie) => {
+						expect(originalIdxCookie).to.exist;
 
 						// Visit register again
 						cy.visit(

--- a/cypress/integration/ete-okta/sign_in.1.cy.ts
+++ b/cypress/integration/ete-okta/sign_in.1.cy.ts
@@ -132,7 +132,7 @@ describe('Sign in flow, Okta enabled', () => {
 						// Get the refreshed session data
 						cy.getCookie('idx').then((newIdxCookie) => {
 							expect(newIdxCookie).to.exist;
-							// `idx` cookie doesn't have same value as original when refreshed, which is different to the Okta Classic `sid` cookie
+							// `idx` cookie doesn't have same value as original when refreshed, which is different to the Okta Classic `idx` cookie
 							expect(newIdxCookie?.value).to.not.equal(orignalIdxCookie?.value);
 							// we want to check the cookie is being set as a persistent cookie and not a session cookie, hence the expiry check
 							expect(newIdxCookie?.expiry).to.exist;
@@ -162,10 +162,10 @@ describe('Sign in flow, Okta enabled', () => {
 					cy.url().should('include', '/consents');
 
 					// Get the current session data
-					cy.getCookie('sid').then((sidCookie) => {
+					cy.getCookie('idx').then((idxCookie) => {
 						// Close the user's current session in Okta
 						cy.closeCurrentOktaSession({
-							sid: sidCookie?.value,
+							idx: idxCookie?.value,
 						}).then(() => {
 							// Refresh our user session
 							cy.visit(
@@ -194,7 +194,7 @@ describe('Sign in flow, Okta enabled', () => {
 					cy.get('[data-cy="main-form-submit-button"]').click();
 					cy.url().should('include', '/consents');
 
-					// Delete the Okta sid cookie
+					// Delete the Okta sid/idx cookie
 					// strange behaviour form Cypress 12
 					// where we need to delete cookie from both domains
 					// to get the test to pass
@@ -204,6 +204,12 @@ describe('Sign in flow, Okta enabled', () => {
 						domain: Cypress.env('BASE_URI'),
 					});
 					cy.clearCookie('sid', {
+						domain: `.${Cypress.env('BASE_URI')}`,
+					});
+					cy.clearCookie('idx', {
+						domain: Cypress.env('BASE_URI'),
+					});
+					cy.clearCookie('idx', {
 						domain: `.${Cypress.env('BASE_URI')}`,
 					});
 
@@ -216,6 +222,7 @@ describe('Sign in flow, Okta enabled', () => {
 					cy.url().should('include', '/reset-password');
 
 					cy.getCookie('sid').should('not.exist');
+					cy.getCookie('idx').should('not.exist');
 				},
 			);
 		});
@@ -334,8 +341,8 @@ describe('Sign in flow, Okta enabled', () => {
 					cy.contains('Change email address');
 
 					// Ensure the user's authentication cookies are not set
-					cy.getCookie('sid').then((sidCookie) => {
-						expect(sidCookie).to.not.exist;
+					cy.getCookie('idx').then((idxCookie) => {
+						expect(idxCookie).to.not.exist;
 
 						cy.checkForEmailAndGetDetails(
 							emailAddress,
@@ -387,8 +394,8 @@ describe('Sign in flow, Okta enabled', () => {
 					cy.url().should('include', '/consents');
 
 					// Get the current session data
-					cy.getCookie('sid').then((originalSidCookie) => {
-						expect(originalSidCookie).to.exist;
+					cy.getCookie('idx').then((originalIdxCookie) => {
+						expect(originalIdxCookie).to.exist;
 
 						// Visit sign in again
 						cy.visit(

--- a/cypress/integration/ete-okta/sign_out.5.cy.ts
+++ b/cypress/integration/ete-okta/sign_out.5.cy.ts
@@ -29,6 +29,7 @@ describe('Sign out flow', () => {
 					cy.url().should('include', `/consents/data`);
 					// check session cookie is set
 					cy.getCookie('sid').should('exist');
+					cy.getCookie('idx').should('exist');
 					// check idapi cookies are set
 					cy.getCookie('SC_GU_U').should('exist');
 					cy.getCookie('SC_GU_LA').should('exist');

--- a/cypress/integration/mocked/okta_register.3.cy.ts
+++ b/cypress/integration/mocked/okta_register.3.cy.ts
@@ -1,6 +1,6 @@
 describe('Okta Register flow', () => {
-	const setSidCookie = () => {
-		cy.setCookie('sid', `the_sid_cookie`, {
+	const setIdxCookie = () => {
+		cy.setCookie('idx', `the_idx_cookie`, {
 			domain: Cypress.env('BASE_URI'),
 		});
 	};
@@ -14,7 +14,7 @@ describe('Okta Register flow', () => {
 			cy.disableCMP();
 		});
 
-		it('should redirect to homepage if the sid Okta session cookie is valid', () => {
+		it('should redirect to homepage if the idx Okta session cookie is valid', () => {
 			cy.mockPattern(
 				200,
 				{
@@ -40,7 +40,7 @@ describe('Okta Register flow', () => {
 
 			cy.visit('/register');
 
-			setSidCookie();
+			setIdxCookie();
 
 			cy.get('input[name="email"]').type('example@example.com');
 			cy.mockNext(200, {
@@ -71,12 +71,12 @@ describe('Okta Register flow', () => {
 			cy.contains('Sign in with a different email');
 		});
 
-		it('should redirect to /reauthenticate if the sid Okta session cookie is set, but invalid', () => {
+		it('should redirect to /reauthenticate if the idx Okta session cookie is set, but invalid', () => {
 			cy.mockPattern(404, '/api/v1/sessions/me');
 
 			cy.mockPattern(204, {}, '/api/v1/users/userId/sessions');
 
-			setSidCookie();
+			setIdxCookie();
 
 			// visit healthcheck to set the cookie
 			cy.visit('/healthcheck');
@@ -85,7 +85,7 @@ describe('Okta Register flow', () => {
 
 			cy.location('pathname').should('eq', '/reauthenticate');
 
-			cy.getCookie('sid').should('not.exist');
+			cy.getCookie('idx').should('not.exist');
 		});
 	});
 
@@ -93,7 +93,7 @@ describe('Okta Register flow', () => {
 		beforeEach(() => {
 			cy.mockPurge();
 		});
-		it('should redirect to homepage if the sid Okta session cookie is valid', () => {
+		it('should redirect to homepage if the idx Okta session cookie is valid', () => {
 			cy.mockPattern(
 				200,
 				{
@@ -115,7 +115,7 @@ describe('Okta Register flow', () => {
 
 			cy.mockPattern(204, {}, '/api/v1/users/userId/sessions');
 
-			setSidCookie();
+			setIdxCookie();
 
 			// disable the cmp on the redirect
 			cy.disableCMP();
@@ -138,12 +138,12 @@ describe('Okta Register flow', () => {
 			cy.contains('Sign in with a different email');
 		});
 
-		it('should redirect to /reauthenticate if the sid Okta session cookie is set but invalid', () => {
+		it('should redirect to /reauthenticate if the idx Okta session cookie is set but invalid', () => {
 			cy.mockPattern(404, '/api/v1/sessions/me');
 
 			cy.mockPattern(204, {}, '/api/v1/users/userId/sessions');
 
-			setSidCookie();
+			setIdxCookie();
 
 			// visit healthcheck to set the cookie
 			cy.visit('/healthcheck');
@@ -152,7 +152,7 @@ describe('Okta Register flow', () => {
 
 			cy.location('pathname').should('eq', '/reauthenticate');
 
-			cy.getCookie('sid').should('not.exist');
+			cy.getCookie('idx').should('not.exist');
 		});
 	});
 });

--- a/cypress/integration/mocked/okta_sign_in.6.cy.ts
+++ b/cypress/integration/mocked/okta_sign_in.6.cy.ts
@@ -26,7 +26,7 @@ describe('Sign in flow', () => {
 
 			cy.mockPattern(204, {}, '/api/v1/users/userId/sessions');
 
-			cy.setCookie('sid', `the_sid_cookie`);
+			cy.setCookie('idx', `the_idx_cookie`);
 
 			// disable the cmp  on the redirect
 			cy.disableCMP();
@@ -85,7 +85,7 @@ describe('Sign in flow', () => {
 				'/api/v1/apps/123',
 			);
 
-			cy.setCookie('sid', `the_sid_cookie`);
+			cy.setCookie('idx', `the_idx_cookie`);
 
 			// disable the cmp  on the redirect
 			cy.disableCMP();

--- a/docs/okta/sessions.md
+++ b/docs/okta/sessions.md
@@ -17,7 +17,7 @@ There are two layers of session in Okta in the following hierarchy.
 
 We generally call this the Global Session or Okta session internally, but is known in the Okta documentation as the IdP Session.
 
-The IdP session is the session that is created when a user logs in to or authenticates with Okta with their credentials and any various MFA options. This session is created by Okta and is identified by a cookie named `sid` in the browser.
+The IdP session is the session that is created when a user logs in to or authenticates with Okta with their credentials and any various MFA options. This session is created by Okta and is identified by a cookie named `idx` in the browser, and `sid` cookie may also be set, but this is a legacy Okta identification cookie.
 
 This cookie is only valid on the Okta/login domain (at the Guardian this is the `profile` subdomain, e.g. https://profile.theguardian.com), and the value is the session id. This same session id which can be used by the [Okta Sessions API](https://developer.okta.com/docs/reference/api/sessions/). This is an opaque value, and only authenticates the user, it does not contain any information about the user, and should not be used to authenticate the user on any API.
 

--- a/docs/okta/signin.md
+++ b/docs/okta/signin.md
@@ -19,7 +19,7 @@ Throughout the implementation of the sign in code, there are many in line commen
 In general the steps of sign in with email and password are summarised as follows, assuming okta is enabled, this does not detail all technical requirements, just the main high level:
 
 - User navigates to `/signin`
-  - Check `sid` cookie for existing Okta session, if this is present it checks if the session is still valid.
+  - Check `idx` cookie for existing Okta session, if this is present it checks if the session is still valid.
   - If the current session does not exist, or is invalid, sign in page shown
     - user enters email and password, makes request to gateway `POST /signin`
     - Use okta authenticate endpoint with the email and password `/api/v1/authn`
@@ -41,7 +41,7 @@ sequenceDiagram
   participant Okta
   participant Identity API
   Browser->>Gateway: Request gateway /signin
-  note over Gateway: Sign in session is checked by inspecting the `sid` cookie
+  note over Gateway: Sign in session is checked by inspecting the `idx` cookie
   Gateway->>Okta: GET /api/v1/sessions/:sessionId
   Okta->>Gateway: return invalid session response
   Gateway->>Browser: render sign in page
@@ -74,7 +74,7 @@ sequenceDiagram
   participant Okta
   participant Identity API
   Browser->>Gateway: Request gateway /signin
-  note over Gateway: Sign in session is checked by inspecting the `sid` cookie and validating the session against the Okta session API
+  note over Gateway: Sign in session is checked by inspecting the `idx` cookie and validating the session against the Okta session API
   note over Okta: check for existing session<br>in this case a session exists
   Gateway->>Okta: GET /api/v1/sessions/:sessionId
   Okta->>Gateway: return valid session response
@@ -103,7 +103,7 @@ participant Social
 participant Identity API
 
 Browser ->> Gateway: Request /signin (or /register),<br>will just be referred to as /signin or sign in for<br>simplicity, as the same thing happens<br>in either case
-note over Gateway: Sign in session is checked by inspecting the `sid` cookie
+note over Gateway: Sign in session is checked by inspecting the `idx` cookie
 Gateway ->> Okta: GET /api/v1/sessions/:sessionId
 Okta ->> Gateway: Return invalid session response
 Gateway ->> Browser: Render sign in page
@@ -156,7 +156,7 @@ participant Social
 participant Identity API
 
 Browser ->> Gateway: Request /signin (or /register),<br>will just be referred to as /signin or sign in for<br>simplicity, as the same thing happens<br>in either case
-note over Gateway: Sign in session is checked by inspecting the `sid` cookie
+note over Gateway: Sign in session is checked by inspecting the `idx` cookie
 Gateway ->> Okta: GET /api/v1/sessions/:sessionId
 Okta ->> Gateway: Return invalid session response
 Gateway ->> Browser: Render sign in page

--- a/docs/okta/tokens.md
+++ b/docs/okta/tokens.md
@@ -138,7 +138,7 @@ However, public clients such as browser-based applications have a much higher ri
 
 Refresh tokens are valid for 90 days by default, but can be configured to be longer or shorter, from 5 mins to unlimited, we also recommend that you rotate the refresh token after each use.
 
-Refresh tokens provide an additional "session" layer on top of the in browser `sid` cookie (which is set after login in browser). Meaning these two sessions are independent of each other, and can be used to manage the user's session in different ways. You can see the [Sessions](sessions.md) documentation for more information on how we use these sessions.
+Refresh tokens provide an additional "session" layer on top of the in browser `idx` cookie (which is set after login in browser). Meaning these two sessions are independent of each other, and can be used to manage the user's session in different ways. You can see the [Sessions](sessions.md) documentation for more information on how we use these sessions.
 
 ### Token management
 


### PR DESCRIPTION
## What does this change?

As it says in the title, this PR switches from the `sid` cookie to the `idx` cookie in tests and documentation, in some cases we still keep both where the `sid` and `idx` cookie might be set together, e.g. on Sign Out tests, and tests where we need to check if certain cookies exist or not.