### PR TITLE
AWS Cloudformation | Replace launch configuration with launch template

### DIFF
--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -211,7 +211,9 @@ Resources:
   AutoScalingGroup:
     Type: AWS::AutoScaling::AutoScalingGroup
     Properties:
-      LaunchConfigurationName: !Ref LaunchConfig
+      LaunchTemplate:
+        LaunchTemplateId: !Ref LaunchTemplate
+        Version: !GetAtt 'LaunchTemplate.LatestVersionNumber'
       HealthCheckType: ELB
       HealthCheckGracePeriod: 300
       MinSize: !FindInMap [StageVariables, !Ref Stage, MinInstances]
@@ -232,48 +234,51 @@ Resources:
         - Key: Stage
           Value: !Ref Stage
           PropagateAtLaunch: true
-  LaunchConfig:
-    Type: AWS::AutoScaling::LaunchConfiguration
+  LaunchTemplate:
+    Type: AWS::EC2::LaunchTemplate
     Properties:
-      AssociatePublicIpAddress: false
-      ImageId: !Ref AMI
-      IamInstanceProfile: !Ref InstanceProfile
-      InstanceType: t4g.small
-      SecurityGroups:
-        - !Ref 'InstanceSecurityGroup'
-        - !Ref 'SshAccessSecurityGroup'
-      UserData:
-        Fn::Base64: !Sub
-          - |+
-            #!/bin/bash -ev
+      LaunchTemplateName: !Sub '${Stage}-${Stack}-${App}'
+      LaunchTemplateData:
+        ImageId: !Ref AMI
+        IamInstanceProfile:
+          Arn: !GetAtt 'InstanceProfile.Arn'
+        InstanceType: t4g.small
+        KeyName: !Ref KeyName
+        SecurityGroupIds:
+          - !Ref InstanceSecurityGroup
+          - !Ref SshAccessSecurityGroup
+        UserData:
+          Fn::Base64: !Sub
+            - |+
+              #!/bin/bash -ev
 
-            mkdir /etc/gu
+              mkdir /etc/gu
 
-            # Get Riff Raff deployed artefact S3
-            aws s3 cp s3://${IdentityArtifactBucket}/${Stage}/${App}/${App}.zip /etc/gu
-            unzip -o /etc/gu/${App}.zip -d /etc/gu
+              # Get Riff Raff deployed artefact S3
+              aws s3 cp s3://${IdentityArtifactBucket}/${Stage}/${App}/${App}.zip /etc/gu
+              unzip -o /etc/gu/${App}.zip -d /etc/gu
 
-            # Get Rate Limiter configuration file
-            # Try multiple times to the config file. The s3 cp command can fail when called immediately on instance startup.
-            while true; do
-              if \
-                aws s3 cp s3://${IdentityConfigBucket}/${Stage}/${App}/.ratelimit.json /etc/gu/.ratelimit.json
-                then break
-              fi
-              sleep 1
-            done
+              # Get Rate Limiter configuration file
+              # Try multiple times to the config file. The s3 cp command can fail when called immediately on instance startup.
+              while true; do
+                if \
+                  aws s3 cp s3://${IdentityConfigBucket}/${Stage}/${App}/.ratelimit.json /etc/gu/.ratelimit.json
+                  then break
+                fi
+                sleep 1
+              done
 
-            # Setup user
-            groupadd identity-gateway
-            useradd -r -s /usr/bin/nologin -g identity-gateway identity-gateway
-            chown -R identity-gateway:identity-gateway /etc/gu
+              # Setup user
+              groupadd identity-gateway
+              useradd -r -s /usr/bin/nologin -g identity-gateway identity-gateway
+              chown -R identity-gateway:identity-gateway /etc/gu
 
-            # Setup logs
-            touch /var/log/identity-gateway.log
-            chown identity-gateway:identity-gateway /var/log/identity-gateway.log
+              # Setup logs
+              touch /var/log/identity-gateway.log
+              chown identity-gateway:identity-gateway /var/log/identity-gateway.log
 
-            # Try multiple times to get parameter store values. The SSM command can fail when called immediately on instance startup.
-            while true; do
+              # Try multiple times to get parameter store values. The SSM command can fail when called immediately on instance startup.
+              while true; do
                 if \
                   IDAPI_CLIENT_ACCESS_TOKEN=$(aws ssm get-parameter --name '/${Stack}/${App}/${Stage}/idapi-client-access-token' --with-decryption --region eu-west-1 --query="Parameter.Value" --output="text") && \
                   APP_SECRET=$(aws ssm get-parameter --name '/${Stack}/${App}/${Stage}/appSecret' --with-decryption --region eu-west-1 --query="Parameter.Value" --output="text") && \
@@ -290,66 +295,64 @@ Resources:
                   OKTA_GUARDIAN_USERS_ALL_GROUP_ID=$(aws ssm get-parameter --name '/${Stack}/${App}/${Stage}/oktaGuardianUsersAllGroupId' --with-decryption --region eu-west-1 --query="Parameter.Value" --output="text")
                   DELETE_ACCOUNT_STEP_FUNCTION_URL=$(aws ssm get-parameter --name '/${Stack}/${App}/${Stage}/deleteAccountStepFunctionUrl' --with-decryption --region eu-west-1 --query="Parameter.Value" --output="text")
                   DELETE_ACCOUNT_STEP_FUNCTION_API_KEY=$(aws ssm get-parameter --name '/${Stack}/${App}/${Stage}/deleteAccountStepFunctionApiKey' --with-decryption --region eu-west-1 --query="Parameter.Value" --output="text")
-
                   then break
                 fi
 
                 sleep 1
-            done
+              done
 
+              # systemd setup
+              cat > /etc/systemd/system/identity-gateway.service <<EOL
+              [Service]
+              ExecStart=/bin/sh -ec '/usr/bin/node /etc/gu/server.js > /var/log/identity-gateway.log 2>&1'
+              Restart=always
+              StandardOutput=syslog
+              StandardError=syslog
+              SyslogIdentifier=identity-gateway
+              User=identity-gateway
+              Group=identity-gateway
+              Environment=NODE_ENV=production
+              Environment=PORT=9233
+              Environment=IDAPI_CLIENT_ACCESS_TOKEN=$IDAPI_CLIENT_ACCESS_TOKEN
+              Environment=IDAPI_BASE_URL=${IdapiBaseUrl}
+              Environment=SIGN_IN_PAGE_URL=${SignInPageUrl}
+              Environment=OAUTH_BASE_URL=${OauthBaseUrl}
+              Environment=BASE_URI=${BaseUri}
+              Environment=DEFAULT_RETURN_URI=${DefaultReturnUri}
+              Environment=STAGE=${Stage}
+              Environment=IS_HTTPS=true
+              Environment=APP_SECRET=$APP_SECRET
+              Environment=GOOGLE_RECAPTCHA_SITE_KEY=$GOOGLE_RECAPTCHA_SITE_KEY
+              Environment=GOOGLE_RECAPTCHA_SECRET_KEY=$GOOGLE_RECAPTCHA_SECRET_KEY
+              Environment=ENCRYPTION_SECRET_KEY=$ENCRYPTION_SECRET_KEY
+              Environment=OKTA_ORG_URL=${OktaOrgUrl}
+              Environment=OKTA_API_TOKEN=$OKTA_API_TOKEN
+              Environment=OKTA_CUSTOM_OAUTH_SERVER=$OKTA_CUSTOM_OAUTH_SERVER
+              Environment=OKTA_CLIENT_ID=$OKTA_CLIENT_ID
+              Environment=OKTA_CLIENT_SECRET=$OKTA_CLIENT_SECRET
+              Environment=OKTA_IDP_APPLE=$OKTA_IDP_APPLE
+              Environment=OKTA_IDP_GOOGLE=$OKTA_IDP_GOOGLE
+              Environment=OKTA_GUARDIAN_USERS_ALL_GROUP_ID=$OKTA_GUARDIAN_USERS_ALL_GROUP_ID            
+              Environment=LOGGING_KINESIS_STREAM=${KinesisStream}
+              Environment=EC2_INSTANCE_ID=$(curl -s http://169.254.169.254/latest/meta-data/instance-id)
+              Environment=SENTRY_DSN=${SentryDsn}
+              Environment=REDIS_PASSWORD=$REDIS_PASSWORD
+              Environment=REDIS_HOST=${RedisHost}
+              Environment=REDIS_SSL_ON=true
+              Environment=MEMBERS_DATA_API_URL=${MembersDataApiUrl}
+              Environment=DELETE_ACCOUNT_STEP_FUNCTION_URL=$DELETE_ACCOUNT_STEP_FUNCTION_URL
+              Environment=DELETE_ACCOUNT_STEP_FUNCTION_API_KEY=$DELETE_ACCOUNT_STEP_FUNCTION_API_KEY
 
-            # systemd setup
-            cat > /etc/systemd/system/identity-gateway.service <<EOL
-            [Service]
-            ExecStart=/bin/sh -ec '/usr/bin/node /etc/gu/server.js > /var/log/identity-gateway.log 2>&1'
-            Restart=always
-            StandardOutput=syslog
-            StandardError=syslog
-            SyslogIdentifier=identity-gateway
-            User=identity-gateway
-            Group=identity-gateway
-            Environment=NODE_ENV=production
-            Environment=PORT=9233
-            Environment=IDAPI_CLIENT_ACCESS_TOKEN=$IDAPI_CLIENT_ACCESS_TOKEN
-            Environment=IDAPI_BASE_URL=${IdapiBaseUrl}
-            Environment=SIGN_IN_PAGE_URL=${SignInPageUrl}
-            Environment=OAUTH_BASE_URL=${OauthBaseUrl}
-            Environment=BASE_URI=${BaseUri}
-            Environment=DEFAULT_RETURN_URI=${DefaultReturnUri}
-            Environment=STAGE=${Stage}
-            Environment=IS_HTTPS=true
-            Environment=APP_SECRET=$APP_SECRET
-            Environment=GOOGLE_RECAPTCHA_SITE_KEY=$GOOGLE_RECAPTCHA_SITE_KEY
-            Environment=GOOGLE_RECAPTCHA_SECRET_KEY=$GOOGLE_RECAPTCHA_SECRET_KEY
-            Environment=ENCRYPTION_SECRET_KEY=$ENCRYPTION_SECRET_KEY
-            Environment=OKTA_ORG_URL=${OktaOrgUrl}
-            Environment=OKTA_API_TOKEN=$OKTA_API_TOKEN
-            Environment=OKTA_CUSTOM_OAUTH_SERVER=$OKTA_CUSTOM_OAUTH_SERVER
-            Environment=OKTA_CLIENT_ID=$OKTA_CLIENT_ID
-            Environment=OKTA_CLIENT_SECRET=$OKTA_CLIENT_SECRET
-            Environment=OKTA_IDP_APPLE=$OKTA_IDP_APPLE
-            Environment=OKTA_IDP_GOOGLE=$OKTA_IDP_GOOGLE
-            Environment=OKTA_GUARDIAN_USERS_ALL_GROUP_ID=$OKTA_GUARDIAN_USERS_ALL_GROUP_ID            
-            Environment=LOGGING_KINESIS_STREAM=${KinesisStream}
-            Environment=EC2_INSTANCE_ID=$(curl -s http://169.254.169.254/latest/meta-data/instance-id)
-            Environment=SENTRY_DSN=${SentryDsn}
-            Environment=REDIS_PASSWORD=$REDIS_PASSWORD
-            Environment=REDIS_HOST=${RedisHost}
-            Environment=REDIS_SSL_ON=true
-            Environment=MEMBERS_DATA_API_URL=${MembersDataApiUrl}
-            Environment=DELETE_ACCOUNT_STEP_FUNCTION_URL=$DELETE_ACCOUNT_STEP_FUNCTION_URL
-            Environment=DELETE_ACCOUNT_STEP_FUNCTION_API_KEY=$DELETE_ACCOUNT_STEP_FUNCTION_API_KEY
+              [Install]
+              WantedBy=multi-user.target
+              EOL
 
-            [Install]
-            WantedBy=multi-user.target
-            EOL
+              systemctl enable identity-gateway
+              systemctl start identity-gateway
 
-            systemctl enable identity-gateway
-            systemctl start identity-gateway
-
-          - BaseUri: !FindInMap [StageVariables, !Ref Stage, BaseUri]
-            DefaultReturnUri:
-              !FindInMap [StageVariables, !Ref Stage, DefaultReturnUri]
+            - BaseUri: !FindInMap [StageVariables, !Ref Stage, BaseUri]
+              DefaultReturnUri:
+                !FindInMap [StageVariables, !Ref Stage, DefaultReturnUri]
 
   InstanceProfile:
     Type: AWS::IAM::InstanceProfile


### PR DESCRIPTION
## What does this change?

EC2 Auto Scaling no longer supports new EC2 features or new EC2 instance types released after December 31, 2022 through launch configurations. AWS recommended that you use launch templates to create new Auto Scaling groups and migrate any existing launch configurations to launch templates.

Migration guide: https://docs.aws.amazon.com/autoscaling/ec2/userguide/migrate-launch-configurations-with-cloudformation.html

This PR does just that. Mostly a straightforward migration just adding and renaming a few things in our CloudFormation.

## Tested
- [x] CODE -> made sure application deploys successfully, and main features still work