### PR TITLE
Okta IDX API | API setup for passcode registration

### DIFF
--- a/src/server/lib/okta/idx/challenge.ts
+++ b/src/server/lib/okta/idx/challenge.ts
@@ -1,0 +1,53 @@
+import { z } from 'zod';
+import {
+	IdxBaseResponse,
+	IdxStateHandleBody,
+	baseRemediationValueSchema,
+	idxBaseResponseSchema,
+	idxFetch,
+} from './shared';
+import { selectAuthenticationEnrollSchema } from './enroll';
+
+const skipSchema = baseRemediationValueSchema.merge(
+	z.object({
+		name: z.literal('skip'),
+	}),
+);
+
+const challengeAnswerResponseSchema = idxBaseResponseSchema.merge(
+	z.object({
+		remediation: z.object({
+			type: z.string(),
+			value: z.array(
+				z.union([
+					selectAuthenticationEnrollSchema,
+					skipSchema,
+					baseRemediationValueSchema,
+				]),
+			),
+		}),
+	}),
+);
+type ChallengeAnswerResponse = z.infer<typeof challengeAnswerResponseSchema>;
+
+type ChallengeAnswerPasswordBody = IdxStateHandleBody<{
+	credentials: {
+		passcode: string;
+	};
+}>;
+
+export const challengeAnswer = (
+	stateHandle: IdxBaseResponse['stateHandle'],
+	body: ChallengeAnswerPasswordBody['credentials'],
+	request_id?: string,
+): Promise<ChallengeAnswerResponse> => {
+	return idxFetch<ChallengeAnswerResponse, ChallengeAnswerPasswordBody>({
+		path: 'challenge/answer',
+		body: {
+			stateHandle,
+			credentials: body,
+		},
+		schema: challengeAnswerResponseSchema,
+		request_id,
+	});
+};

--- a/src/server/lib/okta/idx/challenge.ts
+++ b/src/server/lib/okta/idx/challenge.ts
@@ -10,6 +10,7 @@ import {
 import { selectAuthenticationEnrollSchema } from './enroll';
 import { ResponseWithRequestState } from '@/server/models/Express';
 
+// Schema for the 'skip' object inside the challenge response remediation object
 export const skipSchema = baseRemediationValueSchema.merge(
 	z.object({
 		name: z.literal('skip'),
@@ -17,6 +18,7 @@ export const skipSchema = baseRemediationValueSchema.merge(
 	}),
 );
 
+// Schema for the challenge/answer response
 const challengeAnswerResponseSchema = idxBaseResponseSchema.merge(
 	z.object({
 		remediation: z.object({
@@ -33,12 +35,22 @@ const challengeAnswerResponseSchema = idxBaseResponseSchema.merge(
 );
 type ChallengeAnswerResponse = z.infer<typeof challengeAnswerResponseSchema>;
 
+// Body type for the challenge/answer request - passcode can refer to a OTP code or a password
 type ChallengeAnswerPasswordBody = IdxStateHandleBody<{
 	credentials: {
 		passcode: string;
 	};
 }>;
 
+/**
+ * @name challengeAnswerPasscode
+ * @description Okta IDX API/Interaction Code flow - Answer a challenge with a passcode (OTP code or password).
+ *
+ * @param stateHandle - The state handle from the previous step
+ * @param body - The passcode object, containing the passcode
+ * @param request_id - The request id
+ * @returns Promise<ChallengeAnswerResponse> - The challenge answer response
+ */
 export const challengeAnswerPasscode = (
 	stateHandle: IdxBaseResponse['stateHandle'],
 	body: ChallengeAnswerPasswordBody['credentials'],
@@ -55,6 +67,15 @@ export const challengeAnswerPasscode = (
 	});
 };
 
+/**
+ * @name setPasswordAndRedirect
+ * @description Okta IDX API/Interaction Code flow - Answer a challenge with a password, and redirect the user to set a global session and then back to the app. This could be one the final possible steps in the authentication process.
+ * @param stateHandle - The state handle from the previous step
+ * @param body - The password object, containing the password
+ * @param expressRes - The express response object
+ * @param request_id - The request id
+ * @returns Promise<void> - Performs a express redirect
+ */
 export const setPasswordAndRedirect = async (
 	stateHandle: IdxBaseResponse['stateHandle'],
 	body: ChallengeAnswerPasswordBody['credentials'],

--- a/src/server/lib/okta/idx/challenge.ts
+++ b/src/server/lib/okta/idx/challenge.ts
@@ -5,12 +5,15 @@ import {
 	baseRemediationValueSchema,
 	idxBaseResponseSchema,
 	idxFetch,
+	idxFetchCompletion,
 } from './shared';
 import { selectAuthenticationEnrollSchema } from './enroll';
+import { ResponseWithRequestState } from '@/server/models/Express';
 
-const skipSchema = baseRemediationValueSchema.merge(
+export const skipSchema = baseRemediationValueSchema.merge(
 	z.object({
 		name: z.literal('skip'),
+		href: z.string().url(),
 	}),
 );
 
@@ -36,7 +39,7 @@ type ChallengeAnswerPasswordBody = IdxStateHandleBody<{
 	};
 }>;
 
-export const challengeAnswer = (
+export const challengeAnswerPasscode = (
 	stateHandle: IdxBaseResponse['stateHandle'],
 	body: ChallengeAnswerPasswordBody['credentials'],
 	request_id?: string,
@@ -48,6 +51,23 @@ export const challengeAnswer = (
 			credentials: body,
 		},
 		schema: challengeAnswerResponseSchema,
+		request_id,
+	});
+};
+
+export const setPasswordAndRedirect = async (
+	stateHandle: IdxBaseResponse['stateHandle'],
+	body: ChallengeAnswerPasswordBody['credentials'],
+	expressRes: ResponseWithRequestState,
+	request_id?: string,
+): Promise<void> => {
+	return await idxFetchCompletion<ChallengeAnswerPasswordBody>({
+		path: 'challenge/answer',
+		body: {
+			stateHandle,
+			credentials: body,
+		},
+		expressRes,
 		request_id,
 	});
 };

--- a/src/server/lib/okta/idx/credential.ts
+++ b/src/server/lib/okta/idx/credential.ts
@@ -1,0 +1,53 @@
+import { z } from 'zod';
+import {
+	IdxBaseResponse,
+	IdxStateHandleBody,
+	baseRemediationValueSchema,
+	idxBaseResponseSchema,
+	idxFetch,
+} from './shared';
+import {
+	enrollAuthenticatorSchema,
+	selectAuthenticationEnrollSchema,
+} from './enroll';
+import { skipSchema } from './challenge';
+
+const credentialEnrollResponse = idxBaseResponseSchema.merge(
+	z.object({
+		remediation: z.object({
+			type: z.string(),
+			value: z.array(
+				z.union([
+					enrollAuthenticatorSchema,
+					selectAuthenticationEnrollSchema,
+					skipSchema,
+					baseRemediationValueSchema,
+				]),
+			),
+		}),
+	}),
+);
+type CredentialEnrollResponse = z.infer<typeof credentialEnrollResponse>;
+
+type CredentialEnrollBody = IdxStateHandleBody<{
+	authenticator: {
+		id: string;
+		methodType: 'password';
+	};
+}>;
+
+export const credentialEnroll = (
+	stateHandle: IdxBaseResponse['stateHandle'],
+	body: CredentialEnrollBody['authenticator'],
+	request_id?: string,
+): Promise<CredentialEnrollResponse> => {
+	return idxFetch<CredentialEnrollResponse, CredentialEnrollBody>({
+		path: 'credential/enroll',
+		body: {
+			stateHandle,
+			authenticator: body,
+		},
+		schema: credentialEnrollResponse,
+		request_id,
+	});
+};

--- a/src/server/lib/okta/idx/credential.ts
+++ b/src/server/lib/okta/idx/credential.ts
@@ -12,6 +12,7 @@ import {
 } from './enroll';
 import { skipSchema } from './challenge';
 
+// Schema for the credential/enroll response - very similar to the enroll response
 const credentialEnrollResponse = idxBaseResponseSchema.merge(
 	z.object({
 		remediation: z.object({
@@ -29,6 +30,7 @@ const credentialEnrollResponse = idxBaseResponseSchema.merge(
 );
 type CredentialEnrollResponse = z.infer<typeof credentialEnrollResponse>;
 
+// Body type for the credential/enroll request
 type CredentialEnrollBody = IdxStateHandleBody<{
 	authenticator: {
 		id: string;
@@ -36,6 +38,14 @@ type CredentialEnrollBody = IdxStateHandleBody<{
 	};
 }>;
 
+/**
+ * @name credentialEnroll
+ * @description Okta IDX API/Interaction Code flow - Enroll a new credential (currently `password`) for the user.
+ * @param stateHandle - The state handle from the `enroll` step
+ * @param body - The credential object, containing the authenticator id and method type
+ * @param request_id - The request id
+ * @returns	Promise<CredentialEnrollResponse> - The credential enroll response
+ */
 export const credentialEnroll = (
 	stateHandle: IdxBaseResponse['stateHandle'],
 	body: CredentialEnrollBody['authenticator'],

--- a/src/server/lib/okta/idx/enroll.ts
+++ b/src/server/lib/okta/idx/enroll.ts
@@ -1,0 +1,115 @@
+import { z } from 'zod';
+import {
+	IdxBaseResponse,
+	IdxStateHandleBody,
+	baseRemediationValueSchema,
+	idxBaseResponseSchema,
+	idxFetch,
+} from './shared';
+
+const enrollProfileSchema = baseRemediationValueSchema.merge(
+	z.object({
+		name: z.literal('enroll-profile'),
+	}),
+);
+
+const enrollResponseSchema = idxBaseResponseSchema.merge(
+	z.object({
+		remediation: z.object({
+			type: z.string(),
+			value: z.array(
+				z.union([enrollProfileSchema, baseRemediationValueSchema]),
+			),
+		}),
+	}),
+);
+type EnrollResponse = z.infer<typeof enrollResponseSchema>;
+
+export const enroll = (
+	stateHandle: IdxBaseResponse['stateHandle'],
+	request_id?: string,
+): Promise<EnrollResponse> => {
+	return idxFetch<EnrollResponse, IdxStateHandleBody>({
+		path: 'enroll',
+		body: {
+			stateHandle,
+		},
+		schema: enrollResponseSchema,
+		request_id,
+	});
+};
+
+type EnrollNewWithEmailBody = IdxStateHandleBody<{
+	userProfile: {
+		email: string;
+		isGuardianUser: true;
+		registrationLocation?: string;
+		registrationPlatform?: string;
+	};
+}>;
+
+const enrollAuthenticatorSchema = baseRemediationValueSchema.merge(
+	z.object({
+		name: z.literal('enroll-authenticator'),
+		value: z.array(
+			z.union([
+				z.object({
+					name: z.literal('credentials'),
+					form: z.object({
+						value: z.array(z.object({ name: z.literal('passcode') })),
+					}),
+				}),
+				z.object({
+					name: z.literal('stateHandle'),
+				}),
+			]),
+		),
+	}),
+);
+
+const selectAuthenticationEnrollSchema = baseRemediationValueSchema.merge(
+	z.object({
+		name: z.literal('select-authenticator-enroll'),
+	}),
+);
+
+const enrollNewSchema = idxBaseResponseSchema.merge(
+	z.object({
+		remediation: z.object({
+			type: z.literal('array'),
+			value: z.array(
+				z.union([
+					enrollAuthenticatorSchema,
+					selectAuthenticationEnrollSchema,
+					baseRemediationValueSchema,
+				]),
+			),
+		}),
+		currentAuthenticator: z.object({
+			type: z.literal('object'),
+			value: z.object({
+				type: z.literal('email'),
+				resend: z.object({
+					name: z.literal('resend'),
+				}),
+			}),
+		}),
+	}),
+);
+type EnrollNewResponse = z.infer<typeof enrollNewSchema>;
+
+export const enrollNewWithEmail = (
+	stateHandle: IdxBaseResponse['stateHandle'],
+	body: EnrollNewWithEmailBody['userProfile'],
+	request_id?: string,
+): Promise<EnrollNewResponse> => {
+	return idxFetch<EnrollNewResponse, EnrollNewWithEmailBody>({
+		path: 'enroll/new',
+		body: {
+			stateHandle,
+			userProfile: body,
+		},
+		schema: enrollNewSchema,
+		request_id,
+	});
+};

--- a/src/server/lib/okta/idx/enroll.ts
+++ b/src/server/lib/okta/idx/enroll.ts
@@ -67,13 +67,42 @@ const enrollAuthenticatorSchema = baseRemediationValueSchema.merge(
 	}),
 );
 
-const selectAuthenticationEnrollSchema = baseRemediationValueSchema.merge(
-	z.object({
-		name: z.literal('select-authenticator-enroll'),
-	}),
+export const selectAuthenticationEnrollValueSchema = z.array(
+	z.union([
+		z.object({
+			name: z.literal('authenticator'),
+			type: z.string(),
+			options: z.array(
+				z.object({
+					label: z.string(),
+					value: z.object({
+						form: z.object({
+							value: z.array(
+								z.object({
+									name: z.enum(['id', 'methodType']),
+									value: z.string(),
+								}),
+							),
+						}),
+					}),
+				}),
+			),
+		}),
+		z.object({
+			name: z.literal('stateHandle'),
+		}),
+	]),
 );
 
-const enrollNewSchema = idxBaseResponseSchema.merge(
+export const selectAuthenticationEnrollSchema =
+	baseRemediationValueSchema.merge(
+		z.object({
+			name: z.literal('select-authenticator-enroll'),
+			value: selectAuthenticationEnrollValueSchema,
+		}),
+	);
+
+const enrollNewResponseSchema = idxBaseResponseSchema.merge(
 	z.object({
 		remediation: z.object({
 			type: z.literal('array'),
@@ -96,7 +125,7 @@ const enrollNewSchema = idxBaseResponseSchema.merge(
 		}),
 	}),
 );
-type EnrollNewResponse = z.infer<typeof enrollNewSchema>;
+type EnrollNewResponse = z.infer<typeof enrollNewResponseSchema>;
 
 export const enrollNewWithEmail = (
 	stateHandle: IdxBaseResponse['stateHandle'],
@@ -109,7 +138,7 @@ export const enrollNewWithEmail = (
 			stateHandle,
 			userProfile: body,
 		},
-		schema: enrollNewSchema,
+		schema: enrollNewResponseSchema,
 		request_id,
 	});
 };

--- a/src/server/lib/okta/idx/enroll.ts
+++ b/src/server/lib/okta/idx/enroll.ts
@@ -7,12 +7,14 @@ import {
 	idxFetch,
 } from './shared';
 
+// schema for the enroll-profile object inside the enroll response remediation object
 const enrollProfileSchema = baseRemediationValueSchema.merge(
 	z.object({
 		name: z.literal('enroll-profile'),
 	}),
 );
 
+// schema for the enroll response
 const enrollResponseSchema = idxBaseResponseSchema.merge(
 	z.object({
 		remediation: z.object({
@@ -25,6 +27,14 @@ const enrollResponseSchema = idxBaseResponseSchema.merge(
 );
 type EnrollResponse = z.infer<typeof enrollResponseSchema>;
 
+/**
+ * @name enroll
+ * @description Okta IDX API/Interaction Code flow - Use the stateHandle from the `introspect` step to start the enrollment process. This is used when registration a new user. Has to be called before `enrollNewWithEmail`.
+ *
+ * @param stateHandle - The state handle from the `introspect` step
+ * @param request_id - The request id
+ * @returns Promise<EnrollResponse> - The enroll response
+ */
 export const enroll = (
 	stateHandle: IdxBaseResponse['stateHandle'],
 	request_id?: string,
@@ -39,6 +49,7 @@ export const enroll = (
 	});
 };
 
+// Request body type for the enroll/new endpoint
 type EnrollNewWithEmailBody = IdxStateHandleBody<{
 	userProfile: {
 		email: string;
@@ -48,6 +59,7 @@ type EnrollNewWithEmailBody = IdxStateHandleBody<{
 	};
 }>;
 
+// schema for the enroll-authenticator object inside the enroll new response remediation object
 export const enrollAuthenticatorSchema = baseRemediationValueSchema.merge(
 	z.object({
 		name: z.literal('enroll-authenticator'),
@@ -67,7 +79,8 @@ export const enrollAuthenticatorSchema = baseRemediationValueSchema.merge(
 	}),
 );
 
-export const selectAuthenticationEnrollValueSchema = z.array(
+// schema for the select-authenticator-enroll value object inside selectAuthenticationEnrollSchema
+const selectAuthenticationEnrollValueSchema = z.array(
 	z.union([
 		z.object({
 			name: z.literal('authenticator'),
@@ -94,6 +107,7 @@ export const selectAuthenticationEnrollValueSchema = z.array(
 	]),
 );
 
+// schema for the select-authenticator-enroll object inside the enroll new response remediation object
 export const selectAuthenticationEnrollSchema =
 	baseRemediationValueSchema.merge(
 		z.object({
@@ -102,6 +116,7 @@ export const selectAuthenticationEnrollSchema =
 		}),
 	);
 
+// schema for the enroll/new response
 const enrollNewResponseSchema = idxBaseResponseSchema.merge(
 	z.object({
 		remediation: z.object({
@@ -127,6 +142,15 @@ const enrollNewResponseSchema = idxBaseResponseSchema.merge(
 );
 type EnrollNewResponse = z.infer<typeof enrollNewResponseSchema>;
 
+/**
+ * @name enrollNewWithEmail
+ * @description Okta IDX API/Interaction Code flow - Enroll a new user with an email address. This is used when registering a new user. Should be called after `enroll`.
+ *
+ * @param stateHandle - The state handle from the `enroll`/`introspect` step
+ * @param body - The user profile object, containing the email address
+ * @param request_id - The request id
+ * @returns Promise<EnrollNewResponse> - The enroll new response
+ */
 export const enrollNewWithEmail = (
 	stateHandle: IdxBaseResponse['stateHandle'],
 	body: EnrollNewWithEmailBody['userProfile'],

--- a/src/server/lib/okta/idx/enroll.ts
+++ b/src/server/lib/okta/idx/enroll.ts
@@ -48,7 +48,7 @@ type EnrollNewWithEmailBody = IdxStateHandleBody<{
 	};
 }>;
 
-const enrollAuthenticatorSchema = baseRemediationValueSchema.merge(
+export const enrollAuthenticatorSchema = baseRemediationValueSchema.merge(
 	z.object({
 		name: z.literal('enroll-authenticator'),
 		value: z.array(

--- a/src/server/lib/okta/idx/introspect.ts
+++ b/src/server/lib/okta/idx/introspect.ts
@@ -41,6 +41,14 @@ const introspectResponseSchema = idxBaseResponseSchema.merge(
 );
 export type IntrospectResponse = z.infer<typeof introspectResponseSchema>;
 
+type IntrospectBody =
+	| {
+			interactionHandle: InteractResponse['interaction_handle'];
+	  }
+	| {
+			stateHandle: IntrospectResponse['stateHandle'];
+	  };
+
 /**
  * @name introspect
  * @description Okta IDX API/Interaction Code flow - Step 2: Use the interaction handle generated from the `interact` step to start the authentication process.
@@ -55,17 +63,12 @@ export type IntrospectResponse = z.infer<typeof introspectResponseSchema>;
  * @returns Promise<IntrospectResponse> - The introspect response
  */
 export const introspect = (
-	interactionHandle: InteractResponse['interaction_handle'],
+	body: IntrospectBody,
 	request_id?: string,
 ): Promise<IntrospectResponse> => {
-	return idxFetch<
-		IntrospectResponse,
-		{ interactionHandle: InteractResponse['interaction_handle'] }
-	>({
+	return idxFetch<IntrospectResponse, IntrospectBody>({
 		path: 'introspect',
-		body: {
-			interactionHandle,
-		},
+		body,
 		schema: introspectResponseSchema,
 		request_id,
 	});

--- a/src/server/lib/okta/idx/introspect.ts
+++ b/src/server/lib/okta/idx/introspect.ts
@@ -16,6 +16,13 @@ export const redirectIdpSchema = baseRemediationValueSchema.merge(
 	}),
 );
 
+// Base schema for the 'select-enroll-profile' object inside the introspect response remediation object
+export const selectEnrollProfileSchema = baseRemediationValueSchema.merge(
+	z.object({
+		name: z.literal('select-enroll-profile'),
+	}),
+);
+
 // Schema for the introspect response
 const introspectResponseSchema = idxBaseResponseSchema.merge(
 	z.object({
@@ -23,7 +30,11 @@ const introspectResponseSchema = idxBaseResponseSchema.merge(
 			type: z.string(),
 			value: z.array(
 				// social idp object
-				z.union([redirectIdpSchema, baseRemediationValueSchema]),
+				z.union([
+					redirectIdpSchema,
+					selectEnrollProfileSchema,
+					baseRemediationValueSchema,
+				]),
 			),
 		}),
 	}),

--- a/src/server/lib/okta/idx/introspect.ts
+++ b/src/server/lib/okta/idx/introspect.ts
@@ -41,6 +41,7 @@ const introspectResponseSchema = idxBaseResponseSchema.merge(
 );
 export type IntrospectResponse = z.infer<typeof introspectResponseSchema>;
 
+// Introspect body type - can use either interactionHandle or stateHandle
 type IntrospectBody =
 	| {
 			interactionHandle: InteractResponse['interaction_handle'];

--- a/src/server/lib/okta/idx/introspect.ts
+++ b/src/server/lib/okta/idx/introspect.ts
@@ -1,68 +1,34 @@
-import { joinUrl } from '@guardian/libs';
-import { InteractResponse } from './interact';
-import { getConfiguration } from '@/server/lib/getConfiguration';
-import { logger } from '@/server/lib/serverSideLogger';
 import { z } from 'zod';
-import { OAuthError } from '@/server/models/okta/Error';
-import { trackMetric } from '../../trackMetric';
-
-const { okta } = getConfiguration();
-
-const idxVersionSchema = z.string().refine((val) => {
-	// warn if the version is not 1.0.0
-	if (val !== '1.0.0') {
-		logger.warn('Okta IDX - unexpected version:', val);
-		trackMetric('OktaIDX::UnexpectedVersion');
-	}
-
-	// but pass validation regardless
-	return true;
-});
+import { InteractResponse } from './interact';
+import {
+	baseRemediationValueSchema,
+	idxBaseResponseSchema,
+	idxFetch,
+} from './shared';
 
 // Schema for the 'redirect-idp' object inside the introspect response remediation object
-export const redirectIdpSchema = z.object({
-	name: z.literal('redirect-idp'),
-	type: z.enum(['APPLE', 'GOOGLE']),
-	href: z.string().url(),
-	method: z.literal('GET'),
-});
+export const redirectIdpSchema = baseRemediationValueSchema.merge(
+	z.object({
+		name: z.literal('redirect-idp'),
+		type: z.enum(['APPLE', 'GOOGLE']),
+		href: z.string().url(),
+		method: z.literal('GET'),
+	}),
+);
 
 // Schema for the introspect response
-const introspectResponseSchema = z.object({
-	version: idxVersionSchema,
-	stateHandle: z.string(),
-	expiresAt: z.coerce.date(),
-	remediation: z.object({
-		type: z.string(),
-		value: z.array(
-			// social idp object
-			z.union([
-				redirectIdpSchema,
-				z.object({
-					// any other name thats not one of the above
-					name: z.string(),
-					type: z.string().optional(),
-					href: z.string().optional(),
-					method: z.string().optional(),
-				}),
-			]),
-		),
+const introspectResponseSchema = idxBaseResponseSchema.merge(
+	z.object({
+		remediation: z.object({
+			type: z.string(),
+			value: z.array(
+				// social idp object
+				z.union([redirectIdpSchema, baseRemediationValueSchema]),
+			),
+		}),
 	}),
-});
+);
 export type IntrospectResponse = z.infer<typeof introspectResponseSchema>;
-
-const introspectResponseErrorSchema = z.object({
-	version: idxVersionSchema,
-	messages: z.object({
-		type: z.literal('array'),
-		value: z.array(
-			z.object({
-				message: z.string(),
-				i18n: z.object({ key: z.string() }),
-			}),
-		),
-	}),
-});
 
 /**
  * @name introspect
@@ -77,87 +43,19 @@ const introspectResponseErrorSchema = z.object({
  * @param request_id - The request id
  * @returns Promise<IntrospectResponse> - The introspect response
  */
-export const introspect = async (
+export const introspect = (
 	interactionHandle: InteractResponse['interaction_handle'],
 	request_id?: string,
 ): Promise<IntrospectResponse> => {
-	try {
-		const response = await fetch(joinUrl(okta.orgUrl, '/idp/idx/introspect'), {
-			method: 'POST',
-			headers: {
-				Accept: 'application/ion+json; okta-version=1.0.0',
-				'Content-Type': 'application/ion+json; okta-version=1.0.0',
-			},
-			body: JSON.stringify({
-				interactionHandle,
-			}),
-		});
-
-		if (!response.ok) {
-			await handleError(response);
-		}
-
-		const introspectResponse = introspectResponseSchema.parse(
-			await response.json(),
-		);
-
-		trackMetric('OktaIDXIntrospect::Success');
-
-		return introspectResponse;
-	} catch (error) {
-		trackMetric('OktaIDXIntrospect::Failure');
-		logger.error('Error - Okta IDX introspect:', error, {
-			request_id,
-		});
-
-		throw error;
-	}
-};
-
-const handleError = async (response: Response) => {
-	// Check if the body is likely json using the content-type header
-	const contentType = response.headers.get('content-type');
-	if (
-		contentType &&
-		(contentType.includes('application/json') ||
-			contentType.includes('application/ion+json'))
-	) {
-		// if so, parse the body as json and see if it matches the schema
-		const json = await response.json().catch((e) => {
-			throw new OAuthError(
-				{
-					error: 'invalid_json',
-					error_description: e.message,
-				},
-				response.status,
-			);
-		});
-		const error = introspectResponseErrorSchema.safeParse(json);
-
-		if (error.success) {
-			throw new OAuthError(
-				{
-					error: error.data.messages.value[0].i18n.key,
-					error_description: error.data.messages.value[0].message,
-				},
-				response.status,
-			);
-		} else {
-			throw new OAuthError(
-				{
-					error: 'unknown_error',
-					error_description: JSON.stringify(json),
-				},
-				response.status,
-			);
-		}
-	}
-
-	throw new OAuthError(
-		{
-			error: 'unknown_error',
-			error_description: await response.text(),
+	return idxFetch<
+		IntrospectResponse,
+		{ interactionHandle: InteractResponse['interaction_handle'] }
+	>({
+		path: 'introspect',
+		body: {
+			interactionHandle,
 		},
-		response.status,
-	);
+		schema: introspectResponseSchema,
+		request_id,
+	});
 };

--- a/src/server/lib/okta/idx/shared.ts
+++ b/src/server/lib/okta/idx/shared.ts
@@ -329,7 +329,7 @@ const handleError = async (response: Response) => {
 		// find the error message in the json
 		const error = findErrorMessage(json);
 
-		// if we found and error message
+		// if we found an error message
 		if (error) {
 			// check if it's unparsed (string)
 			if (typeof error === 'string') {
@@ -341,7 +341,7 @@ const handleError = async (response: Response) => {
 					response.status,
 				);
 			} else {
-				// or it it's parsed (object)
+				// or if it's parsed (object)
 				// most errors should be this case and have an i18n key and message
 				throw new OAuthError(
 					{

--- a/src/server/lib/okta/idx/shared.ts
+++ b/src/server/lib/okta/idx/shared.ts
@@ -1,0 +1,140 @@
+import { z } from 'zod';
+import { logger } from '@/server/lib/serverSideLogger';
+import { trackMetric } from '@/server/lib/trackMetric';
+import { OAuthError } from '@/server/models/okta/Error';
+import { getConfiguration } from '@/server/lib/getConfiguration';
+import { joinUrl } from '@guardian/libs';
+
+const { okta } = getConfiguration();
+
+const idxPaths = ['introspect', 'enroll', 'enroll/new'] as const;
+export type IDXPath = (typeof idxPaths)[number];
+
+const idxVersionSchema = z.string().refine((val) => {
+	// warn if the version is not 1.0.0
+	if (val !== '1.0.0') {
+		logger.warn('Okta IDX - unexpected version:', val);
+		trackMetric('OktaIDX::UnexpectedVersion');
+	}
+
+	// but pass validation regardless
+	return true;
+});
+
+export const idxBaseResponseSchema = z.object({
+	version: idxVersionSchema,
+	stateHandle: z.string(),
+	expiresAt: z.coerce.date(),
+});
+export type IdxBaseResponse = z.infer<typeof idxBaseResponseSchema>;
+
+export const baseRemediationValueSchema = z.object({
+	name: z.string(),
+	type: z.string().optional(),
+	href: z.string().optional(),
+	method: z.string().optional(),
+});
+
+export type IdxStateHandleBody<T = object> = T & {
+	stateHandle: IdxBaseResponse['stateHandle'];
+};
+
+const idxErrorSchema = z.object({
+	version: idxVersionSchema,
+	messages: z.object({
+		type: z.literal('array'),
+		value: z.array(
+			z.object({
+				message: z.string(),
+				i18n: z.object({ key: z.string() }).optional(),
+			}),
+		),
+	}),
+});
+
+export const idxFetch = async <ResponseType, BodyType>({
+	path,
+	body,
+	schema,
+	request_id,
+}: {
+	path: IDXPath;
+	body: BodyType;
+	schema: z.Schema<ResponseType>;
+	request_id?: string;
+}): Promise<ResponseType> => {
+	try {
+		const response = await fetch(joinUrl(okta.orgUrl, `/idp/idx/${path}`), {
+			method: 'POST',
+			headers: {
+				Accept: 'application/ion+json; okta-version=1.0.0',
+				'Content-Type': 'application/ion+json; okta-version=1.0.0',
+			},
+			body: JSON.stringify(body),
+		});
+
+		if (!response.ok) {
+			await handleError(response);
+		}
+
+		const parsed = schema.parse(await response.json());
+
+		trackMetric(`OktaIDX::${path}::Success`);
+
+		return parsed;
+	} catch (error) {
+		trackMetric(`OktaIDX::${path}::Failure`);
+		logger.error(`Okta IDX ${path}`, error, {
+			request_id,
+		});
+		throw error;
+	}
+};
+
+export const handleError = async (response: Response) => {
+	// Check if the body is likely json using the content-type header
+	const contentType = response.headers.get('content-type');
+	if (
+		contentType &&
+		(contentType.includes('application/json') ||
+			contentType.includes('application/ion+json'))
+	) {
+		// if so, parse the body as json and see if it matches the schema
+		const json = await response.json().catch((e) => {
+			throw new OAuthError(
+				{
+					error: 'invalid_json',
+					error_description: e.message,
+				},
+				response.status,
+			);
+		});
+		const error = idxErrorSchema.safeParse(json);
+
+		if (error.success) {
+			throw new OAuthError(
+				{
+					error: error.data.messages.value[0].i18n?.key || 'idx_error',
+					error_description: error.data.messages.value[0].message,
+				},
+				response.status,
+			);
+		} else {
+			throw new OAuthError(
+				{
+					error: 'idx_error',
+					error_description: JSON.stringify(json),
+				},
+				response.status,
+			);
+		}
+	}
+
+	throw new OAuthError(
+		{
+			error: 'idx_error',
+			error_description: await response.text(),
+		},
+		response.status,
+	);
+};

--- a/src/server/lib/okta/idx/shared.ts
+++ b/src/server/lib/okta/idx/shared.ts
@@ -7,7 +7,12 @@ import { joinUrl } from '@guardian/libs';
 
 const { okta } = getConfiguration();
 
-const idxPaths = ['introspect', 'enroll', 'enroll/new'] as const;
+const idxPaths = [
+	'challenge/answer',
+	'enroll',
+	'enroll/new',
+	'introspect',
+] as const;
 export type IDXPath = (typeof idxPaths)[number];
 
 const idxVersionSchema = z.string().refine((val) => {
@@ -33,6 +38,7 @@ export const baseRemediationValueSchema = z.object({
 	type: z.string().optional(),
 	href: z.string().optional(),
 	method: z.string().optional(),
+	value: z.unknown().optional(),
 });
 
 export type IdxStateHandleBody<T = object> = T & {

--- a/src/server/models/Metrics.ts
+++ b/src/server/models/Metrics.ts
@@ -2,6 +2,7 @@
 
 import { BucketType } from '@/server/lib/rate-limit';
 import { PasswordRoutePath } from '@/shared/model/Routes';
+import { IDXPath } from '@/server/lib/okta/idx/shared';
 
 // Specific emails to track
 type EmailMetrics =
@@ -41,7 +42,7 @@ type ConditionalMetrics =
 	| 'OAuthDeleteCallback'
 	| 'OktaAccountVerification'
 	| 'OktaIDXInteract'
-	| 'OktaIDXIntrospect'
+	| `OktaIDX::${IDXPath}`
 	| 'OktaRegistration'
 	| 'OktaRegistrationResendEmail'
 	| 'OktaResetPassword'

--- a/src/server/routes/signIn.ts
+++ b/src/server/routes/signIn.ts
@@ -600,8 +600,8 @@ router.get(
 				setAuthorizationStateCookie(updatedAuthState, res);
 
 				const introspectIdp = introspectResponse.remediation.value.find(
-					(o) =>
-						o.name === 'redirect-idp' && o.type === socialIdp.toUpperCase(),
+					({ name, type }) =>
+						name === 'redirect-idp' && type === socialIdp.toUpperCase(),
 				);
 
 				if (

--- a/src/server/routes/signIn.ts
+++ b/src/server/routes/signIn.ts
@@ -590,7 +590,9 @@ router.get(
 					closeExistingSession: true,
 				});
 
-				const introspectResponse = await introspect(interaction_handle);
+				const introspectResponse = await introspect({
+					interactionHandle: interaction_handle,
+				});
 
 				const updatedAuthState = updateAuthorizationStateData(authState, {
 					socialProvider: socialIdp,


### PR DESCRIPTION
## What does this change?

This PR sets up the rest of the IDX API calls needed for passcode registration. It builds upon the initial setup in https://github.com/guardian/gateway/pull/2625

It does not actually use any of these APIs yet. This will be set up in a separate PR.

In general the IDX API works in the following steps in order to authenticate a user.

1. Start the interaction code flow using the `interact` call (not modified in this PR). This returns an `interaction_handle`, which as far as i can tell is only used to get the `stateHandle` from the next step, and can be discarded. The `interact` calls takes the same parameters as an Authorization Code flow call. So we need to set and preserve anything in the `AuthorizationState` at this point too, so that it can be read by the callback endpoint at the end.
2. Call the `introspect` endpoint with the `interaction_handle` to get the `stateHandle`. The `stateHandle` should be securely preserved and used in all following calls to the IDX API to identify the authentication state. The `introspect` calls returns the start of the authentication process, with a number of `remediation` steps to take to get the user authenticated. We add the `stateHandle` to be preserved in the `AuthorizationState` too.
3. Pick a `remediation` option from the `introspect` call, and call it. This could be, as will be set up for passcode registration, creating a new user by calling the `enroll` endpoint
4. The endpoint that you call will return another object with a `remediation` step within it. Keep checking the `remediation` object for next steps and taking the action it says.
5. Eventually you'll call an endpoint that completes the flow. In this case it will NOT return an `remediation` step, and instead return a `Set-Cookie` header with an `idx` cookie, and a basic `user` object in the response.
6. Since we're taking all these actions server side, we need to extract the `Set-Cookie` header for the `idx` cookie, and make sure this is set on the users response object. However this `idx` cookie weirdly isn't a global session cookie, and can't be used to create OAuth tokens.
7. You have to redirect the user to the `/login/token/redirect?stateToken=${stateHandlePart}` where `stateHandlePart` is the `stateHandle` but split at the `~` character, and take the first part. Weird I know, but we roll with it. This converts the `idx` cookie into a global session cookie, and completes the Interaction Code flow, in the same way as an Authorization Code flow is completed, i.e redirecting to the OAuth callback url with the  `code` and `state` params.
8. The user has now authenticated!

This PR sets up the following IDX API endpoint

- A `shared` file, with lots of methods and options that are used by all of the different IDX API calls
  - This includes a base `fetch` call that handles the call to the IDX API
  - Base Zod schemas and types for the response schemas, remediation schemas, and error schemas
  - Error handling for all the IDX API endpoints
  - Handling for the completion call and redirect to the `/login/token/redirect?stateToken=${stateHandlePart}` endpoint and setting the `idx` cookie
- Updates the `introspect` file
  - To use the new base `idxFetch` method instead of implementing it itself. 
  - And to allow the `introspect` call to use the `stateHandle` as an option in the body alongside the `interaction_handle`
    - This allows us to check the state of the authentication process at any time
- The `enroll` file
  - `enroll` endpoint that starts the process to register a new user
  - `enroll/new` endpoint to create a new user in Okta, this sends the user a passcode
- The `challenge` file
  - A `challenge/answer` endpoint to supply the OTP to that the user would enter (`challengeAnswerPasscode`)
  - A `setPasswordAndRedirect` method, that also calls `challenge/answer` but to set a password instead, but also is the final step in the registration process, so logs the user in and redirects them.
- The `credential` file
  - `credential/enroll` endpoint in order to enroll a new credential for the user, currently only supports `password` but could be expanded in the future
- Updates the `Metrics` so that the metric is automatically based on the IDX API path that we're calling.

## Notes

As mentioned, in this PR none of these new methods/APIs are being used with the exception of `interact` and `introspect` which were previously set up for social sign in (#2625). So there isn't any tests set up yet.

When we come to implementing this API in the frontend we will do this.
