### PR TITLE
Add new Feast fields to MDAPI response schema

### DIFF
--- a/src/shared/lib/members-data-api.ts
+++ b/src/shared/lib/members-data-api.ts
@@ -4,37 +4,35 @@ import { z } from 'zod';
  * This type is manually kept in sync with the Membership API:
  * https://github.com/guardian/members-data-api/blob/main/membership-attribute-service/app/models/Attributes.scala
  */
-export const userAttributesResponseSchema = z
-	.object({
-		userId: z.string(),
+export const userAttributesResponseSchema = z.object({
+	userId: z.string(),
 
-		tier: z.string().optional(),
-		recurringContributionPaymentPlan: z.string().optional(),
-		oneOffContributionDate: z.string().optional(),
-		membershipJoinDate: z.string().optional(),
-		digitalSubscriptionExpiryDate: z.string().optional(),
-		paperSubscriptionExpiryDate: z.string().optional(),
-		guardianWeeklyExpiryDate: z.string().optional(),
-		liveAppSubscriptionExpiryDate: z.string().optional(),
-		guardianPatronExpiryDate: z.string().optional(),
-		alertAvailableFor: z.string().optional(),
+	tier: z.string().optional(),
+	recurringContributionPaymentPlan: z.string().optional(),
+	oneOffContributionDate: z.string().optional(),
+	membershipJoinDate: z.string().optional(),
+	digitalSubscriptionExpiryDate: z.string().optional(),
+	paperSubscriptionExpiryDate: z.string().optional(),
+	guardianWeeklyExpiryDate: z.string().optional(),
+	liveAppSubscriptionExpiryDate: z.string().optional(),
+	guardianPatronExpiryDate: z.string().optional(),
+	alertAvailableFor: z.string().optional(),
 
-		showSupportMessaging: z.boolean(),
-		feastIosSubscriptionGroup: z.string().optional(),
+	showSupportMessaging: z.boolean(),
+	feastIosSubscriptionGroup: z.string().optional(),
 
-		contentAccess: z.object({
-			member: z.boolean(),
-			paidMember: z.boolean(),
-			recurringContributor: z.boolean(),
-			supporterPlus: z.boolean(),
-			digitalPack: z.boolean(),
-			paperSubscriber: z.boolean(),
-			guardianWeeklySubscriber: z.boolean(),
-			guardianPatron: z.boolean(),
-			feast: z.boolean().optional(),
-		}),
-	})
-	.strict();
+	contentAccess: z.object({
+		member: z.boolean(),
+		paidMember: z.boolean(),
+		recurringContributor: z.boolean(),
+		supporterPlus: z.boolean(),
+		digitalPack: z.boolean(),
+		paperSubscriber: z.boolean(),
+		guardianWeeklySubscriber: z.boolean(),
+		guardianPatron: z.boolean(),
+		feast: z.boolean().optional(),
+	}),
+});
 export type UserAttributesResponse = z.infer<
 	typeof userAttributesResponseSchema
 >;

--- a/src/shared/lib/members-data-api.ts
+++ b/src/shared/lib/members-data-api.ts
@@ -20,6 +20,7 @@ export const userAttributesResponseSchema = z
 		alertAvailableFor: z.string().optional(),
 
 		showSupportMessaging: z.boolean(),
+		feastIosSubscriptionGroup: z.string().optional(),
 
 		contentAccess: z.object({
 			member: z.boolean(),
@@ -30,6 +31,7 @@ export const userAttributesResponseSchema = z
 			paperSubscriber: z.boolean(),
 			guardianWeeklySubscriber: z.boolean(),
 			guardianPatron: z.boolean(),
+			feast: z.boolean().optional(),
 		}),
 	})
 	.strict();


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

The MDAPI user attributes response schema is getting two new fields in this PR: https://github.com/guardian/members-data-api/pull/1045

As our Zod schema for this response is `.strict()`, the Zod parser fails on MDAPI responses which have the new fields. This adds the new fields to the Zod schema.

As a side note, should we remove `.strict()` from the MDAPI response? With it set to strict, we need to know whenever other teams change the response.

## Tests

- [ ] Tested in CODE