### PR TITLE
Okta | Remove `sid` cookie and only rely on the `idx` cookie

### DIFF
--- a/cypress/integration/ete-okta/jobs_terms.4.cy.ts
+++ b/cypress/integration/ete-okta/jobs_terms.4.cy.ts
@@ -29,7 +29,6 @@ describe('Jobs terms and conditions flow in Okta', () => {
 			const termsAcceptPageUrl = `https://${Cypress.env(
 				'BASE_URI',
 			)}/agree/GRS?returnUrl=https://profile.thegulocal.com/signin?returnUrl=https%3A%2F%2Fm.code.dev-theguardian.com%2F`;
-			cy.setCookie('sid', 'invalid-cookie');
 			cy.setCookie('idx', 'invalid-cookie');
 			cy.visit(termsAcceptPageUrl);
 			cy.url().should(
@@ -194,7 +193,6 @@ describe('Jobs terms and conditions flow in Okta', () => {
 					// check sign in has worked first
 					cy.url().should('include', `/agree/GRS`);
 					// check session cookie is set
-					cy.getCookie('sid').should('exist');
 					cy.getCookie('idx').should('exist');
 					// check idapi cookies are set
 					cy.getCookie('SC_GU_U').should('exist');

--- a/cypress/integration/ete-okta/sign_in.1.cy.ts
+++ b/cypress/integration/ete-okta/sign_in.1.cy.ts
@@ -189,18 +189,12 @@ describe('Sign in flow, Okta enabled', () => {
 					cy.get('[data-cy="main-form-submit-button"]').click();
 					cy.url().should('include', '/consents');
 
-					// Delete the Okta sid/idx cookie
+					// Delete the Okta idx cookie
 					// strange behaviour form Cypress 12
 					// where we need to delete cookie from both domains
 					// to get the test to pass
 					// cypress 12 seems to have issues with hostOnly cookies not being removed or persisting after clear
 					// https://github.com/cypress-io/cypress/issues/25174
-					cy.clearCookie('sid', {
-						domain: Cypress.env('BASE_URI'),
-					});
-					cy.clearCookie('sid', {
-						domain: `.${Cypress.env('BASE_URI')}`,
-					});
 					cy.clearCookie('idx', {
 						domain: Cypress.env('BASE_URI'),
 					});
@@ -216,7 +210,6 @@ describe('Sign in flow, Okta enabled', () => {
 					);
 					cy.url().should('include', '/reset-password');
 
-					cy.getCookie('sid').should('not.exist');
 					cy.getCookie('idx').should('not.exist');
 				},
 			);
@@ -247,7 +240,7 @@ describe('Sign in flow, Okta enabled', () => {
 					);
 					cy.url().should('include', '/signin');
 
-					cy.getCookie('sid').should('not.exist');
+					cy.getCookie('idx').should('not.exist');
 					cy.getCookie('sc_gu_u').should('not.exist');
 					cy.getCookie('sc_gu_la').should('not.exist');
 				},

--- a/cypress/integration/ete-okta/sign_out.5.cy.ts
+++ b/cypress/integration/ete-okta/sign_out.5.cy.ts
@@ -20,7 +20,6 @@ describe('Sign out flow', () => {
 					// check sign in has worked first
 					cy.url().should('include', `/consents/data`);
 					// check session cookie is set
-					cy.getCookie('sid').should('exist');
 					cy.getCookie('idx').should('exist');
 					// check idapi cookies are set
 					cy.getCookie('SC_GU_U').should('exist');

--- a/cypress/support/commands/testUser.ts
+++ b/cypress/support/commands/testUser.ts
@@ -496,15 +496,9 @@ export const findEmailValidatedOktaGroupId = () => {
 	}
 };
 
-export const getCurrentOktaSession = ({
-	sid,
-	idx,
-}: {
-	sid?: string;
-	idx?: string;
-}) => {
+export const getCurrentOktaSession = ({ idx }: { idx?: string }) => {
 	try {
-		const Cookie = `${sid ? `sid=${sid};` : ''}${idx ? `idx=${idx};` : ''}`;
+		const Cookie = `${idx ? `idx=${idx};` : ''}`;
 		return cy
 			.request({
 				url: `${Cypress.env('OKTA_ORG_URL')}/api/v1/sessions/me`,
@@ -523,15 +517,9 @@ export const getCurrentOktaSession = ({
 	}
 };
 
-export const closeCurrentOktaSession = ({
-	sid,
-	idx,
-}: {
-	sid?: string;
-	idx?: string;
-}) => {
+export const closeCurrentOktaSession = ({ idx }: { idx?: string }) => {
 	try {
-		const Cookie = `${sid ? `sid=${sid};` : ''}${idx ? `idx=${idx};` : ''}`;
+		const Cookie = `${idx ? `idx=${idx};` : ''}`;
 		return cy
 			.request({
 				url: `${Cypress.env('OKTA_ORG_URL')}/api/v1/sessions/me`,

--- a/docs/okta/sessions.md
+++ b/docs/okta/sessions.md
@@ -17,7 +17,7 @@ There are two layers of session in Okta in the following hierarchy.
 
 We generally call this the Global Session or Okta session internally, but is known in the Okta documentation as the IdP Session.
 
-The IdP session is the session that is created when a user logs in to or authenticates with Okta with their credentials and any various MFA options. This session is created by Okta and is identified by a cookie named `idx` in the browser, and `sid` cookie may also be set, but this is a legacy Okta identification cookie.
+The IdP session is the session that is created when a user logs in to or authenticates with Okta with their credentials and any various MFA options. This session is created by Okta and is identified by a cookie named `idx` in the browser, and `sid` cookie may also be set, but this is a legacy Okta identification cookie, which we no longer use.
 
 This cookie is only valid on the Okta/login domain (at the Guardian this is the `profile` subdomain, e.g. https://profile.theguardian.com), and the value is the session id. This same session id which can be used by the [Okta Sessions API](https://developer.okta.com/docs/reference/api/sessions/). This is an opaque value, and only authenticates the user, it does not contain any information about the user, and should not be used to authenticate the user on any API.
 

--- a/scripts/nginx.conf
+++ b/scripts/nginx.conf
@@ -58,6 +58,20 @@ http {
         proxy_next_upstream error timeout http_404 non_idempotent;
         proxy_set_header "X-Forwarded-Proto" "https";
         proxy_set_header "X-GU-Okta-Env" "profile.code.dev-theguardian.com";
+        ######
+        # remove `sid` cookie in requests to Gateway
+        # save original "Cookie" header value
+        set $altered_cookie $http_cookie;
+        # check if the "sid" cookie is present
+        if ($http_cookie ~ '(.*)(^|;\s)sid=("[^"]*"|[^\s]*[^;]?)(\2|$|;$)(?:;\s)?(.*)') {
+          # cut "sid" cookie from the string
+          set $altered_cookie $1$4$5;
+        }
+        # hide original "Cookie" header
+        proxy_hide_header Cookie;
+        # set "Cookie" header to the new value
+        proxy_set_header  Cookie $altered_cookie;
+        ######
         # handle nginx backend errors by proxying to gateway
         error_page 502 = @fallback;
       }
@@ -71,6 +85,20 @@ http {
         proxy_set_header        X-Forwarded-For         $proxy_add_x_forwarded_for;
         proxy_set_header        X-Forwarded-Protocol    $scheme;
         proxy_set_header        Referer                 https://profile.code.dev-theguardian.com;
+        ######
+        # remove `sid` cookie in requests to Okta
+        # save original "Cookie" header value
+        set $altered_cookie $http_cookie;
+        # check if the "sid" cookie is present
+        if ($http_cookie ~ '(.*)(^|;\s)sid=("[^"]*"|[^\s]*[^;]?)(\2|$|;$)(?:;\s)?(.*)') {
+          # cut "sid" cookie from the string
+          set $altered_cookie $1$4$5;
+        }
+        # hide original "Cookie" header
+        proxy_hide_header Cookie;
+        # set "Cookie" header to the new value
+        proxy_set_header  Cookie $altered_cookie;
+        ######
         # rewrite any domain in the response to our proxy
         proxy_set_header        Accept-Encoding "";
         sub_filter_types        application/json;

--- a/src/server/lib/__tests__/okta/api/sessions.test.ts
+++ b/src/server/lib/__tests__/okta/api/sessions.test.ts
@@ -27,31 +27,12 @@ describe('okta#signOutUser', () => {
 		jest.clearAllMocks();
 	});
 
-	test('should sign out a user given a current valid session - Okta Identity Classic (`sid` cookie)', async () => {
-		const sessionData = {
-			id: '123',
-			login: 'email@example.com',
-			userId: '123',
-			expiresAt: '2016-01-03T09:13:17.000Z',
-			status: 'ACTIVE',
-			lastPasswordVerification: '2016-01-03T07:02:00.000Z',
-		};
-
-		json.mockResolvedValueOnce(sessionData);
-		mockedFetch.mockReturnValueOnce(
-			Promise.resolve({ ok: true, status: 200, json } as Response),
-		);
-
-		const sessionResponse = await getCurrentSession({ sid: sessionId });
-		expect(sessionResponse).toEqual(sessionData);
-	});
-
-	test('should throw an error after invalid session response from Okta', async () => {
+	test('should throw an error after invalid session response from Okta - Okta Identity Engine (`idx` cookie)', async () => {
 		mockedFetch.mockReturnValueOnce(
 			Promise.resolve({ ok: false, status: 404 } as Response),
 		);
 
-		await expect(getCurrentSession({ sid: sessionId })).rejects.toThrowError(
+		await expect(getCurrentSession({ idx: sessionId })).rejects.toThrowError(
 			new OktaError({ message: 'Could not parse Okta error response' }),
 		);
 	});
@@ -71,49 +52,7 @@ describe('okta#signOutUser', () => {
 			Promise.resolve({ ok: true, status: 200, json } as Response),
 		);
 
-		const sessionResponse = await getCurrentSession({ sid: sessionId });
+		const sessionResponse = await getCurrentSession({ idx: sessionId });
 		expect(sessionResponse).toEqual(sessionData);
-	});
-
-	test('should throw an error after invalid session response from Okta', async () => {
-		mockedFetch.mockReturnValueOnce(
-			Promise.resolve({ ok: false, status: 404 } as Response),
-		);
-
-		await expect(getCurrentSession({ sid: sessionId })).rejects.toThrowError(
-			new OktaError({ message: 'Could not parse Okta error response' }),
-		);
-	});
-
-	test('should sign out a user given a current valid session - `idx` cookie & `sid` cookie', async () => {
-		const sessionData = {
-			id: '123',
-			login: 'email@example.com',
-			userId: '123',
-			expiresAt: '2016-01-03T09:13:17.000Z',
-			status: 'ACTIVE',
-			lastPasswordVerification: '2016-01-03T07:02:00.000Z',
-		};
-
-		json.mockResolvedValueOnce(sessionData);
-		mockedFetch.mockReturnValueOnce(
-			Promise.resolve({ ok: true, status: 200, json } as Response),
-		);
-
-		const sessionResponse = await getCurrentSession({
-			sid: sessionId,
-			idx: sessionId,
-		});
-		expect(sessionResponse).toEqual(sessionData);
-	});
-
-	test('should throw an error after invalid session response from Okta', async () => {
-		mockedFetch.mockReturnValueOnce(
-			Promise.resolve({ ok: false, status: 404 } as Response),
-		);
-
-		await expect(getCurrentSession({ sid: sessionId })).rejects.toThrowError(
-			new OktaError({ message: 'Could not parse Okta error response' }),
-		);
 	});
 });

--- a/src/server/lib/middleware/login.ts
+++ b/src/server/lib/middleware/login.ts
@@ -47,10 +47,8 @@ export const loginMiddlewareOAuth = async (
 		// Okta Identity Engine session cookie is called `idx`
 		const oktaIdentityEngineSessionCookieId: string | undefined =
 			req.cookies.idx;
-		// Okta Classic session cookie is called `sid`
-		const oktaClassicSessionCookieId: string | undefined = req.cookies.sid;
 
-		if (!oktaIdentityEngineSessionCookieId && !oktaClassicSessionCookieId) {
+		if (!oktaIdentityEngineSessionCookieId) {
 			// if there is no okta session cookie, go to the catch block
 			throw new Error('No Okta session cookie');
 		}
@@ -58,7 +56,6 @@ export const loginMiddlewareOAuth = async (
 		// if there is an okta session cookie, check if it is valid, if not `getSession` will throw an error
 		await getCurrentSession({
 			idx: oktaIdentityEngineSessionCookieId,
-			sid: oktaClassicSessionCookieId,
 		});
 	} catch (error) {
 		trackMetric('LoginMiddlewareOAuth::NoOktaSession');
@@ -133,9 +130,6 @@ export const loginMiddlewareOAuth = async (
 	} else {
 		trackMetric('LoginMiddlewareOAuth::NoOAuthTokens');
 	}
-
-	// no: check if the user has a `sid` cookie which is the Okta session cookie
-	// we can use this to check if the user is probably logged in
 
 	// no: attempt to do auth code flow to get new tokens
 	// perform the auth code flow

--- a/src/server/lib/middleware/rateLimit.ts
+++ b/src/server/lib/middleware/rateLimit.ts
@@ -57,7 +57,7 @@ export const rateLimiterMiddleware = async (
 
 	// If Okta is enabled, rate limit based on the Okta identifier.
 	const { useIdapi } = res.locals.queryParams;
-	const oktaSessionCookieId: string | undefined = req.cookies.sid;
+	const oktaSessionCookieId: string | undefined = req.cookies.idx;
 	const isOktaInUse = okta.enabled && !useIdapi && oktaSessionCookieId;
 
 	const rateLimitData = {

--- a/src/server/lib/middleware/redirectIfLoggedIn.ts
+++ b/src/server/lib/middleware/redirectIfLoggedIn.ts
@@ -27,18 +27,12 @@ export const redirectIfLoggedIn = async (
 
 	// Okta Identity Engine session cookie is called `idx`
 	const oktaIdentityEngineSessionCookieId: string | undefined = req.cookies.idx;
-	// Okta Classic session cookie is called `sid`
-	const oktaClassicSessionCookieId: string | undefined = req.cookies.sid;
 
 	const identitySessionCookie = req.cookies.SC_GU_U;
 	const identityLastAccessCookie = req.cookies.SC_GU_LA;
 
 	// Check if the user has an existing Okta session.
-	if (
-		okta.enabled &&
-		!useIdapi &&
-		(oktaIdentityEngineSessionCookieId || oktaClassicSessionCookieId)
-	) {
+	if (okta.enabled && !useIdapi && oktaIdentityEngineSessionCookieId) {
 		try {
 			// check if maxAge is set. If it is, the user last authenticated more than maxAge ago.
 			// This is automatically checked by Okta during the authorization code flow so we don't
@@ -56,7 +50,6 @@ export const redirectIfLoggedIn = async (
 			// (this throws if the session is invalid)
 			const session = await getCurrentSession({
 				idx: oktaIdentityEngineSessionCookieId,
-				sid: oktaClassicSessionCookieId,
 			});
 
 			// pull the user email from the session, which we need to display

--- a/src/server/lib/okta/api/sessions.ts
+++ b/src/server/lib/okta/api/sessions.ts
@@ -11,7 +11,6 @@ const { okta } = getConfiguration();
 /**
  * Get a User session by session cookie
  *
- * For Identity Classic the cookie is called `sid`
  * For Identity Engine the cookie is called `idx`
  *
  * https://developer.okta.com/docs/api/openapi/okta-management/management/tag/Session/#tag/Session/operation/getCurrentSession
@@ -22,19 +21,17 @@ const { okta } = getConfiguration();
  * We convert a successful API response to a Session response,
  * or throw an error on a failed response.
  *
- * @param sessionId Okta session ID
+ * @param idx Okta Identity Engine session cookie
  * @returns Promise<SessionResponse>
  */
 export const getCurrentSession = async ({
-	sid,
 	idx,
 }: {
-	sid?: string;
 	idx?: string;
 }): Promise<SessionResponse> => {
 	const path = buildUrl('/api/v1/sessions/me');
 
-	const Cookie = `${sid ? `sid=${sid};` : ''}${idx ? `idx=${idx};` : ''}`;
+	const Cookie = `${idx ? `idx=${idx};` : ''}`;
 
 	const response = await fetch(joinUrl(okta.orgUrl, path), {
 		headers: { ...defaultHeaders, Cookie },
@@ -57,7 +54,6 @@ export const getCurrentSession = async ({
 /**
  * Close a User session by session cookie
  *
- * For Identity Classic the cookie is called `sid`
  * For Identity Engine the cookie is called `idx`
  *
  * https://developer.okta.com/docs/api/openapi/okta-management/management/tag/Session/#tag/Session/operation/closeCurrentSession
@@ -65,20 +61,17 @@ export const getCurrentSession = async ({
  * The Okta API closes the users session on success or
  * returns a 404 on invalid.
  *
- * @param sid Okta Identity Classic session cookie
  * @param idx Okta Identity Engine session cookie
  * @returns Promise<void>
  */
 export const closeCurrentSession = async ({
-	sid,
 	idx,
 }: {
-	sid?: string;
 	idx?: string;
 }): Promise<undefined> => {
 	const path = buildUrl('/api/v1/sessions/me');
 
-	const Cookie = `${sid ? `sid=${sid};` : ''}${idx ? `idx=${idx};` : ''}`;
+	const Cookie = `${idx ? `idx=${idx};` : ''}`;
 
 	const response = await fetch(joinUrl(okta.orgUrl, path), {
 		method: 'DELETE',

--- a/src/server/lib/okta/oauth.ts
+++ b/src/server/lib/okta/oauth.ts
@@ -120,12 +120,9 @@ export const performAuthorizationCodeFlow = async (
 		// Okta Identity Engine session cookie is called `idx`
 		const oktaIdentityEngineSessionCookieId: string | undefined =
 			req.cookies.idx;
-		// Okta Classic session cookie is called `sid`
-		const oktaClassicSessionCookieId: string | undefined = req.cookies.sid; // clear existing okta session cookie if it exists
-		if (oktaIdentityEngineSessionCookieId || oktaClassicSessionCookieId) {
+		if (oktaIdentityEngineSessionCookieId) {
 			await closeCurrentSession({
 				idx: oktaIdentityEngineSessionCookieId,
-				sid: oktaClassicSessionCookieId,
 			});
 		}
 	}

--- a/src/server/routes/signIn.ts
+++ b/src/server/routes/signIn.ts
@@ -356,23 +356,20 @@ const oktaSignInController = async ({
 
 	// Okta Identity Engine session cookie is called `idx`
 	const oktaIdentityEngineSessionCookieId: string | undefined = req.cookies.idx;
-	// Okta Classic session cookie is called `sid`
-	const oktaClassicSessionCookieId: string | undefined = req.cookies.sid;
 
 	if (!isReauthenticate) {
 		try {
-			if (oktaIdentityEngineSessionCookieId || oktaClassicSessionCookieId) {
+			if (oktaIdentityEngineSessionCookieId) {
 				// if a session already exists then we redirect back to the returnUrl for apps, and the dotcom homepage for web
 				await getCurrentSession({
 					idx: oktaIdentityEngineSessionCookieId,
-					sid: oktaClassicSessionCookieId,
 				});
 				return res.redirect(accountManagementUrl);
 			}
 		} catch {
 			// We log this scenario as it is quite unlikely, but we continue to sign the user in.
 			logger.info(
-				'User POSTed to /signin with an invalid `sid` session cookie',
+				'User POSTed to /signin with an invalid `idx` session cookie',
 				undefined,
 				{ request_id: res.locals.requestId },
 			);
@@ -506,23 +503,17 @@ router.get(
 		// Okta Identity Engine session cookie is called `idx`
 		const oktaIdentityEngineSessionCookieId: string | undefined =
 			req.cookies.idx;
-		// Okta Classic session cookie is called `sid`
-		const oktaClassicSessionCookieId: string | undefined = req.cookies.sid;
 		const identitySessionCookie = req.cookies.SC_GU_U;
 
 		const redirectUrl = returnUrl || defaultReturnUri;
 
 		// Check if the user has an existing Okta session.
-		if (
-			okta.enabled &&
-			(oktaIdentityEngineSessionCookieId || oktaClassicSessionCookieId)
-		) {
+		if (okta.enabled && oktaIdentityEngineSessionCookieId) {
 			try {
 				// If the user session is valid, we re-authenticate them, supplying
-				// the SID cookie value to Okta.
+				// the idx cookie value to Okta.
 				await getCurrentSession({
 					idx: oktaIdentityEngineSessionCookieId,
-					sid: oktaClassicSessionCookieId,
 				});
 				return performAuthorizationCodeFlow(req, res, {
 					doNotSetLastAccessCookie: true,

--- a/src/server/routes/signOut.ts
+++ b/src/server/routes/signOut.ts
@@ -62,7 +62,7 @@ const clearDotComCookies = (res: ResponseWithRequestState) => {
 export const clearOktaCookies = (res: ResponseWithRequestState) => {
 	// We do not set a domain attribute as doing this makes the hostOnly=false
 	// and when the cookie is set by Okta, they do not specify a domain in the set-cookie header,
-	// so the Okta sid cookie is consider hostOnly=true
+	// so the Okta /idx cookie is considered hostOnly=true
 	// https://www.appsecmonkey.com/blog/cookie-security#hostonly-property
 	res.cookie(OKTA_IDENTITY_CLASSIC_SESSION_COOKIE_NAME, '', {
 		maxAge: 0,


### PR DESCRIPTION
## What does this change?

Remove the Okta `sid` cookie, which was the legacy session cookie in Okta Identity Classic, and only rely on the new Okta Identity Engine `idx` cookie to determine if a session is available for the user.

In cypress nginx config, no longer send the `sid` cookies in requests to the application, thus making sure we and Okta APIs only rely on the `idx` cookie.

# Why?

When we upgraded to Okta Identity Engine on PROD, we have an issue with existing Okta Identity Classic sessions not being transferred to the new Okta Identity Engine sessions, for as yet unknown reasons. While we're in contact with Okta support, we're prepping for the situation where we want to sign users out gradually and get them to log in again, thus getting a new session in Identity Engine.

The other reason is that now that we're in Identity Engine, we only really want to rely on a single session identifier, and avoid confusion with having 2 session cookies, so only rely on the `idx` cookie going forward. 

In both scenarios, users who only have a `sid` cookie will silently be logged out over a period of 90 days (our max session length) as we no longer refresh sessions for those users. Therefore overtime users will have to log in again in order to get a session set. Once they've logged in again, session refreshing will work as expected as the `idx` cookie will be used to refresh the session.

# Tested
- [x] CODE

- The `sid` cookie is ignored if it's already set, so behaves as if no `sid` cookie
- Going to `/signin/refresh` if you have a `sid` cookie and identity cookies does nothing (i.e doesn't set new cookies), so the user will eventually get logged out
- If `idx` cookie set, then refresh works as expected, `idx` cookie is set, `sid` cookie not set, identity cookies are refreshed

# Related PR

- Removing `sid` cookie from Fastly and Nginx configuration: https://github.com/guardian/identity-platform/pull/688
  - This has to go in at the same time as this PR