### PR TITLE
Add Ophan tracking for registration consents and newsletters

### DIFF
--- a/src/client/lib/consentsTracking.ts
+++ b/src/client/lib/consentsTracking.ts
@@ -1,5 +1,7 @@
 import { PageData } from '@/shared/model/ClientState';
 import { sendOphanInteractionEvent } from './ophan';
+import { Consents } from '@/shared/model/Consent';
+import { Newsletters } from '@/shared/model/Newsletter';
 
 const trackInputElementInteraction = (
 	inputElem: HTMLInputElement,
@@ -84,4 +86,30 @@ export const onboardingFormSubmitOphanTracking = (
 		default:
 			return;
 	}
+};
+
+// handle registration form submit event on /register/email page and welcome/:social page
+// we have to manually track the consents and newsletters here, and manually set the values
+// for any new consents or newsletters added in the future
+export const registrationFormSubmitOphanTracking = (
+	target: HTMLFormElement,
+): void => {
+	const inputElems = target.querySelectorAll('input');
+
+	inputElems.forEach((elem) => {
+		if (elem.type === 'checkbox') {
+			switch (elem.name) {
+				case Newsletters.SATURDAY_EDITION:
+					trackInputElementInteraction(elem, 'newsletter', 'saturday-edition');
+					break;
+				case Consents.SIMILAR_GUARDIAN_PRODUCTS:
+					trackInputElementInteraction(
+						elem,
+						'consent',
+						'similar-guardian-products',
+					);
+					break;
+			}
+		}
+	});
 };

--- a/src/client/pages/RegisterWithEmail.tsx
+++ b/src/client/pages/RegisterWithEmail.tsx
@@ -14,6 +14,7 @@ import { GeoLocation } from '@/shared/model/Geolocation';
 import { SATURDAY_EDITION_SMALL_SQUARE_IMAGE } from '@/client/assets/newsletters';
 import { RegistrationConsentsFormFields } from '@/shared/model/Consent';
 import { RegistrationNewslettersFormFields } from '@/shared/model/Newsletter';
+import { registrationFormSubmitOphanTracking } from '@/client/lib/consentsTracking';
 
 export type RegisterWithEmailProps = RegistrationProps & {
 	geolocation?: GeoLocation;
@@ -53,6 +54,10 @@ export const RegisterWithEmail = ({
 				formTrackingName={formTrackingName}
 				disableOnSubmit
 				formErrorMessageFromParent={formError}
+				onSubmit={(e) => {
+					registrationFormSubmitOphanTracking(e.target as HTMLFormElement);
+					return undefined;
+				}}
 			>
 				<EmailInput defaultValue={email} autoComplete="off" />
 				<CmpConsentedStateHiddenInput cmpConsentedState={hasCmpConsent} />

--- a/src/client/pages/WelcomeSocial.tsx
+++ b/src/client/pages/WelcomeSocial.tsx
@@ -25,6 +25,7 @@ import { GeoLocation } from '@/shared/model/Geolocation';
 import { SATURDAY_EDITION_SMALL_SQUARE_IMAGE } from '@/client/assets/newsletters';
 import { RegistrationConsentsFormFields } from '@/shared/model/Consent';
 import { RegistrationNewslettersFormFields } from '@/shared/model/Newsletter';
+import { registrationFormSubmitOphanTracking } from '@/client/lib/consentsTracking';
 
 const inlineMessage = (socialProvider: SocialProvider) => css`
 	display: flex;
@@ -95,6 +96,10 @@ export const WelcomeSocial = ({
 				disableOnSubmit
 				formErrorMessageFromParent={formError}
 				largeFormMarginTop
+				onSubmit={(e) => {
+					registrationFormSubmitOphanTracking(e.target as HTMLFormElement);
+					return undefined;
+				}}
 			>
 				{socialProvider === 'google' && (
 					<MainBodyText cssOverrides={inlineMessage(socialProvider)}>


### PR DESCRIPTION
## What does this change?

In https://github.com/guardian/gateway/pull/2548 and https://github.com/guardian/gateway/pull/2455 we introduced the ability for readers to opt in to newsletters or marketing consents from within the registration flow.

However these weren't being tracking in Ophan/Data Lake, unlike those in the Onboarding flow.

This PR adds in tracking using the same methods as the ones used within the Onboarding flow so analysts have access to this data, which is their preferred way after speaking with them

<table>

<tr>

<th>

<th> Params

<th> URL

<tr>

<th> Saturday Edition 

<td>

<img width="535" alt="Screenshot 2024-02-07 at 08 58 34" src="https://github.com/guardian/gateway/assets/13315440/5602a95c-2fd2-4005-8471-ecf96ee22dca">

<td>

<img width="950" alt="Screenshot 2024-02-07 at 08 58 41" src="https://github.com/guardian/gateway/assets/13315440/6b81ea39-2c29-405b-8b65-4235b87cdf42">

<tr> 

<th> Onboarding Flow Example

<td>

<img width="453" alt="Screenshot 2024-02-07 at 09 02 17" src="https://github.com/guardian/gateway/assets/13315440/ef18c735-24d9-42c8-a46c-c9bbdf3e8655">

<td>

<img width="945" alt="Screenshot 2024-02-07 at 09 02 25" src="https://github.com/guardian/gateway/assets/13315440/07644444-ab8e-4fdb-a87a-143fe9914ccd">

</table>

## Tested

- [x] DEV - Ophan event being sent in same way as that on the onboarding flow
- [x] CODE - Ophan event being sent in same way as that on the onboarding flow 