### PR TITLE
Registration Platform | Make sure this is updated for social users

### DIFF
--- a/src/server/lib/okta/register.ts
+++ b/src/server/lib/okta/register.ts
@@ -25,40 +25,9 @@ import { RegistrationConsents } from '@/shared/model/RegistrationConsents';
 import { RegistrationLocation } from '@/shared/model/RegistrationLocation';
 import { TrackingQueryParams } from '@/shared/model/QueryParams';
 import { emailSendMetric } from '@/server/models/Metrics';
-import { getApp } from '@/server/lib/okta/api/apps';
+import { getRegistrationPlatform } from '../registrationPlatform';
 
 const { okta } = getConfiguration();
-
-/**
- * @name getRegistrationPlatform
- * @description Get the registration platform (app) based on the appClientId, this will be used to determine the platform the user is registering from, which is helpful for tracking purposes
- *
- * @param appClientId - the appClientId to get the app info for, corresponds to an app in Okta
- * @returns {Promise<string>} Promise that resolves to the app label, or `profile` if no appClientId is provided/error occurs, since this is the name of Gateway app in Okta
- */
-const getRegistrationPlatform = async (
-	appClientId?: string,
-): Promise<string> => {
-	// If no appClientId is provided, we default to `profile` (name of Gateway app in Okta)
-	if (!appClientId) {
-		return 'profile';
-	}
-
-	// If an appClientId is provided, we use the app label to determine the platform
-	try {
-		const app = await getApp(appClientId);
-
-		// label is what's set up in Okta as the name of the app
-		// e.g. the android live app label is `android_live_app` or mma (manage.theguardian.com) is `manage_my_account`
-		const label = app.label.toLowerCase();
-
-		return label;
-	} catch (error) {
-		// If we fail to get the app info, we default to `profile`
-		logger.error('Error getting app info in getRegistrationPlatform', error);
-		return 'profile';
-	}
-};
 
 /**
  * @name sendRegistrationEmailByUserState

--- a/src/server/lib/registrationPlatform.ts
+++ b/src/server/lib/registrationPlatform.ts
@@ -1,0 +1,66 @@
+import { logger } from '@/server/lib/serverSideLogger';
+import { Jwt } from '@okta/jwt-verifier';
+import { getUser, updateUser } from '@/server/lib/okta/api/users';
+import { getApp } from './okta/api/apps';
+
+/**
+ * @name getRegistrationPlatform
+ * @description Get the registration platform (app) based on the appClientId, this will be used to determine the platform the user is registering from, which is helpful for tracking purposes
+ *
+ * @param appClientId - the appClientId to get the app info for, corresponds to an app in Okta
+ * @returns {Promise<string>} Promise that resolves to the app label, or `profile` if no appClientId is provided/error occurs, since this is the name of Gateway app in Okta
+ */
+export const getRegistrationPlatform = async (
+	appClientId?: string,
+): Promise<string> => {
+	// If no appClientId is provided, we default to `profile` (name of Gateway app in Okta)
+	if (!appClientId) {
+		return 'profile';
+	}
+
+	// If an appClientId is provided, we use the app label to determine the platform
+	try {
+		const app = await getApp(appClientId);
+
+		// label is what's set up in Okta as the name of the app
+		// e.g. the android live app label is `android_live_app` or mma (manage.theguardian.com) is `manage_my_account`
+		const label = app.label.toLowerCase();
+
+		return label;
+	} catch (error) {
+		// If we fail to get the app info, we default to `profile`
+		logger.error('Error getting app info in getRegistrationPlatform', error);
+		return 'profile';
+	}
+};
+
+export const updateRegistrationPlatform = async (
+	accessToken: Jwt,
+	appClientId?: string,
+	request_id?: string,
+): Promise<void> => {
+	if (!accessToken) {
+		throw new Error('No access token provided');
+	}
+
+	try {
+		const registrationPlatform = await getRegistrationPlatform(appClientId);
+
+		const user = await getUser(accessToken.claims.sub);
+
+		// don't update users who already have a platform set
+		if (!!user.profile.registrationPlatform) {
+			return;
+		}
+
+		await updateUser(accessToken.claims.sub, {
+			profile: {
+				registrationPlatform,
+			},
+		});
+	} catch (error) {
+		logger.error(`Error updating registrationLocation via Okta`, error, {
+			request_id,
+		});
+	}
+};

--- a/src/server/routes/welcome.ts
+++ b/src/server/routes/welcome.ts
@@ -27,6 +27,7 @@ import { update as updateNewsletters } from '@/server/lib/idapi/newsletters';
 import { rateLimitedTypedRouter as router } from '@/server/lib/typedRoutes';
 import { RegistrationConsents } from '@/shared/model/RegistrationConsents';
 import { RegistrationNewslettersFormFields } from '@/shared/model/Newsletter';
+import { updateRegistrationPlatform } from '../lib/registrationPlatform';
 
 const { okta } = getConfiguration();
 
@@ -81,6 +82,14 @@ router.post(
 					}))
 					.filter((newsletter) => newsletter.subscribed),
 			};
+
+			// update the registration platform for social users, as we're not able to do this
+			// at the time of registration, as that happens in Okta
+			await updateRegistrationPlatform(
+				state.oauthState.accessToken!,
+				state.queryParams.appClientId,
+				state.requestId,
+			);
 
 			const runningInCypress = process.env.RUNNING_IN_CYPRESS === 'true';
 


### PR DESCRIPTION
## What does this change?

In #2562 we added the ability to get the `registrationPlatform`, i.e. the app the user registered, into the user profile, which is helpful for tracking purposes.

However in hindsight we only set this up for users who created an account with email and password, and overlooked social users.

This PR fixes this by manually updating the `registrationPlatform` for social users on the same screen that they see the registration opt-out newsletters/consents (`/welcome/:social` page)

## Tested
- [x] CODE