### PR TITLE
Remove app link for feast app

### DIFF
--- a/src/client/.well-known/apple-app-site-association
+++ b/src/client/.well-known/apple-app-site-association
@@ -21,25 +21,6 @@
 						"comment": "Matches any URL whose path starts with /set-password/il_<randomString> where <randomString> is a token"
 					}
 				]
-			},
-			{
-				"appIDs": [
-					"998P9U5NGJ.uk.co.guardian.Feast"
-				],
-				"components": [
-					{
-						"/": "/welcome/if_*",
-						"comment": "Matches any URL whose path starts with /welcome/if_<randomString> where <randomString> is a token"
-					},
-					{
-						"/": "/reset-password/if_*",
-						"comment": "Matches any URL whose path starts with /reset-password/if_<randomString> where <randomString> is a token"
-					},
-					{
-						"/": "/set-password/if_*",
-						"comment": "Matches any URL whose path starts with /set-password/if_<randomString> where <randomString> is a token"
-					}
-				]
 			}
 		]
 	}


### PR DESCRIPTION
## What does this change?

The url interception currently isn't working too well for the feast app, so we're removing it from the site association file in order to make sure the app doesn't try to link to the app.

Instead users will see our fallback flow telling them to go back to the feast app and sign in after they register.

## Tested

Unfortunately we can't test this on CODE as Feast doesn't have a CODE environment, but this only changes the `/well-known/apple-app-site-association` file which doesn't affect any app specific code.