### PR TITLE
Show "Subscription Confirmation" page when confirming consents

### DIFF
--- a/cypress/integration/ete/consent_token/consent_token.2.cy.ts
+++ b/cypress/integration/ete/consent_token/consent_token.2.cy.ts
@@ -1,5 +1,5 @@
 describe('Consent token flow', () => {
-	it('redirects to the success route when supplied a valid token by a logged in user', () => {
+	it('shows the success page when supplied a valid token by a logged in user', () => {
 		cy.createTestUser({
 			isUserEmailValidated: true,
 		}).then(({ emailAddress, cookies }) => {
@@ -24,12 +24,8 @@ describe('Consent token flow', () => {
 					cy.visit(`/consent-token/${token}/accept`, {
 						failOnStatusCode: false,
 					});
-					// /consents/thank-you isn't hosted by Gateway so all we need to check
-					// is that the cy.visit() redirected successfully, so intercept the request
-					// and return a 200
-					cy.intercept('GET', '/consents/thank-you', (req) => {
-						req.reply(200);
-					});
+					cy.contains('Subscribe Confirmation');
+					cy.url().should('include', '/subscribe/success');
 				});
 			});
 		});

--- a/src/server/routes/consentToken.ts
+++ b/src/server/routes/consentToken.ts
@@ -10,6 +10,7 @@ import {
 import { mergeRequestState } from '@/server/lib/requestState';
 import { logger } from '@/server/lib/serverSideLogger';
 import { trackMetric } from '@/server/lib/trackMetric';
+import { buildUrl } from '@/shared/lib/routeUtils';
 
 // This route is of this specific form because it's a direct copy of the legacy
 // route in identity-frontend, and emails sent by IDAPI contain this URL.
@@ -25,9 +26,7 @@ router.get(
 
 			trackMetric('ConsentToken::Success');
 
-			// Redirect to /consents/thank-you (a page managed by Frontend). This is
-			// to retain the legacy behaviour of the route from identity-frontend.
-			return res.redirect(303, '/consents/thank-you?useIdapi=true');
+			return res.redirect(303, buildUrl('/subscribe/success'));
 		} catch (error) {
 			logger.error(`${req.method} ${req.originalUrl} Error`, error, {
 				request_id: res.locals.requestId,

--- a/src/server/routes/subscriptions.ts
+++ b/src/server/routes/subscriptions.ts
@@ -85,4 +85,21 @@ const handler = (action: SubscriptionAction) =>
 router.get('/unsubscribe/:emailType/:data/:token', handler('unsubscribe'));
 router.get('/subscribe/:emailType/:data/:token', handler('subscribe'));
 
+router.get(
+	'/subscribe/success',
+	(_: Request, res: ResponseWithRequestState) => {
+		// show the subscribe confirmation page
+		const html = renderer(`/subscribe/success`, {
+			requestState: mergeRequestState(res.locals, {
+				pageData: {
+					accountManagementUrl,
+				},
+			}),
+			pageTitle: `Subscribe Confirmation`,
+		});
+
+		return res.type('html').send(html);
+	},
+);
+
 export default router.router;


### PR DESCRIPTION
## What does this change?

Previously when a user was sent an email to confirm their subscription to a consent, they would click on a CTA and either be taken to the `/consents/thank-you` page, or the sign in page.

In either case the user consent was set in the database, but they would not see a confirmation if they were not logged in already, and be shown the sign in page instead, which isn't great UX.

The `/consents/thank-you` page is a legacy identity page on the [`guardian/frontend`](https://github.com/guardian/frontend) repo that hasn't been updated in years, we were planning on removing or changing this page at some point, but had not been prioritised.

So instead we decided on a small change to just show a "Subscription Confirmation" page when a user confirmed their consent, which is the same as the page that was set up in https://github.com/guardian/gateway/pull/2261 for newsletters.

This means that all users get a confirmation page regardless if logged in or not, and we have a link going to MMA that allows a user to manage their email communications!

https://github.com/guardian/gateway/assets/13315440/3a5175e3-0347-428a-9d61-d92ba56f7d95

## Tested

- [x] Cypress E2E
- [x] CODE