### PR TITLE
Signed in as Page | Handle `login_required` error with helpful messaging

### DIFF
--- a/src/client/components/DetailedRecaptchaError.tsx
+++ b/src/client/components/DetailedRecaptchaError.tsx
@@ -1,11 +1,6 @@
 import React from 'react';
 import { space } from '@guardian/source-foundations';
-import { css } from '@emotion/react';
-
-const errorContextSpacing = css`
-	margin: 0;
-	margin-top: ${space[2]}px;
-`;
+import { errorContextSpacing } from '@/client/styles/Shared';
 
 export const DetailedRecaptchaError = () => (
 	<>

--- a/src/client/pages/SignedInAs.stories.tsx
+++ b/src/client/pages/SignedInAs.stories.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Meta } from '@storybook/react';
 
 import { SignedInAs } from './SignedInAs';
+import { SignInErrors } from '../../shared/model/Errors';
 
 export default {
 	title: 'Pages/SignedInAs',
@@ -28,5 +29,15 @@ export const Error = () => (
 		continueLink="#"
 		signOutLink="#"
 		pageError={'Something went wrong'}
+	/>
+);
+
+export const LoginRequiredError = () => (
+	<SignedInAs
+		email="test@example.com"
+		continueLink="#"
+		signOutLink="#"
+		pageError={SignInErrors.GENERIC}
+		queryParams={{ returnUrl: '#', error: 'login_required' }}
 	/>
 );

--- a/src/client/pages/SignedInAs.tsx
+++ b/src/client/pages/SignedInAs.tsx
@@ -1,8 +1,12 @@
-import React from 'react';
+import React, { ReactNode, useEffect } from 'react';
 import { buttonStyles, MainLayout } from '@/client/layouts/Main';
 import { MainBodyText } from '@/client/components/MainBodyText';
 import { Link, LinkButton } from '@guardian/source-react-components';
 import { IsNativeApp } from '@/shared/model/ClientState';
+import { QueryParams } from '@/shared/model/QueryParams';
+import { OpenIdErrors } from '@/shared/model/OpenIdErrors';
+import { errorContextSpacing } from '@/client/styles/Shared';
+import { space } from '@guardian/source-foundations';
 
 interface Props {
 	email: string;
@@ -10,7 +14,33 @@ interface Props {
 	signOutLink: string;
 	isNativeApp?: IsNativeApp;
 	pageError?: string;
+	queryParams?: QueryParams;
 }
+
+const DetailedLoginRequiredError = ({
+	signOutLink,
+}: {
+	signOutLink: string;
+}) => (
+	<>
+		<p css={errorContextSpacing}>
+			If the problem persists please try the following:
+		</p>
+		<ul css={errorContextSpacing}>
+			<li>
+				<Link href={signOutLink}>Sign out</Link> and attempt to sign in again
+			</li>
+			<li>Clear browser cookies and cache</li>
+		</ul>
+		<p css={[errorContextSpacing, { marginBottom: `${space[3]}px` }]}>
+			For further help please contact our customer service team at{' '}
+			<Link href="email:customer.help@theguardian.com">
+				customer.help@theguardian.com
+			</Link>
+			.
+		</p>
+	</>
+);
 
 export const SignedInAs = ({
 	email,
@@ -18,28 +48,43 @@ export const SignedInAs = ({
 	signOutLink,
 	isNativeApp,
 	pageError,
-}: Props) => (
-	<MainLayout
-		pageHeader={`Sign in to the Guardian${!!isNativeApp ? ' app' : ''}`}
-		errorOverride={pageError}
-		errorSmallMarginBottom={!!pageError}
-	>
-		<MainBodyText noMarginBottom>
-			You are signed in with <br />
-			<b>{email}</b>.
-		</MainBodyText>
-		<LinkButton
-			css={buttonStyles({
-				halfWidth: true,
-				halfWidthAtMobile: true,
-				hasMarginBottom: true,
-			})}
-			href={continueLink}
+	queryParams,
+}: Props) => {
+	const [errorContext, setErrorContext] = React.useState<
+		ReactNode | undefined
+	>();
+	const { error: errorFromQueryParams } = queryParams || {};
+
+	useEffect(() => {
+		if (errorFromQueryParams === OpenIdErrors.LOGIN_REQUIRED) {
+			setErrorContext(<DetailedLoginRequiredError signOutLink={signOutLink} />);
+		}
+	}, [errorFromQueryParams, signOutLink]);
+
+	return (
+		<MainLayout
+			pageHeader={`Sign in to the Guardian${!!isNativeApp ? ' app' : ''}`}
+			errorOverride={pageError}
+			errorSmallMarginBottom={!!pageError}
+			errorContext={errorContext}
 		>
-			Continue
-		</LinkButton>
-		<MainBodyText noMarginBottom>
-			<Link href={signOutLink}>Sign in</Link> with a different email.
-		</MainBodyText>
-	</MainLayout>
-);
+			<MainBodyText noMarginBottom>
+				You are signed in with <br />
+				<b>{email}</b>.
+			</MainBodyText>
+			<LinkButton
+				css={buttonStyles({
+					halfWidth: true,
+					halfWidthAtMobile: true,
+					hasMarginBottom: true,
+				})}
+				href={continueLink}
+			>
+				Continue
+			</LinkButton>
+			<MainBodyText noMarginBottom>
+				<Link href={signOutLink}>Sign in</Link> with a different email.
+			</MainBodyText>
+		</MainLayout>
+	);
+};

--- a/src/client/pages/SignedInAsPage.tsx
+++ b/src/client/pages/SignedInAsPage.tsx
@@ -4,7 +4,7 @@ import { SignedInAs } from '@/client/pages/SignedInAs';
 
 export const SignedInAsPage = () => {
 	const clientState = useClientState();
-	const { pageData = {}, globalMessage = {} } = clientState;
+	const { pageData = {}, globalMessage = {}, queryParams } = clientState;
 	const {
 		email = '',
 		continueLink = '',
@@ -20,6 +20,7 @@ export const SignedInAsPage = () => {
 			signOutLink={signOutLink}
 			isNativeApp={isNativeApp}
 			pageError={pageError}
+			queryParams={queryParams}
 		/>
 	);
 };

--- a/src/client/styles/Shared.ts
+++ b/src/client/styles/Shared.ts
@@ -37,3 +37,8 @@ export const socialButtonDivider = css`
 		margin: 8px;
 	}
 `;
+
+export const errorContextSpacing = css`
+	margin: 0;
+	margin-top: ${space[2]}px;
+`;

--- a/src/server/lib/okta/openid-connect.ts
+++ b/src/server/lib/okta/openid-connect.ts
@@ -169,27 +169,6 @@ export const getOpenIdClient = (req: Request): OpenIdClient => {
 };
 
 /**
- * Possible `error` types return by OpenID Connect and social login flows with okta
- * Sourced from https://developer.okta.com/docs/reference/error-codes/#example-errors-for-openid-connect-and-social-login
- */
-export enum OpenIdErrors {
-	UNAUTHORIZED_CLIENT = 'unauthorized_client',
-	ACCESS_DENIED = 'access_denied',
-	UNSUPPORTED_RESPONSE_TYPE = 'unsupported_response_type',
-	INVALID_SCOPE = 'invalid_scope',
-	SERVER_ERROR = 'server_error',
-	TEMPORARILY_UNAVAILABLE = 'temporarily_unavailable',
-	INVALID_CLIENT = 'invalid_client',
-	LOGIN_REQUIRED = 'login_required',
-	INVALID_REQUEST = 'invalid_request',
-	USER_CANCELED_REQUEST = 'user_canceled_request',
-}
-
-export enum OpenIdErrorDescriptions {
-	ACCOUNT_LINKING_DENIED_GROUPS = 'User linking was denied because the user is not in any of the specified groups.',
-}
-
-/**
  * @function generateRandomString
  *
  * Generate a cryptographically secure random string to be used

--- a/src/server/routes/oauth.ts
+++ b/src/server/routes/oauth.ts
@@ -6,8 +6,6 @@ import {
 	deleteAuthorizationStateCookie,
 	getAuthorizationStateCookie,
 	getOpenIdClient,
-	OpenIdErrorDescriptions,
-	OpenIdErrors,
 	ProfileOpenIdClientRedirectUris,
 } from '@/server/lib/okta/openid-connect';
 import { logger } from '@/server/lib/serverSideLogger';
@@ -34,6 +32,10 @@ import {
 	setOAuthTokenCookie,
 } from '@/server/lib/okta/tokens';
 import { getConfiguration } from '@/server/lib/getConfiguration';
+import {
+	OpenIdErrors,
+	OpenIdErrorDescriptions,
+} from '@/shared/model/OpenIdErrors';
 
 const { baseUri, deleteAccountStepFunction } = getConfiguration();
 
@@ -440,7 +442,10 @@ router.get(
 			// used to check if a session existed before the user is shown a sign in page
 			if (callbackParams.error === OpenIdErrors.LOGIN_REQUIRED) {
 				return res.redirect(
-					addQueryParamsToPath('/signin', authState.queryParams),
+					addQueryParamsToPath('/signin', authState.queryParams, {
+						error: callbackParams.error,
+						error_description: callbackParams.error_description,
+					}),
 				);
 			}
 

--- a/src/shared/model/OpenIdErrors.ts
+++ b/src/shared/model/OpenIdErrors.ts
@@ -1,0 +1,20 @@
+/**
+ * Possible `error` types return by OpenID Connect and social login flows with okta
+ * Sourced from https://developer.okta.com/docs/reference/error-codes/#example-errors-for-openid-connect-and-social-login
+ */
+export enum OpenIdErrors {
+	UNAUTHORIZED_CLIENT = 'unauthorized_client',
+	ACCESS_DENIED = 'access_denied',
+	UNSUPPORTED_RESPONSE_TYPE = 'unsupported_response_type',
+	INVALID_SCOPE = 'invalid_scope',
+	SERVER_ERROR = 'server_error',
+	TEMPORARILY_UNAVAILABLE = 'temporarily_unavailable',
+	INVALID_CLIENT = 'invalid_client',
+	LOGIN_REQUIRED = 'login_required',
+	INVALID_REQUEST = 'invalid_request',
+	USER_CANCELED_REQUEST = 'user_canceled_request',
+}
+
+export enum OpenIdErrorDescriptions {
+	ACCOUNT_LINKING_DENIED_GROUPS = 'User linking was denied because the user is not in any of the specified groups.',
+}


### PR DESCRIPTION
## What does this change?

Users would sometimes click the "Continue" on the "Signed in as" page, and they would be redirected back to the same page because of an error, specifically when there was a `login_required` error if there was an issue with the users session

However this error would sometimes not propagate to the "Signed in as" page. This PR makes sure it does, and adds in helpful messaging to unblock the user, namely by Signing Out and back in again, clearing cache/cookies, or contacting customer support.

![Screenshot 2023-11-01 at 10 06 28](https://github.com/guardian/gateway/assets/13315440/60941ec7-c26a-4e45-9e96-aea457093721)
