### PR TITLE
Fix Sign Out / Sign In issue

### DIFF
--- a/src/server/lib/idapi/IDAPICookies.ts
+++ b/src/server/lib/idapi/IDAPICookies.ts
@@ -89,7 +89,3 @@ export const setSignOutCookie = (res: Response) => {
 		},
 	);
 };
-
-export const clearSignOutCookie = (res: Response) => {
-	res.clearCookie('GU_SO', sharedCookieOptions('GU_SO'));
-};

--- a/src/server/lib/middleware/login.ts
+++ b/src/server/lib/middleware/login.ts
@@ -73,26 +73,8 @@ export const loginMiddlewareOAuth = async (
 		);
 	}
 
-	// if a user has the GU_SO cookie, they have recently signed out
-	// so we need to clear any existing tokens
-	// and perform the auth code flow to get new tokens
-	// and log the user in if necessary
-	if (req.cookies.GU_SO) {
-		trackMetric('LoginMiddlewareOAuth::SignedOutCookie');
-
-		// clear existing tokens
-		checkAndDeleteOAuthTokenCookies(req, res);
-
-		// perform the auth code flow
-		return performAuthorizationCodeFlow(req, res, {
-			redirectUri: ProfileOpenIdClientRedirectUris.APPLICATION,
-			scopes: scopesForApplication,
-			confirmationPagePath: req.path as RoutePaths, //req.path will always be a RoutePaths
-		});
-	}
-
-	// no
-	// 2. has valid oauth access and id tokens
+	// 1. Check if the reader has a valid access token and id token.
+	// This does not mean that the current reader is definitely signed in, so we have to perform additional checks.
 	const accessTokenCookie = getOAuthTokenCookie(req, 'GU_ACCESS_TOKEN');
 	const idTokenCookie = getOAuthTokenCookie(req, 'GU_ID_TOKEN');
 
@@ -101,7 +83,6 @@ export const loginMiddlewareOAuth = async (
 		const accessToken = await verifyAccessToken(accessTokenCookie);
 		const idToken = await verifyIdToken(idTokenCookie);
 
-		// yes: isLoggedIn = true, no need to get new tokens
 		if (
 			// check access token is valid
 			accessToken &&
@@ -114,6 +95,39 @@ export const loginMiddlewareOAuth = async (
 				scopesForApplication.includes(scope as Scopes),
 			)
 		) {
+			// valid tokens at this point
+			// 2. Check if the user has the `GU_SO` cookie
+			if (req.cookies.GU_SO) {
+				// if the user has a `GU_SO` cookie, compare the value to the `iat` claim in the access and id tokens
+				// if the `GU_SO` cookie (lastSignOut) is newer than the tokens, the user has recently signed out and we need to clear the tokens
+				const lastSignOut = parseInt(req.cookies.GU_SO);
+				const accessTokenIat = accessToken.claims.iat;
+				const idTokenIat = idToken.claims.iat;
+
+				if (
+					// validate `iat`
+					typeof accessTokenIat === 'number' &&
+					typeof idTokenIat === 'number' &&
+					// check if lastSignOut is in the past
+					lastSignOut <= Math.floor(Date.now() / 1000) &&
+					// check if lastSignOut is newer than the tokens
+					(lastSignOut > accessTokenIat || lastSignOut > idTokenIat)
+				) {
+					trackMetric('LoginMiddlewareOAuth::SignedOutCookie');
+
+					// clear existing tokens
+					checkAndDeleteOAuthTokenCookies(req, res);
+
+					// perform the auth code flow
+					return performAuthorizationCodeFlow(req, res, {
+						redirectUri: ProfileOpenIdClientRedirectUris.APPLICATION,
+						scopes: scopesForApplication,
+						confirmationPagePath: req.path as RoutePaths, //req.path will always be a RoutePaths
+					});
+				}
+			}
+
+			// otherwise the user has not recently signed out, so we can continue
 			trackMetric('LoginMiddlewareOAuth::OAuthTokensValid');
 
 			// store the oauth state in res.locals state
@@ -127,8 +141,6 @@ export const loginMiddlewareOAuth = async (
 		} else {
 			trackMetric('LoginMiddlewareOAuth::OAuthTokensInvalid');
 		}
-	} else {
-		trackMetric('LoginMiddlewareOAuth::NoOAuthTokens');
 	}
 
 	// no: attempt to do auth code flow to get new tokens

--- a/src/server/routes/oauth.ts
+++ b/src/server/routes/oauth.ts
@@ -12,10 +12,7 @@ import { logger } from '@/server/lib/serverSideLogger';
 import { trackMetric } from '@/server/lib/trackMetric';
 import { handleAsyncErrors } from '@/server/lib/expressWrappers';
 import { exchangeAccessTokenForCookies } from '@/server/lib/idapi/auth';
-import {
-	clearSignOutCookie,
-	setIDAPICookies,
-} from '@/server/lib/idapi/IDAPICookies';
+import { setIDAPICookies } from '@/server/lib/idapi/IDAPICookies';
 import {
 	FederationErrors,
 	GenericErrors,
@@ -222,9 +219,6 @@ const authenticationHandler = async (
 			res,
 			requestId: res.locals.requestId,
 		});
-
-		// clear the sign out cookie if it exists
-		clearSignOutCookie(res);
 
 		// clear any existing oauth application cookies if they exist
 		checkAndDeleteOAuthTokenCookies(req, res);

--- a/src/server/routes/signIn.ts
+++ b/src/server/routes/signIn.ts
@@ -6,10 +6,7 @@ import { renderer } from '@/server/lib/renderer';
 import { ResponseWithRequestState } from '@/server/models/Express';
 import { trackMetric } from '@/server/lib/trackMetric';
 import { handleAsyncErrors } from '@/server/lib/expressWrappers';
-import {
-	clearSignOutCookie,
-	setIDAPICookies,
-} from '@/server/lib/idapi/IDAPICookies';
+import { setIDAPICookies } from '@/server/lib/idapi/IDAPICookies';
 import { getConfiguration } from '@/server/lib/getConfiguration';
 import { decrypt } from '@/server/lib/idapi/decryptToken';
 import {
@@ -292,7 +289,6 @@ const idapiSignInController = async (
 		// cookies to keep the sessions in sync
 		clearOktaCookies(res);
 		setIDAPICookies(res, cookies);
-		clearSignOutCookie(res);
 
 		trackMetric('SignIn::Success');
 


### PR DESCRIPTION
## The problem

The `GU_SO` cookie is set when the user signs out, which would tell applications to clear tokens if it exists when they come to check if a user is signed in.

However this cookie is cleared when a user signs in.

This can lead to a problem where if a user signs out, and then immediately signs in again, especially noticeable as a different user, and goes to an application like MMA, then it will appear that the user is signed in as the previous user if they were using MMA before, showing the data for the previous user.

## The solution

1. Check if valid access/id tokens exist, then check if the `GU_SO` cookie exist.
2. Check if the `iat` claim from the access/id token to the `GU_SO` cookie value.
3. If `iat` is after `GU_SO` then all is fine, the user signed in after the last sign out, if the `iat` < GU_SO then the tokens are invalid and for the previous session, so they should be cleared.
4. Make sure the `GU_SO` isn't cleared on sign in

## The PR

- Update the "Web Apps Integration Guide" with the new logic and flowchart
  - Moved to #2530
- Implement the new logic in `loginMiddlewareOAuth`
- Remove the `clearSignOutCookie` method

## Other changes

This logic needs to be replicated/changed in all user facing web applications, namely Gateway (here), MMA, dotcom (through [`identity-auth`](https://github.com/guardian/csnx/tree/main/libs/%40guardian/identity-auth)), and support.

## Tested

- [x] CODE
    - Signed out of an account first to set the `GU_SO` cookie
    - Signed into a new account
    - Visited `/consents` page to get a `GU_ACCESS_TOKEN` and `GU_ID_TOKEN` cookie set
    - Manually modified the `GU_SO` cookie value to be after the `iat` claim of the other two
    - Refreshed the page. Noticed that it did the authorization code flow again to get new tokens with `iat` claims set after the `GU_SO` cookie
    - Refreshed the page again, now with the new `iat` claims after the `GU_SO` cookie value, and no authorization code flow was performed, which meant that the app used the existing tokens
    - **Success!**