### PR TITLE
Copy and link amendments for help centre and help email

### DIFF
--- a/cypress/integration/ete/registration/register_email_sent.3.cy.ts
+++ b/cypress/integration/ete/registration/register_email_sent.3.cy.ts
@@ -1,5 +1,6 @@
 import { injectAndCheckAxe } from '../../../support/cypress-axe';
 import { randomMailosaurEmail } from '../../../support/commands/testUser';
+import { SUPPORT_EMAIL } from '../../../../src/shared/model/Configuration';
 
 describe('Registration email sent page', () => {
 	context('A11y checks', () => {
@@ -181,7 +182,7 @@ describe('Registration email sent page', () => {
 
 				cy.contains('Google reCAPTCHA verification failed.');
 				cy.contains('If the problem persists please try the following:');
-				cy.contains('customer.help@');
+				cy.contains(SUPPORT_EMAIL);
 
 				const timeRequestWasMade = new Date();
 				cy.contains('Resend email').click();

--- a/cypress/integration/ete/reset_password/reset_password.4.cy.ts
+++ b/cypress/integration/ete/reset_password/reset_password.4.cy.ts
@@ -1,3 +1,4 @@
+import { SUPPORT_EMAIL } from '../../../../src/shared/model/Configuration';
 import { randomPassword } from '../../../support/commands/testUser';
 
 describe('Password reset flow', () => {
@@ -30,7 +31,7 @@ describe('Password reset flow', () => {
 					cy.get('[data-cy="main-form-submit-button"]').click();
 					cy.contains('Google reCAPTCHA verification failed.');
 					cy.contains('If the problem persists please try the following:');
-					cy.contains('customer.help@');
+					cy.contains(SUPPORT_EMAIL);
 
 					// Continue checking the password reset flow after reCAPTCHA assertions above.
 					cy.get('[data-cy="main-form-submit-button"]').click();
@@ -82,7 +83,7 @@ describe('Password reset flow', () => {
 					cy.get('[data-cy="main-form-submit-button"]').click();
 					cy.contains('Google reCAPTCHA verification failed.');
 					cy.contains('If the problem persists please try the following:');
-					cy.contains('customer.help@');
+					cy.contains(SUPPORT_EMAIL);
 
 					// Continue checking the password reset flow after reCAPTCHA assertions above.
 					cy.get('[data-cy="main-form-submit-button"]').click();
@@ -141,7 +142,7 @@ describe('Password set flow', () => {
 					cy.contains('Send me a link').click();
 					cy.contains('Google reCAPTCHA verification failed.');
 					cy.contains('If the problem persists please try the following:');
-					cy.contains('customer.help@');
+					cy.contains(SUPPORT_EMAIL);
 
 					// Continue checking the password reset flow after reCAPTCHA assertions above.
 					cy.contains('Send me a link').click();

--- a/cypress/integration/mocked/reset_password.5.cy.ts
+++ b/cypress/integration/mocked/reset_password.5.cy.ts
@@ -1,3 +1,4 @@
+import { SUPPORT_EMAIL } from '../../../src/shared/model/Configuration';
 import { injectAndCheckAxe } from '../../support/cypress-axe';
 import PageResetPassword from '../../support/pages/reset_password_page';
 
@@ -86,7 +87,7 @@ describe('Password reset flow', () => {
 			page.submitEmailAddress(email);
 			cy.contains('Google reCAPTCHA verification failed.');
 			cy.contains('If the problem persists please try the following:');
-			cy.contains('customer.help@');
+			cy.contains(SUPPORT_EMAIL);
 		});
 	});
 });

--- a/cypress/integration/mocked/set_password.5.cy.ts
+++ b/cypress/integration/mocked/set_password.5.cy.ts
@@ -1,5 +1,6 @@
 /// <reference types="cypress" />
 
+import { SUPPORT_EMAIL } from '../../../src/shared/model/Configuration';
 import { injectAndCheckAxe } from '../../support/cypress-axe';
 
 describe('Password set/create flow', () => {
@@ -126,7 +127,7 @@ describe('Password set/create flow', () => {
 			cy.get('button[type="submit"]').click();
 			cy.contains('Google reCAPTCHA verification failed.');
 			cy.contains('If the problem persists please try the following:');
-			cy.contains('customer.help@');
+			cy.contains(SUPPORT_EMAIL);
 		});
 
 		it('shows the session time out page if the token expires while on the set password page', () => {

--- a/cypress/integration/mocked/verify_email.4.cy.ts
+++ b/cypress/integration/mocked/verify_email.4.cy.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
+import { SUPPORT_EMAIL } from '../../../src/shared/model/Configuration';
 import { injectAndCheckAxe } from '../../support/cypress-axe';
 import { authRedirectSignInRecentlyEmailValidated } from '../../support/idapi/auth';
 import { CONSENTS_ENDPOINT, allConsents } from '../../support/idapi/consent';
@@ -319,7 +320,7 @@ describe('Verify email flow', () => {
 			cy.contains(VerifyEmail.CONTENT.SEND_LINK).click();
 			cy.contains('Google reCAPTCHA verification failed.');
 			cy.contains('If the problem persists please try the following:');
-			cy.contains('customer.help@');
+			cy.contains(SUPPORT_EMAIL);
 		});
 	});
 });

--- a/cypress/integration/mocked/welcome.4.cy.ts
+++ b/cypress/integration/mocked/welcome.4.cy.ts
@@ -1,3 +1,4 @@
+import { SUPPORT_EMAIL } from '../../../src/shared/model/Configuration';
 import { injectAndCheckAxe } from '../../support/cypress-axe';
 import {
 	authRedirectSignInRecentlyEmailValidated,
@@ -317,7 +318,7 @@ describe('Welcome and set password page', () => {
 			cy.get('button[type="submit"]').click();
 			cy.contains('Google reCAPTCHA verification failed.');
 			cy.contains('If the problem persists please try the following:');
-			cy.contains('customer.help@');
+			cy.contains(SUPPORT_EMAIL);
 		});
 
 		it('takes user back to link expired page if "Change email address" clicked', () => {

--- a/src/client/components/DetailedRecaptchaError.tsx
+++ b/src/client/components/DetailedRecaptchaError.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { space } from '@guardian/source-foundations';
 import { errorContextSpacing } from '@/client/styles/Shared';
+import locations from '@/shared/lib/locations';
+import { SUPPORT_EMAIL } from '@/shared/model/Configuration';
 
 export const DetailedRecaptchaError = () => (
 	<>
@@ -14,9 +16,7 @@ export const DetailedRecaptchaError = () => (
 		</ul>
 		<p css={[errorContextSpacing, { marginBottom: `${space[3]}px` }]}>
 			For further help please contact our customer service team at{' '}
-			<a href="email:customer.help@theguardian.com">
-				customer.help@theguardian.com
-			</a>
+			<a href={locations.SUPPORT_EMAIL_MAILTO}>{SUPPORT_EMAIL}</a>
 		</p>
 	</>
 );

--- a/src/client/pages/DeleteAccountBlocked.tsx
+++ b/src/client/pages/DeleteAccountBlocked.tsx
@@ -5,6 +5,7 @@ import { ExternalLink } from '@/client/components/ExternalLink';
 import locations from '@/shared/lib/locations';
 import { DeleteAccountReturnLink } from '@/client/components/DeleteAccountReturnLink';
 import { UserAttributesResponse } from '@/shared/lib/members-data-api';
+import { SUPPORT_EMAIL } from '@/shared/model/Configuration';
 
 interface Props {
 	contentAccess?: Partial<UserAttributesResponse['contentAccess']>;
@@ -89,8 +90,8 @@ export const DeleteAccountBlocked = ({ contentAccess = {} }: Props) => {
 						You cannot delete your account while you have an active
 						subscription. If you would like to cancel your subscription, please
 						email the Subscriptions Team at{' '}
-						<ExternalLink href="mailto:customer.help@theguardian.com">
-							customer.help@theguardian.com
+						<ExternalLink href={locations.SUPPORT_EMAIL_MAILTO}>
+							{SUPPORT_EMAIL}
 						</ExternalLink>
 						.
 					</MainBodyText>

--- a/src/client/pages/EmailSent.tsx
+++ b/src/client/pages/EmailSent.tsx
@@ -11,6 +11,8 @@ import { EmailInput } from '@/client/components/EmailInput';
 import { ExternalLink } from '@/client/components/ExternalLink';
 import { css } from '@emotion/react';
 import { buildUrl } from '@/shared/lib/routeUtils';
+import locations from '@/shared/lib/locations';
+import { SUPPORT_EMAIL } from '@/shared/model/Configuration';
 
 type Props = {
 	email?: string;
@@ -122,9 +124,9 @@ export const EmailSent = ({
 						cssOverrides={css`
 							font-weight: 700;
 						`}
-						href="mailto:customer.help@theguardian.com"
+						href={locations.SUPPORT_EMAIL_MAILTO}
 					>
-						customer.help@theguardian.com
+						{SUPPORT_EMAIL}
 					</ExternalLink>
 					.
 				</MainBodyText>

--- a/src/client/pages/ResetPassword.tsx
+++ b/src/client/pages/ResetPassword.tsx
@@ -75,10 +75,11 @@ export const ResetPassword = ({
 			</MainForm>
 			{showNoAccessEmail && (
 				<MainBodyText cssOverrides={belowFormMarginTopSpacingStyle}>
-					If you no longer have access to this email account please{' '}
-					<ExternalLink href={locations.REPORT_ISSUE}>
-						contact our help department
+					Having trouble resetting your password? Please visit our{' '}
+					<ExternalLink href={locations.SIGN_IN_HELP_CENTRE}>
+						Help Centre
 					</ExternalLink>
+					.
 				</MainBodyText>
 			)}
 			{showRecentEmailSummary && (
@@ -88,10 +89,11 @@ export const ResetPassword = ({
 					context={
 						<>
 							If you are having trouble, please contact our customer service
-							team at{' '}
+							team using our{' '}
 							<ExternalLink href={locations.REPORT_ISSUE}>
-								customer.help@theguardian.com
+								Help Centre
 							</ExternalLink>
+							.
 						</>
 					}
 				/>

--- a/src/client/pages/SignedInAs.tsx
+++ b/src/client/pages/SignedInAs.tsx
@@ -7,6 +7,8 @@ import { QueryParams } from '@/shared/model/QueryParams';
 import { OpenIdErrors } from '@/shared/model/OpenIdErrors';
 import { errorContextSpacing } from '@/client/styles/Shared';
 import { space } from '@guardian/source-foundations';
+import locations from '@/shared/lib/locations';
+import { SUPPORT_EMAIL } from '@/shared/model/Configuration';
 
 interface Props {
 	email: string;
@@ -34,10 +36,7 @@ const DetailedLoginRequiredError = ({
 		</ul>
 		<p css={[errorContextSpacing, { marginBottom: `${space[3]}px` }]}>
 			For further help please contact our customer service team at{' '}
-			<Link href="email:customer.help@theguardian.com">
-				customer.help@theguardian.com
-			</Link>
-			.
+			<Link href={locations.SUPPORT_EMAIL_MAILTO}>{SUPPORT_EMAIL}</Link>.
 		</p>
 	</>
 );

--- a/src/email/components/Footer.tsx
+++ b/src/email/components/Footer.tsx
@@ -3,6 +3,8 @@ import { MjmlSection, MjmlColumn, MjmlText } from '@faire/mjml-react';
 
 import { background, text } from '@guardian/source-foundations';
 import { Link } from '@/email/components/Link';
+import locations from '@/shared/lib/locations';
+import { SUPPORT_EMAIL } from '@/shared/model/Configuration';
 
 type Props = {
 	mistakeParagraphComponent?: React.ReactNode;
@@ -39,10 +41,7 @@ export const Footer = ({ mistakeParagraphComponent }: Props) => (
 			<FooterText>
 				If you have any queries about why you are receiving this email, please
 				contact our customer service team at{' '}
-				<Link href="mailto:customer.help@theguardian.com">
-					customer.help@theguardian.com
-				</Link>
-				.
+				<Link href={locations.SUPPORT_EMAIL_MAILTO}>{SUPPORT_EMAIL}</Link>.
 			</FooterText>
 			<FooterText noPaddingBottom>
 				Guardian News and Media Limited, Kings Place, 90 York Way, London, N1

--- a/src/email/templates/AccidentalEmail/AccidentalEmailText.ts
+++ b/src/email/templates/AccidentalEmail/AccidentalEmailText.ts
@@ -1,3 +1,5 @@
+import { SUPPORT_EMAIL } from '@/shared/model/Configuration';
+
 export const AccidentalEmailText = () => `
 Hello,
 
@@ -5,7 +7,7 @@ We're doing some housekeeping and will be moving your contact details over to a 
 
 This email has been triggered accidentally. You don't have to do anything in response and you haven't been added onto any mailing list. We're very sorry for bothering you.
 
-If you're concerned or have questions, please contact our customer service team at customer.help@theguardian.com.
+If you're concerned or have questions, please contact our customer service team at ${SUPPORT_EMAIL}.
 
 The Guardian
 

--- a/src/email/templates/AccountExists/AccountExistsText.ts
+++ b/src/email/templates/AccountExists/AccountExistsText.ts
@@ -1,3 +1,5 @@
+import { SUPPORT_EMAIL } from '@/shared/model/Configuration';
+
 export const AccountExistsText = () => `
 Hello again,
 
@@ -15,7 +17,7 @@ $passwordResetLink
 
 If you didn’t try to register, please ignore this email. Your details won’t be changed and no one has accessed your account.
 
-If you have any queries about this email please contact our customer service team at customer.help@theguardian.com
+If you have any queries about this email please contact our customer service team at ${SUPPORT_EMAIL}
 
 Guardian News and Media Limited, Kings Place, 90 York Way, London, N1 9GU, United Kingdom
 `;

--- a/src/email/templates/AccountWithoutPasswordExists/AccountWithoutPasswordExistsText.ts
+++ b/src/email/templates/AccountWithoutPasswordExists/AccountWithoutPasswordExistsText.ts
@@ -1,3 +1,5 @@
+import { SUPPORT_EMAIL } from '@/shared/model/Configuration';
+
 export const AccountWithoutPasswordExistsText = () => `
 Hello again,
 
@@ -11,7 +13,7 @@ $createPasswordLink
 
 If you didn’t try to register, please ignore this email. Your details won’t be changed and no one has accessed your account.
 
-If you have any queries about this email please contact our customer service team at customer.help@theguardian.com
+If you have any queries about this email please contact our customer service team at ${SUPPORT_EMAIL}
 
 Guardian News and Media Limited, Kings Place, 90 York Way, London, N1 9GU, United Kingdom
 `;

--- a/src/email/templates/CompleteRegistration/CompleteRegistrationText.ts
+++ b/src/email/templates/CompleteRegistration/CompleteRegistrationText.ts
@@ -1,3 +1,5 @@
+import { SUPPORT_EMAIL } from '@/shared/model/Configuration';
+
 export const CompleteRegistrationText = () => `
 Welcome to the Guardian,
 
@@ -11,7 +13,7 @@ The Guardian
 
 If you received this email by mistake, please delete it. Your registration won't be complete if you don't click the link above.
 
-If you have any queries about this email please contact our customer services team at customer.help@theguardian.com
+If you have any queries about this email please contact our customer services team at ${SUPPORT_EMAIL}
 
 Guardian News and Media Limited, Kings Place, 90 York Way, London, N1 9GU, United Kingdom
 `;

--- a/src/email/templates/CreatePassword/CreatePasswordText.ts
+++ b/src/email/templates/CreatePassword/CreatePasswordText.ts
@@ -1,3 +1,5 @@
+import { SUPPORT_EMAIL } from '@/shared/model/Configuration';
+
 export const CreatePasswordText = () => `
 Hello again,
 
@@ -11,7 +13,7 @@ The Guardian
 
 If you didn’t try to register, please ignore this email. Your details won’t be changed and no one has accessed your account.
 
-If you have any queries about why you are receiving this email, please contact our customer service team at customer.help@theguardian.com.
+If you have any queries about why you are receiving this email, please contact our customer service team at ${SUPPORT_EMAIL}.
 
 Guardian News and Media Limited, Kings Place, 90 York Way, London, N1 9GU, United Kingdom
 `;

--- a/src/email/templates/NoAccount/NoAccountText.ts
+++ b/src/email/templates/NoAccount/NoAccountText.ts
@@ -1,4 +1,5 @@
 import { buildUrl } from '@/shared/lib/routeUtils';
+import { SUPPORT_EMAIL } from '@/shared/model/Configuration';
 
 export const NoAccountText = () => `
 Hello,
@@ -13,7 +14,7 @@ https://profile.theguardian.com${buildUrl('/register')}
 
 The Guardian
 
-If you have any queries about this email please contact our customer services team at customer.help@theguardian.com
+If you have any queries about this email please contact our customer services team at ${SUPPORT_EMAIL}
 
 Your Data: To find out what personal data we collect and how we use it, please visit our privacy policy at https://www.theguardian.com/help/privacy-policy
 

--- a/src/email/templates/ResetPassword/ResetPasswordText.ts
+++ b/src/email/templates/ResetPassword/ResetPasswordText.ts
@@ -1,3 +1,5 @@
+import { SUPPORT_EMAIL } from '@/shared/model/Configuration';
+
 export const ResetPasswordText = () => `
 Hello,
 
@@ -11,7 +13,7 @@ The Guardian
 
 If you didn’t request to reset your password, please ignore this email. Your details won’t be changed and no one has accessed your account.
 
-If you have any queries about why you are receiving this email, please contact our customer service team at customer.help@theguardian.com
+If you have any queries about why you are receiving this email, please contact our customer service team at ${SUPPORT_EMAIL}
 
 Guardian News and Media Limited, Kings Place, 90 York Way London N1 9GU, United Kingdom
 `;

--- a/src/email/templates/UnvalidatedEmailResetPassword/UnvalidatedEmailResetPasswordText.ts
+++ b/src/email/templates/UnvalidatedEmailResetPassword/UnvalidatedEmailResetPasswordText.ts
@@ -1,3 +1,5 @@
+import { SUPPORT_EMAIL } from '@/shared/model/Configuration';
+
 export const UnvalidatedEmailResetPasswordText = () => `
 Hello,
 
@@ -10,7 +12,7 @@ The Guardian
 
 If you didn’t try to sign in to the Guardian, please ignore this email. Your details won’t be changed and no one has accessed your account.
 
-If you have any queries about why you are receiving this email, please contact our customer service team at customer.help@theguardian.com
+If you have any queries about why you are receiving this email, please contact our customer service team at ${SUPPORT_EMAIL}
 
 Guardian News and Media Limited, Kings Place, 90 York Way London N1 9GU, United Kingdom
 `;

--- a/src/shared/lib/locations.ts
+++ b/src/shared/lib/locations.ts
@@ -1,3 +1,5 @@
+import { SUPPORT_EMAIL } from '@/shared/model/Configuration';
+
 export default {
 	HELP: 'https://www.theguardian.com/help/identity-faq',
 	TERMS: 'https://www.theguardian.com/help/terms-of-service',
@@ -13,11 +15,14 @@ export default {
 	CONTRIBUTION_CANCEL: 'https://manage.theguardian.com/cancel/contributions',
 	SUBSCRIPTION_HELP:
 		'https://www.theguardian.com/subscriber-direct/subscription-frequently-asked-questions',
-	IN_APP_PURCHASES_HELP: 'ttps://www.theguardian.com/info/2013/aug/12/1',
+	IN_APP_PURCHASES_HELP: 'https://www.theguardian.com/info/2013/aug/12/1',
 	JOBS_HELP: 'https://jobs.theguardian.com/article/faq',
 	EMAIL_SUBSCRIPTIONS_HELP:
 		'https://www.theguardian.com/help/problems-with-your-email-subscriptions',
 	SAVED_FOR_LATER_HELP:
 		'https://www.theguardian.com/help/insideguardian/2015/jul/21/introducing-save-for-later',
 	MANAGE_SETTINGS: 'https://manage.theguardian.com/account-settings',
+	SIGN_IN_HELP_CENTRE:
+		'https://manage.theguardian.com/help-centre/article/trouble-signing-in-and-staying-signed-into-the-guardian-live-app-on-android-and-ios',
+	SUPPORT_EMAIL_MAILTO: `mailto:${SUPPORT_EMAIL}`,
 };

--- a/src/shared/model/Configuration.ts
+++ b/src/shared/model/Configuration.ts
@@ -1,1 +1,3 @@
 export type Stage = 'DEV' | 'CODE' | 'PROD';
+
+export const SUPPORT_EMAIL = 'signinsupport@theguardian.com';


### PR DESCRIPTION
## What does this change?

Change: If you no longer have access to this email account please contact our help department
To: Having trouble resetting your password? Please visit our Help Centre

Change: If you are still having trouble, contact our customer service team  at customer.help@theguardian.com
To: If you are still having trouble, contact our customer service team  at signinsupport@theguardian.com

I've also taken the liberty to make sure the email and mailto links are defined in a single place, in case it needs to change in the future.
