### PR TITLE
Add new ESLint rules to improve async code quality

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -15,7 +15,12 @@
 	"parserOptions": {
 		"ecmaFeatures": {
 			"jsx": true
-		}
+		},
+		"project": [
+			"./tsconfig.json",
+			"./cypress/tsconfig.json",
+			"./scripts/okta/tsconfig.json"
+		]
 	},
 	"plugins": ["functional"],
 	"rules": {
@@ -37,7 +42,10 @@
 		"prefer-const": "error",
 		"no-sequences": "error",
 		"no-console": "error",
-		"react/no-unknown-property": ["error", { "ignore": ["css"] }]
+		"react/no-unknown-property": ["error", { "ignore": ["css"] }],
+		"require-await": "error",
+		"@typescript-eslint/await-thenable": "error",
+		"@typescript-eslint/no-floating-promises": "error"
 	},
 	"overrides": [
 		{

--- a/cypress/support/commands/network.ts
+++ b/cypress/support/commands/network.ts
@@ -16,11 +16,11 @@ declare global {
  * @param options Option to toggle the offline state.
  */
 export const network = (options: { offline: boolean }) => {
-	Cypress.automation('remote:debugger:protocol', {
+	void Cypress.automation('remote:debugger:protocol', {
 		command: 'Network.enable',
 	});
 
-	Cypress.automation('remote:debugger:protocol', {
+	void Cypress.automation('remote:debugger:protocol', {
 		command: 'Network.emulateNetworkConditions',
 		params: {
 			offline: options.offline,

--- a/cypress/tsconfig.json
+++ b/cypress/tsconfig.json
@@ -15,5 +15,6 @@
 			"@/*": ["../src/*"]
 		}
 	},
-	"include": ["**/*.ts"]
+	"include": ["**/*.ts", "../cypress.config.ts"],
+	"exclude": []
 }

--- a/scripts/okta/tsconfig.json
+++ b/scripts/okta/tsconfig.json
@@ -10,8 +10,8 @@
 		"lib": ["ES2022", "DOM"],
 		"skipLibCheck": true,
 		"noEmit": true,
-		"removeComments": true,
-		"outFile": "./okta.js"
+		"removeComments": true
 	},
-	"files": ["okta-login.ts"]
+	"include": ["**/*"],
+	"exclude": []
 }

--- a/src/client/__tests__/EmailInput.test.tsx
+++ b/src/client/__tests__/EmailInput.test.tsx
@@ -19,7 +19,7 @@ const setup = () => {
 	};
 };
 
-test('errors with nothing submitted', async () => {
+test('errors with nothing submitted', () => {
 	const { emailInput, queryByText } = setup();
 	// Input empty text to trigger error
 	fireEvent.input(emailInput, { target: { value: '' } });
@@ -33,7 +33,7 @@ test('errors with nothing submitted', async () => {
 // test doesn't seem to work with @testing-library/preact
 // despite the fact that it works in the browser, cypress, and storybook
 // and used to work with @testing-library/react
-test.skip('errors with an invalid email', async () => {
+test.skip('errors with an invalid email', () => {
 	const { emailInput, queryByText } = setup();
 	// Input text and blur to trigger error
 	fireEvent.change(emailInput, { target: { value: 'invalid.email.com' } });
@@ -45,7 +45,7 @@ test.skip('errors with an invalid email', async () => {
 	expect(error).toBeInTheDocument();
 });
 
-test('does not error with a valid email', async () => {
+test('does not error with a valid email', () => {
 	const { emailInput, queryByText } = setup();
 	// Input text and blur to trigger error
 	fireEvent.change(emailInput, { target: { value: 'valid@email.com' } });
@@ -63,7 +63,7 @@ test('does not error with a valid email', async () => {
 // test doesn't seem to work with @testing-library/preact
 // despite the fact that it works in the browser, cypress, and storybook
 // and used to work with @testing-library/react
-test.skip('error is corrected once a valid email is submitted', async () => {
+test.skip('error is corrected once a valid email is submitted', () => {
 	const { emailInput, queryByText } = setup();
 	// Input text and blur to trigger error
 	fireEvent.change(emailInput, { target: { value: 'invalid.email.com' } });

--- a/src/client/__tests__/MainForm.test.tsx
+++ b/src/client/__tests__/MainForm.test.tsx
@@ -98,7 +98,7 @@ test('calls the form submit override method if defined', async () => {
 		expect(mockedSubmitOverride).toBeCalledTimes(0);
 	});
 
-	act(() => {
+	void act(() => {
 		fireEvent.click(submitButton);
 	});
 
@@ -120,7 +120,7 @@ test('disables the form submit button when disableOnSubmit is set', async () => 
 
 	expect(submitButton).not.toBeDisabled();
 
-	act(() => {
+	void act(() => {
 		fireEvent.click(submitButton);
 	});
 
@@ -142,7 +142,7 @@ test('enables the form submit button when onSubmit returns an error state', asyn
 
 	expect(submitButton).not.toBeDisabled();
 
-	act(() => {
+	void act(() => {
 		fireEvent.click(submitButton);
 	});
 
@@ -206,7 +206,7 @@ test('sets error message and context and prevents form submission when the reCAP
 
 	expect(submitButton).not.toBeDisabled();
 
-	act(() => {
+	void act(() => {
 		fireEvent.click(submitButton);
 	});
 
@@ -232,7 +232,7 @@ test('sets error message and context and prevents form submission when the reCAP
 		expect(setRecaptchaErrorContext).not.toBeCalled();
 	});
 
-	act(() => {
+	void act(() => {
 		fireEvent.click(submitButton);
 	});
 
@@ -304,7 +304,7 @@ test('submits the form when the reCAPTCHA validation check is successful', async
 
 	const submitButton = await findByText('Submit');
 
-	act(() => {
+	void act(() => {
 		fireEvent.click(submitButton);
 	});
 

--- a/src/client/components/PasswordForm.tsx
+++ b/src/client/components/PasswordForm.tsx
@@ -305,7 +305,7 @@ export const PasswordForm = ({
 			// Only make api calls to check if breached when length rules are not broken
 			setIsChecking(true);
 			if (cryptoSubtleFeatureTest(browserName)) {
-				isBreached(password).then((breached) => {
+				void isBreached(password).then((breached) => {
 					if (breached) {
 						// Password is breached ❌
 						setIsWeak(true);
@@ -433,7 +433,7 @@ export const PasswordFormMainLayout = ({
 			// Only make api calls to check if breached when length rules are not broken
 			setIsChecking(true);
 			if (cryptoSubtleFeatureTest(browserName)) {
-				isBreached(password).then((breached) => {
+				void isBreached(password).then((breached) => {
 					if (breached) {
 						// Password is breached ❌
 						setIsWeak(true);

--- a/src/client/lib/hooks/__tests__/useRecaptcha.test.tsx
+++ b/src/client/lib/hooks/__tests__/useRecaptcha.test.tsx
@@ -120,7 +120,7 @@ test('should receive a valid token back when the reCAPTCHA check is successful',
 	);
 
 	// Request a token from recaptcha.
-	act(() => {
+	void act(() => {
 		const captchaExecutionResult = result.current?.executeCaptcha();
 		expect(captchaExecutionResult).toBe(true);
 	});
@@ -138,9 +138,9 @@ test('should receive a valid token back when the reCAPTCHA check is successful',
 	windowSpy.mockRestore();
 });
 
-test('should not be able to execute a call to reCAPTCHA if the script has not loaded yet', async () => {
+test('should not be able to execute a call to reCAPTCHA if the script has not loaded yet', () => {
 	// Begin test.
-	await act(async () => {
+	void act(async () => {
 		const { result, waitFor } = renderHook(() =>
 			useRecaptcha('public-recaptcha-token', 'render-element'),
 		);
@@ -201,7 +201,7 @@ test('should receive an error back when the reCAPTCHA check is unsuccessful', as
 	);
 
 	// Request a token from recaptcha.
-	act(() => {
+	void act(() => {
 		result.current?.executeCaptcha();
 	});
 
@@ -394,7 +394,7 @@ test('should try again successfully after an unsuccessful reCAPTCHA check and re
 	);
 
 	// Request a token from recaptcha.
-	act(() => {
+	void act(() => {
 		result.current?.executeCaptcha();
 	});
 
@@ -423,7 +423,7 @@ test('should try again successfully after an unsuccessful reCAPTCHA check and re
 	}));
 
 	// Request a token from recaptcha.
-	act(() => {
+	void act(() => {
 		result.current?.executeCaptcha();
 	});
 

--- a/src/client/lib/hooks/__tests__/useRecaptcha.test.tsx
+++ b/src/client/lib/hooks/__tests__/useRecaptcha.test.tsx
@@ -325,7 +325,7 @@ test('should expect an error state when the Google reCAPTCHA script fails to loa
 	windowSpy.mockRestore();
 });
 
-test('should expect an error state when no siteToken is provided', async () => {
+test('should expect an error state when no siteToken is provided', () => {
 	renderHook(() =>
 		expect(() =>
 			useRecaptcha('', 'element-id'),
@@ -335,7 +335,7 @@ test('should expect an error state when no siteToken is provided', async () => {
 	);
 });
 
-test('should expect an error state when no renderElement is provided', async () => {
+test('should expect an error state when no renderElement is provided', () => {
 	renderHook(() =>
 		expect(() =>
 			useRecaptcha('valid-site-key', ''),

--- a/src/client/lib/hooks/useCmpConsent.ts
+++ b/src/client/lib/hooks/useCmpConsent.ts
@@ -13,7 +13,7 @@ export const useCmpConsent: () => boolean = () => {
 			const consentState: ConsentState = await onConsent();
 			setCmpConsent(consentState.canTarget); // canTarget if user has consented to all consents
 		};
-		checkCmpConsent();
+		void checkCmpConsent();
 	}, []);
 
 	return hasCmpConsent;

--- a/src/client/static/index.tsx
+++ b/src/client/static/index.tsx
@@ -24,7 +24,7 @@ if (!routingConfig.clientState.pageData?.isNativeApp) {
 	if (window.Cypress) {
 		cmp.init({ country: 'GB' }); // CI hosted on GithubActions runs in US by default
 	} else {
-		(async () => {
+		void (async () => {
 			const country = await getLocale();
 
 			if (country) {

--- a/src/server/controllers/changePassword.ts
+++ b/src/server/controllers/changePassword.ts
@@ -204,7 +204,7 @@ const changePasswordInOkta = async (
 		validatePasswordFieldForOkta(password);
 
 		// decrypt the recovery token
-		const decryptedRecoveryToken = await decryptOktaRecoveryToken({
+		const decryptedRecoveryToken = decryptOktaRecoveryToken({
 			encryptedToken: encryptedRecoveryToken,
 			request_id: res.locals.requestId,
 		});
@@ -264,7 +264,7 @@ const changePasswordInOkta = async (
 
 			// fire ophan component event if applicable
 			if (res.locals.queryParams.componentEventParams) {
-				sendOphanComponentEventFromQueryParamsServer(
+				void sendOphanComponentEventFromQueryParamsServer(
 					res.locals.queryParams.componentEventParams,
 					'SIGN_IN',
 					'web',

--- a/src/server/controllers/checkPasswordToken.ts
+++ b/src/server/controllers/checkPasswordToken.ts
@@ -153,7 +153,7 @@ export const checkTokenInOkta = async (
 
 	try {
 		// decrypt the recovery token
-		const decryptedRecoveryToken = await decryptOktaRecoveryToken({
+		const decryptedRecoveryToken = decryptOktaRecoveryToken({
 			encryptedToken: token,
 			request_id: res.locals.requestId,
 		});

--- a/src/server/lib/__tests__/deeplink/oktaRecoveryToken.test.ts
+++ b/src/server/lib/__tests__/deeplink/oktaRecoveryToken.test.ts
@@ -162,7 +162,7 @@ describe('encryptOktaRecoveryToken', () => {
 		});
 
 		const [decryptedToken, decryptedEncryptedRegistrationConsents] =
-			await decryptOktaRecoveryToken({ encryptedToken: output });
+			decryptOktaRecoveryToken({ encryptedToken: output });
 
 		expect(output).not.toBe(token);
 		expect(decryptedToken).toBe(token);
@@ -178,7 +178,7 @@ describe('encryptOktaRecoveryToken', () => {
 		});
 
 		const [decryptedToken, decryptedEncryptedRegistrationConsents] =
-			await decryptOktaRecoveryToken({ encryptedToken: output });
+			decryptOktaRecoveryToken({ encryptedToken: output });
 
 		expect(output).not.toBe(token);
 		expect(output).not.toBe(encryptedRegistrationConsents);
@@ -210,7 +210,7 @@ describe('encryptOktaRecoveryToken', () => {
 		});
 
 		const [decryptedToken, decryptedEncryptedRegistrationConsents] =
-			await decryptOktaRecoveryToken({ encryptedToken: output });
+			decryptOktaRecoveryToken({ encryptedToken: output });
 
 		expect(output.startsWith('al_')).toBe(true);
 		expect(output).not.toBe(token);
@@ -230,7 +230,7 @@ describe('decryptOktaRecoveryToken', () => {
 		});
 
 		const [decryptedToken, decryptedEncryptedRegistrationConsents] =
-			await decryptOktaRecoveryToken({ encryptedToken });
+			decryptOktaRecoveryToken({ encryptedToken });
 
 		expect(decryptedToken).toBe(token);
 		expect(decryptedEncryptedRegistrationConsents).toBeUndefined();
@@ -245,7 +245,7 @@ describe('decryptOktaRecoveryToken', () => {
 		});
 
 		const [decryptedToken, decryptedEncryptedRegistrationConsents] =
-			await decryptOktaRecoveryToken({ encryptedToken });
+			decryptOktaRecoveryToken({ encryptedToken });
 
 		expect(decryptedToken).toBe(token);
 		expect(decryptedEncryptedRegistrationConsents).toBe(
@@ -277,7 +277,7 @@ describe('decryptOktaRecoveryToken', () => {
 		expect(encryptedToken.startsWith('al_')).toBe(true);
 
 		const [decryptedToken, decryptedEncryptedRegistrationConsents] =
-			await decryptOktaRecoveryToken({ encryptedToken });
+			decryptOktaRecoveryToken({ encryptedToken });
 
 		expect(decryptedToken).toBe(token);
 		expect(decryptedEncryptedRegistrationConsents).toBe(
@@ -285,11 +285,11 @@ describe('decryptOktaRecoveryToken', () => {
 		);
 	});
 
-	it('should return token if decryption fails', async () => {
+	it('should return token if decryption fails', () => {
 		const token = 'token';
 
 		const [decryptedToken, decryptedEncryptedRegistrationConsents] =
-			await decryptOktaRecoveryToken({ encryptedToken: token });
+			decryptOktaRecoveryToken({ encryptedToken: token });
 
 		expect(decryptedToken).toBe(token);
 		expect(decryptedEncryptedRegistrationConsents).toBeUndefined();

--- a/src/server/lib/__tests__/rate-limit/rateLimit.test.ts
+++ b/src/server/lib/__tests__/rate-limit/rateLimit.test.ts
@@ -27,7 +27,7 @@ describe('rateLimit', () => {
 	afterEach((done) => {
 		// in-memory redis store is persisted after each run
 		// make sure to clear the store after each test
-		new Redis().flushall().then(() => done());
+		void new Redis().flushall().then(() => done());
 	});
 
 	afterAll(() => {

--- a/src/server/lib/__tests__/rate-limit/rateLimitMiddleware.test.ts
+++ b/src/server/lib/__tests__/rate-limit/rateLimitMiddleware.test.ts
@@ -70,7 +70,7 @@ describe('rate limiter middleware', () => {
 	afterEach((done) => {
 		// in-memory redis store is persisted after each run
 		// make sure to clear the store after each test
-		new Redis().flushall().then(() => done());
+		void new Redis().flushall().then(() => done());
 	});
 
 	afterAll(() => {

--- a/src/server/lib/__tests__/rate-limit/rateLimitMiddleware.test.ts
+++ b/src/server/lib/__tests__/rate-limit/rateLimitMiddleware.test.ts
@@ -32,7 +32,7 @@ describe('rate limiter middleware', () => {
 		jest.mock('@/server/lib/idapi/guest');
 		jest.mock('@/server/lib/idapi/decryptToken');
 		jest.mock('@/server/lib/idapi/auth', () => ({
-			authenticate: async () => ({
+			authenticate: () => ({
 				values: [],
 			}),
 		}));

--- a/src/server/lib/deeplink/oktaRecoveryToken.ts
+++ b/src/server/lib/deeplink/oktaRecoveryToken.ts
@@ -158,9 +158,7 @@ export const decryptOktaRecoveryToken = ({
 }: {
 	encryptedToken: string;
 	request_id?: string;
-}): Promise<
-	[recoveryToken: string, encryptedRegistrationConsents?: string]
-> => {
+}): [recoveryToken: string, encryptedRegistrationConsents?: string] => {
 	try {
 		const token = extractOktaRecoveryToken(encryptedToken);
 

--- a/src/server/lib/deeplink/oktaRecoveryToken.ts
+++ b/src/server/lib/deeplink/oktaRecoveryToken.ts
@@ -110,7 +110,7 @@ export const addAppPrefixToOktaRecoveryToken = async (
  * @param request_id string representing the request id
  * @returns string representing the encrypted recovery token
  */
-export const encryptOktaRecoveryToken = async ({
+export const encryptOktaRecoveryToken = ({
 	token,
 	encryptedRegistrationConsents,
 	appClientId,
@@ -152,7 +152,7 @@ export const encryptOktaRecoveryToken = async ({
  * @param request_id string representing the request id
  * @returns [string] representing the decrypted recovery token
  */
-export const decryptOktaRecoveryToken = async ({
+export const decryptOktaRecoveryToken = ({
 	encryptedToken,
 	request_id,
 }: {

--- a/src/server/lib/idapi/resetPassword.ts
+++ b/src/server/lib/idapi/resetPassword.ts
@@ -23,13 +23,13 @@ const handleError = ({ error, status = 500 }: IDAPIError) => {
 	throw new IdapiError({ message: ResetPasswordErrors.GENERIC, status });
 };
 
-export async function sendResetPasswordEmail(
+export const sendResetPasswordEmail = (
 	email: string,
 	ip: string,
 	returnUrl: string,
 	ref?: string,
 	refViewId?: string,
-) {
+) => {
 	const options = APIPostOptions({
 		'email-address': email,
 		returnUrl,
@@ -40,4 +40,4 @@ export async function sendResetPasswordEmail(
 		options: APIAddClientAccessToken(options, ip),
 		queryParams: { returnUrl, ref, refViewId },
 	}).catch(handleError);
-}
+};

--- a/src/server/lib/okta/api/users.ts
+++ b/src/server/lib/okta/api/users.ts
@@ -98,7 +98,7 @@ export const updateUser = async (
  * @returns Promise<UserResponse>
  */
 
-export const getUser = async (id: string): Promise<UserResponse> => {
+export const getUser = (id: string): Promise<UserResponse> => {
 	const path = buildUrl('/api/v1/users/:id', { id });
 	return fetch(joinUrl(okta.orgUrl, path), {
 		headers: { ...defaultHeaders, ...authorizationHeader() },
@@ -116,7 +116,7 @@ export const getUser = async (id: string): Promise<UserResponse> => {
  * @returns Promise<Group[]>
  */
 
-export const getUserGroups = async (id: string): Promise<Group[]> => {
+export const getUserGroups = (id: string): Promise<Group[]> => {
 	const path = buildUrl('/api/v1/users/:id/groups', { id });
 	return fetch(joinUrl(okta.orgUrl, path), {
 		headers: { ...defaultHeaders, ...authorizationHeader() },

--- a/src/server/routes/agree.ts
+++ b/src/server/routes/agree.ts
@@ -86,7 +86,7 @@ const IDAPIAgreeGetController = async (
 	}
 };
 
-const OktaAgreeGetController = async (
+const OktaAgreeGetController = (
 	req: Request,
 	res: ResponseWithRequestState,
 ) => {

--- a/src/server/routes/magicLink.ts
+++ b/src/server/routes/magicLink.ts
@@ -6,7 +6,6 @@ import { logger } from '@/server/lib/serverSideLogger';
 import { renderer } from '@/server/lib/renderer';
 import { trackMetric } from '@/server/lib/trackMetric';
 import { ResponseWithRequestState } from '@/server/models/Express';
-import { handleAsyncErrors } from '@/server/lib/expressWrappers';
 import { ApiError } from '@/server/models/Error';
 import handleRecaptcha from '@/server/lib/recaptcha';
 import { mergeRequestState } from '@/server/lib/requestState';
@@ -22,7 +21,7 @@ router.get('/magic-link', (req: Request, res: ResponseWithRequestState) => {
 router.post(
 	'/magic-link',
 	handleRecaptcha,
-	handleAsyncErrors(async (req: Request, res: ResponseWithRequestState) => {
+	(req: Request, res: ResponseWithRequestState) => {
 		const state = res.locals;
 
 		const { email = '' } = req.body;
@@ -54,7 +53,7 @@ router.post(
 		trackMetric('SendMagicLink::Success');
 
 		return res.redirect(303, buildUrl('/magic-link/email-sent'));
-	}),
+	},
 );
 
 router.get(

--- a/src/server/routes/oauth.ts
+++ b/src/server/routes/oauth.ts
@@ -191,7 +191,7 @@ const authenticationHandler = async (
 
 		// Apply the registration consents if they exist
 		if (authState.data?.encryptedRegistrationConsents) {
-			const decryptedConsents = await decryptRegistrationConsents(
+			const decryptedConsents = decryptRegistrationConsents(
 				authState.data.encryptedRegistrationConsents,
 			);
 			if (decryptedConsents && decryptedConsents.consents) {

--- a/src/server/routes/register.ts
+++ b/src/server/routes/register.ts
@@ -163,7 +163,7 @@ const OktaRegistration = async (
 
 		// fire ophan component event if applicable
 		if (res.locals.queryParams.componentEventParams) {
-			sendOphanComponentEventFromQueryParamsServer(
+			void sendOphanComponentEventFromQueryParamsServer(
 				res.locals.queryParams.componentEventParams,
 				'CREATE_ACCOUNT',
 				'web',

--- a/src/server/routes/signIn.ts
+++ b/src/server/routes/signIn.ts
@@ -398,7 +398,7 @@ const oktaSignInController = async ({
 
 		// fire ophan component event if applicable when a session is set
 		if (res.locals.queryParams.componentEventParams) {
-			sendOphanComponentEventFromQueryParamsServer(
+			void sendOphanComponentEventFromQueryParamsServer(
 				res.locals.queryParams.componentEventParams,
 				'SIGN_IN',
 				'web',
@@ -555,7 +555,7 @@ router.get(
 
 			// fire ophan component event if applicable when a session is set
 			if (res.locals.queryParams.componentEventParams) {
-				sendOphanComponentEventFromQueryParamsServer(
+				void sendOphanComponentEventFromQueryParamsServer(
 					res.locals.queryParams.componentEventParams,
 					'SIGN_IN',
 					req.params.social,

--- a/src/server/routes/signOut.ts
+++ b/src/server/routes/signOut.ts
@@ -98,10 +98,7 @@ export const sharedSignOutHandler = (
  * @name signOutFromIDAPILocal
  * @description Clear identity session and cookies from the current device/browser the user used to call this endpoint
  */
-const signOutFromIDAPILocal = async (
-	_: Request,
-	res: ResponseWithRequestState,
-): Promise<void> => {
+const signOutFromIDAPILocal = (_: Request, res: ResponseWithRequestState) => {
 	// sign out from idapi will invalidate ALL IDAPI sessions for the user no matter the device/browser
 	// so we've changed from using the IDAPI sign out endpoint to just clearing the IDAPI cookies
 	// so that the user is only signed out from the current device/browser
@@ -222,7 +219,7 @@ router.get(
 		// if the user has no Okta sid cookie, we will then try and log them out from IDAPI
 		// the user will be in this state if they previously had their Okta cookie removed and got
 		// redirected back to the /signout endpoint
-		await signOutFromIDAPILocal(req, res);
+		signOutFromIDAPILocal(req, res);
 
 		// clear other cookies
 		sharedSignOutHandler(req, res);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,5 +18,5 @@
 		"lib": ["ES2022", "DOM"],
 		"importHelpers": true
 	},
-	"include": ["src"]
+	"include": ["src", "scripts/generate-rate-limit-schema.ts"]
 }


### PR DESCRIPTION
## What does this change?

- Adds three new ESLint rules:
  - `require-await`: Disallow async functions which have no `await` expression inside the function body, i.e. that are marked `async` but... aren't
  - `@typescript-eslint/await-thenable`: Disallow awaiting a value that is not a Thenable, i.e. prevent putting `await` in front of functions that aren't `async`
  - `@typescript-eslint/no-floating-promises`: Require Promise-like statements to be handled appropriately, i.e. the best one, prevent calling functions that _are_ `async` without either a `void` or `await` keyword. In JS, an async function called without `await` or a `.then()` just returns a `Promise`, which is valid but usually very unhelpful.

This trio of rules will catch a host of easily made but potentially hard-to-debug mistakes. In the first instance, they've already caught a bunch of uses of unnecessary `async`s and `await`s.

To make these rules work, we've also updated the ESLint config to properly handle our _three_ `tsconfig.json` files, and updated those files to cover all of the TS files that ESLint lints.