### PR TITLE
Phase one of Gateway styling changes

### DIFF
--- a/cypress/integration/ete-okta/onboarding_flow.5.cy.ts
+++ b/cypress/integration/ete-okta/onboarding_flow.5.cy.ts
@@ -33,7 +33,7 @@ describe('Onboarding flow', () => {
 			cy.enableCMP();
 			cy.visit(`/register?returnUrl=${returnUrl}`);
 			cy.acceptCMP();
-			cy.contains('Sign up with email').click();
+			cy.contains('Continue with email').click();
 
 			const timeRequestWasMade = new Date();
 			cy.get('input[name=email]').type(unregisteredEmail);
@@ -148,7 +148,7 @@ describe('Onboarding flow', () => {
 
 			cy.visit(`/register?returnUrl=${returnUrl}`);
 
-			cy.contains('Sign up with email').click();
+			cy.contains('Continue with email').click();
 			// opt out of newsletter
 			cy.contains('Saturday Edition').click();
 			// opt out of supporter consent

--- a/cypress/integration/ete-okta/onboarding_flow.5.cy.ts
+++ b/cypress/integration/ete-okta/onboarding_flow.5.cy.ts
@@ -41,8 +41,8 @@ describe('Onboarding flow', () => {
 
 			cy.contains('Check your email inbox');
 			cy.contains(unregisteredEmail);
-			cy.contains('Resend email');
-			cy.contains('Change email address');
+			cy.contains('send again');
+			cy.contains('try another address');
 
 			cy.checkForEmailAndGetDetails(
 				unregisteredEmail,
@@ -160,8 +160,8 @@ describe('Onboarding flow', () => {
 
 			cy.contains('Check your email inbox');
 			cy.contains(unregisteredEmail);
-			cy.contains('Resend email');
-			cy.contains('Change email address');
+			cy.contains('send again');
+			cy.contains('try another address');
 
 			cy.checkForEmailAndGetDetails(
 				unregisteredEmail,

--- a/cypress/integration/ete-okta/registration_1.2.cy.ts
+++ b/cypress/integration/ete-okta/registration_1.2.cy.ts
@@ -30,8 +30,8 @@ describe('Registration flow - Split 1/2', () => {
 
 			cy.contains('Check your email inbox');
 			cy.contains(unregisteredEmail);
-			cy.contains('Resend email');
-			cy.contains('Change email address');
+			cy.contains('send again');
+			cy.contains('try another address');
 
 			cy.checkForEmailAndGetDetails(
 				unregisteredEmail,
@@ -100,8 +100,8 @@ describe('Registration flow - Split 1/2', () => {
 
 			cy.contains('Check your email inbox');
 			cy.contains(unregisteredEmail);
-			cy.contains('Resend email');
-			cy.contains('Change email address');
+			cy.contains('send again');
+			cy.contains('try another address');
 
 			cy.checkForEmailAndGetDetails(
 				unregisteredEmail,
@@ -196,8 +196,8 @@ describe('Registration flow - Split 1/2', () => {
 
 			cy.contains('Check your email inbox');
 			cy.contains(unregisteredEmail);
-			cy.contains('Resend email');
-			cy.contains('Change email address');
+			cy.contains('send again');
+			cy.contains('try another address');
 
 			cy.checkForEmailAndGetDetails(
 				unregisteredEmail,
@@ -230,8 +230,8 @@ describe('Registration flow - Split 1/2', () => {
 
 			cy.contains('Check your email inbox');
 			cy.contains(unregisteredEmail);
-			cy.contains('Resend email');
-			cy.contains('Change email address');
+			cy.contains('send again');
+			cy.contains('try another address');
 
 			cy.checkForEmailAndGetDetails(
 				unregisteredEmail,
@@ -285,8 +285,8 @@ describe('Registration flow - Split 1/2', () => {
 
 			cy.contains('Check your email inbox');
 			cy.contains(unregisteredEmail);
-			cy.contains('Resend email');
-			cy.contains('Change email address');
+			cy.contains('send again');
+			cy.contains('try another address');
 
 			cy.checkForEmailAndGetDetails(
 				unregisteredEmail,
@@ -345,8 +345,8 @@ describe('Registration flow - Split 1/2', () => {
 
 						cy.contains('Check your email inbox');
 						cy.contains(emailAddress);
-						cy.contains('Resend email');
-						cy.contains('Change email address');
+						cy.contains('send again');
+						cy.contains('try another address');
 
 						cy.checkForEmailAndGetDetails(
 							emailAddress,
@@ -402,8 +402,8 @@ describe('Registration flow - Split 1/2', () => {
 
 						cy.contains('Check your email inbox');
 						cy.contains(emailAddress);
-						cy.contains('Resend email');
-						cy.contains('Change email address');
+						cy.contains('send again');
+						cy.contains('try another address');
 
 						cy.checkForEmailAndGetDetails(
 							emailAddress,
@@ -447,8 +447,8 @@ describe('Registration flow - Split 1/2', () => {
 
 							cy.contains('Check your email inbox');
 							cy.contains(emailAddress);
-							cy.contains('Resend email');
-							cy.contains('Change email address');
+							cy.contains('send again');
+							cy.contains('try another address');
 
 							cy.checkForEmailAndGetDetails(
 								emailAddress,
@@ -494,8 +494,8 @@ describe('Registration flow - Split 1/2', () => {
 							'For security reasons we need you to change your password.',
 						).should('not.exist');
 						cy.contains(emailAddress);
-						cy.contains('Resend email');
-						cy.contains('Change email address');
+						cy.contains('send again');
+						cy.contains('try another address');
 
 						cy.checkForEmailAndGetDetails(
 							emailAddress,
@@ -535,8 +535,8 @@ describe('Registration flow - Split 1/2', () => {
 
 						cy.contains('Check your email inbox');
 						cy.contains(emailAddress);
-						cy.contains('Resend email');
-						cy.contains('Change email address');
+						cy.contains('send again');
+						cy.contains('try another address');
 
 						cy.checkForEmailAndGetDetails(
 							emailAddress,
@@ -583,8 +583,8 @@ describe('Registration flow - Split 1/2', () => {
 
 						cy.contains('Check your email inbox');
 						cy.contains(emailAddress);
-						cy.contains('Resend email');
-						cy.contains('Change email address');
+						cy.contains('send again');
+						cy.contains('try another address');
 
 						cy.checkForEmailAndGetDetails(
 							emailAddress,
@@ -627,8 +627,8 @@ describe('Registration flow - Split 1/2', () => {
 
 							cy.contains('Check your email inbox');
 							cy.contains(emailAddress);
-							cy.contains('Resend email');
-							cy.contains('Change email address');
+							cy.contains('send again');
+							cy.contains('try another address');
 
 							cy.checkForEmailAndGetDetails(
 								emailAddress,
@@ -671,8 +671,8 @@ describe('Registration flow - Split 1/2', () => {
 
 							cy.contains('Check your email inbox');
 							cy.contains(emailAddress);
-							cy.contains('Resend email');
-							cy.contains('Change email address');
+							cy.contains('send again');
+							cy.contains('try another address');
 
 							cy.checkForEmailAndGetDetails(
 								emailAddress,

--- a/cypress/integration/ete-okta/registration_2.6.cy.ts
+++ b/cypress/integration/ete-okta/registration_2.6.cy.ts
@@ -27,8 +27,8 @@ describe('Registration flow - Split 2/2', () => {
 
 							cy.contains('Check your email inbox');
 							cy.contains(emailAddress);
-							cy.contains('Resend email');
-							cy.contains('Change email address');
+							cy.contains('send again');
+							cy.contains('try another address');
 
 							// Wait for the first email to arrive...
 							cy.checkForEmailAndGetDetails(
@@ -84,8 +84,8 @@ describe('Registration flow - Split 2/2', () => {
 
 								cy.contains('Check your email inbox');
 								cy.contains(emailAddress);
-								cy.contains('Resend email');
-								cy.contains('Change email address');
+								cy.contains('send again');
+								cy.contains('try another address');
 
 								cy.checkForEmailAndGetDetails(
 									emailAddress,
@@ -136,8 +136,8 @@ describe('Registration flow - Split 2/2', () => {
 
 							cy.contains('Check your email inbox');
 							cy.contains(emailAddress);
-							cy.contains('Resend email');
-							cy.contains('Change email address');
+							cy.contains('send again');
+							cy.contains('try another address');
 
 							cy.checkForEmailAndGetDetails(
 								emailAddress,
@@ -188,8 +188,8 @@ describe('Registration flow - Split 2/2', () => {
 
 								cy.contains('Check your email inbox');
 								cy.contains(emailAddress);
-								cy.contains('Resend email');
-								cy.contains('Change email address');
+								cy.contains('send again');
+								cy.contains('try another address');
 
 								cy.checkForEmailAndGetDetails(
 									emailAddress,
@@ -241,8 +241,8 @@ describe('Registration flow - Split 2/2', () => {
 
 								cy.contains('Check your email inbox');
 								cy.contains(emailAddress);
-								cy.contains('Resend email');
-								cy.contains('Change email address');
+								cy.contains('send again');
+								cy.contains('try another address');
 
 								cy.checkForEmailAndGetDetails(
 									emailAddress,
@@ -292,8 +292,8 @@ describe('Registration flow - Split 2/2', () => {
 
 			cy.contains('Check your email inbox');
 			cy.contains(unregisteredEmail);
-			cy.contains('Resend email');
-			cy.contains('Change email address');
+			cy.contains('send again');
+			cy.contains('try another address');
 
 			cy.checkForEmailAndGetDetails(
 				unregisteredEmail,
@@ -336,8 +336,8 @@ describe('Registration flow - Split 2/2', () => {
 
 						cy.contains('Check your email inbox');
 						cy.contains(emailAddress);
-						cy.contains('Resend email');
-						cy.contains('Change email address');
+						cy.contains('send again');
+						cy.contains('try another address');
 
 						// Wait for the first email to arrive...
 						cy.checkForEmailAndGetDetails(
@@ -392,8 +392,8 @@ describe('Registration flow - Split 2/2', () => {
 
 							cy.contains('Check your email inbox');
 							cy.contains(emailAddress);
-							cy.contains('Resend email');
-							cy.contains('Change email address');
+							cy.contains('send again');
+							cy.contains('try another address');
 
 							cy.checkForEmailAndGetDetails(
 								emailAddress,
@@ -444,8 +444,8 @@ describe('Registration flow - Split 2/2', () => {
 
 						cy.contains('Check your email inbox');
 						cy.contains(emailAddress);
-						cy.contains('Resend email');
-						cy.contains('Change email address');
+						cy.contains('send again');
+						cy.contains('try another address');
 
 						cy.checkForEmailAndGetDetails(
 							emailAddress,
@@ -496,8 +496,8 @@ describe('Registration flow - Split 2/2', () => {
 
 							cy.contains('Check your email inbox');
 							cy.contains(emailAddress);
-							cy.contains('Resend email');
-							cy.contains('Change email address');
+							cy.contains('send again');
+							cy.contains('try another address');
 
 							cy.checkForEmailAndGetDetails(
 								emailAddress,
@@ -549,8 +549,8 @@ describe('Registration flow - Split 2/2', () => {
 
 							cy.contains('Check your email inbox');
 							cy.contains(emailAddress);
-							cy.contains('Resend email');
-							cy.contains('Change email address');
+							cy.contains('send again');
+							cy.contains('try another address');
 
 							cy.checkForEmailAndGetDetails(
 								emailAddress,
@@ -660,8 +660,8 @@ describe('Registration flow - Split 2/2', () => {
 
 			cy.contains('Check your email inbox');
 			cy.contains(unregisteredEmail);
-			cy.contains('Resend email');
-			cy.contains('Change email address');
+			cy.contains('send again');
+			cy.contains('try another address');
 
 			cy.checkForEmailAndGetDetails(
 				unregisteredEmail,

--- a/cypress/integration/ete-okta/reset_password.3.cy.ts
+++ b/cypress/integration/ete-okta/reset_password.3.cy.ts
@@ -278,8 +278,8 @@ describe('Password reset flow in Okta', () => {
 
 					cy.contains('Check your email inbox');
 					cy.contains(emailAddress);
-					cy.contains('Resend email');
-					cy.contains('Change email address');
+					cy.contains('send again');
+					cy.contains('try another address');
 
 					cy.checkForEmailAndGetDetails(
 						emailAddress,
@@ -332,8 +332,8 @@ describe('Password reset flow in Okta', () => {
 
 					cy.contains('Check your email inbox');
 					cy.contains(emailAddress);
-					cy.contains('Resend email');
-					cy.contains('Change email address');
+					cy.contains('send again');
+					cy.contains('try another address');
 
 					cy.checkForEmailAndGetDetails(
 						emailAddress,
@@ -384,8 +384,8 @@ describe('Password reset flow in Okta', () => {
 
 						cy.contains('Check your email inbox');
 						cy.contains(emailAddress);
-						cy.contains('Resend email');
-						cy.contains('Change email address');
+						cy.contains('send again');
+						cy.contains('try another address');
 
 						cy.checkForEmailAndGetDetails(
 							emailAddress,
@@ -437,8 +437,8 @@ describe('Password reset flow in Okta', () => {
 
 						cy.contains('Check your email inbox');
 						cy.contains(emailAddress);
-						cy.contains('Resend email');
-						cy.contains('Change email address');
+						cy.contains('send again');
+						cy.contains('try another address');
 
 						cy.checkForEmailAndGetDetails(
 							emailAddress,
@@ -489,8 +489,8 @@ describe('Password reset flow in Okta', () => {
 
 						cy.contains('Check your email inbox');
 						cy.contains(emailAddress);
-						cy.contains('Resend email');
-						cy.contains('Change email address');
+						cy.contains('send again');
+						cy.contains('try another address');
 
 						cy.checkForEmailAndGetDetails(
 							emailAddress,

--- a/cypress/integration/ete-okta/sign_in.1.cy.ts
+++ b/cypress/integration/ete-okta/sign_in.1.cy.ts
@@ -325,8 +325,8 @@ describe('Sign in flow, Okta enabled', () => {
 						'For security reasons we need you to change your password.',
 					);
 					cy.contains(emailAddress);
-					cy.contains('Resend email');
-					cy.contains('Change email address');
+					cy.contains('send again');
+					cy.contains('try another address');
 
 					// Ensure the user's authentication cookies are not set
 					cy.getCookie('idx').then((idxCookie) => {

--- a/cypress/integration/ete/registration/register.2.cy.ts
+++ b/cypress/integration/ete/registration/register.2.cy.ts
@@ -304,23 +304,23 @@ describe('Registration flow', () => {
 		);
 	});
 
-	it('Sign up with Google button links to /signin/google', () => {
+	it('Continue with Google button links to /signin/google', () => {
 		cy.visit('/register?useIdapi=true');
-		cy.contains('Sign up with Google')
+		cy.contains('Continue with Google')
 			.should('have.attr', 'href')
 			.and('include', '/signin/google');
 	});
 
-	it('Sign up with Apple button links to /signin/apple', () => {
+	it('Continue with Apple button links to /signin/apple', () => {
 		cy.visit('/register?useIdapi=true');
-		cy.contains('Sign up with Apple')
+		cy.contains('Continue with Apple')
 			.should('have.attr', 'href')
 			.and('include', '/signin/apple');
 	});
 
-	it('Sign up with Email button links to /register/email', () => {
+	it('Continue with Email button links to /register/email', () => {
 		cy.visit('/register?useIdapi=true');
-		cy.contains('Sign up with email')
+		cy.contains('Continue with email')
 			.should('have.attr', 'href')
 			.and('include', '/register/email');
 	});

--- a/cypress/integration/ete/registration/register.2.cy.ts
+++ b/cypress/integration/ete/registration/register.2.cy.ts
@@ -124,8 +124,8 @@ describe('Registration flow', () => {
 
 		cy.contains('Check your email inbox');
 		cy.contains(unregisteredEmail);
-		cy.contains('Resend email');
-		cy.contains('Change email address');
+		cy.contains('send again');
+		cy.contains('try another address');
 
 		cy.checkForEmailAndGetDetails(
 			unregisteredEmail,
@@ -156,8 +156,8 @@ describe('Registration flow', () => {
 
 				cy.contains('Check your email inbox');
 				cy.contains(emailAddress);
-				cy.contains('Resend email');
-				cy.contains('Change email address');
+				cy.contains('send again');
+				cy.contains('try another address');
 
 				cy.checkForEmailAndGetDetails(emailAddress, timeRequestWasMade).then(
 					({ links, body }) => {
@@ -195,8 +195,8 @@ describe('Registration flow', () => {
 
 				cy.contains('Check your email inbox');
 				cy.contains(emailAddress);
-				cy.contains('Resend email');
-				cy.contains('Change email address');
+				cy.contains('send again');
+				cy.contains('try another address');
 
 				cy.checkForEmailAndGetDetails(
 					emailAddress,
@@ -237,8 +237,8 @@ describe('Registration flow', () => {
 
 				cy.contains('Check your email inbox');
 				cy.contains(emailAddress);
-				cy.contains('Resend email');
-				cy.contains('Change email address');
+				cy.contains('send again');
+				cy.contains('try another address');
 
 				cy.checkForEmailAndGetDetails(
 					emailAddress,

--- a/cypress/integration/ete/registration/register_email_sent.3.cy.ts
+++ b/cypress/integration/ete/registration/register_email_sent.3.cy.ts
@@ -21,8 +21,8 @@ describe('Registration email sent page', () => {
 
 		cy.contains('Check your email inbox');
 		cy.contains(unregisteredEmail);
-		cy.contains('Resend email');
-		cy.contains('Change email address');
+		cy.contains('send again');
+		cy.contains('try another address');
 
 		// test and delete initial email
 		cy.checkForEmailAndGetDetails(
@@ -33,7 +33,7 @@ describe('Registration email sent page', () => {
 		});
 
 		const timeRequestWasMade = new Date();
-		cy.contains('Resend email').click();
+		cy.contains('send again').click();
 		cy.contains('Check your email inbox');
 		cy.contains(unregisteredEmail);
 
@@ -60,8 +60,8 @@ describe('Registration email sent page', () => {
 
 				cy.contains('Check your email inbox');
 				cy.contains(emailAddress);
-				cy.contains('Resend email');
-				cy.contains('Change email address');
+				cy.contains('send again');
+				cy.contains('try another address');
 
 				// test and delete initial email
 				cy.checkForEmailAndGetDetails(
@@ -77,7 +77,7 @@ describe('Registration email sent page', () => {
 				});
 
 				const timeRequestWasMade = new Date();
-				cy.contains('Resend email').click();
+				cy.contains('send again').click();
 				cy.contains('Check your email inbox');
 				cy.contains(emailAddress);
 
@@ -108,8 +108,8 @@ describe('Registration email sent page', () => {
 
 				cy.contains('Check your email inbox');
 				cy.contains(emailAddress);
-				cy.contains('Resend email');
-				cy.contains('Change email address');
+				cy.contains('send again');
+				cy.contains('try another address');
 
 				cy.checkForEmailAndGetDetails(
 					emailAddress,
@@ -121,7 +121,7 @@ describe('Registration email sent page', () => {
 				});
 
 				const timeRequestWasMade = new Date();
-				cy.contains('Resend email').click();
+				cy.contains('send again').click();
 				cy.contains('Check your email inbox');
 				cy.contains(emailAddress);
 
@@ -138,14 +138,14 @@ describe('Registration email sent page', () => {
 
 	it('should navigate back to the correct page when change email is clicked', () => {
 		cy.visit('/register/email-sent?useIdapi=true');
-		cy.contains('Change email address').click();
+		cy.contains('try another address').click();
 		cy.contains('Register');
 		cy.title().should('eq', 'Register | The Guardian');
 	});
 
 	it('should render properly if the encrypted email cookie is not set', () => {
 		cy.visit('/register/email-sent?useIdapi=true');
-		cy.contains('Change email address');
+		cy.contains('try another address');
 		cy.contains('Check your email inbox');
 	});
 
@@ -164,8 +164,8 @@ describe('Registration email sent page', () => {
 
 				cy.contains('Check your email inbox');
 				cy.contains(emailAddress);
-				cy.contains('Resend email');
-				cy.contains('Change email address');
+				cy.contains('send again');
+				cy.contains('try another address');
 
 				cy.checkForEmailAndGetDetails(
 					emailAddress,
@@ -174,18 +174,18 @@ describe('Registration email sent page', () => {
 
 				cy.interceptRecaptcha();
 
-				cy.contains('Resend email').click();
+				cy.contains('send again').click();
 				cy.contains('Google reCAPTCHA verification failed. Please try again.');
 
 				// On second click, an expanded error is shown.
-				cy.contains('Resend email').click();
+				cy.contains('send again').click();
 
 				cy.contains('Google reCAPTCHA verification failed.');
 				cy.contains('If the problem persists please try the following:');
 				cy.contains(SUPPORT_EMAIL);
 
 				const timeRequestWasMade = new Date();
-				cy.contains('Resend email').click();
+				cy.contains('send again').click();
 
 				cy.contains(
 					'Google reCAPTCHA verification failed. Please try again.',

--- a/cypress/integration/ete/reset_password/reset_password.4.cy.ts
+++ b/cypress/integration/ete/reset_password/reset_password.4.cy.ts
@@ -148,8 +148,8 @@ describe('Password set flow', () => {
 					cy.contains('Send me a link').click();
 					cy.contains('Check your email inbox');
 					cy.contains(emailAddress);
-					cy.contains('Resend email');
-					cy.contains('Change email address');
+					cy.contains('send again');
+					cy.contains('try another address');
 					cy.checkForEmailAndGetDetails(
 						emailAddress,
 						timeRequestWasMadeLinkExpired,
@@ -162,9 +162,9 @@ describe('Password set flow', () => {
 						expect(body).to.have.string('Create password');
 					});
 
-					// resend email
+					// send again
 					const timeRequestWasMadeResend = new Date();
-					cy.contains('Resend email').click();
+					cy.contains('send again').click();
 					cy.contains('Check your email inbox');
 					cy.contains(emailAddress);
 					cy.checkForEmailAndGetDetails(

--- a/cypress/integration/mocked-okta/registerController.1.cy.ts
+++ b/cypress/integration/mocked-okta/registerController.1.cy.ts
@@ -11,7 +11,7 @@ beforeEach(() => {
 });
 const verifyInRegularEmailSentPage = () => {
 	cy.contains('Check your email inbox');
-	cy.contains('Resend email');
+	cy.contains('send again');
 };
 
 userStatuses.forEach((status) => {

--- a/cypress/integration/mocked-okta/resendEmailController.3.cy.ts
+++ b/cypress/integration/mocked-okta/resendEmailController.3.cy.ts
@@ -11,7 +11,7 @@ beforeEach(() => {
 });
 const verifyInRegularEmailSentPage = () => {
 	cy.contains('Check your email inbox');
-	cy.contains('Resend email');
+	cy.contains('send again');
 	cy.contains('Email sent');
 	cy.contains('within 2 minutes').should('not.exist');
 };
@@ -204,7 +204,7 @@ userStatuses.forEach((status) => {
 							cy.mockNext(userGroupsResponse.code, userGroupsResponse.response);
 							cy.get('[data-cy="main-form-submit-button"]').click();
 							cy.contains('Check your email inbox');
-							cy.contains('Resend email');
+							cy.contains('send again');
 							cy.contains('Email sent');
 						},
 					);
@@ -234,7 +234,7 @@ userStatuses.forEach((status) => {
 							});
 							cy.get('[data-cy="main-form-submit-button"]').click();
 							cy.contains('Check your email inbox');
-							cy.contains('Resend email');
+							cy.contains('send again');
 							cy.contains('Email sent');
 						},
 					);
@@ -473,7 +473,7 @@ userStatuses.forEach((status) => {
 							);
 							cy.get('[data-cy="main-form-submit-button"]').click();
 							cy.contains('Check your email inbox');
-							cy.contains('Resend email');
+							cy.contains('send again');
 							cy.contains('Email sent');
 						},
 					);

--- a/cypress/integration/mocked-okta/resetPasswordController.4.cy.ts
+++ b/cypress/integration/mocked-okta/resetPasswordController.4.cy.ts
@@ -13,13 +13,13 @@ beforeEach(() => {
 
 const verifyIn2MinutesEmailSentPage = () => {
 	cy.contains('Check your email inbox');
-	cy.contains('Resend email');
+	cy.contains('send again');
 	cy.contains('Email sent');
 	cy.contains('within 2 minutes');
 };
 const verifyInRegularEmailSentPage = () => {
 	cy.contains('Check your email inbox');
-	cy.contains('Resend email');
+	cy.contains('send again');
 	cy.contains('Email sent');
 	cy.contains('within 2 minutes').should('not.exist');
 };

--- a/cypress/integration/mocked/okta_send_reset_password.4.cy.ts
+++ b/cypress/integration/mocked/okta_send_reset_password.4.cy.ts
@@ -110,7 +110,7 @@ describe('Send password reset email in Okta', () => {
 			cy.get('button[type="submit"]').click();
 			cy.contains('Check your email inbox');
 			cy.contains('email within 2 minutes');
-			cy.contains('Resend email');
+			cy.contains('send again');
 		});
 	});
 
@@ -174,7 +174,7 @@ describe('Send password reset email in Okta', () => {
 			cy.get('button[type="submit"]').click();
 			cy.contains('Check your email inbox');
 			cy.contains('email within 2 minutes');
-			cy.contains('Resend email');
+			cy.contains('send again');
 		});
 	});
 
@@ -190,7 +190,7 @@ describe('Send password reset email in Okta', () => {
 			cy.get('button[type="submit"]').click();
 			cy.contains('Check your email inbox');
 			cy.contains('email within 2 minutes');
-			cy.contains('Resend email');
+			cy.contains('send again');
 		});
 	});
 
@@ -206,7 +206,7 @@ describe('Send password reset email in Okta', () => {
 			cy.get('button[type="submit"]').click();
 			cy.contains('Check your email inbox');
 			cy.contains('email within 2 minutes');
-			cy.contains('Resend email');
+			cy.contains('send again');
 		});
 	});
 
@@ -223,7 +223,7 @@ describe('Send password reset email in Okta', () => {
 			cy.get('button[type="submit"]').click();
 			cy.contains('Check your email inbox');
 			cy.contains('email within 2 minutes');
-			cy.contains('Resend email');
+			cy.contains('send again');
 		});
 	});
 
@@ -240,7 +240,7 @@ describe('Send password reset email in Okta', () => {
 			cy.get('button[type="submit"]').click();
 			cy.contains('Check your email inbox');
 			cy.contains('email within 2 minutes');
-			cy.contains('Resend email');
+			cy.contains('send again');
 		});
 	});
 
@@ -258,7 +258,7 @@ describe('Send password reset email in Okta', () => {
 			cy.get('button[type="submit"]').click();
 			cy.contains('Check your email inbox');
 			cy.contains('email within 2 minutes');
-			cy.contains('Resend email');
+			cy.contains('send again');
 		});
 	});
 

--- a/cypress/integration/mocked/welcome.4.cy.ts
+++ b/cypress/integration/mocked/welcome.4.cy.ts
@@ -275,7 +275,7 @@ describe('Welcome and set password page', () => {
 			cy.get('button[type="submit"]').click();
 			cy.contains('Check your email inbox');
 			cy.contains(checkTokenSuccessResponse().user.primaryEmailAddress);
-			cy.contains('Resend email');
+			cy.contains('send again');
 		});
 
 		it('shows the session time out page if the token expires while on the set password page', () => {
@@ -301,7 +301,7 @@ describe('Welcome and set password page', () => {
 			cy.contains('Check your email inbox');
 		});
 
-		it('fails to resend email if reCAPTCHA check is unsuccessful', () => {
+		it('fails to send again if reCAPTCHA check is unsuccessful', () => {
 			cy.visit(`/welcome/resend?useIdapi=true`);
 
 			cy.mockNext(200);
@@ -321,7 +321,7 @@ describe('Welcome and set password page', () => {
 			cy.contains(SUPPORT_EMAIL);
 		});
 
-		it('takes user back to link expired page if "Change email address" clicked', () => {
+		it('takes user back to link expired page if "try another address" clicked', () => {
 			cy.visit(`/welcome/resend?useIdapi=true`);
 
 			cy.mockNext(200);
@@ -330,7 +330,7 @@ describe('Welcome and set password page', () => {
 			);
 			cy.get('button[type="submit"]').click();
 
-			cy.contains('Change email address').click();
+			cy.contains('try another address').click();
 
 			cy.contains('Link expired');
 		});

--- a/cypress/integration/shared/sign_in.shared.ts
+++ b/cypress/integration/shared/sign_in.shared.ts
@@ -221,9 +221,9 @@ export const navigatesToRegistration = (isIdapi = false) => {
 			const visitUrl = isIdapi ? '/signin?useIdapi=true' : '/signin';
 			cy.visit(visitUrl);
 			cy.contains('Register').click();
-			cy.contains('Sign up with Google');
-			cy.contains('Sign up with Apple');
-			cy.contains('Sign up with email');
+			cy.contains('Continue with Google');
+			cy.contains('Continue with Apple');
+			cy.contains('Continue with email');
 		},
 	] as const;
 };

--- a/src/client/__tests__/Registration.test.tsx
+++ b/src/client/__tests__/Registration.test.tsx
@@ -46,17 +46,13 @@ test('Default terms and conditions in document when clientId not set', async () 
 	};
 
 	const defaultTerms = queryByTextContent(
-		'By proceeding, you agree to our terms & conditions.',
-	);
-	const privacyPolicy = queryByTextContent(
-		'For information about how we use your data, see our privacy policy.',
+		'By proceeding, you agree to our terms & conditions. For information about how we use your data, see our privacy policy.',
 	);
 	const jobsTerms = queryByTextContent(
 		'By proceeding, you agree to our Guardian Jobs terms & conditions.',
 	);
 	await waitFor(() => {
 		expect(defaultTerms).toBeInTheDocument();
-		expect(privacyPolicy).toBeInTheDocument();
 		expect(jobsTerms).not.toBeInTheDocument();
 	});
 });
@@ -89,15 +85,11 @@ test('Jobs terms and conditions in document when clientId equals "jobs"', async 
 	const defaultTerms = queryByTextContent(
 		'By proceeding, you agree to our terms & conditions',
 	);
-	const privacyPolicy = queryByTextContent(
-		'For information about how we use your data, see our Guardian Jobs privacy policy.',
-	);
 	const jobsTerms = queryByTextContent(
-		'By proceeding, you agree to our Guardian Jobs terms & conditions.',
+		'By proceeding, you agree to our Guardian Jobs terms & conditions. For information about how we use your data, see our Guardian Jobs privacy policy.',
 	);
 	await waitFor(() => {
 		expect(defaultTerms).not.toBeInTheDocument();
-		expect(privacyPolicy).toBeInTheDocument();
 		expect(jobsTerms).toBeInTheDocument();
 	});
 });

--- a/src/client/__tests__/SignIn.test.tsx
+++ b/src/client/__tests__/SignIn.test.tsx
@@ -54,17 +54,13 @@ test('Default terms and conditions in document when clientId not set', async () 
 	};
 
 	const defaultTerms = queryByTextContent(
-		'By proceeding, you agree to our terms & conditions.',
-	);
-	const privacyPolicy = queryByTextContent(
-		'For information about how we use your data, see our privacy policy.',
+		'By proceeding, you agree to our terms & conditions. For information about how we use your data, see our privacy policy.',
 	);
 	const jobsTerms = queryByTextContent(
 		'By proceeding, you agree to our Guardian Jobs terms & conditions.',
 	);
 	await waitFor(() => {
 		expect(defaultTerms).toBeInTheDocument();
-		expect(privacyPolicy).toBeInTheDocument();
 		expect(jobsTerms).not.toBeInTheDocument();
 	});
 });
@@ -97,15 +93,11 @@ test('Jobs terms and conditions in document when clientId equals "jobs"', async 
 	const defaultTerms = queryByTextContent(
 		'By proceeding, you agree to our terms & conditions',
 	);
-	const privacyPolicy = queryByTextContent(
-		'For information about how we use your data, see our Guardian Jobs privacy policy.',
-	);
 	const jobsTerms = queryByTextContent(
-		'By proceeding, you agree to our Guardian Jobs terms & conditions.',
+		'By proceeding, you agree to our Guardian Jobs terms & conditions. For information about how we use your data, see our Guardian Jobs privacy policy.',
 	);
 	await waitFor(() => {
 		expect(defaultTerms).not.toBeInTheDocument();
-		expect(privacyPolicy).toBeInTheDocument();
 		expect(jobsTerms).toBeInTheDocument();
 	});
 });

--- a/src/client/components/AuthProviderButtons.stories.tsx
+++ b/src/client/components/AuthProviderButtons.stories.tsx
@@ -10,7 +10,6 @@ export default {
 
 export const Desktop = () => (
 	<AuthProviderButtons
-		context="Sign in"
 		queryParams={{ returnUrl: 'https://www.theguardian.com/uk/' }}
 		providers={['social']}
 	/>
@@ -25,7 +24,6 @@ Desktop.parameters = {
 
 export const Mobile = () => (
 	<AuthProviderButtons
-		context="Sign in"
 		queryParams={{ returnUrl: 'https://www.theguardian.com/uk/' }}
 		providers={['social']}
 	/>
@@ -40,7 +38,6 @@ Mobile.parameters = {
 
 export const NativeAppAndroid = () => (
 	<AuthProviderButtons
-		context="Sign in"
 		queryParams={{ returnUrl: 'https://www.theguardian.com/uk/' }}
 		isNativeApp="android"
 		providers={['social']}
@@ -50,7 +47,6 @@ NativeAppAndroid.storyName = 'Android native app';
 
 export const NativeAppIos = () => (
 	<AuthProviderButtons
-		context="Sign in"
 		queryParams={{ returnUrl: 'https://www.theguardian.com/uk/' }}
 		isNativeApp="ios"
 		providers={['social']}
@@ -60,7 +56,6 @@ NativeAppIos.storyName = 'iOS native app';
 
 export const DesktopWithEmail = () => (
 	<AuthProviderButtons
-		context="Sign in"
 		queryParams={{ returnUrl: 'https://www.theguardian.com/uk/' }}
 		providers={['social', 'email']}
 	/>
@@ -75,7 +70,6 @@ DesktopWithEmail.parameters = {
 
 export const MobileWithEmail = () => (
 	<AuthProviderButtons
-		context="Sign in"
 		queryParams={{ returnUrl: 'https://www.theguardian.com/uk/' }}
 		providers={['social', 'email']}
 	/>
@@ -90,7 +84,6 @@ MobileWithEmail.parameters = {
 
 export const NativeAppAndroidWithEmail = () => (
 	<AuthProviderButtons
-		context="Sign in"
 		queryParams={{ returnUrl: 'https://www.theguardian.com/uk/' }}
 		isNativeApp="android"
 		providers={['social', 'email']}
@@ -100,7 +93,6 @@ NativeAppAndroidWithEmail.storyName = 'Android native app (with email)';
 
 export const NativeAppIosWithEmail = () => (
 	<AuthProviderButtons
-		context="Sign in"
 		queryParams={{ returnUrl: 'https://www.theguardian.com/uk/' }}
 		isNativeApp="ios"
 		providers={['social', 'email']}

--- a/src/client/components/AuthProviderButtons.tsx
+++ b/src/client/components/AuthProviderButtons.tsx
@@ -11,11 +11,9 @@ import { QueryParams } from '@/shared/model/QueryParams';
 import { buildUrlWithQueryParams } from '@/shared/lib/routeUtils';
 import { IsNativeApp } from '@/shared/model/ClientState';
 
-type AuthProviderButtonContext = 'Sign in' | 'Sign up';
 type AuthButtonProvider = 'social' | 'email';
 
 type AuthProviderButtonsProps = {
-	context: AuthProviderButtonContext;
 	queryParams: QueryParams;
 	marginTop?: boolean;
 	isNativeApp?: IsNativeApp;
@@ -26,9 +24,7 @@ type AuthProviderButtonProps = {
 	label: string;
 	icon: React.ReactElement;
 	socialProvider: string;
-	context: AuthProviderButtonContext;
 	queryParams: QueryParams;
-	isNativeApp?: IsNativeApp;
 };
 
 const containerStyles = (marginTop = false) => css`
@@ -70,9 +66,7 @@ const SocialButton = ({
 	label,
 	icon,
 	socialProvider,
-	context,
 	queryParams,
-	isNativeApp,
 }: AuthProviderButtonProps) => {
 	return (
 		<>
@@ -90,25 +84,18 @@ const SocialButton = ({
 				data-cy={`${socialProvider}-sign-in-button`}
 				data-link-name={`${socialProvider}-social-button`}
 			>
-				{authProviderButtonLabel(label, context, isNativeApp)}
+				{authProviderButtonLabel(label)}
 			</LinkButton>
 		</>
 	);
 };
 
-const authProviderButtonLabel = (
-	label: string,
-	context: string,
-	isNativeApp?: IsNativeApp,
-) => {
+const authProviderButtonLabel = (label: string) => {
 	// We don't capitalize 'email', but we do capitalize 'google' and 'apple'
 	const capitalisedLabel =
 		label === 'email' ? label : label.charAt(0).toUpperCase() + label.slice(1);
-	if (isNativeApp) {
-		return `Continue with ${capitalisedLabel}`;
-	} else {
-		return `${context} with ${capitalisedLabel}`;
-	}
+
+	return `Continue with ${capitalisedLabel}`;
 };
 
 const socialButtonIcon = (socialProvider: string): React.ReactElement => {
@@ -137,7 +124,6 @@ const getButtonOrder = (isNativeApp?: IsNativeApp): string[] => {
 };
 
 export const AuthProviderButtons = ({
-	context,
 	queryParams,
 	marginTop,
 	isNativeApp,
@@ -153,9 +139,7 @@ export const AuthProviderButtons = ({
 						label={socialProvider}
 						icon={socialButtonIcon(socialProvider)}
 						socialProvider={socialProvider}
-						context={context}
 						queryParams={queryParams}
-						isNativeApp={isNativeApp}
 					/>
 				))}
 			{providers.includes('email') && (
@@ -165,7 +149,7 @@ export const AuthProviderButtons = ({
 					priority="tertiary"
 					href={buildUrlWithQueryParams('/register/email', {}, queryParams)}
 				>
-					{authProviderButtonLabel('email', context, isNativeApp)}
+					{authProviderButtonLabel('email')}
 				</LinkButton>
 			)}
 		</div>

--- a/src/client/components/InformationBox.stories.tsx
+++ b/src/client/components/InformationBox.stories.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { Meta } from '@storybook/react';
+
+import { InformationBoxText, InformationBox } from './InformationBox';
+import { ButtonLink, Link } from '@guardian/source-react-components';
+import { ExternalLink } from './ExternalLink';
+
+export default {
+	title: 'Components/InformationBox',
+	component: InformationBox,
+} as Meta;
+
+export const Default = () => (
+	<InformationBox>
+		<InformationBoxText>
+			This is some useful stuff in the information box
+		</InformationBoxText>
+		<InformationBoxText>
+			And some more useful stuff in the information box but this one is a{' '}
+			<Link href="#">link</Link>.
+		</InformationBoxText>
+		<InformationBoxText>
+			This also works with <ExternalLink href="#">external links</ExternalLink>{' '}
+			too. As well as <ButtonLink>buttons that look like links</ButtonLink>.
+		</InformationBoxText>
+	</InformationBox>
+);
+Default.storyName = 'default';
+
+export const WithMarginTop = () => (
+	<InformationBox withMarginTop>
+		<InformationBoxText>
+			This is some useful stuff in the information box, with a margin top!
+		</InformationBoxText>
+		<InformationBoxText>
+			And some more useful stuff in the information box but this one is a{' '}
+			<Link href="#">link</Link>.
+		</InformationBoxText>
+		<InformationBoxText>
+			This also works with <ExternalLink href="#">external links</ExternalLink>{' '}
+			too. As well as <ButtonLink>buttons that look like links</ButtonLink>.
+		</InformationBoxText>
+	</InformationBox>
+);
+WithMarginTop.storyName = 'withMarginTop';

--- a/src/client/components/InformationBox.tsx
+++ b/src/client/components/InformationBox.tsx
@@ -1,0 +1,42 @@
+import React, { PropsWithChildren } from 'react';
+import { css } from '@emotion/react';
+import { palette, space, textSans } from '@guardian/source-foundations';
+
+interface InformationBoxProps {
+	withMarginTop?: boolean;
+}
+
+const informationBoxStyles = ({ withMarginTop }: InformationBoxProps) => css`
+	background-color: ${palette.neutral[93]};
+	border-radius: 4px;
+	padding: ${space[3]}px ${space[3]}px;
+	${withMarginTop && `margin-top: ${space[5]}px;`}
+`;
+
+const informationBoxTextStyle = css`
+	${textSans.xsmall()}
+	margin: 0 0 ${space[2]}px 0;
+	&:last-of-type {
+		margin: 0;
+	}
+
+	a {
+		${textSans.xsmall()}
+	}
+
+	button {
+		${textSans.xsmall()}
+	}
+`;
+export const InformationBoxText = ({
+	children,
+}: {
+	children: React.ReactNode;
+}) => <div css={informationBoxTextStyle}>{children}</div>;
+
+export const InformationBox = ({
+	children,
+	withMarginTop,
+}: PropsWithChildren<InformationBoxProps>) => (
+	<div css={informationBoxStyles({ withMarginTop })}>{children}</div>
+);

--- a/src/client/components/MainBodyText.tsx
+++ b/src/client/components/MainBodyText.tsx
@@ -5,12 +5,20 @@ interface Props {
 	noMarginBottom?: boolean;
 	marginTop?: boolean;
 	cssOverrides?: SerializedStyles;
+	smallText?: boolean;
 }
 
-const mainBodyTextStyles = (noMarginBottom = false, marginTop = false) => css`
-	${textSans.medium({ lineHeight: 'regular' })}
-	font-size: 17px;
+const mainBodyTextStyles = (
+	noMarginBottom = false,
+	marginTop = false,
+	smallText = false,
+) => css`
+	${smallText
+		? textSans.small({ lineHeight: 'regular' })
+		: textSans.medium({ lineHeight: 'regular' })}
+
 	color: ${text.primary};
+
 	${marginTop
 		? ''
 		: css`
@@ -24,6 +32,12 @@ const mainBodyTextStyles = (noMarginBottom = false, marginTop = false) => css`
 		: css`
 				margin-bottom: ${space[3]}px;
 			`}
+			
+	& a {
+		${smallText
+			? textSans.small({ lineHeight: 'regular' })
+			: textSans.medium({ lineHeight: 'regular' })}
+	}
 `;
 
 export const MainBodyText = ({
@@ -31,8 +45,14 @@ export const MainBodyText = ({
 	cssOverrides,
 	noMarginBottom,
 	marginTop,
+	smallText,
 }: PropsWithChildren<Props>) => (
-	<p css={[mainBodyTextStyles(noMarginBottom, marginTop), cssOverrides]}>
+	<p
+		css={[
+			mainBodyTextStyles(noMarginBottom, marginTop, smallText),
+			cssOverrides,
+		]}
+	>
 		{children}
 	</p>
 );

--- a/src/client/components/MainForm.stories.tsx
+++ b/src/client/components/MainForm.stories.tsx
@@ -78,6 +78,13 @@ export const TertiarySubmitButton = () => (
 );
 TertiarySubmitButton.storyName = 'TertiarySubmitButton';
 
+export const ButtonLinkSubmit = () => (
+	<MainForm formAction="" submitButtonText="Send me a link" submitButtonLink>
+		<EmailInput hidden />
+	</MainForm>
+);
+ButtonLinkSubmit.storyName = 'ButtonLinkSubmit';
+
 export const FormWithError = () => (
 	<MainForm
 		formAction=""

--- a/src/client/components/MainForm.stories.tsx
+++ b/src/client/components/MainForm.stories.tsx
@@ -96,3 +96,14 @@ export const FormWithError = () => (
 	</MainForm>
 );
 FormWithError.storyName = 'FormWithError';
+
+export const WithAdditionalTerms = () => (
+	<MainForm
+		formAction=""
+		submitButtonText="Send me a link"
+		additionalTerms="These are some additional terms"
+	>
+		<EmailInput />
+	</MainForm>
+);
+WithAdditionalTerms.storyName = 'WithAdditionalTerms';

--- a/src/client/components/MainForm.tsx
+++ b/src/client/components/MainForm.tsx
@@ -80,7 +80,7 @@ export const inputMarginBottomSpacingStyle = css`
 `;
 
 export const belowFormMarginTopSpacingStyle = css`
-	margin-top: ${space[6]}px;
+	margin-top: ${space[5]}px;
 `;
 
 export const MainForm = ({

--- a/src/client/components/MainForm.tsx
+++ b/src/client/components/MainForm.tsx
@@ -13,8 +13,6 @@ import {
 	GuardianTerms,
 	JobsTerms,
 	RecaptchaTerms,
-	TermsBox,
-	TermsText,
 } from '@/client/components/Terms';
 import { space } from '@guardian/source-foundations';
 import { buttonStyles } from '@/client/layouts/Main';
@@ -29,6 +27,7 @@ import { trackFormFocusBlur, trackFormSubmit } from '@/client/lib/ophan';
 import { logger } from '@/client/lib/clientSideLogger';
 import { ErrorSummary } from '@guardian/source-react-components-development-kitchen';
 import locations from '@/shared/lib/locations';
+import { InformationBox, InformationBoxText } from './InformationBox';
 
 export interface MainFormProps {
 	formAction: string;
@@ -61,7 +60,7 @@ export interface MainFormProps {
 	largeFormMarginTop?: boolean;
 	submitButtonLink?: boolean;
 	hideRecaptchaMessage?: boolean;
-	additionalTerms?: string;
+	additionalTerms?: ReactNode;
 }
 
 const formStyles = (
@@ -317,12 +316,14 @@ export const MainForm = ({
 				hasGuardianTerms ||
 				hasJobsTerms ||
 				(recaptchaEnabled && !hideRecaptchaMessage)) && (
-				<TermsBox>
+				<InformationBox>
 					{hasGuardianTerms && <GuardianTerms />}
 					{hasJobsTerms && <JobsTerms />}
-					{additionalTerms && <TermsText>{additionalTerms}</TermsText>}
+					{additionalTerms && (
+						<InformationBoxText>{additionalTerms}</InformationBoxText>
+					)}
 					{recaptchaEnabled && !hideRecaptchaMessage && <RecaptchaTerms />}
-				</TermsBox>
+				</InformationBox>
 			)}
 
 			{submitButtonLink ? (

--- a/src/client/components/MainForm.tsx
+++ b/src/client/components/MainForm.tsx
@@ -7,7 +7,7 @@ import React, {
 	useState,
 } from 'react';
 import { css } from '@emotion/react';
-import { Button } from '@guardian/source-react-components';
+import { Button, ButtonLink } from '@guardian/source-react-components';
 import { CsrfFormField } from '@/client/components/CsrfFormField';
 import {
 	GuardianTerms,
@@ -57,14 +57,28 @@ export interface MainFormProps {
 	formTrackingName?: string;
 	disableOnSubmit?: boolean;
 	largeFormMarginTop?: boolean;
+	submitButtonLink?: boolean;
+	hideRecaptchaMessage?: boolean;
 }
 
-const formStyles = (largeFormMarginTop = false) => css`
-	margin-top: ${largeFormMarginTop ? space[6] : space[4]}px;
+const formStyles = (
+	largeFormMarginTop = false,
+	submitButtonLink = false,
+) => css`
+	${!submitButtonLink &&
+	css`
+		margin-top: ${largeFormMarginTop ? space[6] : space[4]}px;
+	`}
+
+	${submitButtonLink &&
+	css`
+		display: inline-block;
+	`}
 `;
 
-const inputStyles = (hasTerms = false) => css`
+const inputStyles = (hasTerms = false, submitButtonLink = false) => css`
 	${hasTerms &&
+	!submitButtonLink &&
 	css`
 		margin-bottom: ${space[2]}px;
 	`}
@@ -80,7 +94,7 @@ export const inputMarginBottomSpacingStyle = css`
 `;
 
 export const belowFormMarginTopSpacingStyle = css`
-	margin-top: ${space[5]}px;
+	margin-top: ${space[3]}px;
 `;
 
 export const MainForm = ({
@@ -101,6 +115,8 @@ export const MainForm = ({
 	largeFormMarginTop = false,
 	formErrorMessageFromParent,
 	formErrorContextFromParent,
+	submitButtonLink,
+	hideRecaptchaMessage,
 }: PropsWithChildren<MainFormProps>) => {
 	const recaptchaEnabled = !!recaptchaSiteKey;
 	const hasTerms = recaptchaEnabled || hasGuardianTerms || hasJobsTerms;
@@ -259,7 +275,7 @@ export const MainForm = ({
 
 	return (
 		<form
-			css={formStyles(largeFormMarginTop)}
+			css={formStyles(largeFormMarginTop, submitButtonLink)}
 			method="post"
 			action={formAction}
 			onSubmit={handleSubmit}
@@ -291,25 +307,36 @@ export const MainForm = ({
 			)}
 			<CsrfFormField />
 			<RefTrackingFormFields />
-			<div css={inputStyles(hasTerms)}>{children}</div>
+			<div css={inputStyles(hasTerms, submitButtonLink)}>{children}</div>
 			{hasGuardianTerms && <GuardianTerms />}
 			{hasJobsTerms && <JobsTerms />}
-			{recaptchaEnabled && <RecaptchaTerms />}
-			<Button
-				css={buttonStyles({
-					hasTerms,
-					halfWidth: submitButtonHalfWidth,
-				})}
-				type="submit"
-				priority={submitButtonPriority}
-				data-cy="main-form-submit-button"
-				isLoading={isFormDisabled}
-				disabled={isFormDisabled}
-				aria-disabled={isFormDisabled}
-				iconSide="right"
-			>
-				{submitButtonText}
-			</Button>
+			{recaptchaEnabled && !hideRecaptchaMessage && <RecaptchaTerms />}
+			{submitButtonLink ? (
+				<ButtonLink
+					type="submit"
+					data-cy="main-form-submit-button"
+					disabled={isFormDisabled}
+					aria-disabled={isFormDisabled}
+				>
+					{submitButtonText}
+				</ButtonLink>
+			) : (
+				<Button
+					css={buttonStyles({
+						hasTerms,
+						halfWidth: submitButtonHalfWidth,
+					})}
+					type="submit"
+					priority={submitButtonPriority}
+					data-cy="main-form-submit-button"
+					isLoading={isFormDisabled}
+					disabled={isFormDisabled}
+					aria-disabled={isFormDisabled}
+					iconSide="right"
+				>
+					{submitButtonText}
+				</Button>
+			)}
 		</form>
 	);
 };

--- a/src/client/components/MainForm.tsx
+++ b/src/client/components/MainForm.tsx
@@ -13,6 +13,8 @@ import {
 	GuardianTerms,
 	JobsTerms,
 	RecaptchaTerms,
+	TermsBox,
+	TermsText,
 } from '@/client/components/Terms';
 import { space } from '@guardian/source-foundations';
 import { buttonStyles } from '@/client/layouts/Main';
@@ -59,6 +61,7 @@ export interface MainFormProps {
 	largeFormMarginTop?: boolean;
 	submitButtonLink?: boolean;
 	hideRecaptchaMessage?: boolean;
+	additionalTerms?: string;
 }
 
 const formStyles = (
@@ -117,9 +120,11 @@ export const MainForm = ({
 	formErrorContextFromParent,
 	submitButtonLink,
 	hideRecaptchaMessage,
+	additionalTerms,
 }: PropsWithChildren<MainFormProps>) => {
 	const recaptchaEnabled = !!recaptchaSiteKey;
-	const hasTerms = recaptchaEnabled || hasGuardianTerms || hasJobsTerms;
+	const hasTerms =
+		recaptchaEnabled || hasGuardianTerms || hasJobsTerms || !!additionalTerms;
 
 	// These setters are used to set the error message locally, in this component.
 	// We want to use these when we want to display errors at the level of the form.
@@ -308,9 +313,18 @@ export const MainForm = ({
 			<CsrfFormField />
 			<RefTrackingFormFields />
 			<div css={inputStyles(hasTerms, submitButtonLink)}>{children}</div>
-			{hasGuardianTerms && <GuardianTerms />}
-			{hasJobsTerms && <JobsTerms />}
-			{recaptchaEnabled && !hideRecaptchaMessage && <RecaptchaTerms />}
+			{(additionalTerms ||
+				hasGuardianTerms ||
+				hasJobsTerms ||
+				(recaptchaEnabled && !hideRecaptchaMessage)) && (
+				<TermsBox>
+					{hasGuardianTerms && <GuardianTerms />}
+					{hasJobsTerms && <JobsTerms />}
+					{additionalTerms && <TermsText>{additionalTerms}</TermsText>}
+					{recaptchaEnabled && !hideRecaptchaMessage && <RecaptchaTerms />}
+				</TermsBox>
+			)}
+
 			{submitButtonLink ? (
 				<ButtonLink
 					type="submit"

--- a/src/client/components/RegistrationConsents.stories.tsx
+++ b/src/client/components/RegistrationConsents.stories.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { Meta } from '@storybook/react';
+
+import { RegistrationConsents } from './RegistrationConsents';
+
+export default {
+	title: 'Components/RegistrationConsents',
+	component: RegistrationConsents,
+} as Meta;
+
+export const Default = () => {
+	return <RegistrationConsents geolocation="GB" />;
+};
+Default.storyName = 'default';
+
+export const US = () => {
+	return <RegistrationConsents geolocation="US" />;
+};
+US.storyName = 'US geolocation';
+
+export const NoMarginBottom = () => {
+	return <RegistrationConsents geolocation="GB" noMarginBottom />;
+};
+NoMarginBottom.storyName = 'NoMarginBottom';

--- a/src/client/components/RegistrationConsents.tsx
+++ b/src/client/components/RegistrationConsents.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { RegistrationConsentsFormFields } from '@/shared/model/Consent';
+import { RegistrationNewslettersFormFields } from '@/shared/model/Newsletter';
+import { css } from '@emotion/react';
+import { space } from '@guardian/source-foundations';
+import { RegistrationMarketingConsentFormField } from './RegistrationMarketingConsentFormField';
+import { RegistrationNewsletterFormField } from './RegistrationNewsletterFormField';
+import { GeoLocation } from '@/shared/model/Geolocation';
+
+interface RegistrationConsentsProps {
+	geolocation?: string;
+	useIdapi?: boolean;
+	noMarginBottom?: boolean;
+}
+
+const consentToggleCss = (noMarginBottom = false) => css`
+	display: flex;
+	margin-top: ${space[6]}px;
+	${noMarginBottom ? 'margin-bottom: 0;' : `margin-bottom: ${space[4]}px;`}
+	flex-direction: column;
+	gap: ${space[3]}px;
+`;
+
+export const RegistrationConsents = ({
+	geolocation,
+	useIdapi,
+	noMarginBottom,
+}: RegistrationConsentsProps) => {
+	// don't show the Saturday Edition newsletter option for US and AUS
+	const showSaturdayEdition = !(['US', 'AU'] as GeoLocation[]).some(
+		(location: GeoLocation) => location === geolocation,
+	);
+
+	if (useIdapi) {
+		return <></>;
+	}
+
+	return (
+		<div css={consentToggleCss(noMarginBottom)}>
+			{showSaturdayEdition && (
+				<RegistrationNewsletterFormField
+					id={RegistrationNewslettersFormFields.saturdayEdition.id}
+					label={`${RegistrationNewslettersFormFields.saturdayEdition.label} newsletter`}
+					context={RegistrationNewslettersFormFields.saturdayEdition.context}
+				/>
+			)}
+			<RegistrationMarketingConsentFormField
+				id={RegistrationConsentsFormFields.similarGuardianProducts.id}
+				label={RegistrationConsentsFormFields.similarGuardianProducts.label}
+			/>
+		</div>
+	);
+};

--- a/src/client/components/RegistrationMarketingConsentFormField.tsx
+++ b/src/client/components/RegistrationMarketingConsentFormField.tsx
@@ -1,25 +1,22 @@
 import { css } from '@emotion/react';
 import { palette, space, textSans } from '@guardian/source-foundations';
-import { Divider } from '@guardian/source-react-components-development-kitchen';
 import React from 'react';
-import { divider } from '@/client/styles/Shared';
 import { ToggleSwitchInput } from './ToggleSwitchInput';
 
 const switchRow = css`
 	border: 0;
 	padding: 0;
-	margin: ${space[6]}px ${space[2]}px 0 ${space[2]}px;
+	margin: 0;
 	${textSans.medium()}
+	border-radius: 4px;
+	border: 1px solid ${palette.neutral[38]};
+	padding: ${space[2]}px;
 `;
 
 const labelStyles = css`
 	justify-content: space-between;
 	color: ${palette.neutral[46]};
 	${textSans.xsmall()}
-`;
-
-const bottomDividerStyles = css`
-	margin-top: ${space[4]}px;
 `;
 
 type Props = {
@@ -38,10 +35,6 @@ export const RegistrationMarketingConsentFormField = ({ id, label }: Props) => {
 					cssOverrides={labelStyles}
 				/>
 			</fieldset>
-			<Divider
-				spaceAbove="tight"
-				cssOverrides={[divider, bottomDividerStyles]}
-			/>
 		</>
 	);
 };

--- a/src/client/components/RegistrationNewsletterFormField.stories.tsx
+++ b/src/client/components/RegistrationNewsletterFormField.stories.tsx
@@ -14,10 +14,20 @@ export const Default = () => {
 	return (
 		<RegistrationNewsletterFormField
 			id={RegistrationNewslettersFormFields.saturdayEdition.id}
-			label={RegistrationNewslettersFormFields.saturdayEdition.label}
+			label={`${RegistrationNewslettersFormFields.saturdayEdition.label} newsletter`}
 			context={RegistrationNewslettersFormFields.saturdayEdition.context}
 			imagePath={SATURDAY_EDITION_SMALL_SQUARE_IMAGE}
 		/>
 	);
 };
 Default.storyName = 'default';
+
+export const WithoutImage = () => {
+	return (
+		<RegistrationNewsletterFormField
+			id={RegistrationNewslettersFormFields.saturdayEdition.id}
+			label={`${RegistrationNewslettersFormFields.saturdayEdition.label} newsletter`}
+			context={RegistrationNewslettersFormFields.saturdayEdition.context}
+		/>
+	);
+};

--- a/src/client/components/RegistrationNewsletterFormField.tsx
+++ b/src/client/components/RegistrationNewsletterFormField.tsx
@@ -6,10 +6,10 @@ import { ToggleSwitchInput } from '@/client/components/ToggleSwitchInput';
 const switchRow = css`
 	border: 0;
 	padding: 0;
-	margin: ${space[6]}px 0 0 0;
+	margin: 0;
 	${textSans.medium()}
 	border-radius: 4px;
-	border: 1px dashed ${palette.neutral[38]};
+	border: 1px solid ${palette.neutral[38]};
 	padding: ${space[2]}px;
 `;
 
@@ -20,6 +20,7 @@ const labelStyles = css`
 		${textSans.xsmall({ fontWeight: 'bold' })}
 	}
 	& > span:last-of-type {
+		align-self: flex-start;
 		color: ${palette.neutral[46]};
 		${textSans.xsmall()}
 	}

--- a/src/client/components/Terms.stories.tsx
+++ b/src/client/components/Terms.stories.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import { Meta } from '@storybook/react';
 
-import { GuardianTerms, JobsTerms, RecaptchaTerms, TermsBox } from './Terms';
+import { GuardianTerms, JobsTerms, RecaptchaTerms } from './Terms';
+import { InformationBox } from './InformationBox';
 
 export default {
 	title: 'Components/Terms',
@@ -9,19 +10,19 @@ export default {
 } as Meta;
 
 export const Default = () => (
-	<TermsBox>
+	<InformationBox>
 		<GuardianTerms />
 		<RecaptchaTerms />
-	</TermsBox>
+	</InformationBox>
 );
 
 Default.storyName = 'Terms';
 
 export const Jobs = () => (
-	<TermsBox>
+	<InformationBox>
 		<JobsTerms />
 		<RecaptchaTerms />
-	</TermsBox>
+	</InformationBox>
 );
 
 Jobs.storyName = 'Jobs terms';

--- a/src/client/components/Terms.stories.tsx
+++ b/src/client/components/Terms.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Meta } from '@storybook/react';
 
-import { GuardianTerms, JobsTerms, RecaptchaTerms } from './Terms';
+import { GuardianTerms, JobsTerms, RecaptchaTerms, TermsBox } from './Terms';
 
 export default {
 	title: 'Components/Terms',
@@ -9,19 +9,19 @@ export default {
 } as Meta;
 
 export const Default = () => (
-	<>
+	<TermsBox>
 		<GuardianTerms />
 		<RecaptchaTerms />
-	</>
+	</TermsBox>
 );
 
 Default.storyName = 'Terms';
 
 export const Jobs = () => (
-	<>
+	<TermsBox>
 		<JobsTerms />
 		<RecaptchaTerms />
-	</>
+	</TermsBox>
 );
 
 Jobs.storyName = 'Jobs terms';

--- a/src/client/components/Terms.tsx
+++ b/src/client/components/Terms.tsx
@@ -1,87 +1,45 @@
-import React, { PropsWithChildren } from 'react';
-import { css } from '@emotion/react';
-import { palette, space, textSans } from '@guardian/source-foundations';
-import { ExternalLink } from '@/client/components/ExternalLink';
-
-interface TermsProps {
-	withMarginTop?: boolean;
-}
-
-const termsBoxStyle = ({ withMarginTop }: TermsProps) => css`
-	background-color: ${palette.neutral[93]};
-	border-radius: 4px;
-	padding: ${space[3]}px ${space[3]}px;
-	${withMarginTop && `margin-top: ${space[5]}px;`}
-`;
-
-const termsBoxTextStyle = css`
-	${textSans.xsmall()}
-	margin: 0 0 ${space[2]}px 0;
-	&:last-of-type {
-		margin: 0;
-	}
-`;
-
-export const TermsText = ({ children }: { children: React.ReactNode }) => (
-	<p css={termsBoxTextStyle}>{children}</p>
-);
-
-const TermsLink = ({ children, href }: PropsWithChildren<{ href: string }>) => (
-	<ExternalLink
-		cssOverrides={css`
-			${textSans.xsmall()}
-		`}
-		href={href}
-	>
-		{children}
-	</ExternalLink>
-);
-
-export const TermsBox = ({
-	children,
-	withMarginTop,
-}: PropsWithChildren<TermsProps>) => (
-	<div css={termsBoxStyle({ withMarginTop })}>{children}</div>
-);
+import React from 'react';
+import { InformationBoxText } from './InformationBox';
+import { ExternalLink } from './ExternalLink';
 
 export const GuardianTerms = () => (
-	<TermsText>
+	<InformationBoxText>
 		By proceeding, you agree to our{' '}
-		<TermsLink href="https://www.theguardian.com/help/terms-of-service">
+		<ExternalLink href="https://www.theguardian.com/help/terms-of-service">
 			terms &amp; conditions
-		</TermsLink>
+		</ExternalLink>
 		. For information about how we use your data, see our{' '}
-		<TermsLink href="https://www.theguardian.com/help/privacy-policy">
+		<ExternalLink href="https://www.theguardian.com/help/privacy-policy">
 			privacy policy
-		</TermsLink>
+		</ExternalLink>
 		.
-	</TermsText>
+	</InformationBoxText>
 );
 
 export const JobsTerms = () => (
-	<TermsText>
+	<InformationBoxText>
 		By proceeding, you agree to our{' '}
-		<TermsLink href="https://jobs.theguardian.com/terms-and-conditions/">
+		<ExternalLink href="https://jobs.theguardian.com/terms-and-conditions/">
 			Guardian Jobs terms &amp; conditions
-		</TermsLink>
+		</ExternalLink>
 		. For information about how we use your data, see our{' '}
-		<TermsLink href="https://jobs.theguardian.com/privacy-policy/">
+		<ExternalLink href="https://jobs.theguardian.com/privacy-policy/">
 			Guardian Jobs privacy policy
-		</TermsLink>
+		</ExternalLink>
 		.
-	</TermsText>
+	</InformationBoxText>
 );
 
 export const RecaptchaTerms = () => (
-	<TermsText>
+	<InformationBoxText>
 		This service is protected by reCAPTCHA and the Google{' '}
-		<TermsLink href="https://policies.google.com/privacy">
+		<ExternalLink href="https://policies.google.com/privacy">
 			privacy policy
-		</TermsLink>{' '}
+		</ExternalLink>{' '}
 		and{' '}
-		<TermsLink href="https://policies.google.com/terms">
+		<ExternalLink href="https://policies.google.com/terms">
 			terms of service
-		</TermsLink>{' '}
+		</ExternalLink>{' '}
 		apply.
-	</TermsText>
+	</InformationBoxText>
 );

--- a/src/client/components/Terms.tsx
+++ b/src/client/components/Terms.tsx
@@ -1,18 +1,24 @@
 import React from 'react';
 import { css } from '@emotion/react';
-import { space, textSans } from '@guardian/source-foundations';
+import { palette, space, textSans } from '@guardian/source-foundations';
 import { ExternalLink } from '@/client/components/ExternalLink';
 
-export const termsContainer = css`
-	margin-top: ${space[5]}px;
+interface TermsProps {
+	withMarginTop?: boolean;
+}
+
+const termsBox = ({ withMarginTop }: TermsProps) => css`
+	background-color: ${palette.neutral[93]};
+	border-radius: 4px;
+	padding: ${space[3]}px ${space[3]}px;
+	${withMarginTop && `margin-top: ${space[5]}px;`}
 `;
 
 const Text = ({ children }: { children: React.ReactNode }) => (
 	<p
 		css={css`
-			${textSans.xxsmall()}
-			margin-top: 0;
-			margin-bottom: 6px;
+			${textSans.xsmall()}
+			margin: 0;
 		`}
 	>
 		{children}
@@ -28,7 +34,7 @@ const TermsLink = ({
 }) => (
 	<ExternalLink
 		cssOverrides={css`
-			${textSans.xxsmall()}
+			${textSans.xsmall()}
 		`}
 		href={href}
 	>
@@ -36,54 +42,50 @@ const TermsLink = ({
 	</ExternalLink>
 );
 
-export const GuardianTerms = () => (
-	<>
+export const GuardianTerms = (props: TermsProps) => (
+	<div css={termsBox(props)}>
 		<Text>
 			By proceeding, you agree to our{' '}
 			<TermsLink href="https://www.theguardian.com/help/terms-of-service">
 				terms &amp; conditions
 			</TermsLink>
-			.
-		</Text>
-		<Text>
-			For information about how we use your data, see our{' '}
+			. For information about how we use your data, see our{' '}
 			<TermsLink href="https://www.theguardian.com/help/privacy-policy">
 				privacy policy
 			</TermsLink>
 			.
 		</Text>
-	</>
+	</div>
 );
 
-export const JobsTerms = () => (
-	<>
+export const JobsTerms = (props: TermsProps) => (
+	<div css={termsBox(props)}>
 		<Text>
 			By proceeding, you agree to our{' '}
 			<TermsLink href="https://jobs.theguardian.com/terms-and-conditions/">
 				Guardian Jobs terms &amp; conditions
 			</TermsLink>
-			.
-		</Text>
-		<Text>
-			For information about how we use your data, see our{' '}
+			. For information about how we use your data, see our{' '}
 			<TermsLink href="https://jobs.theguardian.com/privacy-policy/">
 				Guardian Jobs privacy policy
 			</TermsLink>
 			.
 		</Text>
-	</>
+	</div>
 );
 
-export const RecaptchaTerms = () => (
-	<Text>
-		This service is protected by reCAPTCHA and the Google{' '}
-		<TermsLink href="https://policies.google.com/privacy">
-			privacy policy
-		</TermsLink>{' '}
-		and{' '}
-		<TermsLink href="https://policies.google.com/terms">
-			terms of service
-		</TermsLink>{' '}
-		apply.
-	</Text>
+export const RecaptchaTerms = (props: TermsProps) => (
+	<div css={termsBox(props)}>
+		<Text>
+			This service is protected by reCAPTCHA and the Google{' '}
+			<TermsLink href="https://policies.google.com/privacy">
+				privacy policy
+			</TermsLink>{' '}
+			and{' '}
+			<TermsLink href="https://policies.google.com/terms">
+				terms of service
+			</TermsLink>{' '}
+			apply.
+		</Text>
+	</div>
 );

--- a/src/client/components/Terms.tsx
+++ b/src/client/components/Terms.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { PropsWithChildren } from 'react';
 import { css } from '@emotion/react';
 import { palette, space, textSans } from '@guardian/source-foundations';
 import { ExternalLink } from '@/client/components/ExternalLink';
@@ -7,31 +7,26 @@ interface TermsProps {
 	withMarginTop?: boolean;
 }
 
-const termsBox = ({ withMarginTop }: TermsProps) => css`
+const termsBoxStyle = ({ withMarginTop }: TermsProps) => css`
 	background-color: ${palette.neutral[93]};
 	border-radius: 4px;
 	padding: ${space[3]}px ${space[3]}px;
 	${withMarginTop && `margin-top: ${space[5]}px;`}
 `;
 
-const Text = ({ children }: { children: React.ReactNode }) => (
-	<p
-		css={css`
-			${textSans.xsmall()}
-			margin: 0;
-		`}
-	>
-		{children}
-	</p>
+const termsBoxTextStyle = css`
+	${textSans.xsmall()}
+	margin: 0 0 ${space[2]}px 0;
+	&:last-of-type {
+		margin: 0;
+	}
+`;
+
+export const TermsText = ({ children }: { children: React.ReactNode }) => (
+	<p css={termsBoxTextStyle}>{children}</p>
 );
 
-const TermsLink = ({
-	children,
-	href,
-}: {
-	children: React.ReactNode;
-	href: string;
-}) => (
+const TermsLink = ({ children, href }: PropsWithChildren<{ href: string }>) => (
 	<ExternalLink
 		cssOverrides={css`
 			${textSans.xsmall()}
@@ -42,50 +37,51 @@ const TermsLink = ({
 	</ExternalLink>
 );
 
-export const GuardianTerms = (props: TermsProps) => (
-	<div css={termsBox(props)}>
-		<Text>
-			By proceeding, you agree to our{' '}
-			<TermsLink href="https://www.theguardian.com/help/terms-of-service">
-				terms &amp; conditions
-			</TermsLink>
-			. For information about how we use your data, see our{' '}
-			<TermsLink href="https://www.theguardian.com/help/privacy-policy">
-				privacy policy
-			</TermsLink>
-			.
-		</Text>
-	</div>
+export const TermsBox = ({
+	children,
+	withMarginTop,
+}: PropsWithChildren<TermsProps>) => (
+	<div css={termsBoxStyle({ withMarginTop })}>{children}</div>
 );
 
-export const JobsTerms = (props: TermsProps) => (
-	<div css={termsBox(props)}>
-		<Text>
-			By proceeding, you agree to our{' '}
-			<TermsLink href="https://jobs.theguardian.com/terms-and-conditions/">
-				Guardian Jobs terms &amp; conditions
-			</TermsLink>
-			. For information about how we use your data, see our{' '}
-			<TermsLink href="https://jobs.theguardian.com/privacy-policy/">
-				Guardian Jobs privacy policy
-			</TermsLink>
-			.
-		</Text>
-	</div>
+export const GuardianTerms = () => (
+	<TermsText>
+		By proceeding, you agree to our{' '}
+		<TermsLink href="https://www.theguardian.com/help/terms-of-service">
+			terms &amp; conditions
+		</TermsLink>
+		. For information about how we use your data, see our{' '}
+		<TermsLink href="https://www.theguardian.com/help/privacy-policy">
+			privacy policy
+		</TermsLink>
+		.
+	</TermsText>
 );
 
-export const RecaptchaTerms = (props: TermsProps) => (
-	<div css={termsBox(props)}>
-		<Text>
-			This service is protected by reCAPTCHA and the Google{' '}
-			<TermsLink href="https://policies.google.com/privacy">
-				privacy policy
-			</TermsLink>{' '}
-			and{' '}
-			<TermsLink href="https://policies.google.com/terms">
-				terms of service
-			</TermsLink>{' '}
-			apply.
-		</Text>
-	</div>
+export const JobsTerms = () => (
+	<TermsText>
+		By proceeding, you agree to our{' '}
+		<TermsLink href="https://jobs.theguardian.com/terms-and-conditions/">
+			Guardian Jobs terms &amp; conditions
+		</TermsLink>
+		. For information about how we use your data, see our{' '}
+		<TermsLink href="https://jobs.theguardian.com/privacy-policy/">
+			Guardian Jobs privacy policy
+		</TermsLink>
+		.
+	</TermsText>
+);
+
+export const RecaptchaTerms = () => (
+	<TermsText>
+		This service is protected by reCAPTCHA and the Google{' '}
+		<TermsLink href="https://policies.google.com/privacy">
+			privacy policy
+		</TermsLink>{' '}
+		and{' '}
+		<TermsLink href="https://policies.google.com/terms">
+			terms of service
+		</TermsLink>{' '}
+		apply.
+	</TermsText>
 );

--- a/src/client/components/ToggleSwitchInput.tsx
+++ b/src/client/components/ToggleSwitchInput.tsx
@@ -122,7 +122,7 @@ const switchStyles = css`
 `;
 
 const mainLabelStyles = css`
-	align-self: flex-start;
+	align-self: center;
 	width: calc(100% - ${switchComputedWidth}px);
 `;
 

--- a/src/client/layouts/Main.stories.tsx
+++ b/src/client/layouts/Main.stories.tsx
@@ -31,6 +31,13 @@ export const WithPageHeader = () => (
 );
 WithPageHeader.storyName = 'with pageTitle';
 
+export const WithPageHeaderSubText = () => (
+	<MainLayout pageHeader="Some page header" pageSubText="Some sub text too">
+		<Paragraphs />
+	</MainLayout>
+);
+WithPageHeader.storyName = 'with pageTitle and subtext';
+
 export const WithErrorPageHeader = () => (
 	<MainLayout pageHeader="Some page header" errorOverride="Error message">
 		<Paragraphs />
@@ -38,12 +45,34 @@ export const WithErrorPageHeader = () => (
 );
 WithErrorPageHeader.storyName = 'with Error and PageTitle';
 
+export const WithErrorPageHeaderSubText = () => (
+	<MainLayout
+		pageHeader="Some page header"
+		errorOverride="Error message"
+		pageSubText="Some sub text too"
+	>
+		<Paragraphs />
+	</MainLayout>
+);
+WithErrorPageHeaderSubText.storyName = 'with Error, PageTitle and subtext';
+
 export const WithSuccessPageHeader = () => (
 	<MainLayout pageHeader="Some page header" successOverride="Success message">
 		<Paragraphs />
 	</MainLayout>
 );
 WithSuccessPageHeader.storyName = 'with Success and PageTitle';
+
+export const WithSuccessPageHeaderSubText = () => (
+	<MainLayout
+		pageHeader="Some page header"
+		successOverride="Success message"
+		pageSubText="Some sub text too"
+	>
+		<Paragraphs />
+	</MainLayout>
+);
+WithSuccessPageHeaderSubText.storyName = 'with Success, PageTitle, and subtext';
 
 export const WithError = () => (
 	<MainLayout errorOverride="Error message">
@@ -76,6 +105,14 @@ export const WithForm = () => (
 );
 WithForm.storyName = 'with Form';
 
+export const WithFormSubText = () => (
+	<MainLayout pageHeader="Some page header" pageSubText="Some sub text too">
+		<Paragraphs />
+		<BasicForm />
+	</MainLayout>
+);
+WithFormSubText.storyName = 'with Form & header sub text';
+
 export const WithFormAndRecaptcha = () => (
 	<MainLayout pageHeader="Some page header">
 		<Paragraphs />
@@ -100,6 +137,19 @@ export const WithErrorAndFormWithFormLevelError = () => (
 );
 WithErrorAndFormWithFormLevelError.storyName =
 	'with Error and Form with form-level error';
+
+export const WithErrorAndFormWithFormLevelErrorSubText = () => (
+	<MainLayout
+		pageHeader="Some page header"
+		errorOverride="Error message"
+		pageSubText="Some sub text too"
+	>
+		<Paragraphs />
+		<FormWithError />
+	</MainLayout>
+);
+WithErrorAndFormWithFormLevelErrorSubText.storyName =
+	'with Error, Form with form-level error, and header sub text';
 
 export const WithMultipleInputs = () => (
 	<MainLayout pageHeader="Some page header">

--- a/src/client/layouts/Main.tsx
+++ b/src/client/layouts/Main.tsx
@@ -17,9 +17,11 @@ import { Footer } from '@/client/components/Footer';
 import useClientState from '@/client/lib/hooks/useClientState';
 import { Nav, TabType } from '@/client/components/Nav';
 import locations from '@/shared/lib/locations';
+import { MainBodyText } from '../components/MainBodyText';
 
 interface MainLayoutProps {
 	pageHeader?: string;
+	pageSubText?: string;
 	successOverride?: string;
 	errorOverride?: string;
 	errorContext?: React.ReactNode;
@@ -157,9 +159,14 @@ export const buttonStyles = ({
 	`}
 `;
 
+const subTextStyles = css`
+	padding-top: ${space[4]}px;
+`;
+
 export const MainLayout = ({
 	children,
 	pageHeader,
+	pageSubText,
 	successOverride,
 	errorOverride,
 	errorContext,
@@ -205,6 +212,11 @@ export const MainLayout = ({
 					{pageHeader && (
 						<header css={headerStyles(hasSummary)}>
 							<h1 css={[pageTitleStyles]}>{pageHeader}</h1>
+							{pageSubText && (
+								<MainBodyText cssOverrides={subTextStyles} noMarginBottom>
+									{pageSubText}
+								</MainBodyText>
+							)}
 						</header>
 					)}
 					<div css={bodyStyles(hasTitleOrSummary)}>{children}</div>

--- a/src/client/layouts/Main.tsx
+++ b/src/client/layouts/Main.tsx
@@ -116,7 +116,7 @@ export const buttonStyles = ({
 	halfWidthAtMobile = false,
 	hasMarginBottom = false,
 }) => css`
-	margin-top: 22px;
+	margin-top: ${space[4]}px;
 	justify-content: center;
 	width: 100%;
 
@@ -150,7 +150,7 @@ export const buttonStyles = ({
 
 	${hasTerms &&
 	css`
-		margin-top: ${space[4]}px;
+		margin-top: ${space[3]}px;
 	`}
 
 	${hasMarginBottom &&

--- a/src/client/pages/DeleteAccountBlocked.tsx
+++ b/src/client/pages/DeleteAccountBlocked.tsx
@@ -93,7 +93,6 @@ export const DeleteAccountBlocked = ({ contentAccess = {} }: Props) => {
 						<ExternalLink href={locations.SUPPORT_EMAIL_MAILTO}>
 							{SUPPORT_EMAIL}
 						</ExternalLink>
-						.
 					</MainBodyText>
 				</>
 			)}

--- a/src/client/pages/EmailSent.stories.tsx
+++ b/src/client/pages/EmailSent.stories.tsx
@@ -10,9 +10,16 @@ export default {
 	parameters: { layout: 'fullscreen' },
 } as Meta;
 
-export const Defaults = () => <EmailSent changeEmailPage="/reset-password" />;
+export const Defaults = () => <EmailSent />;
 Defaults.story = {
 	name: 'with defaults',
+};
+
+export const ChangeEmail = () => (
+	<EmailSent changeEmailPage="/reset-password" />
+);
+ChangeEmail.story = {
+	name: 'with changeEmailPage',
 };
 
 export const WithEmail = () => (
@@ -62,9 +69,25 @@ WithRecaptchaError.story = {
 	name: 'with reCAPTCHA error',
 };
 
-export const WithHelpText = () => (
-	<EmailSent changeEmailPage="/reset-password" showHelp={true} />
+export const WithInstructionContext = () => (
+	<EmailSent
+		changeEmailPage="/reset-password"
+		email="test@example.com"
+		instructionContext="verify and complete creating your account"
+	/>
 );
-WithHelpText.story = {
-	name: 'with help text',
+WithInstructionContext.story = {
+	name: 'with instruction context',
+};
+
+export const NoChangeEmailPage = () => (
+	<EmailSent
+		email="example@theguardian.com"
+		resendEmailAction="#"
+		noAccountInfo
+		recaptchaSiteKey="6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI"
+	/>
+);
+NoChangeEmailPage.story = {
+	name: 'with no change email',
 };

--- a/src/client/pages/EmailSent.tsx
+++ b/src/client/pages/EmailSent.tsx
@@ -1,18 +1,15 @@
 import React, { PropsWithChildren, ReactNode, useState } from 'react';
 import { Link } from '@guardian/source-react-components';
-import { InfoSummary } from '@guardian/source-react-components-development-kitchen';
 import { MainLayout } from '@/client/layouts/Main';
 import { MainBodyText } from '@/client/components/MainBodyText';
-import {
-	belowFormMarginTopSpacingStyle,
-	MainForm,
-} from '@/client/components/MainForm';
+import { MainForm } from '@/client/components/MainForm';
 import { EmailInput } from '@/client/components/EmailInput';
 import { ExternalLink } from '@/client/components/ExternalLink';
 import { css } from '@emotion/react';
 import { buildUrl } from '@/shared/lib/routeUtils';
 import locations from '@/shared/lib/locations';
 import { SUPPORT_EMAIL } from '@/shared/model/Configuration';
+import { palette, space, textSans } from '@guardian/source-foundations';
 
 type Props = {
 	email?: string;
@@ -25,8 +22,18 @@ type Props = {
 	recaptchaSiteKey?: string;
 	formTrackingName?: string;
 	formError?: string;
-	showHelp?: boolean;
+	instructionContext?: string;
 };
+
+const helpBoxStyles = () => css`
+	background-color: ${palette.neutral[93]};
+	border-radius: 4px;
+	padding: ${space[3]}px ${space[3]}px;
+
+	& button {
+		${textSans.small()};
+	}
+`;
 
 export const EmailSent = ({
 	email,
@@ -40,12 +47,11 @@ export const EmailSent = ({
 	formTrackingName,
 	children,
 	formError,
-	showHelp,
+	instructionContext,
 }: PropsWithChildren<Props>) => {
 	const [recaptchaErrorMessage, setRecaptchaErrorMessage] = useState('');
 	const [recaptchaErrorContext, setRecaptchaErrorContext] =
 		useState<ReactNode>(null);
-	const showHelpBox = showHelp || (email && resendEmailAction);
 	return (
 		<MainLayout
 			pageHeader="Check your email inbox"
@@ -63,74 +69,75 @@ export const EmailSent = ({
 			) : (
 				<MainBodyText>We’ve sent you an email.</MainBodyText>
 			)}
-			<MainBodyText>Please follow the instructions in this email.</MainBodyText>
-			<MainBodyText>
-				<b>The link is valid for 60 minutes.</b>
-			</MainBodyText>
-			{changeEmailPage && (
+			{instructionContext ? (
 				<MainBodyText>
-					Wrong email address?{' '}
-					<Link href={`${changeEmailPage}${queryString}`}>
-						Change email address
-					</Link>
-					.
+					Please follow the link in the email to {instructionContext}.
+				</MainBodyText>
+			) : (
+				<MainBodyText>
+					Please follow the instructions in this email.
 				</MainBodyText>
 			)}
-			{email && resendEmailAction && (
-				<>
-					<InfoSummary
-						message="Didn’t receive an email?"
-						context={
-							<>
-								If you can’t find the email in your inbox or spam folder, please
-								click below and we will send you a new one.
-								{noAccountInfo && (
-									<>
-										<br />
-										<b>
-											If you don’t receive an email within 2 minutes you may not
-											have an account.
-										</b>
-										<br />
-										Don’t have an account?{' '}
-										<Link href={`${buildUrl('/register')}${queryString}`}>
-											Register for free
-										</Link>
-									</>
-								)}
-							</>
-						}
-					/>
-					<MainForm
-						formAction={`${resendEmailAction}${queryString}`}
-						submitButtonText={'Resend email'}
-						submitButtonPriority="tertiary"
-						submitButtonHalfWidth
-						recaptchaSiteKey={recaptchaSiteKey}
-						setRecaptchaErrorContext={setRecaptchaErrorContext}
-						setRecaptchaErrorMessage={setRecaptchaErrorMessage}
-						formTrackingName={formTrackingName}
-						disableOnSubmit
-						formErrorMessageFromParent={formError}
-					>
-						<EmailInput defaultValue={email} hidden hideLabel />
-					</MainForm>
-				</>
-			)}
-			{showHelpBox && (
-				<MainBodyText cssOverrides={belowFormMarginTopSpacingStyle}>
-					If you are still having trouble, contact our customer service team at{' '}
-					<ExternalLink
-						cssOverrides={css`
-							font-weight: 700;
-						`}
-						href={locations.SUPPORT_EMAIL_MAILTO}
-					>
-						{SUPPORT_EMAIL}
-					</ExternalLink>
+			<MainBodyText>
+				<b>
+					For your security, the link in the email will expire in 60 minutes.
+				</b>
+			</MainBodyText>
+			<div css={helpBoxStyles}>
+				<MainBodyText smallText>
+					Didn’t get the email? Check your spam
+					{email && resendEmailAction && (
+						<>
+							,{!changeEmailPage ? <> or </> : <> </>}
+							<MainForm
+								formAction={`${resendEmailAction}${queryString}`}
+								submitButtonText={'send again'}
+								recaptchaSiteKey={recaptchaSiteKey}
+								setRecaptchaErrorContext={setRecaptchaErrorContext}
+								setRecaptchaErrorMessage={setRecaptchaErrorMessage}
+								formTrackingName={formTrackingName}
+								disableOnSubmit
+								formErrorMessageFromParent={formError}
+								submitButtonLink
+								hideRecaptchaMessage
+							>
+								<EmailInput defaultValue={email} hidden hideLabel />
+							</MainForm>
+						</>
+					)}
+					{changeEmailPage && <>, or</>}
+					{changeEmailPage && (
+						<>
+							{' '}
+							<Link href={`${changeEmailPage}${queryString}`}>
+								try another address
+							</Link>
+						</>
+					)}
 					.
 				</MainBodyText>
-			)}
+				{noAccountInfo && (
+					<div>
+						<MainBodyText smallText>
+							If you don’t receive an email within 2 minutes you may not have an
+							account. Don’t have an account?{' '}
+							<Link href={`${buildUrl('/register')}${queryString}`}>
+								Register for free
+							</Link>
+							.
+						</MainBodyText>
+					</div>
+				)}
+				<div>
+					<MainBodyText smallText noMarginBottom>
+						For further assistance, email our customer service team at{' '}
+						<ExternalLink href={locations.SUPPORT_EMAIL_MAILTO}>
+							{SUPPORT_EMAIL}
+						</ExternalLink>
+						.
+					</MainBodyText>
+				</div>
+			</div>
 		</MainLayout>
 	);
 };

--- a/src/client/pages/EmailSent.tsx
+++ b/src/client/pages/EmailSent.tsx
@@ -64,7 +64,7 @@ export const EmailSent = ({
 			{children}
 			{email ? (
 				<MainBodyText>
-					We’ve sent an email to <b>{email}</b>.
+					We’ve sent an email to <b>{email}</b>
 				</MainBodyText>
 			) : (
 				<MainBodyText>We’ve sent you an email.</MainBodyText>
@@ -134,7 +134,6 @@ export const EmailSent = ({
 						<ExternalLink href={locations.SUPPORT_EMAIL_MAILTO}>
 							{SUPPORT_EMAIL}
 						</ExternalLink>
-						.
 					</MainBodyText>
 				</div>
 			</div>

--- a/src/client/pages/EmailSent.tsx
+++ b/src/client/pages/EmailSent.tsx
@@ -5,11 +5,13 @@ import { MainBodyText } from '@/client/components/MainBodyText';
 import { MainForm } from '@/client/components/MainForm';
 import { EmailInput } from '@/client/components/EmailInput';
 import { ExternalLink } from '@/client/components/ExternalLink';
-import { css } from '@emotion/react';
 import { buildUrl } from '@/shared/lib/routeUtils';
 import locations from '@/shared/lib/locations';
 import { SUPPORT_EMAIL } from '@/shared/model/Configuration';
-import { palette, space, textSans } from '@guardian/source-foundations';
+import {
+	InformationBox,
+	InformationBoxText,
+} from '@/client/components/InformationBox';
 
 type Props = {
 	email?: string;
@@ -24,16 +26,6 @@ type Props = {
 	formError?: string;
 	instructionContext?: string;
 };
-
-const helpBoxStyles = () => css`
-	background-color: ${palette.neutral[93]};
-	border-radius: 4px;
-	padding: ${space[3]}px ${space[3]}px;
-
-	& button {
-		${textSans.small()};
-	}
-`;
 
 export const EmailSent = ({
 	email,
@@ -83,8 +75,8 @@ export const EmailSent = ({
 					For your security, the link in the email will expire in 60 minutes.
 				</b>
 			</MainBodyText>
-			<div css={helpBoxStyles}>
-				<MainBodyText smallText>
+			<InformationBox>
+				<InformationBoxText>
 					Didn’t get the email? Check your spam
 					{email && resendEmailAction && (
 						<>
@@ -115,28 +107,24 @@ export const EmailSent = ({
 						</>
 					)}
 					.
-				</MainBodyText>
+				</InformationBoxText>
 				{noAccountInfo && (
-					<div>
-						<MainBodyText smallText>
-							If you don’t receive an email within 2 minutes you may not have an
-							account. Don’t have an account?{' '}
-							<Link href={`${buildUrl('/register')}${queryString}`}>
-								Register for free
-							</Link>
-							.
-						</MainBodyText>
-					</div>
+					<InformationBoxText>
+						If you don’t receive an email within 2 minutes you may not have an
+						account. Don’t have an account?{' '}
+						<Link href={`${buildUrl('/register')}${queryString}`}>
+							Register for free
+						</Link>
+						.
+					</InformationBoxText>
 				)}
-				<div>
-					<MainBodyText smallText noMarginBottom>
-						For further assistance, email our customer service team at{' '}
-						<ExternalLink href={locations.SUPPORT_EMAIL_MAILTO}>
-							{SUPPORT_EMAIL}
-						</ExternalLink>
-					</MainBodyText>
-				</div>
-			</div>
+				<InformationBoxText>
+					For further assistance, email our customer service team at{' '}
+					<ExternalLink href={locations.SUPPORT_EMAIL_MAILTO}>
+						{SUPPORT_EMAIL}
+					</ExternalLink>
+				</InformationBoxText>
+			</InformationBox>
 		</MainLayout>
 	);
 };

--- a/src/client/pages/EmailSentPage.tsx
+++ b/src/client/pages/EmailSentPage.tsx
@@ -6,14 +6,9 @@ import { buildQueryParamsString } from '@/shared/lib/queryParams';
 interface Props {
 	noAccountInfo?: boolean;
 	formTrackingName?: string;
-	showHelp?: boolean;
 }
 
-export const EmailSentPage = ({
-	noAccountInfo,
-	formTrackingName,
-	showHelp,
-}: Props) => {
+export const EmailSentPage = ({ noAccountInfo, formTrackingName }: Props) => {
 	const clientState = useClientState();
 	const {
 		pageData = {},
@@ -42,7 +37,6 @@ export const EmailSentPage = ({
 			noAccountInfo={noAccountInfo}
 			recaptchaSiteKey={recaptchaSiteKey}
 			formTrackingName={formTrackingName}
-			showHelp={showHelp}
 		/>
 	);
 };

--- a/src/client/pages/RegisterWithEmail.tsx
+++ b/src/client/pages/RegisterWithEmail.tsx
@@ -8,13 +8,9 @@ import { CmpConsentedStateHiddenInput } from '@/client/components/CmpConsentStat
 import { useCmpConsent } from '@/client/lib/hooks/useCmpConsent';
 import { RegistrationProps } from '@/client/pages/Registration';
 import { generateSignInRegisterTabs } from '@/client/components/Nav';
-import { RegistrationMarketingConsentFormField } from '@/client/components/RegistrationMarketingConsentFormField';
-import { RegistrationNewsletterFormField } from '@/client/components/RegistrationNewsletterFormField';
 import { GeoLocation } from '@/shared/model/Geolocation';
-import { SATURDAY_EDITION_SMALL_SQUARE_IMAGE } from '@/client/assets/newsletters';
-import { RegistrationConsentsFormFields } from '@/shared/model/Consent';
-import { RegistrationNewslettersFormFields } from '@/shared/model/Newsletter';
 import { registrationFormSubmitOphanTracking } from '@/client/lib/consentsTracking';
+import { RegistrationConsents } from '@/client/components/RegistrationConsents';
 
 export type RegisterWithEmailProps = RegistrationProps & {
 	geolocation?: GeoLocation;
@@ -40,11 +36,6 @@ export const RegisterWithEmail = ({
 
 	const useIdapi = queryParams.useIdapi;
 
-	// don't show the Saturday Edition newsletter option for US and AUS
-	const showSaturdayEdition = !(['US', 'AU'] as GeoLocation[]).some(
-		(location: GeoLocation) => location === geolocation,
-	);
-
 	return (
 		<MainLayout tabs={tabs} pageHeader="Enter your email">
 			<MainForm
@@ -62,26 +53,7 @@ export const RegisterWithEmail = ({
 				<EmailInput defaultValue={email} autoComplete="off" />
 				<CmpConsentedStateHiddenInput cmpConsentedState={hasCmpConsent} />
 
-				{!useIdapi && (
-					<>
-						{showSaturdayEdition && (
-							<RegistrationNewsletterFormField
-								id={RegistrationNewslettersFormFields.saturdayEdition.id}
-								label={RegistrationNewslettersFormFields.saturdayEdition.label}
-								context={
-									RegistrationNewslettersFormFields.saturdayEdition.context
-								}
-								imagePath={SATURDAY_EDITION_SMALL_SQUARE_IMAGE}
-							/>
-						)}
-						<RegistrationMarketingConsentFormField
-							id={RegistrationConsentsFormFields.similarGuardianProducts.id}
-							label={
-								RegistrationConsentsFormFields.similarGuardianProducts.label
-							}
-						/>
-					</>
-				)}
+				<RegistrationConsents useIdapi={useIdapi} geolocation={geolocation} />
 			</MainForm>
 		</MainLayout>
 	);

--- a/src/client/pages/RegisterWithEmail.tsx
+++ b/src/client/pages/RegisterWithEmail.tsx
@@ -46,7 +46,7 @@ export const RegisterWithEmail = ({
 	);
 
 	return (
-		<MainLayout tabs={tabs}>
+		<MainLayout tabs={tabs} pageHeader="Enter your email">
 			<MainForm
 				formAction={buildUrlWithQueryParams('/register', {}, queryParams)}
 				submitButtonText="Register"

--- a/src/client/pages/RegisterWithEmail.tsx
+++ b/src/client/pages/RegisterWithEmail.tsx
@@ -49,6 +49,7 @@ export const RegisterWithEmail = ({
 					registrationFormSubmitOphanTracking(e.target as HTMLFormElement);
 					return undefined;
 				}}
+				additionalTerms="Newsletters may contain info about charities, online ads, and content funded by outside parties."
 			>
 				<EmailInput defaultValue={email} autoComplete="off" />
 				<CmpConsentedStateHiddenInput cmpConsentedState={hasCmpConsent} />

--- a/src/client/pages/Registration.tsx
+++ b/src/client/pages/Registration.tsx
@@ -5,6 +5,11 @@ import { generateSignInRegisterTabs } from '@/client/components/Nav';
 import { AuthProviderButtons } from '@/client/components/AuthProviderButtons';
 import { usePageLoadOphanInteraction } from '@/client/lib/hooks/usePageLoadOphanInteraction';
 import { GuardianTerms, JobsTerms } from '@/client/components/Terms';
+import { Link } from '@guardian/source-react-components';
+import { Divider } from '@guardian/source-react-components-development-kitchen';
+import { MainBodyText } from '@/client/components/MainBodyText';
+import { divider } from '@/client/styles/Shared';
+import { buildUrlWithQueryParams } from '@/shared/lib/routeUtils';
 
 export type RegistrationProps = {
 	email?: string;
@@ -46,6 +51,14 @@ export const Registration = ({ queryParams }: RegistrationProps) => {
 				context="Sign up"
 				providers={['social', 'email']}
 			/>
+			{/* divider */}
+			<Divider spaceAbove="tight" size="full" cssOverrides={divider} />
+			<MainBodyText smallText>
+				Already have an account?{' '}
+				<Link href={buildUrlWithQueryParams('/signin', {}, queryParams)}>
+					Sign in
+				</Link>
+			</MainBodyText>
 		</MainLayout>
 	);
 };

--- a/src/client/pages/Registration.tsx
+++ b/src/client/pages/Registration.tsx
@@ -48,7 +48,6 @@ export const Registration = ({ queryParams }: RegistrationProps) => {
 			<AuthProviderButtons
 				queryParams={queryParams}
 				marginTop={true}
-				context="Sign up"
 				providers={['social', 'email']}
 			/>
 			{/* divider */}

--- a/src/client/pages/Registration.tsx
+++ b/src/client/pages/Registration.tsx
@@ -38,7 +38,11 @@ export const Registration = ({ queryParams }: RegistrationProps) => {
 	});
 
 	return (
-		<MainLayout tabs={tabs}>
+		<MainLayout
+			tabs={tabs}
+			pageHeader="Register an account"
+			pageSubText="One account to access all Guardian products."
+		>
 			<RegistrationTerms isJobs={isJobs} />
 			<AuthProviderButtons
 				queryParams={queryParams}

--- a/src/client/pages/Registration.tsx
+++ b/src/client/pages/Registration.tsx
@@ -4,7 +4,7 @@ import { MainLayout } from '@/client/layouts/Main';
 import { generateSignInRegisterTabs } from '@/client/components/Nav';
 import { AuthProviderButtons } from '@/client/components/AuthProviderButtons';
 import { usePageLoadOphanInteraction } from '@/client/lib/hooks/usePageLoadOphanInteraction';
-import { GuardianTerms, JobsTerms } from '@/client/components/Terms';
+import { GuardianTerms, JobsTerms, TermsBox } from '@/client/components/Terms';
 import { Link } from '@guardian/source-react-components';
 import { Divider } from '@guardian/source-react-components-development-kitchen';
 import { MainBodyText } from '@/client/components/MainBodyText';
@@ -19,10 +19,10 @@ export type RegistrationProps = {
 };
 
 const RegistrationTerms = ({ isJobs }: { isJobs: boolean }) => (
-	<>
-		{!isJobs && <GuardianTerms withMarginTop />}
-		{isJobs && <JobsTerms withMarginTop />}
-	</>
+	<TermsBox withMarginTop>
+		{!isJobs && <GuardianTerms />}
+		{isJobs && <JobsTerms />}
+	</TermsBox>
 );
 
 export const Registration = ({ queryParams }: RegistrationProps) => {

--- a/src/client/pages/Registration.tsx
+++ b/src/client/pages/Registration.tsx
@@ -4,11 +4,7 @@ import { MainLayout } from '@/client/layouts/Main';
 import { generateSignInRegisterTabs } from '@/client/components/Nav';
 import { AuthProviderButtons } from '@/client/components/AuthProviderButtons';
 import { usePageLoadOphanInteraction } from '@/client/lib/hooks/usePageLoadOphanInteraction';
-import {
-	GuardianTerms,
-	JobsTerms,
-	termsContainer,
-} from '@/client/components/Terms';
+import { GuardianTerms, JobsTerms } from '@/client/components/Terms';
 
 export type RegistrationProps = {
 	email?: string;
@@ -18,10 +14,10 @@ export type RegistrationProps = {
 };
 
 const RegistrationTerms = ({ isJobs }: { isJobs: boolean }) => (
-	<div css={termsContainer}>
-		{!isJobs && <GuardianTerms />}
-		{isJobs && <JobsTerms />}
-	</div>
+	<>
+		{!isJobs && <GuardianTerms withMarginTop />}
+		{isJobs && <JobsTerms withMarginTop />}
+	</>
 );
 
 export const Registration = ({ queryParams }: RegistrationProps) => {

--- a/src/client/pages/Registration.tsx
+++ b/src/client/pages/Registration.tsx
@@ -4,12 +4,13 @@ import { MainLayout } from '@/client/layouts/Main';
 import { generateSignInRegisterTabs } from '@/client/components/Nav';
 import { AuthProviderButtons } from '@/client/components/AuthProviderButtons';
 import { usePageLoadOphanInteraction } from '@/client/lib/hooks/usePageLoadOphanInteraction';
-import { GuardianTerms, JobsTerms, TermsBox } from '@/client/components/Terms';
+import { GuardianTerms, JobsTerms } from '@/client/components/Terms';
 import { Link } from '@guardian/source-react-components';
 import { Divider } from '@guardian/source-react-components-development-kitchen';
 import { MainBodyText } from '@/client/components/MainBodyText';
 import { divider } from '@/client/styles/Shared';
 import { buildUrlWithQueryParams } from '@/shared/lib/routeUtils';
+import { InformationBox } from '@/client/components/InformationBox';
 
 export type RegistrationProps = {
 	email?: string;
@@ -19,10 +20,10 @@ export type RegistrationProps = {
 };
 
 const RegistrationTerms = ({ isJobs }: { isJobs: boolean }) => (
-	<TermsBox withMarginTop>
+	<InformationBox withMarginTop>
 		{!isJobs && <GuardianTerms />}
 		{isJobs && <JobsTerms />}
-	</TermsBox>
+	</InformationBox>
 );
 
 export const Registration = ({ queryParams }: RegistrationProps) => {

--- a/src/client/pages/RegistrationEmailSentPage.tsx
+++ b/src/client/pages/RegistrationEmailSentPage.tsx
@@ -28,6 +28,7 @@ export const RegistrationEmailSentPage = () => {
 			queryString={queryString}
 			changeEmailPage={buildUrlWithQueryParams('/register', {}, queryParams)}
 			resendEmailAction={buildUrl('/register/email-sent/resend')}
+			instructionContext="verify and complete creating your account"
 			showSuccess={emailSentSuccess}
 			errorMessage={error}
 			recaptchaSiteKey={recaptchaSiteKey}

--- a/src/client/pages/ResetPassword.tsx
+++ b/src/client/pages/ResetPassword.tsx
@@ -74,7 +74,7 @@ export const ResetPassword = ({
 				<EmailInput label={emailInputLabel} defaultValue={email} />
 			</MainForm>
 			{showNoAccessEmail && (
-				<MainBodyText cssOverrides={belowFormMarginTopSpacingStyle}>
+				<MainBodyText cssOverrides={belowFormMarginTopSpacingStyle} smallText>
 					Having trouble resetting your password? Please visit our{' '}
 					<ExternalLink href={locations.SIGN_IN_HELP_CENTRE}>
 						Help Centre

--- a/src/client/pages/ReturnToApp.tsx
+++ b/src/client/pages/ReturnToApp.tsx
@@ -16,9 +16,8 @@ export const ReturnToApp = ({ email, appName: app }: ReturnToAppProps) => (
 					: <b>{email}</b>
 				</>
 			) : (
-				''
+				'.'
 			)}
-			.
 		</MainBodyText>
 		<MainBodyText>
 			Open the <b>{app ? app : 'Guardian'}</b> app and sign in with your new

--- a/src/client/pages/SignIn.tsx
+++ b/src/client/pages/SignIn.tsx
@@ -125,6 +125,8 @@ export const SignIn = ({
 			errorContext={getErrorContext(pageError)}
 			tabs={tabs}
 			errorSmallMarginBottom={!!pageError}
+			pageHeader="Sign in"
+			pageSubText="One account to access all Guardian products."
 		>
 			{/* AuthProviderButtons component with show boolean */}
 			{showAuthProviderButtons(socialSigninBlocked, queryParams, isJobs)}

--- a/src/client/pages/SignIn.tsx
+++ b/src/client/pages/SignIn.tsx
@@ -14,8 +14,9 @@ import { Link } from '@guardian/source-react-components';
 import { Divider } from '@guardian/source-react-components-development-kitchen';
 import { AuthProviderButtons } from '@/client/components/AuthProviderButtons';
 import { divider, socialButtonDivider } from '@/client/styles/Shared';
-import { GuardianTerms, JobsTerms, TermsBox } from '@/client/components/Terms';
+import { GuardianTerms, JobsTerms } from '@/client/components/Terms';
 import { MainBodyText } from '@/client/components/MainBodyText';
+import { InformationBox } from '@/client/components/InformationBox';
 
 export type SignInProps = {
 	queryParams: QueryParams;
@@ -72,10 +73,10 @@ const showAuthProviderButtons = (
 	if (socialSigninBlocked === false) {
 		return (
 			<>
-				<TermsBox withMarginTop>
+				<InformationBox withMarginTop>
 					{!isJobs && <GuardianTerms />}
 					{isJobs && <JobsTerms />}
-				</TermsBox>
+				</InformationBox>
 				<AuthProviderButtons
 					queryParams={queryParams}
 					marginTop={true}

--- a/src/client/pages/SignIn.tsx
+++ b/src/client/pages/SignIn.tsx
@@ -14,11 +14,7 @@ import { Link } from '@guardian/source-react-components';
 import { Divider } from '@guardian/source-react-components-development-kitchen';
 import { AuthProviderButtons } from '@/client/components/AuthProviderButtons';
 import { socialButtonDivider } from '@/client/styles/Shared';
-import {
-	GuardianTerms,
-	JobsTerms,
-	termsContainer,
-} from '@/client/components/Terms';
+import { GuardianTerms, JobsTerms } from '@/client/components/Terms';
 
 export type SignInProps = {
 	queryParams: QueryParams;
@@ -75,10 +71,8 @@ const showAuthProviderButtons = (
 	if (socialSigninBlocked === false) {
 		return (
 			<>
-				<div css={termsContainer}>
-					{!isJobs && <GuardianTerms />}
-					{isJobs && <JobsTerms />}
-				</div>
+				{!isJobs && <GuardianTerms withMarginTop />}
+				{isJobs && <JobsTerms withMarginTop />}
 				<AuthProviderButtons
 					queryParams={queryParams}
 					marginTop={true}

--- a/src/client/pages/SignIn.tsx
+++ b/src/client/pages/SignIn.tsx
@@ -14,7 +14,7 @@ import { Link } from '@guardian/source-react-components';
 import { Divider } from '@guardian/source-react-components-development-kitchen';
 import { AuthProviderButtons } from '@/client/components/AuthProviderButtons';
 import { divider, socialButtonDivider } from '@/client/styles/Shared';
-import { GuardianTerms, JobsTerms } from '@/client/components/Terms';
+import { GuardianTerms, JobsTerms, TermsBox } from '@/client/components/Terms';
 import { MainBodyText } from '@/client/components/MainBodyText';
 
 export type SignInProps = {
@@ -72,8 +72,10 @@ const showAuthProviderButtons = (
 	if (socialSigninBlocked === false) {
 		return (
 			<>
-				{!isJobs && <GuardianTerms withMarginTop />}
-				{isJobs && <JobsTerms withMarginTop />}
+				<TermsBox withMarginTop>
+					{!isJobs && <GuardianTerms />}
+					{isJobs && <JobsTerms />}
+				</TermsBox>
 				<AuthProviderButtons
 					queryParams={queryParams}
 					marginTop={true}

--- a/src/client/pages/SignIn.tsx
+++ b/src/client/pages/SignIn.tsx
@@ -77,7 +77,6 @@ const showAuthProviderButtons = (
 				<AuthProviderButtons
 					queryParams={queryParams}
 					marginTop={true}
-					context="Sign in"
 					providers={['social']}
 				/>
 				<Divider

--- a/src/client/pages/SignIn.tsx
+++ b/src/client/pages/SignIn.tsx
@@ -13,8 +13,9 @@ import { from, space, textSans } from '@guardian/source-foundations';
 import { Link } from '@guardian/source-react-components';
 import { Divider } from '@guardian/source-react-components-development-kitchen';
 import { AuthProviderButtons } from '@/client/components/AuthProviderButtons';
-import { socialButtonDivider } from '@/client/styles/Shared';
+import { divider, socialButtonDivider } from '@/client/styles/Shared';
 import { GuardianTerms, JobsTerms } from '@/client/components/Terms';
+import { MainBodyText } from '@/client/components/MainBodyText';
 
 export type SignInProps = {
 	queryParams: QueryParams;
@@ -154,6 +155,14 @@ export const SignIn = ({
 					</Link>
 				</Links>
 			</MainForm>
+			{/* divider */}
+			<Divider spaceAbove="tight" size="full" cssOverrides={divider} />
+			<MainBodyText smallText>
+				Not signed in before?{' '}
+				<Link href={buildUrlWithQueryParams('/register', {}, queryParams)}>
+					Register for free
+				</Link>
+			</MainBodyText>
 		</MainLayout>
 	);
 };

--- a/src/client/pages/SignedInAs.tsx
+++ b/src/client/pages/SignedInAs.tsx
@@ -35,7 +35,7 @@ const DetailedLoginRequiredError = ({
 		</ul>
 		<p css={[errorContextSpacing, { marginBottom: `${space[3]}px` }]}>
 			For further help please contact our customer service team at{' '}
-			<Link href={locations.SUPPORT_EMAIL_MAILTO}>{SUPPORT_EMAIL}</Link>.
+			<Link href={locations.SUPPORT_EMAIL_MAILTO}>{SUPPORT_EMAIL}</Link>
 		</p>
 	</>
 );
@@ -68,7 +68,7 @@ export const SignedInAs = ({
 		>
 			<MainBodyText noMarginBottom>
 				You are signed in with <br />
-				<b>{email}</b>.
+				<b>{email}</b>
 			</MainBodyText>
 			<LinkButton
 				css={buttonStyles({

--- a/src/client/pages/WelcomeSocial.tsx
+++ b/src/client/pages/WelcomeSocial.tsx
@@ -18,14 +18,10 @@ import {
 	SvgGoogleBrand,
 	SvgTickRound,
 } from '@guardian/source-react-components';
-import { RegistrationMarketingConsentFormField } from '@/client/components/RegistrationMarketingConsentFormField';
 import { SocialProvider } from '@/shared/model/Social';
-import { RegistrationNewsletterFormField } from '@/client/components/RegistrationNewsletterFormField';
 import { GeoLocation } from '@/shared/model/Geolocation';
-import { SATURDAY_EDITION_SMALL_SQUARE_IMAGE } from '@/client/assets/newsletters';
-import { RegistrationConsentsFormFields } from '@/shared/model/Consent';
-import { RegistrationNewslettersFormFields } from '@/shared/model/Newsletter';
 import { registrationFormSubmitOphanTracking } from '@/client/lib/consentsTracking';
+import { RegistrationConsents } from '@/client/components/RegistrationConsents';
 
 const inlineMessage = (socialProvider: SocialProvider) => css`
 	display: flex;
@@ -82,11 +78,6 @@ export const WelcomeSocial = ({
 
 	usePageLoadOphanInteraction(formTrackingName);
 
-	// don't show the Saturday Edition newsletter option for US and AU
-	const showSaturdayEdition = !(['US', 'AU'] as GeoLocation[]).some(
-		(location: GeoLocation) => location === geolocation,
-	);
-
 	return (
 		<MainLayout>
 			<MainForm
@@ -115,22 +106,7 @@ export const WelcomeSocial = ({
 						<SvgTickRound />
 					</MainBodyText>
 				)}
-				<>
-					{showSaturdayEdition && (
-						<RegistrationNewsletterFormField
-							id={RegistrationNewslettersFormFields.saturdayEdition.id}
-							label={RegistrationNewslettersFormFields.saturdayEdition.label}
-							context={
-								RegistrationNewslettersFormFields.saturdayEdition.context
-							}
-							imagePath={SATURDAY_EDITION_SMALL_SQUARE_IMAGE}
-						/>
-					)}
-					<RegistrationMarketingConsentFormField
-						id={RegistrationConsentsFormFields.similarGuardianProducts.id}
-						label={RegistrationConsentsFormFields.similarGuardianProducts.label}
-					/>
-				</>
+				<RegistrationConsents geolocation={geolocation} noMarginBottom />
 			</MainForm>
 		</MainLayout>
 	);

--- a/src/client/routes.tsx
+++ b/src/client/routes.tsx
@@ -226,9 +226,7 @@ const routes: Array<{
 	},
 	{
 		path: '/consent-token/email-sent',
-		element: (
-			<EmailSentPage formTrackingName="consent-resend" showHelp={true} />
-		),
+		element: <EmailSentPage formTrackingName="consent-resend" />,
 	},
 	{
 		path: '/delete',

--- a/src/email/components/Footer.tsx
+++ b/src/email/components/Footer.tsx
@@ -41,7 +41,7 @@ export const Footer = ({ mistakeParagraphComponent }: Props) => (
 			<FooterText>
 				If you have any queries about why you are receiving this email, please
 				contact our customer service team at{' '}
-				<Link href={locations.SUPPORT_EMAIL_MAILTO}>{SUPPORT_EMAIL}</Link>.
+				<Link href={locations.SUPPORT_EMAIL_MAILTO}>{SUPPORT_EMAIL}</Link>
 			</FooterText>
 			<FooterText noPaddingBottom>
 				Guardian News and Media Limited, Kings Place, 90 York Way, London, N1

--- a/src/email/templates/AccidentalEmail/AccidentalEmailText.ts
+++ b/src/email/templates/AccidentalEmail/AccidentalEmailText.ts
@@ -7,7 +7,7 @@ We're doing some housekeeping and will be moving your contact details over to a 
 
 This email has been triggered accidentally. You don't have to do anything in response and you haven't been added onto any mailing list. We're very sorry for bothering you.
 
-If you're concerned or have questions, please contact our customer service team at ${SUPPORT_EMAIL}.
+If you're concerned or have questions, please contact our customer service team at ${SUPPORT_EMAIL}
 
 The Guardian
 

--- a/src/email/templates/CreatePassword/CreatePasswordText.ts
+++ b/src/email/templates/CreatePassword/CreatePasswordText.ts
@@ -13,7 +13,7 @@ The Guardian
 
 If you didn’t try to register, please ignore this email. Your details won’t be changed and no one has accessed your account.
 
-If you have any queries about why you are receiving this email, please contact our customer service team at ${SUPPORT_EMAIL}.
+If you have any queries about why you are receiving this email, please contact our customer service team at ${SUPPORT_EMAIL}
 
 Guardian News and Media Limited, Kings Place, 90 York Way, London, N1 9GU, United Kingdom
 `;

--- a/src/shared/model/Newsletter.ts
+++ b/src/shared/model/Newsletter.ts
@@ -38,6 +38,6 @@ export const RegistrationNewslettersFormFields = {
 		id: Newsletters.SATURDAY_EDITION,
 		label: 'Saturday Edition',
 		context:
-			'An exclusive email highlighting the week’s best Guardian journalism from the editor-in-chief, Katharine Viner. Newsletters may contain info about charities, online ads, and content funded by outside parties.',
+			'An exclusive email highlighting the week’s best Guardian journalism from the editor-in-chief, Katharine Viner.',
 	},
 };


### PR DESCRIPTION
## What does this change?

We're undertaking a large piece of work to update Gateway to use a new design with improved UX.

However this is a while away, so in the interim, we're implementing a "phase one" design that incorporates some of the features from the new design.

The key changes are as follows:

- Add "sub text" below header
  - [`6fa20be` (#2582)](https://github.com/guardian/gateway/pull/2582/commits/6fa20be14438b2f42c192a345cb75f3d365c9c7c)
  - and add to the register and sign in page
    - [`36057b2` (#2582)](https://github.com/guardian/gateway/pull/2582/commits/36057b2ca2bcf18d5c9602ebe782036b4a34a341)
- Add a divider and sign in/register text on the respective pages
  - [`93fc746` (#2582)](https://github.com/guardian/gateway/pull/2582/commits/93fc7463ac2a76ede1e59faf7171d8de99d5a22c)
- Update the terms box to use the new design with background
  - [`8512510` (#2582)](https://github.com/guardian/gateway/pull/2582/commits/85125100a58eaf131e83693eba87a0323b257b3f)
  - [`0cc4dbc` (#2582)](https://github.com/guardian/gateway/pull/2582/commits/0cc4dbc92233441b8e6f699db51e4b92c3a4f3a2)
  - [`2882b48` (#2582)](https://github.com/guardian/gateway/pull/2582/commits/2882b48dfc024bb6d792f641d81abd1ee97fb5ae)
- Update styling of the registration consents (Saturday Edition & marketing consent)
  - [`940049d` (#2582)](https://github.com/guardian/gateway/pull/2582/commits/940049df1706d93c8755160a0fe9eb87d6075273)
- Updating the email sent page to use new designs and copy
  - Moving supporting text to a single box, e.g. for resend/changing email and additional context
  - Adding ability to customise the message shown on the page
  - [`e6247cd` (#2582)](https://github.com/guardian/gateway/pull/2582/commits/e6247cd3c66a79a4f54bd83f284786bc2220cc46)
- Remove the full stop (`.`) after any sentence finishing with an email
  - [`876c0c3` (#2582)](https://github.com/guardian/gateway/pull/2582/commits/876c0c31ccc2768288cacadc683d1575dbcdcfeb)
- On social buttons, always use "Continue with X" as the text
  - [`82a605a` (#2582)](https://github.com/guardian/gateway/pull/2582/commits/82a605ac57c31cdd7fb2bc94a173b4bf8ba8d62b)
- Refactored the new box into a component called the `InformationBox`
  - [`2882b48` (#2582)](https://github.com/guardian/gateway/pull/2582/commits/2882b48dfc024bb6d792f641d81abd1ee97fb5ae)

The Trello card containing a link to the figma is [here](https://trello.com/c/ZT1ysg8Z/4699-content-updates-for-our-current-sign-in-account-creation-and-reset-password-journeys).

All visual changes can be seen in the Chromatic build: https://www.chromatic.com/build?appId=60929d168594f80039336501&number=3991

The main pages are included below:

<table>
<tr>
<th> Sign In
<th> Register
<th> Register with email
<th> Email sent page
<tr>
<td>

![60929d168594f80039336501-ehmupdzjii chromatic com_iframe html_args= id=pages-signin--with-email viewMode=story(iPhone 14 Pro Max)](https://github.com/guardian/gateway/assets/13315440/b8828aae-cf17-4435-afa8-96fa260fc24b)

<td>

![60929d168594f80039336501-ehmupdzjii chromatic com_iframe html_args= id=pages-registration--default viewMode=story(iPhone 14 Pro Max)](https://github.com/guardian/gateway/assets/13315440/24fcd0a7-7042-4ba7-89a3-a4d0e31b4bfc)

<td>

![60929d168594f80039336501-ehmupdzjii chromatic com_iframe html_args= id=pages-registerwithemail--email(iPhone 14 Pro Max)](https://github.com/guardian/gateway/assets/13315440/c6f11b17-2798-47c8-b13e-52f53a6308eb)

<td>

![60929d168594f80039336501-ehmupdzjii chromatic com_iframe html_args= id=pages-emailsent--with-email-resend-no-account viewMode=story(iPhone 14 Pro Max)](https://github.com/guardian/gateway/assets/13315440/a0668af1-e68a-43f3-a514-fbfb52aef271)

</table>