### PR TITLE
Delete Account | Fix set password flow

### DIFF
--- a/src/client/pages/DeleteAccountEmailPasswordValidation.tsx
+++ b/src/client/pages/DeleteAccountEmailPasswordValidation.tsx
@@ -16,7 +16,10 @@ export const DeleteAccountEmailPasswordValidation = ({
 	queryParams,
 }: DeleteAccountEmailPasswordVerificationProps) => {
 	return (
-		<MainLayout pageHeader="Delete your Guardian account">
+		<MainLayout
+			pageHeader="Delete your Guardian account"
+			errorOverride={queryParams.error_description}
+		>
 			{validationType === 'email' && (
 				<MainForm
 					formAction={buildUrlWithQueryParams(


### PR DESCRIPTION
## What does this change?

Fix the flow when the user doesn't have a password and needs to set one before they can delete their account.

Some users, such as social only users, don't have a password set on their account, this means that before they delete their account they have to set a password. However this flow was failing with no obvious error message.

https://github.com/guardian/gateway/assets/13315440/9bea5ae3-71f2-4b9c-8fdd-ea49da8406f4

This PR updates this by checking if the user has a password set or not. If they don't then make sure to set a temporary password before sending them the set password email.

https://github.com/guardian/gateway/assets/13315440/c10ee67f-7f94-4590-979a-23b2fd4f40aa

Also fix the error message not appearing if something were to fail:

![profile code dev-theguardian com_delete_error_description=Sorry%2C+something+went+wrong +Please+try+again ref=https%3A%2F%2Fprofile code dev-theguardian com%2Fdelete refViewId=lq6gld6fc6mv9gritxtb returnUrl=https%3A%2F%2Fmanage code dev-th](https://github.com/guardian/gateway/assets/13315440/333b3f08-3875-4ac6-8f81-f6f2af3efc67)

## Tested

- [x] CODE

