### PR TITLE
Add track email metrics for post-registration emails

### DIFF
--- a/src/server/models/Metrics.ts
+++ b/src/server/models/Metrics.ts
@@ -15,7 +15,9 @@ type EmailMetrics =
 	| 'OktaCompleteRegistration'
 	| 'OktaCreatePassword'
 	| 'OktaResetPassword'
-	| 'OktaUnvalidatedEmailResetPassword';
+	| 'OktaUnvalidatedEmailResetPassword'
+	| 'GuardianLiveOffer'
+	| 'MyGuardianOffer';
 
 // Rate limit buckets to track
 type RateLimitMetrics = BucketType;


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

- Adds two metrics for the two new emails we may send after a user completes the registration flow via a sign in gate.