### PR TITLE
Change name and description for `events` consent

### DIFF
--- a/cypress/support/idapi/consent.ts
+++ b/cypress/support/idapi/consent.ts
@@ -75,9 +75,9 @@ export const allConsents = [
 		id: 'events',
 		isOptOut: false,
 		isChannel: false,
-		name: 'Events & Masterclasses',
+		name: 'Guardian Live events',
 		description:
-			'Learn from leading minds at our Guardian live events, including discussions and debates, short courses and bespoke training. Available in the UK, Aus and US.',
+			'Receive weekly newsletters about our new livestreamed and interactive events that you can access from wherever you are in the world.',
 	},
 	{
 		id: 'personalised_advertising',

--- a/cypress/support/pages/onboarding/newsletters_page.ts
+++ b/cypress/support/pages/onboarding/newsletters_page.ts
@@ -18,7 +18,7 @@ class NewslettersPage extends OnboardingPage {
 			THIS_IS_EUROPE: 'This is Europe',
 		},
 		Consents: {
-			EVENTS: 'Events & Masterclasses',
+			EVENTS: 'Guardian Live events',
 		},
 	};
 	static checkboxWithTitle(title: string) {

--- a/src/client/pages/ConsentsNewsletters.stories.tsx
+++ b/src/client/pages/ConsentsNewsletters.stories.tsx
@@ -83,9 +83,9 @@ NewslettersAndEvents.args = {
 			type: 'consent' as const,
 			consent: {
 				id: 'events',
-				name: 'Events & Masterclasses',
+				name: 'Guardian Live events',
 				description:
-					'Receive weekly newsletters about our upcoming Live events and Masterclasses. Interact with leading minds and nourish your curiosity in our immersive online events, available worldwide.',
+					'Receive weekly newsletters about our new livestreamed and interactive events that you can access from wherever you are in the world.',
 			},
 		},
 	],


### PR DESCRIPTION
## What does this change?

In https://github.com/guardian/identity/pull/2476 we updated the consent name and description for the `events` consent. 

This PR in Gateway updates the tests and stories to use the new description.
