### PR TITLE
Add `getRegistrationPlatform` method and correct `registrationPlatform`

### DIFF
--- a/cypress/integration/ete-okta/registration_1.2.cy.ts
+++ b/cypress/integration/ete-okta/registration_1.2.cy.ts
@@ -64,6 +64,12 @@ describe('Registration flow - Split 1/2', () => {
 				cy.url().should('contain', clientId);
 				cy.url().should('not.contain', appClientId);
 				cy.url().should('not.contain', fromURI);
+
+				// test the registration platform is set correctly
+				cy.getTestOktaUser(unregisteredEmail).then((oktaUser) => {
+					expect(oktaUser.status).to.eq(Status.ACTIVE);
+					expect(oktaUser.profile.registrationPlatform).to.eq('profile');
+				});
 			});
 		});
 
@@ -133,6 +139,14 @@ describe('Registration flow - Split 1/2', () => {
 				cy.get('input[name="password"]').type(randomPassword());
 				cy.get('button[type="submit"]').click();
 				cy.url().should('contain', 'https://m.code.dev-theguardian.com/');
+
+				// test the registration platform is set correctly
+				cy.getTestOktaUser(unregisteredEmail).then((oktaUser) => {
+					expect(oktaUser.status).to.eq(Status.ACTIVE);
+					expect(oktaUser.profile.registrationPlatform).to.eq(
+						'android_live_app',
+					);
+				});
 			});
 		});
 

--- a/src/server/lib/okta/register.ts
+++ b/src/server/lib/okta/register.ts
@@ -25,8 +25,40 @@ import { RegistrationConsents } from '@/shared/model/RegistrationConsents';
 import { RegistrationLocation } from '@/shared/model/RegistrationLocation';
 import { TrackingQueryParams } from '@/shared/model/QueryParams';
 import { emailSendMetric } from '@/server/models/Metrics';
+import { getApp } from '@/server/lib/okta/api/apps';
 
 const { okta } = getConfiguration();
+
+/**
+ * @name getRegistrationPlatform
+ * @description Get the registration platform (app) based on the appClientId, this will be used to determine the platform the user is registering from, which is helpful for tracking purposes
+ *
+ * @param appClientId - the appClientId to get the app info for, corresponds to an app in Okta
+ * @returns {Promise<string>} Promise that resolves to the app label, or `profile` if no appClientId is provided/error occurs, since this is the name of Gateway app in Okta
+ */
+const getRegistrationPlatform = async (
+	appClientId?: string,
+): Promise<string> => {
+	// If no appClientId is provided, we default to `profile` (name of Gateway app in Okta)
+	if (!appClientId) {
+		return 'profile';
+	}
+
+	// If an appClientId is provided, we use the app label to determine the platform
+	try {
+		const app = await getApp(appClientId);
+
+		// label is what's set up in Okta as the name of the app
+		// e.g. the android live app label is `android_live_app` or mma (manage.theguardian.com) is `manage_my_account`
+		const label = app.label.toLowerCase();
+
+		return label;
+	} catch (error) {
+		// If we fail to get the app info, we default to `profile`
+		logger.error('Error getting app info in getRegistrationPlatform', error);
+		return 'profile';
+	}
+};
 
 /**
  * @name sendRegistrationEmailByUserState
@@ -296,7 +328,7 @@ export const register = async ({
 				email,
 				login: email,
 				isGuardianUser: true,
-				registrationPlatform: 'identity-gateway',
+				registrationPlatform: await getRegistrationPlatform(appClientId),
 				registrationLocation: registrationLocation,
 			},
 			groupIds: [okta.groupIds.GuardianUserAll],

--- a/src/server/models/okta/User.ts
+++ b/src/server/models/okta/User.ts
@@ -56,6 +56,7 @@ export const userResponseSchema = z.object({
 		lastName: true,
 		isJobsUser: true,
 		registrationLocation: true,
+		registrationPlatform: true,
 	}),
 	credentials: userCredentialsSchema,
 });


### PR DESCRIPTION
## What does this change?

Currently the `registrationPlatform` parameter on the user object within Otka is always set to `identity-gateway`, even if the user registers from a native app or another web application like mma (manage).

This means we lose the information about where the user registered from, which is useful for tracking purposes.

We were already providing the `appClientId` to the registration method when creating a user. We can use this ID to call the `getApp` function in order to retrieve the app name from Okta, and use this as the registration platform. This applies to all applications which use OAuth currently to sign in and register.

We also change the default from `identity-gateway` to `profile`, as `profile` is the name of the Gateway application (this project) within Okta. This also means that for any user with `identity-gateway` we don't know their true registration platform, but going forward we know every users registration platform.

<table>

<tr>

<th> `profile` (default)

<th> `android_live_app` (using `appClientId` query parameter)

<tr>

<td>

<img width="344" alt="Screenshot 2024-02-07 at 10 22 48" src="https://github.com/guardian/gateway/assets/13315440/b1e04d04-a352-4ce8-a5dc-79ef3be4055f">

<td>

<img width="430" alt="Screenshot 2024-02-07 at 10 25 47" src="https://github.com/guardian/gateway/assets/13315440/79eaa6a8-a239-43db-b2cc-5d7a0f404b41">

</table>

## Tested

- [x] Cypress - Android and Gateway
- [x] CODE - Android and Gateway