### PR TITLE
Create braze user for new users

### DIFF
--- a/src/server/lib/idapi/newsletters.ts
+++ b/src/server/lib/idapi/newsletters.ts
@@ -3,6 +3,7 @@ import {
 	APIGetOptions,
 	APIPatchOptions,
 	APIOptionSelect,
+	APIPostOptions,
 } from '@/server/lib/IDAPIFetch';
 import { NewslettersErrors } from '@/shared/model/Errors';
 import { NewsLetter } from '@/shared/model/Newsletter';
@@ -127,6 +128,38 @@ export const readUserNewsletters = async ({
 				request_id,
 			},
 		);
+		return handleError();
+	}
+};
+
+export const touchBraze = async ({
+	ip,
+	sc_gu_u,
+	accessToken,
+	request_id,
+}: {
+	ip?: string;
+	sc_gu_u?: string;
+	accessToken?: string;
+	request_id?: string;
+}) => {
+	const options = APIOptionSelect({
+		ip,
+		sc_gu_u,
+		accessToken,
+		options: APIPostOptions(),
+	});
+
+	try {
+		await idapiFetch({
+			path: '/users/me/touch-braze',
+			options,
+		});
+		return;
+	} catch (error) {
+		logger.error(`IDAPI Error touchBraze '/users/me/touch-braze'`, error, {
+			request_id,
+		});
 		return handleError();
 	}
 };

--- a/src/shared/model/Routes.ts
+++ b/src/shared/model/Routes.ts
@@ -111,7 +111,8 @@ export type ApiRoutePaths =
 	| '/user/type/:email'
 	| '/user/validate-email/:token'
 	| '/users/me/consents'
-	| '/users/me/newsletters';
+	| '/users/me/newsletters'
+	| '/users/me/touch-braze';
 
 type OktaApiRoutePaths =
 	| '/api/v1/apps/:id'


### PR DESCRIPTION
## What does this change?

Users aren't created in braze until the overnight job runs (OAW Dump) or they subscribe to a newsletter, however a use case has come up where a user needs to exist in braze when an account is created, specifically for the Feast team to send service emails to users who create an account.

We created a new endpoint in IDAPI to facilitate this: https://github.com/guardian/identity/pull/2500

This PR uses that new endpoint in Gateway.

It calls this endpoint when a user updated their registration consents, but doesn't have a newsletter they're subscribing too, or when they're a new social user.

If a user subscribed to a newsletter, then we don't call this endpoint as they'll get automatically created in braze. If they don't then we call this endpoint to create them.

## Tested

- [x] CODE