### PR TITLE
IDX API / Interaction Code Flow | API Setup + Social Sign In

### DIFF
--- a/src/server/lib/okta/idx/interact.ts
+++ b/src/server/lib/okta/idx/interact.ts
@@ -1,0 +1,168 @@
+import { Request } from 'express';
+import { ResponseWithRequestState } from '@/server/models/Express';
+import { logger } from '@/server/lib/serverSideLogger';
+import { AuthorizationParameters, generators } from 'openid-client';
+import { getConfiguration } from '@/server/lib/getConfiguration';
+import {
+	AuthorizationState,
+	ProfileOpenIdClientRedirectUris,
+	generateAuthorizationState,
+	setAuthorizationStateCookie,
+} from '@/server/lib/okta/openid-connect';
+import {
+	PerformAuthorizationCodeFlowOptions,
+	scopesForAuthentication,
+} from '@/server/lib/okta/oauth';
+import { joinUrl } from '@guardian/libs';
+import { z } from 'zod';
+import { closeCurrentSession } from '@/server/lib/okta/api/sessions';
+import { getPersistableQueryParams } from '@/shared/lib/queryParams';
+import { OAuthError, isOAuthError } from '@/server/models/okta/Error';
+
+const { okta } = getConfiguration();
+
+const interactResponseSchema = z.object({
+	interaction_handle: z.string(),
+});
+export type InteractResponse = z.infer<typeof interactResponseSchema>;
+
+/**
+ * @name interact
+ * @description Okta IDX API/Interaction Code flow - Step 1: Initiates the interaction code flow, and returns an interaction handle which should be used in the next step, specifically `introspect`
+ *
+ * This is very similar to the standard authorization code flow, using similar parameters and the PKCE flow, but the authentication
+ * is different.
+ *
+ * In Gateway we only use the interaction code flow for authentication, in order to avoid using the Okta hosted sign in page. The
+ * standard authorization code flow is used for everything else.
+ *
+ * @param req - Express request
+ * @param res - Express response
+ * @param AuthorizationCodeFlowOptions - Subset of the `PerformAuthorizationCodeFlowOptions` used by our standard authorization code flow, namely the parameters needed for authentication
+ * @returns Promise<[InteractResponse, AuthorizationState]> - Array containing the interaction handle and the authorization state
+ */
+export const interact = async (
+	req: Request,
+	res: ResponseWithRequestState,
+	{
+		confirmationPagePath,
+		closeExistingSession,
+		doNotSetLastAccessCookie = false,
+		extraData,
+	}: Pick<
+		PerformAuthorizationCodeFlowOptions,
+		| 'confirmationPagePath'
+		| 'closeExistingSession'
+		| 'doNotSetLastAccessCookie'
+		| 'extraData'
+	>,
+): Promise<[InteractResponse, AuthorizationState]> => {
+	try {
+		// determines if the current session, should it exist, be closed
+		if (closeExistingSession) {
+			// Okta Identity Engine session cookie is called `idx`
+			const oktaIdentityEngineSessionCookieId: string | undefined =
+				req.cookies.idx;
+			if (oktaIdentityEngineSessionCookieId) {
+				await closeCurrentSession({
+					idx: oktaIdentityEngineSessionCookieId,
+				});
+			}
+		}
+
+		// generate the code verifier and code challenge for PKCE
+		// see https://www.oauth.com/oauth2-servers/pkce/authorization-request/
+		// the `code_verifier` is a cryptographically random string
+		// the `code_challenge` is the `code_verifier` hashed with SHA-256 and then base64url encoded
+		const codeVerifier = generators.codeVerifier(64);
+		const codeChallenge = generators.codeChallenge(codeVerifier);
+
+		// generate and store a "state"
+		// as a http only, secure, signed session cookie
+		// which is a json object that contains a stateParam and the query params
+		// the stateParam is used to protect against csrf
+		// we also set additional data in the state cookie that we need to persist
+		// between the authorization request and the callback
+		const authState = generateAuthorizationState(
+			getPersistableQueryParams(res.locals.queryParams),
+			confirmationPagePath,
+			doNotSetLastAccessCookie,
+			{
+				appPrefix: extraData?.appPrefix,
+				encryptedRegistrationConsents: extraData?.encryptedRegistrationConsents,
+				codeVerifier,
+			},
+		);
+		setAuthorizationStateCookie(authState, res);
+
+		// set up the authorization parameters to send to the /interact endpoint
+		// in order to start the interaction code flow
+		// see https://developer.okta.com/docs/concepts/interaction-code/
+		const authorizationParams: AuthorizationParameters = {
+			// the client_id is the id of the client application
+			client_id: okta.clientId,
+			// only use the interaction code flow callback uri, everything else is handled by standard authorization code flow
+			redirect_uri: ProfileOpenIdClientRedirectUris.INTERACTION_CODE,
+			// only authentication scopes for interaction code flow, everything else is handled by standard authorization code flow
+			scope: scopesForAuthentication.join(' '),
+			// we send the generated code challenge
+			code_challenge: codeChallenge,
+			// we use the S256 code challenge method, which is the only method supported
+			code_challenge_method: 'S256',
+			// we send the generated stateParam as the state parameter
+			state: authState.stateParam,
+		};
+
+		const authorizationSearchParams = new URLSearchParams(
+			authorizationParams as Record<string, string>,
+		);
+
+		const response = await fetch(
+			joinUrl(okta.orgUrl, '/oauth2/', okta.authServerId, '/v1/interact'),
+			{
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/x-www-form-urlencoded',
+				},
+				body: authorizationSearchParams.toString(),
+			},
+		);
+
+		if (!response.ok) {
+			// Check if the body is likely json using the content-type header
+			const contentType = response.headers.get('content-type');
+			if (contentType && contentType.includes('application/json')) {
+				// if so, parse the body as json, and handle the error
+				const error = await response.json().catch((e) => {
+					throw new OAuthError(
+						{
+							error: 'invalid_json',
+							error_description: e.message,
+						},
+						response.status,
+					);
+				});
+
+				if (isOAuthError(error)) {
+					throw new OAuthError(error, response.status);
+				}
+			} else {
+				throw new OAuthError(
+					{
+						error: 'unknown_error',
+						error_description: await response.text(),
+					},
+					response.status,
+				);
+			}
+		}
+
+		return [interactResponseSchema.parse(await response.json()), authState];
+	} catch (error) {
+		logger.error('Error - Okta IDX interact:', error, {
+			request_id: res.locals.requestId,
+		});
+
+		throw error;
+	}
+};

--- a/src/server/lib/okta/idx/interact.ts
+++ b/src/server/lib/okta/idx/interact.ts
@@ -18,6 +18,7 @@ import { z } from 'zod';
 import { closeCurrentSession } from '@/server/lib/okta/api/sessions';
 import { getPersistableQueryParams } from '@/shared/lib/queryParams';
 import { OAuthError, isOAuthError } from '@/server/models/okta/Error';
+import { trackMetric } from '../../trackMetric';
 
 const { okta } = getConfiguration();
 
@@ -157,8 +158,15 @@ export const interact = async (
 			}
 		}
 
-		return [interactResponseSchema.parse(await response.json()), authState];
+		const interactResponse = interactResponseSchema.parse(
+			await response.json(),
+		);
+
+		trackMetric('OktaIDXInteract::Success');
+
+		return [interactResponse, authState];
 	} catch (error) {
+		trackMetric('OktaIDXInteract::Failure');
 		logger.error('Error - Okta IDX interact:', error, {
 			request_id: res.locals.requestId,
 		});

--- a/src/server/lib/okta/idx/introspect.ts
+++ b/src/server/lib/okta/idx/introspect.ts
@@ -1,0 +1,145 @@
+import { joinUrl } from '@guardian/libs';
+import { InteractResponse } from './interact';
+import { getConfiguration } from '@/server/lib/getConfiguration';
+import { logger } from '@/server/lib/serverSideLogger';
+import { z } from 'zod';
+import { OAuthError } from '@/server/models/okta/Error';
+
+const { okta } = getConfiguration();
+
+// Schema for the 'redirect-idp' object inside the introspect response remediation object
+export const redirectIdpSchema = z.object({
+	name: z.literal('redirect-idp'),
+	type: z.enum(['APPLE', 'GOOGLE']),
+	href: z.string().url(),
+	method: z.literal('GET'),
+});
+
+// Schema for the introspect response
+const introspectResponseSchema = z.object({
+	stateHandle: z.string(),
+	expiresAt: z.coerce.date(),
+	remediation: z.object({
+		type: z.string(),
+		value: z.array(
+			// social idp object
+			z.union([
+				redirectIdpSchema,
+				z.object({
+					// any other name thats not one of the above
+					name: z.string(),
+					type: z.string().optional(),
+					href: z.string().optional(),
+					method: z.string().optional(),
+				}),
+			]),
+		),
+	}),
+});
+export type IntrospectResponse = z.infer<typeof introspectResponseSchema>;
+
+const introspectResponseErrorSchema = z.object({
+	version: z.literal('1.0.0'),
+	messages: z.object({
+		type: z.literal('array'),
+		value: z.array(
+			z.object({
+				message: z.string(),
+				i18n: z.object({ key: z.string() }),
+			}),
+		),
+	}),
+});
+
+/**
+ * @name introspect
+ * @description Okta IDX API/Interaction Code flow - Step 2: Use the interaction handle generated from the `interact` step to start the authentication process.
+ *
+ * The introspect step lets us know what kind of authentication we can perform (remediation),
+ * and what the next steps are. It also returns the `stateHandle` which identifies the current
+ * state of the authentication process, and should be preserved and used in any subsequent requests
+ * in the flow.
+ *
+ * @param interactionHandle - The interaction handle returned from the `interact` step
+ * @param request_id - The request id
+ * @returns Promise<IntrospectResponse> - The introspect response
+ */
+export const introspect = async (
+	interactionHandle: InteractResponse['interaction_handle'],
+	request_id?: string,
+): Promise<IntrospectResponse> => {
+	try {
+		const response = await fetch(joinUrl(okta.orgUrl, '/idp/idx/introspect'), {
+			method: 'POST',
+			headers: {
+				Accept: 'application/ion+json; okta-version=1.0.0',
+				'Content-Type': 'application/ion+json; okta-version=1.0.0',
+			},
+			body: JSON.stringify({
+				interactionHandle,
+			}),
+		});
+
+		if (!response.ok) {
+			await handleError(response);
+		}
+
+		const data = await response.json();
+
+		return introspectResponseSchema.parse(data);
+	} catch (error) {
+		logger.error('Error - Okta IDX introspect:', error, {
+			request_id,
+		});
+
+		throw error;
+	}
+};
+
+const handleError = async (response: Response) => {
+	// Check if the body is likely json using the content-type header
+	const contentType = response.headers.get('content-type');
+	if (
+		contentType &&
+		(contentType.includes('application/json') ||
+			contentType.includes('application/ion+json'))
+	) {
+		// if so, parse the body as json and see if it matches the schema
+		const json = await response.json().catch((e) => {
+			throw new OAuthError(
+				{
+					error: 'invalid_json',
+					error_description: e.message,
+				},
+				response.status,
+			);
+		});
+		const error = introspectResponseErrorSchema.safeParse(json);
+
+		if (error.success) {
+			throw new OAuthError(
+				{
+					error: error.data.messages.value[0].i18n.key,
+					error_description: error.data.messages.value[0].message,
+				},
+				response.status,
+			);
+		} else {
+			throw new OAuthError(
+				{
+					error: 'unknown_error',
+					error_description: JSON.stringify(json),
+				},
+				response.status,
+			);
+		}
+	}
+
+	throw new OAuthError(
+		{
+			error: 'unknown_error',
+			error_description: await response.text(),
+		},
+		response.status,
+	);
+};

--- a/src/server/lib/okta/oauth.ts
+++ b/src/server/lib/okta/oauth.ts
@@ -79,7 +79,7 @@ export const scopesForSelfServiceDeletion: Scopes[] = [
  * @param scopes (optional) - any scopes to use for the /authorize endpoint, defaults to ['openid']
  * @param sessionToken (optional) - if provided, we'll use this to set the session cookie
  */
-interface PerformAuthorizationCodeFlowOptions {
+export interface PerformAuthorizationCodeFlowOptions {
 	closeExistingSession?: boolean;
 	confirmationPagePath?: RoutePaths;
 	doNotSetLastAccessCookie?: boolean;

--- a/src/server/lib/okta/openid-connect.ts
+++ b/src/server/lib/okta/openid-connect.ts
@@ -37,6 +37,8 @@ export interface AuthorizationState {
 		socialProvider?: SocialProvider; // used to track the social provider used to sign in/register
 		appPrefix?: string; // used to track if the recovery token has a native app prefix
 		signInGateId?: SignInGateIdsForOfferEmails; // used to track the sign in gate id
+		codeVerifier?: string; // used to track the code verifier used in the PKCE flow
+		stateToken?: string; // state handle from Okta IDX /introspect response but only everything before the first tilde (`stateHandle.split('~')[0]`), used to redirect user to login redirect endpoint to set global session (`/login/token/redirect?stateToken=${stateToken}`)
 	};
 }
 
@@ -73,6 +75,10 @@ interface OpenIdClientRedirectUris {
 	>}`;
 	DELETE: `${string}${Extract<
 		'/oauth/authorization-code/delete-callback',
+		RoutePaths
+	>}`;
+	INTERACTION_CODE: `${string}${Extract<
+		'/oauth/authorization-code/interaction-code-callback',
 		RoutePaths
 	>}`;
 }
@@ -113,6 +119,7 @@ export const ProfileOpenIdClientRedirectUris: OpenIdClientRedirectUris = {
 	AUTHENTICATION: `${getProfileUrl()}/oauth/authorization-code/callback`,
 	APPLICATION: `${getProfileUrl()}/oauth/authorization-code/application-callback`,
 	DELETE: `${getProfileUrl()}/oauth/authorization-code/delete-callback`,
+	INTERACTION_CODE: `${getProfileUrl()}/oauth/authorization-code/interaction-code-callback`,
 };
 
 /**

--- a/src/server/lib/okta/openid-connect.ts
+++ b/src/server/lib/okta/openid-connect.ts
@@ -232,6 +232,27 @@ export const generateAuthorizationState = (
 });
 
 /**
+ * @function updateAuthorizationStateData
+ *
+ * Update the `AuthorizationState` data with the provided data, useful for adding extra data
+ * after the initial state has been generated.
+ *
+ * @param {AuthorizationState} state
+ * @param {AuthorizationState['data']} data
+ * @return {*}  {AuthorizationState}
+ */
+export const updateAuthorizationStateData = (
+	state: AuthorizationState,
+	data: Partial<AuthorizationState['data']>,
+): AuthorizationState => ({
+	...state,
+	data: {
+		...state.data,
+		...data,
+	},
+});
+
+/**
  * Name of the Authorization State cookie to set
  * @type {string}
  */

--- a/src/server/models/Metrics.ts
+++ b/src/server/models/Metrics.ts
@@ -40,6 +40,8 @@ type ConditionalMetrics =
 	| 'OAuthAuthenticationCallback'
 	| 'OAuthDeleteCallback'
 	| 'OktaAccountVerification'
+	| 'OktaIDXInteract'
+	| 'OktaIDXIntrospect'
 	| 'OktaRegistration'
 	| 'OktaRegistrationResendEmail'
 	| 'OktaResetPassword'
@@ -76,6 +78,9 @@ type UnconditionalMetrics =
 	| 'LoginMiddlewareOAuth::OAuthTokensValid'
 	| 'LoginMiddlewareOAuth::SignedOutCookie'
 	| 'LoginMiddlewareOAuth::UseIdapi'
+	| 'OktaIDX::UnexpectedVersion'
+	| 'OktaIDXSocialSignIn::Redirect'
+	| 'OktaIDXSocialSignIn::Failure'
 	| `${RateLimitMetrics}GatewayRateLimitHit`
 	| `User-${'EmailValidated' | 'EmailNotValidated'}-${
 			| 'WeakPassword'

--- a/src/server/models/okta/Error.ts
+++ b/src/server/models/okta/Error.ts
@@ -58,3 +58,26 @@ export class OktaError extends Error {
 		this.code = error.code;
 	}
 }
+
+const oauthErrorSchema = z.object({
+	error: z.string(),
+	error_description: z.string(),
+});
+type OAuthErrorType = z.infer<typeof oauthErrorSchema>;
+
+export class OAuthError extends Error {
+	name: string;
+	status: number;
+	code: string;
+	constructor(error: OAuthErrorType, status = 400) {
+		super(error.error_description);
+		this.name = error.error;
+		this.code = error.error;
+		this.status = status;
+		this.message = error.error_description;
+	}
+}
+
+export const isOAuthError = (error: unknown): error is OAuthErrorType => {
+	return oauthErrorSchema.safeParse(error).success;
+};

--- a/src/shared/model/Routes.ts
+++ b/src/shared/model/Routes.ts
@@ -32,6 +32,7 @@ export const ValidRoutePathsArray = [
 	'/oauth/authorization-code/application-callback',
 	'/oauth/authorization-code/callback',
 	'/oauth/authorization-code/delete-callback',
+	'/oauth/authorization-code/interaction-code-callback',
 	'/reauthenticate',
 	'/register',
 	'/register/email',


### PR DESCRIPTION
## What does this change?

The Okta Identity Engine upgrade enables us to use new features, such as passwordless authentication, through their new [Interaction Code Flow](https://developer.okta.com/docs/concepts/interaction-code/) and [IDX API](https://github.com/okta/okta-auth-js/blob/master/docs/idx.md). This also enables us to build our own custom login flows without the need for using the Okta hosted sign in page.

However the IDX API doesn't have its endpoints publicly documented, and instead Okta would prefer we use their own SDKs in order to interface with this API. Unfortunately this isn't viable for us as the SDKs don't perform ideally when using them in a server side environment. So we've taken the option to reverse engineer the IDX API.

We did this by seeing what calls the default Okta hosted sign in page made when authenticating, and seeing what calls we needed to make too.

For social sign in the steps are as follows:

1. Call the `interact` endpoint to start the interaction code flow.
    - The parameters for this call are the same as those provided to the Authorization Code Flow with PCKE
    - But instead make a `POST /oauth2/<auth_server_id>/v1/interact` call, with the parameters encoded in the body as `application/x-www-form-urlencoded`
    - This returns an object with the `interaction_handle` key
2.  Call the `introspect` endpoint with the `interaction_handle` in the body as JSON.
    - `POST /idp/idx/introspect`
    - This returns a whole bunch of stuff, essentially shows all of the authentication options we can perform
    - It also returns a `stateHandle` which is important for identifying the current authentication request, and should be preserved in any future calls to the IDX API
3. From the `introspect` response, in the `remediation` array, find an object with the key `name` and value `redirect-idp`, and the key `type` to be value either `GOOGLE` or `APPLE` depending on which one to authenticate with
4. Once you have this, get the `href` from the same object, and redirect the user to this `href`
5. The user then authenticates with their social provider, and once authenticated redirects back to Okta's `/oauth2/v1/authorize/callback` endpoint
6. This is an Okta controlled endpoint that either creates the user, or signs the user in, and then redirects the user to the callback endpoint defined in the parameters of step 1
7. This callback endpoint receives an `interaction_code` and a `state` (the state was defined in step 1)
8. Redirect the user to `/login/token/redirect?stateToken=${stateToken}`
    - Where `stateToken` is the `stateHandle` from step 2, but only the first part split at the `~`
    - `stateHandle.split('~')[0]`
    - This sets a global okta session, and completes the flow by redirecting the user to the same callback endpoint, but with a `code` parameter (not an `interaction_code`) and the state
9. In this callback endpoint, use a standard OAuth library that supports Authorization Code Flow with PKCE, and complete the flow.
    - The user is authenticated at this point 

This PR does 2 main things
- Sets up the basic framework for the IDX API and Interaction Code flow
- Updates social sign in to use the new flow

The functionality has been set up so that should the IDX API fail for whatever reason, it will fall back to using the old authentication mechanism i.e Okta Classic.

### Set up IDX API

- Set up the new callback URL in our routes definition and OAuth configuration
    - [`d5a77f2` (#2625)](https://github.com/guardian/gateway/pull/2625/commits/d5a77f2e3f28989ed0631de587a306fefb2b8acb)
- Allow the `AuthorizationStateCookie` to preserve the `codeVerifier` (for PKCE), and the `stateToken` (for authentication)
    - [`d5a77f2` (#2625)](https://github.com/guardian/gateway/pull/2625/commits/d5a77f2e3f28989ed0631de587a306fefb2b8acb)
- Set up the `interact` method, schema, and error handling  
    - [`2f89fae` (#2625)](https://github.com/guardian/gateway/pull/2625/commits/2f89faec8338f1bd4eb36f21ad7ef911a545b33e)
- Set up the `introspect` method, schema, and error handling
    - [`c7a049f` (#2625)](https://github.com/guardian/gateway/pull/2625/commits/c7a049fc5edd9fb36a6bb63d503972b828dfe747)
 
### Set up social authentication

[`a12e131` (#2625)](https://github.com/guardian/gateway/pull/2625/commits/a12e131059318141bd1e4581d2af94da72984e7c)

- Set up the `/oauth/authorization-code/interaction-code-callback` route handling
- Allow the `AuthorizationState` to be updated after it's initially generated
    - So we can add the `stateToken` in once thats available to us
- Update the `GET /signin/:social` route to follow the steps mentioned above for social sign in

## Tested
- [x] CODE - Web - Google - Sign In
- [x] CODE - Web - Google - Create account
- [x] CODE - Web - Apple - Sign in
- [x] CODE - Web - Apple - Create account
- [x] CODE - iOS - Google - Sign in
- [x] CODE - iOS - Google - Create account
- [x] CODE - iOS - Apple - Sign in
- [x] CODE - iOS - Apple - Create account
- [x] CODE - Android - Google - Sign in
- [x] CODE - Android - Google - Create account
- [x] CODE - Android - Apple - Sign in
- [x] CODE - Android - Apple - Create account