### PR TITLE
Feast | Set up iOS Feast App links within gateway

### DIFF
--- a/scripts/okta/__tests__/removePrefixFromToken.test.ts
+++ b/scripts/okta/__tests__/removePrefixFromToken.test.ts
@@ -13,6 +13,10 @@ describe('removePrefixFromToken', () => {
 		expect(removePrefixFromToken('il_test')).toEqual('test');
 	});
 
+	it('should return token without prefix if prefix is passed - if_', () => {
+		expect(removePrefixFromToken('if_test')).toEqual('test');
+	});
+
 	it('should return undefined if no token is passed', () => {
 		expect(removePrefixFromToken('')).toBeUndefined();
 		expect(removePrefixFromToken(undefined)).toBeUndefined();

--- a/scripts/okta/lib/helper.ts
+++ b/scripts/okta/lib/helper.ts
@@ -176,7 +176,9 @@ export const removePrefixFromToken = (
 		return undefined;
 	}
 
-	const prefix = ['al_', 'il_'].find((prefix) => token.startsWith(prefix));
+	const prefix = ['al_', 'il_', 'if_'].find((prefix) =>
+		token.startsWith(prefix),
+	);
 
 	if (!prefix) {
 		return token;

--- a/src/server/lib/deeplink/oktaRecoveryToken.ts
+++ b/src/server/lib/deeplink/oktaRecoveryToken.ts
@@ -27,6 +27,7 @@ import {
 const appPrefixes = [
 	'al_', // Android live app
 	'il_', // iOS live app
+	'if_', // iOS feast app
 ];
 type AppPrefix = (typeof appPrefixes)[number];
 
@@ -93,6 +94,8 @@ export const addAppPrefixToOktaRecoveryToken = async (
 					return 'al_';
 				case 'ios_live_app':
 					return 'il_';
+				case 'ios_feast_app':
+					return 'if_';
 				default:
 					return '';
 			}


### PR DESCRIPTION
## What does this change?

Sibling PR to https://github.com/guardian/identity-platform/pull/703

This updates gateway to make sure to add the new app prefix for the iOS feast app (`il_`) and make sure that it's correctly decrypted too.

Gateway will already be aware that Feast is an iOS app due to this line as the label within Okta will be `ios_feast_app`: https://github.com/guardian/gateway/blob/main/src/server/lib/middleware/requestState.ts#L61. In the future, especially if we're going to be serving different experiences to different apps, we may have to extend this functionality to use the app name instead.

We also need to update the [`apple-app-site-association`](https://github.com/guardian/gateway/blob/main/src/client/.well-known/apple-app-site-association) file so that these new links can be intercepted by the Feast app, but need the correct `appIDs` from the team.