### PR TITLE
AB Testing | Send offer emails to new users coming from specific sign in gates

### DIFF
--- a/cypress/tsconfig.json
+++ b/cypress/tsconfig.json
@@ -2,8 +2,8 @@
 	"compilerOptions": {
 		"resolveJsonModule": true,
 		"module": "commonjs",
-		"target": "ES2019",
-		"lib": ["ES2019", "DOM"],
+		"target": "ES2022",
+		"lib": ["ES2022", "DOM"],
 		"noEmit": true,
 		// be explicit about types included
 		// to avoid clashing with Jest types

--- a/src/email/components/Footer.tsx
+++ b/src/email/components/Footer.tsx
@@ -32,7 +32,7 @@ const FooterText = ({
 export const Footer = ({ mistakeParagraphComponent }: Props) => (
 	<MjmlSection padding="0 12px">
 		<MjmlColumn
-			padding="12px 12px 24px 12px"
+			padding="12px 12px 12px 12px"
 			background-color={background.secondary}
 		>
 			{mistakeParagraphComponent && (

--- a/src/email/lib/generateUrl.ts
+++ b/src/email/lib/generateUrl.ts
@@ -1,3 +1,4 @@
+import { SignInGateIdsForOfferEmails } from '@/server/lib/ophan';
 import { TrackingQueryParams } from '@/shared/model/QueryParams';
 
 type Props = {
@@ -5,6 +6,7 @@ type Props = {
 	path: string;
 	token?: string;
 	isIdapiUrl?: boolean;
+	signInGateId?: SignInGateIdsForOfferEmails;
 } & TrackingQueryParams;
 
 export const generateUrl = ({
@@ -14,6 +16,7 @@ export const generateUrl = ({
 	isIdapiUrl = false,
 	ref,
 	refViewId,
+	signInGateId,
 }: Props) => {
 	const params = new URLSearchParams();
 
@@ -27,6 +30,10 @@ export const generateUrl = ({
 
 	if (refViewId) {
 		params.append('refViewId', refViewId);
+	}
+
+	if (signInGateId) {
+		params.append('signInGateId', signInGateId);
 	}
 
 	const urlParts = [

--- a/src/email/templates/CompleteRegistration/sendCompleteRegistration.ts
+++ b/src/email/templates/CompleteRegistration/sendCompleteRegistration.ts
@@ -2,11 +2,13 @@ import { send } from '@/email/lib/send';
 import { generateUrl } from '@/email/lib/generateUrl';
 import { renderedCompleteRegistration } from '../renderedTemplates';
 import { TrackingQueryParams } from '@/shared/model/QueryParams';
+import { SignInGateIdsForOfferEmails } from '@/server/lib/ophan';
 
 type Props = {
 	to: string;
 	subject?: string;
 	activationToken: string;
+	signInGateId?: SignInGateIdsForOfferEmails;
 } & TrackingQueryParams;
 
 export const sendCompleteRegistration = ({
@@ -15,12 +17,14 @@ export const sendCompleteRegistration = ({
 	activationToken,
 	ref,
 	refViewId,
+	signInGateId,
 }: Props) => {
 	const activateUrl = generateUrl({
 		path: 'welcome',
 		token: activationToken,
 		ref,
 		refViewId,
+		signInGateId,
 	});
 	return send({
 		html: renderedCompleteRegistration.html.replace(

--- a/src/email/templates/GuardianLiveOffer/GuardianLiveOffer.stories.tsx
+++ b/src/email/templates/GuardianLiveOffer/GuardianLiveOffer.stories.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { Meta } from '@storybook/react';
+
+import { GuardianLiveOffer } from './GuardianLiveOffer';
+import { renderMJML } from '../../testUtils';
+
+export default {
+	title: 'Email/Templates/GuardianLiveOffer',
+	component: GuardianLiveOffer,
+	parameters: { layout: 'fullscreen' },
+} as Meta;
+
+export const Default = () => {
+	return renderMJML(<GuardianLiveOffer />);
+};
+Default.storyName = 'with defaults';

--- a/src/email/templates/GuardianLiveOffer/GuardianLiveOffer.tsx
+++ b/src/email/templates/GuardianLiveOffer/GuardianLiveOffer.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+
+import { Mjml, MjmlBody, MjmlHead, MjmlTitle } from '@faire/mjml-react';
+import { Header } from '@/email/components/Header';
+import { SubHeader } from '@/email/components/SubHeader';
+import { Text } from '@/email/components/Text';
+import { Footer } from '@/email/components/Footer';
+import { Button } from '@/email/components/Button';
+
+export const GuardianLiveOffer = () => {
+	return (
+		<Mjml>
+			<MjmlHead>
+				<MjmlTitle>
+					Your Guardian account and discount code | The Guardian
+				</MjmlTitle>
+			</MjmlHead>
+			<MjmlBody width={600}>
+				<Header />
+				<SubHeader>Welcome to the Guardian</SubHeader>
+				<Text>Thank you for creating an account with the Guardian.</Text>
+				<Text>
+					Here is your Guardian Live discount code, allowing 20% off all
+					livestreamed events.
+				</Text>
+				<Text>
+					<strong>LIVEREG20</strong>
+				</Text>
+				<Button href="https://www.theguardian.com/guardian-live-events">
+					Visit Guardian Live
+				</Button>
+				<Footer />
+			</MjmlBody>
+		</Mjml>
+	);
+};

--- a/src/email/templates/GuardianLiveOffer/GuardianLiveOfferText.ts
+++ b/src/email/templates/GuardianLiveOffer/GuardianLiveOfferText.ts
@@ -1,0 +1,15 @@
+import { SUPPORT_EMAIL } from '@/shared/model/Configuration';
+
+export const GuardianLiveOfferText = () => `
+Thank you for creating an account with the Guardian.
+
+Here is your Guardian Live discount code, allowing 20% off all livestreamed events:
+
+LIVEREG20
+
+Visit Guardian Live: https://www.theguardian.com/guardian-live-events
+
+If you have any queries about why you are receiving this email, please contact our customer service team at ${SUPPORT_EMAIL}
+
+Guardian News and Media Limited, Kings Place, 90 York Way, London, N1 9GU, United Kingdom
+`;

--- a/src/email/templates/GuardianLiveOffer/sendGuardianLiveOfferEmail.ts
+++ b/src/email/templates/GuardianLiveOffer/sendGuardianLiveOfferEmail.ts
@@ -1,0 +1,25 @@
+import { render } from '@faire/mjml-react/utils/render';
+import { send } from '@/email/lib/send';
+
+import { GuardianLiveOffer } from './GuardianLiveOffer';
+import { GuardianLiveOfferText } from './GuardianLiveOfferText';
+
+type Props = {
+	to: string;
+	subject?: string;
+};
+
+const plainText = GuardianLiveOfferText();
+const { html } = render(GuardianLiveOffer());
+
+export const sendAccidentalEmail = ({
+	to,
+	subject = 'Your Guardian account and discount code',
+}: Props) => {
+	return send({
+		html,
+		plainText,
+		subject,
+		to,
+	});
+};

--- a/src/email/templates/GuardianLiveOffer/sendGuardianLiveOfferEmail.ts
+++ b/src/email/templates/GuardianLiveOffer/sendGuardianLiveOfferEmail.ts
@@ -12,7 +12,7 @@ type Props = {
 const plainText = GuardianLiveOfferText();
 const { html } = render(GuardianLiveOffer());
 
-export const sendAccidentalEmail = ({
+export const sendGuardianLiveOfferEmail = ({
 	to,
 	subject = 'Your Guardian account and discount code',
 }: Props) => {

--- a/src/email/templates/MyGuardianOffer/MyGuardianOffer.stories.tsx
+++ b/src/email/templates/MyGuardianOffer/MyGuardianOffer.stories.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { Meta } from '@storybook/react';
+
+import { MyGuardianOffer } from './MyGuardianOffer';
+import { renderMJML } from '../../testUtils';
+
+export default {
+	title: 'Email/Templates/MyGuardianOffer',
+	component: MyGuardianOffer,
+	parameters: { layout: 'fullscreen' },
+} as Meta;
+
+export const Default = () => {
+	return renderMJML(<MyGuardianOffer />);
+};
+Default.storyName = 'with defaults';

--- a/src/email/templates/MyGuardianOffer/MyGuardianOffer.tsx
+++ b/src/email/templates/MyGuardianOffer/MyGuardianOffer.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+
+import { Mjml, MjmlBody, MjmlHead, MjmlTitle } from '@faire/mjml-react';
+import { Header } from '@/email/components/Header';
+import { SubHeader } from '@/email/components/SubHeader';
+import { Text } from '@/email/components/Text';
+import { Footer } from '@/email/components/Footer';
+import { Button } from '@/email/components/Button';
+
+export const MyGuardianOffer = () => {
+	return (
+		<Mjml>
+			<MjmlHead>
+				<MjmlTitle>Access to My Guardian | The Guardian</MjmlTitle>
+			</MjmlHead>
+			<MjmlBody width={600}>
+				<Header />
+				<SubHeader>Welcome to the Guardian</SubHeader>
+				<Text>
+					Thank you for creating an account with the Guardian, and for
+					expressing an interest in My Guardian, our new personalised space.
+				</Text>
+				<Text>
+					My Guardian is currently available in our app, which you can download
+					from the Apple App Store or Google Play Store. Your expression of
+					interest helps us know to bring it to the web soon.
+				</Text>
+				<Text>
+					To say thank you, here is a Guardian Live discount code, allowing 20%
+					off all livestreamed events.
+				</Text>
+				<Text>
+					<strong>LIVEREG20</strong>
+				</Text>
+				<Button href="https://www.theguardian.com/guardian-live-events">
+					Visit Guardian Live
+				</Button>
+				<Footer />
+			</MjmlBody>
+		</Mjml>
+	);
+};

--- a/src/email/templates/MyGuardianOffer/MyGuardianOfferText.ts
+++ b/src/email/templates/MyGuardianOffer/MyGuardianOfferText.ts
@@ -1,0 +1,17 @@
+import { SUPPORT_EMAIL } from '@/shared/model/Configuration';
+
+export const MyGuardianOfferText = () => `
+Thank you for creating an account with the Guardian, and for expressing an interest in My Guardian, our new personalised space.
+
+My Guardian is currently available in our app, which you can download from the Apple App Store or Google Play Store. Your expression of interest helps us know to bring it to the web soon.
+
+To say thank you, here is a Guardian Live discount code, allowing 20% off all livestreamed events.
+
+LIVEREG20
+
+Visit Guardian Live: https://www.theguardian.com/guardian-live-events
+
+If you have any queries about why you are receiving this email, please contact our customer service team at ${SUPPORT_EMAIL}
+
+Guardian News and Media Limited, Kings Place, 90 York Way, London, N1 9GU, United Kingdom
+`;

--- a/src/email/templates/MyGuardianOffer/sendMyGuardianOfferEmail.ts
+++ b/src/email/templates/MyGuardianOffer/sendMyGuardianOfferEmail.ts
@@ -1,0 +1,25 @@
+import { render } from '@faire/mjml-react/utils/render';
+import { send } from '@/email/lib/send';
+
+import { MyGuardianOffer } from './MyGuardianOffer';
+import { MyGuardianOfferText } from './MyGuardianOfferText';
+
+type Props = {
+	to: string;
+	subject?: string;
+};
+
+const plainText = MyGuardianOfferText();
+const { html } = render(MyGuardianOffer());
+
+export const sendMyGuardianOfferEmail = ({
+	to,
+	subject = 'Access to My Guardian',
+}: Props) => {
+	return send({
+		html,
+		plainText,
+		subject,
+		to,
+	});
+};

--- a/src/server/controllers/changePassword.ts
+++ b/src/server/controllers/changePassword.ts
@@ -45,6 +45,7 @@ import { decryptOktaRecoveryToken } from '@/server/lib/deeplink/oktaRecoveryToke
 import { changePasswordMetric } from '@/server/models/Metrics';
 import { getAppPrefix } from '@/shared/lib/appNameUtils';
 import { sendGuardianLiveOfferEmail } from '@/email/templates/GuardianLiveOffer/sendGuardianLiveOfferEmail';
+import { sendMyGuardianOfferEmail } from '@/email/templates/MyGuardianOffer/sendMyGuardianOfferEmail';
 
 const { okta } = getConfiguration();
 
@@ -294,9 +295,9 @@ const changePasswordInOkta = async (
 								to: encryptedState.email,
 							});
 							break;
-						case 'alternative-wording-personalization':
+						case 'alternative-wording-personalise':
 							// TODO: Change this email once created
-							await sendGuardianLiveOfferEmail({
+							await sendMyGuardianOfferEmail({
 								to: encryptedState.email,
 							});
 							break;

--- a/src/server/controllers/changePassword.ts
+++ b/src/server/controllers/changePassword.ts
@@ -11,7 +11,10 @@ import {
 } from '@/server/lib/idapi/changePassword';
 import { setIDAPICookies } from '@/server/lib/idapi/IDAPICookies';
 import { trackMetric } from '@/server/lib/trackMetric';
-import { updateEncryptedStateCookie } from '@/server/lib/encryptedStateCookie';
+import {
+	readEncryptedStateCookie,
+	updateEncryptedStateCookie,
+} from '@/server/lib/encryptedStateCookie';
 import { ApiError } from '@/server/models/Error';
 import { PasswordRoutePath, RoutePaths } from '@/shared/model/Routes';
 import { PasswordPageTitle } from '@/shared/model/PageTitle';
@@ -41,6 +44,7 @@ import { ProfileOpenIdClientRedirectUris } from '@/server/lib/okta/openid-connec
 import { decryptOktaRecoveryToken } from '@/server/lib/deeplink/oktaRecoveryToken';
 import { changePasswordMetric } from '@/server/models/Metrics';
 import { getAppPrefix } from '@/shared/lib/appNameUtils';
+import { sendGuardianLiveOfferEmail } from '@/email/templates/GuardianLiveOffer/sendGuardianLiveOfferEmail';
 
 const { okta } = getConfiguration();
 
@@ -52,7 +56,7 @@ const changePasswordInIDAPI = async (
 	successRedirectPath: RoutePaths,
 ) => {
 	const { token } = req.params;
-	const { clientId } = req.query;
+	const { clientId } = res.locals.queryParams;
 	const { password, firstName, secondName } = req.body;
 
 	// eslint-disable-next-line functional/no-let
@@ -196,7 +200,7 @@ const changePasswordInOkta = async (
 ) => {
 	const { token: encryptedRecoveryToken } = req.params;
 	const { password, firstName, secondName } = req.body;
-	const { clientId } = req.query;
+	const { clientId, signInGateId } = res.locals.queryParams;
 
 	try {
 		if (!encryptedRecoveryToken) {
@@ -274,6 +278,38 @@ const changePasswordInOkta = async (
 			}
 
 			changePasswordMetric(path, 'Success');
+
+			/* AB TEST START */
+			const encryptedState = readEncryptedStateCookie(req);
+
+			// If the user signed up from one of the sign in gates we're AB testing, we want to send them
+			// the appropriate email
+			// This is for the case where they're signing up with an email and password - for social registration
+			// we handle the email sending directly in the auth code callback.
+			try {
+				if (signInGateId && encryptedState?.email) {
+					switch (signInGateId) {
+						case 'alternative-wording-guardian-live':
+							await sendGuardianLiveOfferEmail({
+								to: encryptedState.email,
+							});
+							break;
+						case 'alternative-wording-personalization':
+							// TODO: Change this email once created
+							await sendGuardianLiveOfferEmail({
+								to: encryptedState.email,
+							});
+							break;
+						default:
+							break;
+					}
+				}
+			} catch (error) {
+				logger.error('Error sending offer email', error, {
+					request_id: res.locals.requestId,
+				});
+			}
+			/* AB TEST END */
 
 			return await performAuthorizationCodeFlow(req, res, {
 				sessionToken,

--- a/src/server/lib/__tests__/queryParams.test.ts
+++ b/src/server/lib/__tests__/queryParams.test.ts
@@ -9,6 +9,12 @@ jest.mock('@/server/lib/getConfiguration', () => ({
 	getConfiguration: () => ({ defaultReturnUri: 'default-uri' }),
 }));
 
+jest.mock('@/server/lib/serverSideLogger', () => ({
+	logger: {
+		error: jest.fn(),
+	},
+}));
+
 describe('parseExpressQueryParams', () => {
 	const { defaultReturnUri } = getConfiguration();
 

--- a/src/server/lib/okta/oauth.ts
+++ b/src/server/lib/okta/oauth.ts
@@ -34,6 +34,7 @@ export type Scopes =
 export const scopesForAuthentication: Scopes[] = [
 	'openid',
 	'profile',
+	'email',
 	'guardian.identity-api.cookies.create.self.secure',
 	'guardian.members-data-api.read.self',
 	'guardian.identity-api.newsletters.read.self',

--- a/src/server/lib/okta/openid-connect.ts
+++ b/src/server/lib/okta/openid-connect.ts
@@ -10,6 +10,7 @@ import { ResponseWithRequestState } from '@/server/models/Express';
 import { logger } from '@/server/lib/serverSideLogger';
 import { RoutePaths } from '@/shared/model/Routes';
 import { SocialProvider } from '@/shared/model/Social';
+import { SignInGateIdsForOfferEmails } from '../ophan';
 
 /**
  * @interface AuthorizationState
@@ -35,6 +36,7 @@ export interface AuthorizationState {
 		encryptedRegistrationConsents?: string; // used to set the consents given during registration on the authentication callback when we have oauth access tokens which can update the user's consents in idapi, should be encrypted, and decrypted on the callback
 		socialProvider?: SocialProvider; // used to track the social provider used to sign in/register
 		appPrefix?: string; // used to track if the recovery token has a native app prefix
+		signInGateId?: SignInGateIdsForOfferEmails; // used to track the sign in gate id
 	};
 }
 

--- a/src/server/lib/okta/register.ts
+++ b/src/server/lib/okta/register.ts
@@ -282,12 +282,14 @@ export const register = async ({
 	consents,
 	ref,
 	refViewId,
+	signInGateId,
 }: {
 	email: string;
 	registrationLocation?: RegistrationLocation;
 	appClientId?: string;
 	request_id?: string;
 	consents?: RegistrationConsents;
+	signInGateId?: string;
 } & TrackingQueryParams): Promise<UserResponse> => {
 	try {
 		// Create the user in Okta, but do not send the activation email
@@ -333,6 +335,7 @@ export const register = async ({
 			}),
 			ref,
 			refViewId,
+			signInGateId,
 		});
 		if (!emailIsSent) {
 			trackMetric(emailSendMetric('OktaCompleteRegistration', 'Failure'));

--- a/src/server/lib/ophan.ts
+++ b/src/server/lib/ophan.ts
@@ -6,12 +6,22 @@ import {
 	OphanComponent,
 	OphanComponentEvent,
 	OphanComponentType,
+	isOneOf,
 } from '@guardian/libs';
 import serialize from 'serialize-javascript';
 import { timeoutSignal } from './timeoutSignal';
 import { removeEmptyKeysFromObjectAndConvertValuesToString } from '@/shared/lib/queryParams';
 
 const ophanUrl = 'https://ophan.theguardian.com/img/2';
+
+/* AB TEST START */
+export const signInGateIdsForOfferEmails = [
+	'alternative-wording-guardian-live',
+	'alternative-wording-personalization',
+] as const;
+export type SignInGateIdsForOfferEmails =
+	(typeof signInGateIdsForOfferEmails)[number];
+/* AB TEST END */
 
 // Component event params is the decoded version of the componentEventParams query parameter
 // defined in the TrackingQueryParams interface from src/shared/model/QueryParams.ts
@@ -70,11 +80,48 @@ export const parseComponentEventParams = async (
 		request_id,
 	});
 };
+/* AB TEST START */
+
+export const getMatchingSignInGateId = (
+	maybeSignInGateId: string | undefined,
+): SignInGateIdsForOfferEmails | undefined => {
+	if (!maybeSignInGateId) {
+		return;
+	}
+	const isOneOfSignInGateIds = isOneOf(signInGateIdsForOfferEmails);
+	if (!isOneOfSignInGateIds(maybeSignInGateId)) {
+		return;
+	}
+	return maybeSignInGateId;
+};
+
+export const getMatchingSignInGateIdFromComponentEventParamsQuery = async ({
+	componentEventParamsQuery,
+	request_id,
+}: {
+	componentEventParamsQuery?: string;
+	request_id?: string;
+}): Promise<SignInGateIdsForOfferEmails | undefined> => {
+	// The query string may be missing entirely
+	if (!componentEventParamsQuery) {
+		return;
+	}
+	const componentEventParams = await parseComponentEventParams(
+		componentEventParamsQuery,
+		request_id,
+	);
+	if (!componentEventParams?.abTestVariant) {
+		return;
+	}
+	return getMatchingSignInGateId(componentEventParams.abTestVariant);
+};
+
+/* AB TEST END */
 
 /**
  * In some cases in DCR and Frontend we send the component type
  * as a lowercase string with no spaces, so we need to convert them
- * to the correct case (upper snake case)
+ * to the correct case (SCREAMING_SNAKE_CASE)
  * otherwise we just return the component type as is
  */
 export const getComponentType = (componentType: string) => {

--- a/src/server/lib/ophan.ts
+++ b/src/server/lib/ophan.ts
@@ -17,7 +17,7 @@ const ophanUrl = 'https://ophan.theguardian.com/img/2';
 /* AB TEST START */
 export const signInGateIdsForOfferEmails = [
 	'alternative-wording-guardian-live',
-	'alternative-wording-personalization',
+	'alternative-wording-personalise',
 ] as const;
 export type SignInGateIdsForOfferEmails =
 	(typeof signInGateIdsForOfferEmails)[number];

--- a/src/server/lib/queryParams.ts
+++ b/src/server/lib/queryParams.ts
@@ -2,6 +2,7 @@ import { QueryParams, TrackingQueryParams } from '@/shared/model/QueryParams';
 import { validateReturnUrl, validateRefUrl } from '@/server/lib/validateUrl';
 import { validateClientId } from '@/server/lib/validateClientId';
 import { isStringBoolean } from './isStringBoolean';
+import { getMatchingSignInGateId } from './ophan';
 
 const validateGetOnlyError = (
 	method: string,
@@ -50,6 +51,7 @@ export const parseExpressQueryParams = (
 		fromURI,
 		appClientId,
 		maxAge,
+		signInGateId,
 	}: Record<keyof QueryParams, string | undefined>, // parameters from req.query
 	// some parameters may be manually passed in req.body too,
 	// generally for tracking purposes
@@ -73,6 +75,7 @@ export const parseExpressQueryParams = (
 		fromURI,
 		appClientId,
 		maxAge: stringToNumber(maxAge),
+		signInGateId: getMatchingSignInGateId(signInGateId),
 	};
 };
 

--- a/src/server/routes/oauth.ts
+++ b/src/server/routes/oauth.ts
@@ -37,6 +37,7 @@ import { decryptRegistrationConsents } from '@/server/lib/registrationConsents';
 import { SocialProvider } from '@/shared/model/Social';
 import { update as updateNewsletters } from '@/server/lib/idapi/newsletters';
 import { RoutePaths } from '@/shared/model/Routes';
+import { sendGuardianLiveOfferEmail } from '@/email/templates/GuardianLiveOffer/sendGuardianLiveOfferEmail';
 
 const { baseUri, deleteAccountStepFunction } = getConfiguration();
 
@@ -131,7 +132,7 @@ const authenticationHandler = async (
 		let isSocialRegistration = false;
 		if (tokenSet.id_token) {
 			// extracting the custom claims from the id_token and the sub (user id)
-			const { user_groups, email_validated, sub } =
+			const { user_groups, email_validated, sub, email } =
 				tokenSet.claims() as CustomClaims;
 			// if the user is in the GuardianUser-EmailValidated group, but the emailValidated field is falsy
 			// then we set the emailValidated field to true in the Okta user profile by manually updating the user
@@ -141,8 +142,39 @@ const authenticationHandler = async (
 			) {
 				isSocialRegistration = true;
 
+				// We now know this user is registering a new Guardian account with social
+
 				// updated the user profile emailValidated to true
 				await updateUser(sub, { profile: { emailValidated: true } });
+
+				/* AB TEST START */
+
+				// If the user signed up from one of the sign in gates we're AB testing, we want to send them
+				// the appropriate email
+				try {
+					const signInGateId = authState.data?.signInGateId;
+					if (signInGateId && email) {
+						switch (signInGateId) {
+							case 'alternative-wording-guardian-live':
+								await sendGuardianLiveOfferEmail({
+									to: email,
+								});
+								break;
+							case 'alternative-wording-personalization':
+								await sendGuardianLiveOfferEmail({
+									to: email,
+								});
+								break;
+							default:
+								break;
+						}
+					}
+				} catch (error) {
+					logger.error('Error sending offer email', error, {
+						request_id: res.locals.requestId,
+					});
+				}
+				/* AB TEST END */
 
 				// since this is a new social user, we want to show the onboarding flow too
 				// we use the `confirmationPage` flag to redirect the user to the onboarding/consents page

--- a/src/server/routes/oauth.ts
+++ b/src/server/routes/oauth.ts
@@ -38,6 +38,7 @@ import { SocialProvider } from '@/shared/model/Social';
 import { update as updateNewsletters } from '@/server/lib/idapi/newsletters';
 import { RoutePaths } from '@/shared/model/Routes';
 import { sendGuardianLiveOfferEmail } from '@/email/templates/GuardianLiveOffer/sendGuardianLiveOfferEmail';
+import { sendMyGuardianOfferEmail } from '@/email/templates/MyGuardianOffer/sendMyGuardianOfferEmail';
 
 const { baseUri, deleteAccountStepFunction } = getConfiguration();
 
@@ -160,8 +161,8 @@ const authenticationHandler = async (
 									to: email,
 								});
 								break;
-							case 'alternative-wording-personalization':
-								await sendGuardianLiveOfferEmail({
+							case 'alternative-wording-personalise':
+								await sendMyGuardianOfferEmail({
 									to: email,
 								});
 								break;

--- a/src/server/routes/register.ts
+++ b/src/server/routes/register.ts
@@ -31,7 +31,10 @@ import { getConfiguration } from '@/server/lib/getConfiguration';
 import { OktaError } from '@/server/models/okta/Error';
 import { causesInclude } from '@/server/lib/okta/api/errors';
 import { redirectIfLoggedIn } from '@/server/lib/middleware/redirectIfLoggedIn';
-import { sendOphanComponentEventFromQueryParamsServer } from '@/server/lib/ophan';
+import {
+	getMatchingSignInGateIdFromComponentEventParamsQuery,
+	sendOphanComponentEventFromQueryParamsServer,
+} from '@/server/lib/ophan';
 import { mergeRequestState } from '@/server/lib/requestState';
 import { UserResponse } from '@/server/models/okta/User';
 import { getRegistrationLocation } from '@/server/lib/getRegistrationLocation';
@@ -131,6 +134,24 @@ const OktaRegistration = async (
 ) => {
 	const { email = '', _cmpConsentedState = false } = req.body;
 
+	const {
+		queryParams: { appClientId, ref, refViewId, componentEventParams },
+		requestId: request_id,
+	} = res.locals;
+
+	/* AB TEST LOGIC START */
+
+	// The componentEventParams query parameter stores Ophan tracking data, but we want to
+	// parse it to check if this registration is coming via specific sign-in gates we're AB testing,
+	// so we can send an offer email after registration is complete.
+	const signInGateId =
+		await getMatchingSignInGateIdFromComponentEventParamsQuery({
+			componentEventParamsQuery: componentEventParams,
+			request_id,
+		});
+
+	/* AB TEST LOGIC END */
+
 	// consents/newsletters are a string with value `'on'` if checked, or `undefined` if not checked
 	// https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/checkbox#value
 	// so we can check the truthiness of the value to determine if the user has consented
@@ -150,11 +171,6 @@ const OktaRegistration = async (
 			.filter((newsletter) => newsletter.subscribed),
 	};
 
-	const {
-		queryParams: { appClientId, ref, refViewId },
-		requestId: request_id,
-	} = res.locals;
-
 	const registrationLocation: RegistrationLocation | undefined =
 		getRegistrationLocation(req, isStringBoolean(_cmpConsentedState));
 
@@ -167,6 +183,7 @@ const OktaRegistration = async (
 			consents,
 			ref,
 			refViewId,
+			signInGateId,
 		});
 
 		// fire ophan component event if applicable

--- a/src/shared/__tests__/queryParams.test.ts
+++ b/src/shared/__tests__/queryParams.test.ts
@@ -34,6 +34,7 @@ describe('getPersistableQueryParams', () => {
 			refViewId: 'refViewId',
 			componentEventParams: 'componentEventParams',
 			useIdapi: undefined,
+			signInGateId: undefined,
 			fromURI: 'fromURI',
 			appClientId: 'appClientId',
 		};

--- a/src/shared/lib/queryParams.ts
+++ b/src/shared/lib/queryParams.ts
@@ -41,6 +41,7 @@ export const getPersistableQueryParams = (
 	componentEventParams: params.componentEventParams,
 	fromURI: params.fromURI,
 	appClientId: params.appClientId,
+	signInGateId: params.signInGateId,
 });
 
 /**

--- a/src/shared/model/QueryParams.ts
+++ b/src/shared/model/QueryParams.ts
@@ -1,3 +1,4 @@
+import { SignInGateIdsForOfferEmails } from '@/server/lib/ophan';
 import { ValidClientId } from '../lib/clientId';
 
 type Stringifiable = string | boolean | number | null | undefined;
@@ -25,6 +26,9 @@ export interface TrackingQueryParams {
 	// we URL encode the value of componentEventParams due to the number of keys available
 	// as well as getting confused with other parameters, so we thought it best to pass it as a URL encoded string, and then do the decoding once it gets to IDAPI
 	componentEventParams?: string;
+	// Only used for AB testing sign in gates which need to send an offer email after successful registration.
+	// Extracted from componentEventParams and whitelisted against a list of IDs we're interested in.
+	signInGateId?: SignInGateIdsForOfferEmails;
 }
 
 /**


### PR DESCRIPTION
## What does this change?

- Adds two new email templates, for emails which are sent _after_ a user successfully registers _if_ that user has come from one of the two sign-in gates we'll be AB testing on DCR: https://github.com/guardian/dotcom-rendering/pull/10767/files
- Fixes a `tsconfig` issue in Cypress - not clear why this popped up
- Fixes email box padding styles
- Adds some methods to capture the `signInGateId` on `GET /signin/:social` and `POST /register`.
    - In the social case, the ID (if it's one of the ones we care about) is passed through the auth code flow and is accessed in the callback to send the appropriate email.
    - In the email/password case, it's saved as a query param on the 'verify email' link, which passes through to the `POST` set password call, and sends the email if that is successful.

## Tests

- [x] Tested on CODE