### PR TITLE
Skip onboarding flow if registration token has app prefix

### DIFF
--- a/cypress/integration/ete-okta/registration_1.2.cy.ts
+++ b/cypress/integration/ete-okta/registration_1.2.cy.ts
@@ -68,6 +68,9 @@ describe('Registration flow - Split 1/2', () => {
 		});
 
 		it('successfully registers using an email with no existing account, and has a prefixed activation token when using a native app', () => {
+			cy.intercept('GET', 'https://m.code.dev-theguardian.com/', (req) => {
+				req.reply(200);
+			});
 			const encodedReturnUrl =
 				'https%3A%2F%2Fm.code.dev-theguardian.com%2Ftravel%2F2019%2Fdec%2F18%2Ffood-culture-tour-bethlehem-palestine-east-jerusalem-photo-essay';
 			const unregisteredEmail = randomMailosaurEmail();
@@ -116,16 +119,20 @@ describe('Registration flow - Split 1/2', () => {
 				//we are reloading here to make sure the params are persisted even on page refresh
 				cy.reload();
 
+				cy.get('form')
+					.should('have.attr', 'action')
+					.and('match', new RegExp(encodedReturnUrl))
+					.and('match', new RegExp(refViewId))
+					.and('match', new RegExp(encodedRef))
+					.and('match', new RegExp(clientId))
+					.and('not.match', new RegExp(appClientId))
+					.and('not.match', new RegExp(fromURI));
+
 				cy.get('input[name="firstName"]').type('First Name');
 				cy.get('input[name="secondName"]').type('Last Name');
 				cy.get('input[name="password"]').type(randomPassword());
 				cy.get('button[type="submit"]').click();
-				cy.url().should('contain', encodedReturnUrl);
-				cy.url().should('contain', refViewId);
-				cy.url().should('contain', encodedRef);
-				cy.url().should('contain', clientId);
-				cy.url().should('not.contain', appClientId);
-				cy.url().should('not.contain', fromURI);
+				cy.url().should('contain', 'https://m.code.dev-theguardian.com/');
 			});
 		});
 

--- a/src/server/controllers/changePassword.ts
+++ b/src/server/controllers/changePassword.ts
@@ -38,7 +38,10 @@ import { sendOphanComponentEventFromQueryParamsServer } from '@/server/lib/ophan
 import { clearOktaCookies } from '@/server/routes/signOut';
 import { mergeRequestState } from '@/server/lib/requestState';
 import { ProfileOpenIdClientRedirectUris } from '@/server/lib/okta/openid-connect';
-import { decryptOktaRecoveryToken } from '@/server/lib/deeplink/oktaRecoveryToken';
+import {
+	decryptOktaRecoveryToken,
+	hasAppPrefix,
+} from '@/server/lib/deeplink/oktaRecoveryToken';
 import { changePasswordMetric } from '@/server/models/Metrics';
 
 const { okta } = getConfiguration();
@@ -283,6 +286,7 @@ const changePasswordInOkta = async (
 				redirectUri: ProfileOpenIdClientRedirectUris.AUTHENTICATION,
 				extraData: {
 					encryptedRegistrationConsents,
+					hasAppPrefix: hasAppPrefix(encryptedRecoveryToken),
 				},
 			});
 		} else {

--- a/src/server/lib/deeplink/oktaRecoveryToken.ts
+++ b/src/server/lib/deeplink/oktaRecoveryToken.ts
@@ -31,6 +31,16 @@ const appPrefixes = [
 type AppPrefix = (typeof appPrefixes)[number];
 
 /**
+ * @name hasAppPrefix
+ * @description To check if a string has a prefix representing an native application.
+ *
+ * @param token	- string that may or may not have a prefix representing an native application
+ * @returns	- boolean representing if the string has a prefix representing an native application
+ */
+export const hasAppPrefix = (token: string): boolean =>
+	appPrefixes.some((prefix) => token.startsWith(prefix));
+
+/**
  * @name extractOktaRecoveryToken
  * @description To extract a recovery token from a larger string that may or may not have a prefix representing an native application.
  *

--- a/src/server/lib/okta/openid-connect.ts
+++ b/src/server/lib/okta/openid-connect.ts
@@ -34,6 +34,7 @@ export interface AuthorizationState {
 		deleteReason?: string; // used to track the reason for self service deletion
 		encryptedRegistrationConsents?: string; // used to set the consents given during registration on the authentication callback when we have oauth access tokens which can update the user's consents in idapi, should be encrypted, and decrypted on the callback
 		socialProvider?: SocialProvider; // used to track the social provider used to sign in/register
+		hasAppPrefix?: boolean; // used to track if the recovery token has a native app prefix
 	};
 }
 

--- a/src/server/routes/oauth.ts
+++ b/src/server/routes/oauth.ts
@@ -270,6 +270,21 @@ const authenticationHandler = async (
 			return res.redirect(303, authState.queryParams.fromURI);
 		}
 
+		// temporary fix: if the user registered on the app (the token will be prefixed),
+		// and instead of ending up back in the app but in a mobile browser instead,
+		//  where we don't want to show the onboarding,
+		// for now we simply redirect them to the default return url when app prefix is set,
+		// and the confirmation page is one of the consent pages, then we redirect to the default return url,
+		// which is normally the guardian home page, by setting authState.confirmationPage to undefined
+		// this will be fixed when we either use a deep link with a custom scheme, or passwordless OTP flow
+		if (
+			authState.data?.hasAppPrefix &&
+			consentPages.some((page) => page.path === authState.confirmationPage)
+		) {
+			// eslint-disable-next-line functional/immutable-data
+			authState.confirmationPage = undefined;
+		}
+
 		const returnUrl = authState.confirmationPage
 			? addQueryParamsToPath(authState.confirmationPage, authState.queryParams)
 			: authState.queryParams.returnUrl;


### PR DESCRIPTION
## What does this change?

There is currently an unhappy path when a user tries to register within the app and clicks on the registration CTA within the email.

The expected behaviour is that when the user clicks the CTA, the native app should intercept the link and open it within the in-app browser flow instead, where everything works as expected for most users.

However some users when the click the CTA on their mobile device, the app doesn't intercept the link and the link opens in the users default browser instead (mobile web). When this happens and a user sets a password they have to go through the whole onboarding flow, and are redirected to the mobile web homepage at the end, which isn't helpful!

While we're unable to fix this bug yet until we investigate a deeplinking CTA or passwordless, we can minimise user frustration by removing the onboarding flow if this happens.

The best way to determine if this is happening is if the recovery token has the app prefix (`al_` for Android Live app, and `il_` for iOS live app), and the `confirmationPage` is pointing to the onboarding flow.

## Tested
- [x] CODE