### PR TITLE
Passcodes | Set up switch and query parameter

### DIFF
--- a/src/server/lib/__tests__/getConfiguration.test.ts
+++ b/src/server/lib/__tests__/getConfiguration.test.ts
@@ -140,6 +140,7 @@ describe('getConfiguration', () => {
 			},
 			membersDataApiUrl: 'members-data-api-url',
 			gatewayOAuthEnabled: true,
+			registrationPasscodesEnabled: true,
 			deleteAccountStepFunction: {
 				url: 'delete-account-step-function-url',
 				apiKey: 'delete-account-api-key',

--- a/src/server/lib/getConfiguration.ts
+++ b/src/server/lib/getConfiguration.ts
@@ -50,6 +50,7 @@ interface StageVariables {
 	apiDomain: string;
 	oktaEnabled: boolean;
 	gatewayOAuthEnabled: boolean;
+	registrationPasscodesEnabled: boolean;
 	accountManagementUrl: string;
 }
 
@@ -61,6 +62,8 @@ const getStageVariables = (stage: Stage): StageVariables => {
 				apiDomain: GU_API_DOMAIN.PROD,
 				oktaEnabled: featureSwitches.oktaEnabled.PROD,
 				gatewayOAuthEnabled: featureSwitches.gatewayOAuthEnabled.PROD,
+				registrationPasscodesEnabled:
+					featureSwitches.registrationPasscodesEnabled.PROD,
 				accountManagementUrl: GU_MANAGE_URL.PROD,
 			};
 		case 'CODE':
@@ -69,6 +72,8 @@ const getStageVariables = (stage: Stage): StageVariables => {
 				apiDomain: GU_API_DOMAIN.CODE,
 				oktaEnabled: featureSwitches.oktaEnabled.CODE,
 				gatewayOAuthEnabled: featureSwitches.gatewayOAuthEnabled.CODE,
+				registrationPasscodesEnabled:
+					featureSwitches.registrationPasscodesEnabled.CODE,
 				accountManagementUrl: GU_MANAGE_URL.CODE,
 			};
 		default:
@@ -77,6 +82,8 @@ const getStageVariables = (stage: Stage): StageVariables => {
 				apiDomain: GU_API_DOMAIN.DEV,
 				oktaEnabled: featureSwitches.oktaEnabled.DEV,
 				gatewayOAuthEnabled: featureSwitches.gatewayOAuthEnabled.DEV,
+				registrationPasscodesEnabled:
+					featureSwitches.registrationPasscodesEnabled.DEV,
 				accountManagementUrl: GU_MANAGE_URL.DEV,
 			};
 	}
@@ -133,6 +140,7 @@ export const getConfiguration = (): Configuration => {
 		oktaEnabled,
 		accountManagementUrl,
 		gatewayOAuthEnabled,
+		registrationPasscodesEnabled,
 	} = getStageVariables(stage);
 
 	const isHttps: boolean = JSON.parse(
@@ -267,6 +275,7 @@ export const getConfiguration = (): Configuration => {
 		rateLimiter,
 		membersDataApiUrl,
 		gatewayOAuthEnabled,
+		registrationPasscodesEnabled,
 		deleteAccountStepFunction,
 	};
 };

--- a/src/server/lib/queryParams.ts
+++ b/src/server/lib/queryParams.ts
@@ -50,6 +50,7 @@ export const parseExpressQueryParams = (
 		fromURI,
 		appClientId,
 		maxAge,
+		usePasscodeRegistration,
 	}: Record<keyof QueryParams, string | undefined>, // parameters from req.query
 	// some parameters may be manually passed in req.body too,
 	// generally for tracking purposes
@@ -73,6 +74,7 @@ export const parseExpressQueryParams = (
 		fromURI,
 		appClientId,
 		maxAge: stringToNumber(maxAge),
+		usePasscodeRegistration: isStringBoolean(usePasscodeRegistration),
 	};
 };
 

--- a/src/server/models/Configuration.ts
+++ b/src/server/models/Configuration.ts
@@ -29,6 +29,7 @@ export interface Configuration {
 	rateLimiter: RateLimiterConfiguration;
 	membersDataApiUrl: string;
 	gatewayOAuthEnabled: boolean;
+	registrationPasscodesEnabled: boolean;
 	deleteAccountStepFunction: {
 		url: string;
 		apiKey: string;

--- a/src/server/routes/register.ts
+++ b/src/server/routes/register.ts
@@ -41,7 +41,7 @@ import { RegistrationConsents } from '@/shared/model/RegistrationConsents';
 import { RegistrationLocation } from '@/shared/model/RegistrationLocation';
 import { RegistrationNewslettersFormFields } from '@/shared/model/Newsletter';
 
-const { okta } = getConfiguration();
+const { okta, registrationPasscodesEnabled } = getConfiguration();
 
 router.get(
 	'/register',
@@ -129,6 +129,14 @@ const OktaRegistration = async (
 	req: Request,
 	res: ResponseWithRequestState,
 ) => {
+	if (
+		registrationPasscodesEnabled &&
+		res.locals.queryParams.usePasscodeRegistration
+	) {
+		// to implement
+		return res.sendStatus(418);
+	}
+
 	const { email = '', _cmpConsentedState = false } = req.body;
 
 	// consents/newsletters are a string with value `'on'` if checked, or `undefined` if not checked

--- a/src/shared/lib/featureSwitches.ts
+++ b/src/shared/lib/featureSwitches.ts
@@ -18,6 +18,11 @@ interface FeatureSwitches {
 		CODE: boolean;
 		PROD: boolean;
 	};
+	registrationPasscodesEnabled: {
+		DEV: boolean;
+		CODE: boolean;
+		PROD: boolean;
+	};
 }
 
 export const featureSwitches: FeatureSwitches = {
@@ -31,5 +36,10 @@ export const featureSwitches: FeatureSwitches = {
 		DEV: true,
 		CODE: true,
 		PROD: true,
+	},
+	registrationPasscodesEnabled: {
+		DEV: true,
+		CODE: true,
+		PROD: false,
 	},
 };

--- a/src/shared/model/QueryParams.ts
+++ b/src/shared/model/QueryParams.ts
@@ -45,6 +45,8 @@ export interface PersistableQueryParams
 	fromURI?: string;
 	// This is the client Id of a calling application in Okta (ie iOS app etc)
 	appClientId?: string;
+	// temporary flag to enable passcode registration
+	usePasscodeRegistration?: boolean;
 }
 
 /**


### PR DESCRIPTION
## What does this change?

Sets up a feature switch (`registrationPasscodesEnabled`) and a query parameter (`usePasscodeRegistration`) in order to determine when a user should go through the yet to be implemented registration with passcodes flow.

For the time being it will require both the switch and the query parameter to be on the request in order to proceed, but will eventually make it switch only when we're happy with testing and release.