### PR TITLE
Fix `.git-blame-ignore-revs` commit from #2499

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -8,4 +8,4 @@
 
 # Rewrite files after dependecy updates 2023-12-11
 # https://github.com/guardian/gateway/pull/2499
-6fe497c82e6ffe2510a0247e20544f8a6df82a27
+1291ad2baf45f3e47414b07d22e4647b43836b8a


### PR DESCRIPTION
Merging https://github.com/guardian/gateway/pull/2499 into main caused the commit that updated the commit hash.

So this PR fixes the commit hash.

The commit to ignore: https://github.com/guardian/gateway/commit/1291ad2baf45f3e47414b07d22e4647b43836b8a

vs

The commit I thought I was going to ignore: https://github.com/guardian/gateway/pull/2499/commits/6fe497c82e6ffe2510a0247e20544f8a6df82a27