### PR TITLE
Update the apple app site association for feast app

### DIFF
--- a/src/client/.well-known/apple-app-site-association
+++ b/src/client/.well-known/apple-app-site-association
@@ -21,6 +21,25 @@
 						"comment": "Matches any URL whose path starts with /set-password/il_<randomString> where <randomString> is a token"
 					}
 				]
+			},
+			{
+				"appIDs": [
+					"998P9U5NGJ.uk.co.guardian.Feast"
+				],
+				"components": [
+					{
+						"/": "/welcome/if_*",
+						"comment": "Matches any URL whose path starts with /welcome/if_<randomString> where <randomString> is a token"
+					},
+					{
+						"/": "/reset-password/if_*",
+						"comment": "Matches any URL whose path starts with /reset-password/if_<randomString> where <randomString> is a token"
+					},
+					{
+						"/": "/set-password/if_*",
+						"comment": "Matches any URL whose path starts with /set-password/if_<randomString> where <randomString> is a token"
+					}
+				]
 			}
 		]
 	}


### PR DESCRIPTION
## What does this change?

The feast app needs to be able to intercept the welcome/reset password/set password links. In #2560 we set up the app links within Gateway, but weren't able to update the `apple-app-site-association` file which Apple uses in `iOS` in order to intercept links.

This PR does just that now that we have the correct app id!

The Feast app will intercept on `il_` prefixed tokens