### PR TITLE
Fix app name not showing correctly in #2580

### DIFF
--- a/cypress/integration/ete-okta/registration_1.2.cy.ts
+++ b/cypress/integration/ete-okta/registration_1.2.cy.ts
@@ -138,7 +138,7 @@ describe('Registration flow - Split 1/2', () => {
 				cy.get('input[name="secondName"]').type('Last Name');
 				cy.get('input[name="password"]').type(randomPassword());
 				cy.get('button[type="submit"]').click();
-				cy.url().should('contain', '/welcome/app/complete');
+				cy.url().should('contain', '/welcome/al_/complete');
 				cy.contains(unregisteredEmail);
 				cy.contains('Guardian app');
 

--- a/cypress/integration/ete-okta/registration_2.6.cy.ts
+++ b/cypress/integration/ete-okta/registration_2.6.cy.ts
@@ -677,7 +677,7 @@ describe('Registration flow - Split 2/2', () => {
 				cy.get('input[name="password"]').type(randomPassword());
 				cy.get('button[type="submit"]').click();
 
-				cy.url().should('contain', '/welcome/app/complete');
+				cy.url().should('contain', '/welcome/al_/complete');
 				cy.contains(unregisteredEmail);
 				cy.contains('Guardian app');
 			});

--- a/src/client/routes.tsx
+++ b/src/client/routes.tsx
@@ -259,7 +259,7 @@ const routes: Array<{
 		element: <EmailSentPage />,
 	},
 	{
-		path: '/welcome/app/complete',
+		path: '/welcome/:app/complete',
 		element: <ReturnToAppPage />,
 	},
 ];

--- a/src/server/controllers/changePassword.ts
+++ b/src/server/controllers/changePassword.ts
@@ -38,11 +38,9 @@ import { sendOphanComponentEventFromQueryParamsServer } from '@/server/lib/ophan
 import { clearOktaCookies } from '@/server/routes/signOut';
 import { mergeRequestState } from '@/server/lib/requestState';
 import { ProfileOpenIdClientRedirectUris } from '@/server/lib/okta/openid-connect';
-import {
-	decryptOktaRecoveryToken,
-	hasAppPrefix,
-} from '@/server/lib/deeplink/oktaRecoveryToken';
+import { decryptOktaRecoveryToken } from '@/server/lib/deeplink/oktaRecoveryToken';
 import { changePasswordMetric } from '@/server/models/Metrics';
+import { getAppPrefix } from '@/shared/lib/appNameUtils';
 
 const { okta } = getConfiguration();
 
@@ -286,7 +284,7 @@ const changePasswordInOkta = async (
 				redirectUri: ProfileOpenIdClientRedirectUris.AUTHENTICATION,
 				extraData: {
 					encryptedRegistrationConsents,
-					hasAppPrefix: hasAppPrefix(encryptedRecoveryToken),
+					appPrefix: getAppPrefix(encryptedRecoveryToken),
 				},
 			});
 		} else {

--- a/src/server/lib/deeplink/oktaRecoveryToken.ts
+++ b/src/server/lib/deeplink/oktaRecoveryToken.ts
@@ -6,40 +6,7 @@ import {
 	base64ToUrlSafeString,
 	urlSafeStringToBase64,
 } from '@/server/lib/base64';
-
-/**
- * list of app prefixes that is used by native apps to determine
- * the links that should be opened in the app via deep linking
- * for example, the android live app uses the prefix 'al_'
- * therefore the deeplink path for reset password would be
- * `/reset-password/al_<token>`
- * where <token> is the okta recovery token, and the android live app
- * will intercept the deeplink on the
- * `/reset-password/al_*` path
- *
- * The reason we do this is that this allows apps to distinguish between
- * each other's deeplinks, for example between the android live app and
- * the android puzzles app (which will have a different prefix)
- * and also allows us to have multiple paths under
- * the same path which should not be intercepted by the app
- * e.g. `/reset-password/email-sent`
- */
-const appPrefixes = [
-	'al_', // Android live app
-	'il_', // iOS live app
-	'if_', // iOS feast app
-];
-type AppPrefix = (typeof appPrefixes)[number];
-
-/**
- * @name hasAppPrefix
- * @description To check if a string has a prefix representing an native application.
- *
- * @param token	- string that may or may not have a prefix representing an native application
- * @returns	- boolean representing if the string has a prefix representing an native application
- */
-export const hasAppPrefix = (token: string): boolean =>
-	appPrefixes.some((prefix) => token.startsWith(prefix));
+import { appPrefixes, apps } from '@/shared/lib/appNameUtils';
 
 /**
  * @name extractOktaRecoveryToken
@@ -88,18 +55,7 @@ export const addAppPrefixToOktaRecoveryToken = async (
 
 		const label = app.label.toLowerCase();
 
-		const appPrefix: AppPrefix = (() => {
-			switch (label) {
-				case 'android_live_app':
-					return 'al_';
-				case 'ios_live_app':
-					return 'il_';
-				case 'ios_feast_app':
-					return 'if_';
-				default:
-					return '';
-			}
-		})();
+		const appPrefix = Object.fromEntries(apps)[label] || '';
 
 		return `${appPrefix}${token}`;
 	} catch (error) {

--- a/src/server/lib/middleware/requestState.ts
+++ b/src/server/lib/middleware/requestState.ts
@@ -12,6 +12,7 @@ import Bowser from 'bowser';
 import { logger } from '@/server/lib/serverSideLogger';
 import { getApp } from '@/server/lib/okta/api/apps';
 import { IsNativeApp } from '@/shared/model/ClientState';
+import { getAppName, isAppLabel } from '@/shared/lib/appNameUtils';
 
 const {
 	idapiBaseUrl,
@@ -60,21 +61,14 @@ const getRequestState = async (
 
 			const label = app.label.toLowerCase();
 
-			if (label.startsWith('android_')) {
-				isNativeApp = 'android';
-			} else if (label.startsWith('ios_')) {
-				isNativeApp = 'ios';
-			}
+			if (isAppLabel(label)) {
+				if (label.startsWith('android_')) {
+					isNativeApp = 'android';
+				} else if (label.startsWith('ios_')) {
+					isNativeApp = 'ios';
+				}
 
-			switch (label) {
-				case 'android_live_app':
-				case 'ios_live_app':
-					appName = 'Guardian';
-					appName = 'Guardian';
-					break;
-				case 'ios_feast_app':
-					appName = 'Guardian Feast';
-					break;
+				appName = getAppName(label);
 			}
 		}
 	} catch (error) {

--- a/src/server/lib/okta/openid-connect.ts
+++ b/src/server/lib/okta/openid-connect.ts
@@ -34,7 +34,7 @@ export interface AuthorizationState {
 		deleteReason?: string; // used to track the reason for self service deletion
 		encryptedRegistrationConsents?: string; // used to set the consents given during registration on the authentication callback when we have oauth access tokens which can update the user's consents in idapi, should be encrypted, and decrypted on the callback
 		socialProvider?: SocialProvider; // used to track the social provider used to sign in/register
-		hasAppPrefix?: boolean; // used to track if the recovery token has a native app prefix
+		appPrefix?: string; // used to track if the recovery token has a native app prefix
 	};
 }
 

--- a/src/server/routes/oauth.ts
+++ b/src/server/routes/oauth.ts
@@ -36,6 +36,7 @@ import { update as updateConsents } from '@/server/lib/idapi/consents';
 import { decryptRegistrationConsents } from '@/server/lib/registrationConsents';
 import { SocialProvider } from '@/shared/model/Social';
 import { update as updateNewsletters } from '@/server/lib/idapi/newsletters';
+import { RoutePaths } from '@/shared/model/Routes';
 
 const { baseUri, deleteAccountStepFunction } = getConfiguration();
 
@@ -321,11 +322,12 @@ const authenticationHandler = async (
 		// We simply redirect them to a page telling them to return to app, when app prefix is set.
 		// This will be fixed when we either use the passcode registration flow.
 		if (
-			authState.data?.hasAppPrefix &&
+			authState.data?.appPrefix &&
 			consentPages.some((page) => page.path === authState.confirmationPage)
 		) {
 			// eslint-disable-next-line functional/immutable-data
-			authState.confirmationPage = '/welcome/app/complete';
+			authState.confirmationPage =
+				`/welcome/${authState.data.appPrefix}/complete` as RoutePaths;
 		}
 
 		const returnUrl = authState.confirmationPage

--- a/src/server/routes/welcome.ts
+++ b/src/server/routes/welcome.ts
@@ -27,21 +27,25 @@ import { update as updateNewsletters } from '@/server/lib/idapi/newsletters';
 import { rateLimitedTypedRouter as router } from '@/server/lib/typedRoutes';
 import { RegistrationConsents } from '@/shared/model/RegistrationConsents';
 import { RegistrationNewslettersFormFields } from '@/shared/model/Newsletter';
-import { updateRegistrationPlatform } from '../lib/registrationPlatform';
+import { updateRegistrationPlatform } from '@/server/lib/registrationPlatform';
+import { getAppName, isAppPrefix } from '@/shared/lib/appNameUtils';
 
 const { okta } = getConfiguration();
 
 // temp return to app page for app users who get stuck in browser
 router.get(
-	'/welcome/app/complete',
+	'/welcome/:app/complete',
 	loginMiddlewareOAuth,
 	(req: Request, res: ResponseWithRequestState) => {
-		const html = renderer('/welcome/app/complete', {
+		const { app } = req.params;
+
+		const html = renderer('/welcome/:app/complete', {
 			pageTitle: 'Welcome',
 			requestState: mergeRequestState(res.locals, {
 				pageData: {
 					// email is type unknown, but we know it's a string
 					email: res.locals.oauthState.idToken?.claims.email as string,
+					appName: isAppPrefix(app) ? getAppName(app) : undefined,
 				},
 			}),
 		});

--- a/src/shared/lib/appNameUtils.ts
+++ b/src/shared/lib/appNameUtils.ts
@@ -1,0 +1,59 @@
+import { isOneOf } from '@guardian/libs';
+
+/**
+ * list of app prefixes and labels that is used by native apps to determine
+ * the links that should be opened in the app via deep linking
+ * for example, the android live app uses the prefix 'al_'
+ * therefore the deeplink path for reset password would be
+ * `/reset-password/al_<token>`
+ * where <token> is the okta recovery token, and the android live app
+ * will intercept the deeplink on the
+ * `/reset-password/al_*` path
+ *
+ * The reason we do this is that this allows apps to distinguish between
+ * each other's deeplinks, for example between the android live app and
+ * the android puzzles app (which will have a different prefix)
+ * and also allows us to have multiple paths under
+ * the same path which should not be intercepted by the app
+ * e.g. `/reset-password/email-sent`
+ */
+export const apps = [
+	['android_live_app', 'al_'],
+	['ios_live_app', 'il_'],
+	['ios_feast_app', 'if_'],
+] as const;
+
+type AppLabel = (typeof apps)[number][0];
+type AppPrefix = (typeof apps)[number][1];
+
+export const appPrefixes = apps.map(([, prefix]) => prefix);
+
+export const isAppPrefix = isOneOf(appPrefixes);
+
+const appLabels = apps.map(([label]) => label);
+export const isAppLabel = isOneOf(appLabels);
+
+/**
+ * @name getAppPrefix
+ * @description To check and get a string has a prefix representing an native application.
+ *
+ * @param token	- string that may or may not have a prefix representing an native application
+ * @returns	- boolean representing if the string has a prefix representing an native application
+ */
+export const getAppPrefix = (token: string): string | undefined =>
+	appPrefixes.find((prefix) => token.startsWith(prefix));
+
+export const getAppName = (
+	labelOrPrefix: AppLabel | AppPrefix,
+): string | undefined => {
+	switch (labelOrPrefix) {
+		case 'al_':
+		case 'android_live_app':
+		case 'il_':
+		case 'ios_live_app':
+			return 'Guardian';
+		case 'if_':
+		case 'ios_feast_app':
+			return 'Feast';
+	}
+};

--- a/src/shared/model/Routes.ts
+++ b/src/shared/model/Routes.ts
@@ -68,7 +68,7 @@ export const ValidRoutePathsArray = [
 	'/verify-email', //this can be removed once Jobs has been migrated
 	'/welcome',
 	'/welcome/:token',
-	'/welcome/app/complete',
+	'/welcome/:app/complete',
 	'/welcome/complete',
 	'/welcome/email-sent',
 	'/welcome/expired',


### PR DESCRIPTION
## What does this change?

In #2580 we added a simple page which tells them to go back to the Guardian app they came from and sign in again.

However, as discovered by @nickhartyyy, when a user came the Feast app, it still showed saying the user had to go back to the "Guardian" app.

This was because this functionality only worked when the `appClientId` parameter was available, however this isn't always available.

So this PR changes this behaviour to rely on the app prefix instead, which is what we attach to recovery/registrations tokens from Okta so we know which the user is coming from (see #2090).

We now redirect to an app specific page, e.g. `/welcome/al_/complete` for Android live app, or `/welcome/if_/complete` for iOS feast app.

To do this we refactored the app prefix behaviour so that we preserve the app prefix where required.

## Tested

- [x] DEV
- [x] Cypress
- [ ] CODE - Android Live
- [ ] CODE - iOS Live
- [ ] CODE - iOS Feast  