### PR TITLE
Passcodes | Set up passcodes for registration

### DIFF
--- a/cypress/integration/ete-okta/registration_2.6.cy.ts
+++ b/cypress/integration/ete-okta/registration_2.6.cy.ts
@@ -748,7 +748,7 @@ describe('Registration flow - Split 2/2', () => {
 						expect(oktaUser.profile.registrationPlatform).to.eq('profile');
 					});
 
-					cy.url().should('contain', '/consents/newsletters');
+					cy.url().should('contain', '/welcome/review');
 				},
 			);
 		});

--- a/cypress/integration/ete-okta/registration_2.6.cy.ts
+++ b/cypress/integration/ete-okta/registration_2.6.cy.ts
@@ -683,4 +683,320 @@ describe('Registration flow - Split 2/2', () => {
 			});
 		});
 	});
+
+	// TODO: These tests should be merged into the existing registration tests when the passcode registration feature flag is removed
+	context('Passcode registration temporary tests', () => {
+		it('successfully registers using an email with no existing account using a passcode', () => {
+			const encodedReturnUrl =
+				'https%3A%2F%2Fm.code.dev-theguardian.com%2Ftravel%2F2019%2Fdec%2F18%2Ffood-culture-tour-bethlehem-palestine-east-jerusalem-photo-essay';
+			const unregisteredEmail = randomMailosaurEmail();
+			const encodedRef = 'https%3A%2F%2Fm.theguardian.com';
+			const refViewId = 'testRefViewId';
+			const clientId = 'jobs';
+
+			cy.visit(
+				`/register/email?returnUrl=${encodedReturnUrl}&ref=${encodedRef}&refViewId=${refViewId}&clientId=${clientId}&usePasscodeRegistration=true`,
+			);
+
+			const timeRequestWasMade = new Date();
+			cy.get('input[name=email]').type(unregisteredEmail);
+			cy.get('[data-cy="main-form-submit-button"]').click();
+
+			cy.contains('Enter your code');
+			cy.contains(unregisteredEmail);
+			cy.contains('send again');
+			cy.contains('try another address');
+
+			cy.checkForEmailAndGetDetails(unregisteredEmail, timeRequestWasMade).then(
+				({ body, codes }) => {
+					// email
+					expect(body).to.have.string('Your verification code');
+					expect(codes?.length).to.eq(1);
+					const code = codes?.[0].value;
+					expect(code).to.match(/^\d{6}$/);
+
+					// passcode page
+					cy.url().should('include', '/register/email-sent');
+					cy.get('input[name=code]').type(code!);
+
+					cy.get('form')
+						.should('have.attr', 'action')
+						.and('match', new RegExp(encodedReturnUrl))
+						.and('match', new RegExp(refViewId))
+						.and('match', new RegExp(encodedRef))
+						.and('match', new RegExp(clientId));
+
+					cy.contains('Submit passcode').click();
+
+					// password page
+					cy.url().should('include', '/welcome/password');
+					cy.get('form')
+						.should('have.attr', 'action')
+						.and('match', new RegExp(encodedReturnUrl))
+						.and('match', new RegExp(refViewId))
+						.and('match', new RegExp(encodedRef))
+						.and('match', new RegExp(clientId));
+
+					cy.get('input[name="firstName"]').type('First Name');
+					cy.get('input[name="secondName"]').type('Last Name');
+					cy.get('input[name="password"]').type(randomPassword());
+					cy.get('button[type="submit"]').click();
+
+					// test the registration platform is set correctly
+					cy.getTestOktaUser(unregisteredEmail).then((oktaUser) => {
+						expect(oktaUser.status).to.eq(Status.ACTIVE);
+						expect(oktaUser.profile.registrationPlatform).to.eq('profile');
+					});
+
+					cy.url().should('contain', '/consents/newsletters');
+				},
+			);
+		});
+
+		it('successfully registers using an email with no existing account using a passcode and redirects to fromURI', () => {
+			const appClientId = 'appClientId1';
+			const fromURI = '%2FfromURI1';
+
+			// Intercept the external redirect page.
+			// We just want to check that the redirect happens, not that the page loads.
+			cy.intercept(
+				'GET',
+				`https://${Cypress.env('BASE_URI')}${decodeURIComponent(fromURI)}`,
+				(req) => {
+					req.reply(200);
+				},
+			);
+
+			const encodedReturnUrl =
+				'https%3A%2F%2Fm.code.dev-theguardian.com%2Ftravel%2F2019%2Fdec%2F18%2Ffood-culture-tour-bethlehem-palestine-east-jerusalem-photo-essay';
+			const unregisteredEmail = randomMailosaurEmail();
+			const encodedRef = 'https%3A%2F%2Fm.theguardian.com';
+			const refViewId = 'testRefViewId';
+
+			cy.visit(
+				`/register/email?returnUrl=${encodedReturnUrl}&ref=${encodedRef}&refViewId=${refViewId}&appClientId=${appClientId}&fromURI=${fromURI}&usePasscodeRegistration=true`,
+			);
+
+			const timeRequestWasMade = new Date();
+			cy.get('input[name=email]').type(unregisteredEmail);
+			cy.get('[data-cy="main-form-submit-button"]').click();
+
+			cy.contains('Enter your code');
+			cy.contains(unregisteredEmail);
+			cy.contains('send again');
+			cy.contains('try another address');
+
+			cy.checkForEmailAndGetDetails(unregisteredEmail, timeRequestWasMade).then(
+				({ body, codes }) => {
+					// email
+					expect(body).to.have.string('Your verification code');
+					expect(codes?.length).to.eq(1);
+					const code = codes?.[0].value;
+					expect(code).to.match(/^\d{6}$/);
+
+					// passcode page
+					cy.url().should('include', '/register/email-sent');
+					cy.get('input[name=code]').type(code!);
+
+					cy.get('form')
+						.should('have.attr', 'action')
+						.and('match', new RegExp(encodedReturnUrl))
+						.and('match', new RegExp(refViewId))
+						.and('match', new RegExp(encodedRef))
+						.and('match', new RegExp(appClientId))
+						.and('match', new RegExp(fromURI));
+
+					cy.contains('Submit passcode').click();
+
+					// password page
+					cy.url().should('include', '/welcome/password');
+					cy.get('form')
+						.should('have.attr', 'action')
+						.and('match', new RegExp(encodedReturnUrl))
+						.and('match', new RegExp(refViewId))
+						.and('match', new RegExp(encodedRef))
+						.and('match', new RegExp(appClientId))
+						.and('match', new RegExp(fromURI));
+
+					cy.get('input[name="password"]').type(randomPassword());
+					cy.get('button[type="submit"]').click();
+
+					// test the registration platform is set correctly
+					cy.getTestOktaUser(unregisteredEmail).then((oktaUser) => {
+						expect(oktaUser.status).to.eq(Status.ACTIVE);
+						expect(oktaUser.profile.registrationPlatform).to.eq('profile');
+					});
+
+					cy.url().should('contain', decodeURIComponent(fromURI));
+				},
+			);
+		});
+
+		it('passcode incorrect functionality', () => {
+			const unregisteredEmail = randomMailosaurEmail();
+			cy.visit(`/register/email?usePasscodeRegistration=true`);
+
+			const timeRequestWasMade = new Date();
+			cy.get('input[name=email]').type(unregisteredEmail);
+			cy.get('[data-cy="main-form-submit-button"]').click();
+
+			cy.contains('Enter your code');
+			cy.contains(unregisteredEmail);
+			cy.contains('send again');
+			cy.contains('try another address');
+
+			cy.checkForEmailAndGetDetails(unregisteredEmail, timeRequestWasMade).then(
+				({ body, codes }) => {
+					// email
+					expect(body).to.have.string('Your verification code');
+					expect(codes?.length).to.eq(1);
+					const code = codes?.[0].value;
+					expect(code).to.match(/^\d{6}$/);
+
+					// passcode page
+					cy.url().should('include', '/register/email-sent');
+					cy.get('input[name=code]').type(`${+code! + 1}`);
+
+					cy.contains('Submit passcode').click();
+
+					cy.url().should('include', '/register/code');
+
+					cy.contains('Incorrect code');
+
+					cy.get('input[name=code]').clear().type(code!);
+					cy.contains('Submit passcode').click();
+
+					cy.url().should('contain', '/welcome/password');
+				},
+			);
+		});
+
+		it('resend email functionality', () => {
+			const unregisteredEmail = randomMailosaurEmail();
+			cy.visit(`/register/email?usePasscodeRegistration=true`);
+
+			const timeRequestWasMade1 = new Date();
+			cy.get('input[name=email]').type(unregisteredEmail);
+			cy.get('[data-cy="main-form-submit-button"]').click();
+
+			cy.contains('Enter your code');
+			cy.contains(unregisteredEmail);
+			cy.contains('send again');
+			cy.contains('try another address');
+
+			cy.checkForEmailAndGetDetails(
+				unregisteredEmail,
+				timeRequestWasMade1,
+			).then(({ body, codes }) => {
+				// email
+				expect(body).to.have.string('Your verification code');
+				expect(codes?.length).to.eq(1);
+				const code = codes?.[0].value;
+				expect(code).to.match(/^\d{6}$/);
+
+				// passcode page
+				cy.url().should('include', '/register/email-sent');
+				const timeRequestWasMade2 = new Date();
+				cy.contains('send again').click();
+				cy.checkForEmailAndGetDetails(
+					unregisteredEmail,
+					timeRequestWasMade2,
+				).then(({ body, codes }) => {
+					// email
+					expect(body).to.have.string('Your verification code');
+					expect(codes?.length).to.eq(1);
+					const code = codes?.[0].value;
+					expect(code).to.match(/^\d{6}$/);
+
+					// passcode page
+					cy.url().should('include', '/register/email-sent');
+
+					cy.get('input[name=code]').type(code!);
+					cy.contains('Submit passcode').click();
+
+					cy.url().should('contain', '/welcome/password');
+				});
+			});
+		});
+
+		it('change email functionality', () => {
+			const unregisteredEmail = randomMailosaurEmail();
+			cy.visit(`/register/email?usePasscodeRegistration=true`);
+
+			const timeRequestWasMade = new Date();
+			cy.get('input[name=email]').type(unregisteredEmail);
+			cy.get('[data-cy="main-form-submit-button"]').click();
+
+			cy.contains('Enter your code');
+			cy.contains(unregisteredEmail);
+			cy.contains('send again');
+			cy.contains('try another address');
+
+			cy.checkForEmailAndGetDetails(unregisteredEmail, timeRequestWasMade).then(
+				({ body, codes }) => {
+					// email
+					expect(body).to.have.string('Your verification code');
+					expect(codes?.length).to.eq(1);
+					const code = codes?.[0].value;
+					expect(code).to.match(/^\d{6}$/);
+
+					// passcode page
+					cy.url().should('include', '/register/email-sent');
+					cy.contains('try another address').click();
+
+					cy.url().should('include', '/register/email');
+				},
+			);
+		});
+
+		it('existing users should fallback to the standard registration flow without passcodes', () => {
+			// Set up an existing user using the test user endpoint
+			cy
+				.createTestUser({
+					isGuestUser: true,
+					isUserEmailValidated: true,
+				})
+				?.then(({ emailAddress }) => {
+					cy.getTestOktaUser(emailAddress).then((oktaUser) => {
+						expect(oktaUser.status).to.eq(Status.STAGED);
+
+						const appClientId = Cypress.env('OKTA_ANDROID_CLIENT_ID');
+						const fromURI = 'fromURI1';
+
+						cy.visit(
+							`/register/email?appClientId=${appClientId}&fromURI=${fromURI}&usePasscodeRegistration=true`,
+						);
+						const timeRequestWasMade = new Date();
+
+						cy.get('input[name=email]').type(emailAddress);
+						cy.get('[data-cy="main-form-submit-button"]').click();
+
+						cy.contains('Check your email inbox');
+						cy.contains(emailAddress);
+						cy.contains('send again');
+						cy.contains('try another address');
+
+						cy.checkForEmailAndGetDetails(
+							emailAddress,
+							timeRequestWasMade,
+							/\/set-password\/([^"]*)/,
+						).then(({ links, body }) => {
+							expect(body).to.have.string('This account already exists');
+
+							expect(body).to.have.string('Create password');
+							expect(links.length).to.eq(2);
+							const setPasswordLink = links.find((s) =>
+								s.text?.includes('Create password'),
+							);
+							expect(setPasswordLink?.href ?? '')
+								.to.have.string('al_')
+								.and.not.to.have.string('useOkta=true');
+							cy.visit(setPasswordLink?.href as string);
+							cy.contains('Create password');
+							cy.contains(emailAddress);
+						});
+					});
+				});
+		});
+	});
 });

--- a/cypress/integration/ete-okta/sign_in.1.cy.ts
+++ b/cypress/integration/ete-okta/sign_in.1.cy.ts
@@ -424,7 +424,7 @@ describe('Sign in flow, Okta enabled', () => {
 								expect(user.profile.legacyIdentityId).to.be.undefined;
 								const postSignInReturnUrl = `https://${Cypress.env(
 									'BASE_URI',
-								)}/consents/data`;
+								)}/welcome/review`;
 								const visitUrl = `/signin?returnUrl=${encodeURIComponent(
 									postSignInReturnUrl,
 								)}`;
@@ -432,7 +432,7 @@ describe('Sign in flow, Okta enabled', () => {
 								cy.get('input[name=email]').type(emailAddress);
 								cy.get('input[name=password]').type(finalPassword);
 								cy.get('[data-cy="main-form-submit-button"]').click();
-								cy.url().should('include', '/consents/data');
+								cy.url().should('include', '/welcome/review');
 								cy.getTestOktaUser(emailAddress).then((user) => {
 									expect(user.profile.legacyIdentityId).to.eq(
 										originalLegacyIdentityId,

--- a/cypress/integration/ete/registration/register_email_sent.3.cy.ts
+++ b/cypress/integration/ete/registration/register_email_sent.3.cy.ts
@@ -139,7 +139,8 @@ describe('Registration email sent page', () => {
 		cy.visit('/register/email-sent?useIdapi=true');
 		cy.contains('try another address').click();
 		cy.contains('Register');
-		cy.title().should('eq', 'Register | The Guardian');
+		cy.contains('Enter your email');
+		cy.title().should('eq', 'Register With Email | The Guardian');
 	});
 
 	it('should render properly if the encrypted email cookie is not set', () => {

--- a/cypress/support/commands/getEmailDetails.ts
+++ b/cypress/support/commands/getEmailDetails.ts
@@ -1,4 +1,4 @@
-import { Link, Message } from 'cypress-mailosaur';
+import { Code, Link, Message } from 'cypress-mailosaur';
 declare global {
 	// eslint-disable-next-line @typescript-eslint/no-namespace
 	namespace Cypress {
@@ -48,6 +48,7 @@ type EmailDetails = {
 	body: string;
 	token?: string;
 	links: Link[];
+	codes?: Code[];
 };
 
 /**
@@ -60,6 +61,8 @@ type EmailDetails = {
 const getEmailDetails = (email: Message, tokenMatcher?: RegExp) => {
 	const { id, html } = email;
 	const { body, links } = html || {};
+	// eslint-disable-next-line functional/no-let
+	let { codes } = html || {};
 	if (id === undefined || body === undefined || links === undefined) {
 		throw new Error('Email details not found');
 	}
@@ -75,5 +78,9 @@ const getEmailDetails = (email: Message, tokenMatcher?: RegExp) => {
 		token = match[1];
 	}
 
-	return cy.wrap<EmailDetails>({ id, body, token, links });
+	if (codes) {
+		codes = codes.filter((code) => code.value?.match(/\d{6}/));
+	}
+
+	return cy.wrap<EmailDetails>({ id, body, token, links, codes });
 };

--- a/src/client/pages/EmailSent.stories.tsx
+++ b/src/client/pages/EmailSent.stories.tsx
@@ -91,3 +91,17 @@ export const NoChangeEmailPage = () => (
 NoChangeEmailPage.story = {
 	name: 'with no change email',
 };
+
+export const WithStateHandle = () => (
+	<EmailSent
+		changeEmailPage="#"
+		email="example@theguardian.com"
+		resendEmailAction="#"
+		recaptchaSiteKey="6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI"
+		hasStateHandle
+		passcodeAction="#"
+	/>
+);
+WithEmailResend.story = {
+	name: 'with stateHandle',
+};

--- a/src/client/pages/EmailSent.tsx
+++ b/src/client/pages/EmailSent.tsx
@@ -1,5 +1,10 @@
-import React, { PropsWithChildren, ReactNode, useState } from 'react';
-import { Link } from '@guardian/source/react-components';
+import React, {
+	PropsWithChildren,
+	ReactNode,
+	useState,
+	useEffect,
+} from 'react';
+import { Link, TextInput } from '@guardian/source/react-components';
 import { MainLayout } from '@/client/layouts/Main';
 import { MainBodyText } from '@/client/components/MainBodyText';
 import { MainForm } from '@/client/components/MainForm';
@@ -12,6 +17,10 @@ import {
 	InformationBox,
 	InformationBoxText,
 } from '@/client/components/InformationBox';
+import { css } from '@emotion/react';
+import { FieldError } from '@/shared/model/ClientState';
+import { logger } from '@/client/lib/clientSideLogger';
+import { space } from '@guardian/source/foundations';
 
 type Props = {
 	email?: string;
@@ -25,6 +34,11 @@ type Props = {
 	formTrackingName?: string;
 	formError?: string;
 	instructionContext?: string;
+	hasStateHandle?: boolean;
+	passcodeAction?: string;
+	fieldErrors?: FieldError[];
+	passcode?: string;
+	timeUntilTokenExpiry?: number;
 };
 
 export const EmailSent = ({
@@ -40,13 +54,55 @@ export const EmailSent = ({
 	children,
 	formError,
 	instructionContext,
+	hasStateHandle,
+	passcodeAction,
+	fieldErrors,
+	passcode,
+	timeUntilTokenExpiry,
 }: PropsWithChildren<Props>) => {
 	const [recaptchaErrorMessage, setRecaptchaErrorMessage] = useState('');
 	const [recaptchaErrorContext, setRecaptchaErrorContext] =
 		useState<ReactNode>(null);
+
+	useEffect(() => {
+		// we only want this to run in the browser as window is not
+		// defined on the server
+		// and we also check that the expiry time exists so that
+		// we redirect to the session expired page
+		// if the token expires while the user is on the current page
+		if (typeof window !== 'undefined' && timeUntilTokenExpiry) {
+			logger.info(`Welcome page: loaded successfully`, undefined, {
+				timeUntilTokenExpiry,
+			});
+			setTimeout(() => {
+				logger.info(
+					`Welcome page: redirecting to token expired page`,
+					undefined,
+					{ timeUntilTokenExpiry },
+				);
+				window.location.replace(buildUrl('/register/code/expired'));
+			}, timeUntilTokenExpiry);
+		}
+	}, [timeUntilTokenExpiry]);
+
+	useEffect(() => {
+		if (typeof window !== 'undefined') {
+			const codeInput: HTMLInputElement | null =
+				window.document.querySelector('input[name="code"]');
+
+			if (codeInput) {
+				codeInput.focus();
+			}
+		}
+	}, []);
+
+	const pageHeader = hasStateHandle
+		? 'Enter your code'
+		: 'Check your email inbox';
+
 	return (
 		<MainLayout
-			pageHeader="Check your email inbox"
+			pageHeader={pageHeader}
 			successOverride={showSuccess ? 'Email sent' : undefined}
 			errorOverride={
 				recaptchaErrorMessage ? recaptchaErrorMessage : errorMessage
@@ -54,27 +110,75 @@ export const EmailSent = ({
 			errorContext={recaptchaErrorContext}
 		>
 			{children}
-			{email ? (
-				<MainBodyText>
-					We’ve sent an email to <b>{email}</b>
-				</MainBodyText>
-			) : (
-				<MainBodyText>We’ve sent you an email.</MainBodyText>
+			{!hasStateHandle && (
+				<>
+					{email ? (
+						<MainBodyText>
+							We’ve sent an email to <b>{email}</b>
+						</MainBodyText>
+					) : (
+						<MainBodyText>We’ve sent you an email.</MainBodyText>
+					)}
+					{instructionContext ? (
+						<MainBodyText>
+							Please follow the link in the email to {instructionContext}.
+						</MainBodyText>
+					) : (
+						<MainBodyText>
+							Please follow the instructions in this email.
+						</MainBodyText>
+					)}
+				</>
 			)}
-			{instructionContext ? (
-				<MainBodyText>
-					Please follow the link in the email to {instructionContext}.
-				</MainBodyText>
-			) : (
-				<MainBodyText>
-					Please follow the instructions in this email.
-				</MainBodyText>
+			{hasStateHandle && (
+				<>
+					{email ? (
+						<MainBodyText>
+							We’ve sent an email to <b>{email}</b> with verification
+							instructions and a verification code.
+						</MainBodyText>
+					) : (
+						<MainBodyText>
+							We’ve sent you an email with verification instructions and a
+							verification code.
+						</MainBodyText>
+					)}
+				</>
 			)}
 			<MainBodyText>
 				<b>
-					For your security, the link in the email will expire in 60 minutes.
+					For your security, the link in the email will expire in{' '}
+					{hasStateHandle && passcodeAction ? '30' : '60'} minutes.
 				</b>
 			</MainBodyText>
+			{hasStateHandle && passcodeAction && (
+				<div
+					css={css`
+						margin-bottom: ${space[3]}px;
+					`}
+				>
+					<MainForm
+						formAction={`${passcodeAction}${queryString}`}
+						submitButtonText="Submit passcode"
+						disableOnSubmit
+					>
+						<TextInput
+							label="Verification code"
+							type="text"
+							width={4}
+							pattern="\d{6}"
+							name="code"
+							autoComplete="one-time-code"
+							inputMode="numeric"
+							maxLength={6}
+							error={
+								fieldErrors?.find((error) => error.field === 'code')?.message
+							}
+							defaultValue={passcode}
+						/>
+					</MainForm>
+				</div>
+			)}
 			<InformationBox>
 				<InformationBoxText>
 					Didn’t get the email? Check your spam
@@ -82,7 +186,11 @@ export const EmailSent = ({
 						<>
 							,{!changeEmailPage ? <> or </> : <> </>}
 							<MainForm
-								formAction={`${resendEmailAction}${queryString}`}
+								formAction={
+									hasStateHandle
+										? `${passcodeAction}/resend${queryString}`
+										: `${resendEmailAction}${queryString}`
+								}
 								submitButtonText={'send again'}
 								recaptchaSiteKey={recaptchaSiteKey}
 								setRecaptchaErrorContext={setRecaptchaErrorContext}

--- a/src/client/pages/EmailSent.tsx
+++ b/src/client/pages/EmailSent.tsx
@@ -85,6 +85,7 @@ export const EmailSent = ({
 		}
 	}, [timeUntilTokenExpiry]);
 
+	// autofocus the code input field when the page loads
 	useEffect(() => {
 		if (typeof window !== 'undefined') {
 			const codeInput: HTMLInputElement | null =

--- a/src/client/pages/RegistrationEmailSentPage.tsx
+++ b/src/client/pages/RegistrationEmailSentPage.tsx
@@ -26,7 +26,11 @@ export const RegistrationEmailSentPage = () => {
 		<EmailSent
 			email={email}
 			queryString={queryString}
-			changeEmailPage={buildUrlWithQueryParams('/register', {}, queryParams)}
+			changeEmailPage={buildUrlWithQueryParams(
+				'/register/email',
+				{},
+				queryParams,
+			)}
 			resendEmailAction={buildUrl('/register/email-sent/resend')}
 			passcodeAction={buildUrl('/register/code')}
 			instructionContext="verify and complete creating your account"

--- a/src/client/pages/RegistrationEmailSentPage.tsx
+++ b/src/client/pages/RegistrationEmailSentPage.tsx
@@ -13,7 +13,7 @@ export const RegistrationEmailSentPage = () => {
 		globalMessage = {},
 		recaptchaConfig,
 	} = clientState;
-	const { email } = pageData;
+	const { email, hasStateHandle, fieldErrors, token } = pageData;
 	const { emailSentSuccess } = queryParams;
 	const { error } = globalMessage;
 	const { recaptchaSiteKey } = recaptchaConfig;
@@ -28,11 +28,15 @@ export const RegistrationEmailSentPage = () => {
 			queryString={queryString}
 			changeEmailPage={buildUrlWithQueryParams('/register', {}, queryParams)}
 			resendEmailAction={buildUrl('/register/email-sent/resend')}
+			passcodeAction={buildUrl('/register/code')}
 			instructionContext="verify and complete creating your account"
 			showSuccess={emailSentSuccess}
 			errorMessage={error}
 			recaptchaSiteKey={recaptchaSiteKey}
 			formTrackingName="register-resend"
+			hasStateHandle={hasStateHandle}
+			fieldErrors={fieldErrors}
+			passcode={token}
 		/>
 	);
 };

--- a/src/server/controllers/changePassword.ts
+++ b/src/server/controllers/changePassword.ts
@@ -29,7 +29,7 @@ import {
 	resetPassword as resetPasswordInOkta,
 	validateRecoveryToken as validateTokenInOkta,
 } from '@/server/lib/okta/api/authentication';
-import { OktaError } from '@/server/models/okta/Error';
+import { OAuthError, OktaError } from '@/server/models/okta/Error';
 import { checkTokenInOkta } from '@/server/controllers/checkPasswordToken';
 import {
 	performAuthorizationCodeFlow,
@@ -46,8 +46,12 @@ import { changePasswordMetric, emailSendMetric } from '@/server/models/Metrics';
 import { getAppPrefix } from '@/shared/lib/appNameUtils';
 import { sendGuardianLiveOfferEmail } from '@/email/templates/GuardianLiveOffer/sendGuardianLiveOfferEmail';
 import { sendMyGuardianOfferEmail } from '@/email/templates/MyGuardianOffer/sendMyGuardianOfferEmail';
+import { introspect } from '@/server/lib/okta/idx/introspect';
+import { setPasswordAndRedirect } from '@/server/lib/okta/idx/challenge';
+import { PasswordFieldErrors } from '@/shared/model/Errors';
+import { isBreachedPassword } from '@/server/lib/breachedPasswordCheck';
 
-const { okta } = getConfiguration();
+const { okta, registrationPasscodesEnabled } = getConfiguration();
 
 const changePasswordInIDAPI = async (
 	path: PasswordRoutePath,
@@ -203,6 +207,96 @@ const changePasswordInOkta = async (
 	const { token: encryptedRecoveryToken } = req.params;
 	const { password, firstName, secondName } = req.body;
 	const { clientId, signInGateId } = res.locals.queryParams;
+
+	// Okta IDX API Flow for setting a password
+	if (
+		registrationPasscodesEnabled &&
+		res.locals.queryParams.usePasscodeRegistration
+	) {
+		try {
+			const encryptedState = readEncryptedStateCookie(req);
+
+			if (
+				encryptedState &&
+				encryptedState.email &&
+				encryptedState.stateHandle
+			) {
+				// introspect the stateHandle to make sure it's valid
+				const introspectResponse = await introspect(
+					{
+						stateHandle: encryptedState.stateHandle,
+					},
+					res.locals.requestId,
+				);
+
+				// check if the remediation array contains a "enroll-authenticator"	object
+				// if it does, then we know the stateHandle is valid
+				const hasEnrollAuthenticator =
+					introspectResponse.remediation.value.some(
+						(remediation) => remediation.name === 'enroll-authenticator',
+					);
+
+				if (!hasEnrollAuthenticator) {
+					throw new OAuthError({
+						error: 'idx_error',
+						error_description: 'Invalid state handle',
+					});
+				}
+
+				validatePasswordFieldForOkta(password);
+
+				const isBreached = await isBreachedPassword(password);
+
+				if (isBreached) {
+					throw new OAuthError({
+						error: 'password.common',
+						error_description: PasswordFieldErrors.COMMON_PASSWORD,
+					});
+				}
+
+				return await setPasswordAndRedirect(
+					encryptedState.stateHandle,
+					{
+						passcode: password,
+					},
+					res,
+					res.locals.requestId,
+				);
+			}
+		} catch (error) {
+			logger.error('Okta IDX setPassword failure', error, {
+				request_id: res.locals.requestId,
+			});
+
+			if (error instanceof OAuthError) {
+				// case for session expired
+				if (error.name === 'idx.session.expired') {
+					return res.redirect(
+						303,
+						addQueryParamsToPath(
+							'/register/code/expired',
+							res.locals.queryParams,
+						),
+					);
+				}
+			}
+
+			const { globalError, fieldErrors } = getErrorMessage(error);
+
+			// If the recovery token is valid, this call will redirect the client back
+			// to the same page, but with an error message. If the token is invalid, the
+			// client will be redirected to the /reset-password/expired page and asked
+			// to request a new reset password link.
+			return await checkTokenInOkta(
+				path,
+				pageTitle,
+				req,
+				res,
+				globalError,
+				fieldErrors,
+			);
+		}
+	}
 
 	try {
 		if (!encryptedRecoveryToken) {

--- a/src/server/controllers/changePassword.ts
+++ b/src/server/controllers/changePassword.ts
@@ -255,14 +255,17 @@ const changePasswordInOkta = async (
 
 				// Set the password in Okta, redirect the user to set a global session, and then complete
 				// the interaction code flow, eventually redirecting the user back to where they need to go.
-				return await setPasswordAndRedirect(
-					encryptedState.stateHandle,
-					{
+				return await setPasswordAndRedirect({
+					stateHandle: encryptedState.stateHandle,
+
+					body: {
 						passcode: password,
 					},
-					res,
-					res.locals.requestId,
-				);
+					expressReq: req,
+					expressRes: res,
+					path,
+					request_id: res.locals.requestId,
+				});
 			}
 		} catch (error) {
 			logger.error('Okta IDX setPassword failure', error, {

--- a/src/server/controllers/checkPasswordToken.ts
+++ b/src/server/controllers/checkPasswordToken.ts
@@ -26,8 +26,11 @@ import { validateReturnUrl } from '@/server/lib/validateUrl';
 import { mergeRequestState } from '@/server/lib/requestState';
 import { decryptOktaRecoveryToken } from '@/server/lib/deeplink/oktaRecoveryToken';
 import { AppName, getAppName, getAppPrefix } from '@/shared/lib/appNameUtils';
+import { introspect } from '@/server/lib/okta/idx/introspect';
+import { OAuthError } from '@/server/models/okta/Error';
 
-const { okta, defaultReturnUri } = getConfiguration();
+const { okta, defaultReturnUri, registrationPasscodesEnabled } =
+	getConfiguration();
 
 const handleBackButtonEventOnWelcomePage = (
 	path: PasswordRoutePath,
@@ -154,6 +157,76 @@ export const checkTokenInOkta = async (
 ) => {
 	const state = res.locals;
 	const { token } = req.params;
+
+	// Okta IDX API Flow for checking a password token
+	if (
+		registrationPasscodesEnabled &&
+		res.locals.queryParams.usePasscodeRegistration &&
+		path === '/welcome' // only check the state handle for registration passcode flow on the welcome page
+	) {
+		try {
+			const encryptedState = readEncryptedStateCookie(req);
+
+			if (
+				encryptedState &&
+				encryptedState.email &&
+				encryptedState.stateHandle
+			) {
+				// introspect the stateHandle to make sure it's valid
+				const introspectResponse = await introspect(
+					{
+						stateHandle: encryptedState.stateHandle,
+					},
+					res.locals.requestId,
+				);
+
+				// check if the remediation array contains a "enroll-authenticator"	object
+				// if it does, then we know the stateHandle is valid
+				const hasEnrollAuthenticator =
+					introspectResponse.remediation.value.some(
+						(remediation) => remediation.name === 'enroll-authenticator',
+					);
+
+				if (!hasEnrollAuthenticator) {
+					throw new OAuthError({
+						error: 'idx_error',
+						error_description: 'Invalid state handle',
+					});
+				}
+
+				const html = renderer(
+					`${path}/:token`,
+					{
+						pageTitle,
+						requestState: mergeRequestState(res.locals, {
+							pageData: {
+								browserName: getBrowserNameFromUserAgent(
+									req.header('User-Agent'),
+								),
+								email: encryptedState.email,
+								fieldErrors,
+								formError: error,
+								token,
+								isNativeApp: state.pageData.isNativeApp,
+								appName: state.pageData.appName,
+							},
+						}),
+					},
+					{ token },
+				);
+
+				return res.type('html').send(html);
+			}
+		} catch (error) {
+			logger.error(
+				'IDX API - check state handle token - checkPasswordToken',
+				error,
+				{
+					request_id: res.locals.requestId,
+				},
+			);
+		}
+	}
 
 	try {
 		// check if the token is prefixed with an app prefix

--- a/src/server/lib/middleware/requestState.ts
+++ b/src/server/lib/middleware/requestState.ts
@@ -13,6 +13,7 @@ import { logger } from '@/server/lib/serverSideLogger';
 import { getApp } from '@/server/lib/okta/api/apps';
 import { IsNativeApp } from '@/shared/model/ClientState';
 import { AppName, getAppName, isAppLabel } from '@/shared/lib/appNameUtils';
+import { readEncryptedStateCookie } from '@/server/lib/encryptedStateCookie';
 
 const {
 	idapiBaseUrl,
@@ -76,6 +77,8 @@ const getRequestState = async (
 		});
 	}
 
+	const encryptedState = readEncryptedStateCookie(req);
+
 	return {
 		queryParams,
 		pageData: {
@@ -83,6 +86,7 @@ const getRequestState = async (
 			returnUrl: queryParams.returnUrl,
 			isNativeApp,
 			appName,
+			hasStateHandle: !!encryptedState?.stateHandle,
 		},
 		globalMessage: {},
 		csrf: {

--- a/src/server/lib/okta/idx/challenge.ts
+++ b/src/server/lib/okta/idx/challenge.ts
@@ -9,6 +9,8 @@ import {
 } from './shared';
 import { selectAuthenticationEnrollSchema } from './enroll';
 import { ResponseWithRequestState } from '@/server/models/Express';
+import { validateEmailAndPasswordSetSecurely } from '@/server/lib/okta/validateEmail';
+import { logger } from '@/server/lib/serverSideLogger';
 
 // Schema for the 'skip' object inside the challenge response remediation object
 export const skipSchema = baseRemediationValueSchema.merge(
@@ -82,13 +84,31 @@ export const setPasswordAndRedirect = async (
 	expressRes: ResponseWithRequestState,
 	request_id?: string,
 ): Promise<void> => {
-	return await idxFetchCompletion<ChallengeAnswerPasswordBody>({
-		path: 'challenge/answer',
-		body: {
-			stateHandle,
-			credentials: body,
-		},
-		expressRes,
-		request_id,
-	});
+	const [completionResponse, redirectUrl] =
+		await idxFetchCompletion<ChallengeAnswerPasswordBody>({
+			path: 'challenge/answer',
+			body: {
+				stateHandle,
+				credentials: body,
+			},
+			expressRes,
+			request_id,
+		});
+
+	// set the validation flags in Okta
+	const { id } = completionResponse.user.value;
+	if (id) {
+		await validateEmailAndPasswordSetSecurely(id);
+	} else {
+		logger.error(
+			'Failed to set validation flags in Okta as there was no id',
+			undefined,
+			{
+				request_id,
+			},
+		);
+	}
+
+	// redirect the user to set a global session and then back to completing the authorization flow
+	return expressRes.redirect(303, redirectUrl);
 };

--- a/src/server/lib/okta/idx/challenge.ts
+++ b/src/server/lib/okta/idx/challenge.ts
@@ -70,6 +70,28 @@ export const challengeAnswerPasscode = (
 };
 
 /**
+ * @name challengeResend
+ * @description Okta IDX API/Interaction Code flow - Resend a challenge.
+ *
+ * @param stateHandle - The state handle from the previous step
+ * @param request_id - The request id
+ * @returns Promise<ChallengeAnswerResponse> - The challenge answer response
+ */
+export const challengeResend = (
+	stateHandle: IdxBaseResponse['stateHandle'],
+	request_id?: string,
+): Promise<ChallengeAnswerResponse> => {
+	return idxFetch<ChallengeAnswerResponse, IdxStateHandleBody>({
+		path: 'challenge/resend',
+		body: {
+			stateHandle,
+		},
+		schema: challengeAnswerResponseSchema,
+		request_id,
+	});
+};
+
+/**
  * @name setPasswordAndRedirect
  * @description Okta IDX API/Interaction Code flow - Answer a challenge with a password, and redirect the user to set a global session and then back to the app. This could be one the final possible steps in the authentication process.
  * @param stateHandle - The state handle from the previous step

--- a/src/server/lib/okta/idx/introspect.ts
+++ b/src/server/lib/okta/idx/introspect.ts
@@ -5,6 +5,7 @@ import {
 	idxBaseResponseSchema,
 	idxFetch,
 } from './shared';
+import { OAuthError } from '@/server/models/okta/Error';
 
 // Schema for the 'redirect-idp' object inside the introspect response remediation object
 export const redirectIdpSchema = baseRemediationValueSchema.merge(
@@ -73,4 +74,31 @@ export const introspect = (
 		schema: introspectResponseSchema,
 		request_id,
 	});
+};
+
+/**
+ * @name validateIntrospectRemediation
+ * @description Validates that the introspect response contains a remediation with the given name, throwing an error if it does not. This is useful for ensuring that the remediation we want to perform is available in the introspect response, and the state is correct.
+ * @param introspectResponse - The introspect response
+ * @param remediationName - The name of the remediation to validate
+ * @throws OAuthError - If the remediation is not found in the introspect response
+ * @returns void
+ */
+export const validateIntrospectRemediation = (
+	introspectResponse: IntrospectResponse,
+	remediationName: string,
+) => {
+	const hasRemediation = introspectResponse.remediation.value.some(
+		({ name }) => name === remediationName,
+	);
+
+	if (!hasRemediation) {
+		throw new OAuthError(
+			{
+				error: 'invalid_request',
+				error_description: `Remediation ${remediationName} not found in introspect response`,
+			},
+			400,
+		);
+	}
 };

--- a/src/server/lib/okta/idx/shared.ts
+++ b/src/server/lib/okta/idx/shared.ts
@@ -11,6 +11,7 @@ const { okta } = getConfiguration();
 // Okta IDX API paths
 const idxPaths = [
 	'challenge/answer',
+	'challenge/resend',
 	'credential/enroll',
 	'enroll',
 	'enroll/new',

--- a/src/server/lib/okta/idx/shared.ts
+++ b/src/server/lib/okta/idx/shared.ts
@@ -34,7 +34,7 @@ const idxVersionSchema = z.string().refine((val) => {
 export const idxBaseResponseSchema = z.object({
 	version: idxVersionSchema,
 	stateHandle: z.string(),
-	expiresAt: z.coerce.date(),
+	expiresAt: z.string(),
 });
 export type IdxBaseResponse = z.infer<typeof idxBaseResponseSchema>;
 

--- a/src/server/lib/okta/idx/shared.ts
+++ b/src/server/lib/okta/idx/shared.ts
@@ -376,3 +376,15 @@ const handleError = async (response: Response) => {
 		response.status,
 	);
 };
+
+/**
+ * @name convertExpiresAtToExpiryTimeInMs
+ * @description Convert the expiresAt string from the IDX API response to a number representing the time until expiry in ms
+ * @param expiresAt - The expiresAt string from the IDX API response
+ * @returns	number | undefined - The time until expiry in ms, or undefined if expiresAt is not provided
+ */
+export const convertExpiresAtToExpiryTimeInMs = (
+	expiresAt?: string,
+): number | undefined => {
+	return expiresAt ? new Date(expiresAt).getTime() - Date.now() : undefined;
+};

--- a/src/server/lib/validatePasswordField.ts
+++ b/src/server/lib/validatePasswordField.ts
@@ -3,7 +3,7 @@ import {
 	PasswordFieldErrors,
 } from '@/shared/model/Errors';
 import { ApiError } from '@/server/models/Error';
-import { ErrorCause, OktaError } from '@/server/models/okta/Error';
+import { ErrorCause, OAuthError, OktaError } from '@/server/models/okta/Error';
 import { causesInclude } from '@/server/lib/okta/api/errors';
 
 export const validatePasswordField = (password: string): void => {
@@ -76,6 +76,15 @@ export const getErrorMessage = (error: unknown) => {
 			],
 		};
 	} else if (error instanceof ApiError && error.field === 'password') {
+		return {
+			fieldErrors: [
+				{
+					field: 'password',
+					message: error.message,
+				},
+			],
+		};
+	} else if (error instanceof OAuthError) {
 		return {
 			fieldErrors: [
 				{

--- a/src/server/models/Metrics.ts
+++ b/src/server/models/Metrics.ts
@@ -44,6 +44,7 @@ type ConditionalMetrics =
 	| 'OAuthDeleteCallback'
 	| 'OktaAccountVerification'
 	| 'OktaIDXInteract'
+	| 'OktaIDXRegister'
 	| `OktaIDX::${IDXPath}`
 	| 'OktaRegistration'
 	| 'OktaRegistrationResendEmail'

--- a/src/server/routes/register.ts
+++ b/src/server/routes/register.ts
@@ -381,14 +381,6 @@ const OktaRegistration = async (
 	req: Request,
 	res: ResponseWithRequestState,
 ) => {
-	if (
-		registrationPasscodesEnabled &&
-		res.locals.queryParams.usePasscodeRegistration
-	) {
-		// to implement
-		return res.sendStatus(418);
-	}
-
 	const { email = '' } = req.body;
 
 	const {

--- a/src/server/routes/register.ts
+++ b/src/server/routes/register.ts
@@ -63,6 +63,7 @@ import {
 	bodyFormFieldsToRegistrationConsents,
 	encryptRegistrationConsents,
 } from '@/server/lib/registrationConsents';
+import { convertExpiresAtToExpiryTimeInMs } from '@/server/lib/okta/idx/shared';
 
 const { okta, registrationPasscodesEnabled } = getConfiguration();
 
@@ -144,10 +145,9 @@ router.get('/register/code', (req: Request, res: ResponseWithRequestState) => {
 			requestState: mergeRequestState(state, {
 				pageData: {
 					email: readEncryptedStateCookie(req)?.email,
-					timeUntilTokenExpiry: encryptedState.stateHandleExpiresAt
-						? new Date(encryptedState.stateHandleExpiresAt).getTime() -
-							Date.now()
-						: undefined,
+					timeUntilTokenExpiry: convertExpiresAtToExpiryTimeInMs(
+						encryptedState.stateHandleExpiresAt,
+					),
 				},
 			}),
 			pageTitle: 'Check Your Inbox',
@@ -268,10 +268,9 @@ router.post(
 								},
 								pageData: {
 									email: readEncryptedStateCookie(req)?.email,
-									timeUntilTokenExpiry: encryptedState.stateHandleExpiresAt
-										? new Date(encryptedState.stateHandleExpiresAt).getTime() -
-											Date.now()
-										: undefined,
+									timeUntilTokenExpiry: convertExpiresAtToExpiryTimeInMs(
+										encryptedState.stateHandleExpiresAt,
+									),
 									fieldErrors: [
 										{
 											field: 'code',

--- a/src/server/routes/register.ts
+++ b/src/server/routes/register.ts
@@ -63,7 +63,6 @@ import {
 	bodyFormFieldsToRegistrationConsents,
 	encryptRegistrationConsents,
 } from '@/server/lib/registrationConsents';
-import { consentPages } from './consents';
 
 const { okta, registrationPasscodesEnabled } = getConfiguration();
 
@@ -445,7 +444,7 @@ const OktaRegistration = async (
 		try {
 			// start the interaction code flow, and get the interaction handle + authState
 			const [{ interaction_handle }, authState] = await interact(req, res, {
-				confirmationPagePath: consentPages[0].path,
+				confirmationPagePath: '/welcome/review',
 				closeExistingSession: true,
 			});
 

--- a/src/server/routes/register.ts
+++ b/src/server/routes/register.ts
@@ -49,7 +49,10 @@ import {
 	selectAuthenticationEnrollSchema,
 } from '@/server/lib/okta/idx/enroll';
 import { interact } from '@/server/lib/okta/idx/interact';
-import { introspect } from '@/server/lib/okta/idx/introspect';
+import {
+	introspect,
+	validateIntrospectRemediation,
+} from '@/server/lib/okta/idx/introspect';
 import {
 	updateAuthorizationStateData,
 	setAuthorizationStateCookie,
@@ -174,12 +177,18 @@ router.post(
 
 			try {
 				// check the state handle is valid and we can proceed with the registration
-				// TODO: possibly check if we can look for a particular remediation property
-				await introspect(
+				const introspectResponse = await introspect(
 					{
 						stateHandle,
 					},
 					requestId,
+				);
+
+				// check if the remediation array contains a "enroll-authenticator"	object
+				// if it does, then we know the stateHandle is valid and we're in the correct state
+				validateIntrospectRemediation(
+					introspectResponse,
+					'enroll-authenticator',
 				);
 
 				// attempt to answer the passcode challenge, if this fails, it falls through to the catch block where we handle the error
@@ -331,12 +340,18 @@ router.post(
 
 			try {
 				// check the state handle is valid
-				// TODO: possibly check if we can look for a particular remediation property
-				await introspect(
+				const introspectResponse = await introspect(
 					{
 						stateHandle,
 					},
 					requestId,
+				);
+
+				// check if the remediation array contains a "enroll-authenticator"	object
+				// if it does, then we know the stateHandle is valid and we're in the correct state
+				validateIntrospectRemediation(
+					introspectResponse,
+					'enroll-authenticator',
 				);
 
 				// attempt to resend the email

--- a/src/server/routes/signIn.ts
+++ b/src/server/routes/signIn.ts
@@ -595,9 +595,12 @@ router.get(
 					closeExistingSession: true,
 				});
 
-				const introspectResponse = await introspect({
-					interactionHandle: interaction_handle,
-				});
+				const introspectResponse = await introspect(
+					{
+						interactionHandle: interaction_handle,
+					},
+					res.locals.requestId,
+				);
 
 				const updatedAuthState = updateAuthorizationStateData(authState, {
 					socialProvider: socialIdp,

--- a/src/shared/__tests__/queryParams.test.ts
+++ b/src/shared/__tests__/queryParams.test.ts
@@ -37,6 +37,7 @@ describe('getPersistableQueryParams', () => {
 			signInGateId: undefined,
 			fromURI: 'fromURI',
 			appClientId: 'appClientId',
+			usePasscodeRegistration: undefined,
 		};
 
 		expect(output).toStrictEqual(expected);

--- a/src/shared/lib/queryParams.ts
+++ b/src/shared/lib/queryParams.ts
@@ -42,6 +42,7 @@ export const getPersistableQueryParams = (
 	fromURI: params.fromURI,
 	appClientId: params.appClientId,
 	signInGateId: params.signInGateId,
+	usePasscodeRegistration: params.usePasscodeRegistration,
 });
 
 /**

--- a/src/shared/model/ClientState.ts
+++ b/src/shared/model/ClientState.ts
@@ -70,6 +70,8 @@ export interface PageData {
 
 	// delete specific
 	contentAccess?: UserAttributesResponse['contentAccess'];
+	// okta idx api specific
+	hasStateHandle?: boolean; // determines if the state handle is present in the encrypted state
 }
 
 export interface RecaptchaConfig {

--- a/src/shared/model/ClientState.ts
+++ b/src/shared/model/ClientState.ts
@@ -71,7 +71,7 @@ export interface PageData {
 	// delete specific
 	contentAccess?: UserAttributesResponse['contentAccess'];
 	// okta idx api specific
-	hasStateHandle?: boolean; // determines if the state handle is present in the encrypted state
+	hasStateHandle?: boolean; // determines if the state handle is present in the encrypted state, so we know if we're in an Okta IDX flow
 }
 
 export interface RecaptchaConfig {

--- a/src/shared/model/EncryptedState.ts
+++ b/src/shared/model/EncryptedState.ts
@@ -8,4 +8,6 @@ export interface EncryptedState {
 	status?: string;
 	signInRedirect?: boolean; // TODO: possibly rename for clarity
 	queryParams?: PersistableQueryParams;
+	stateHandle?: string; // part of the Okta IDX flow
+	stateHandleExpiresAt?: string; // part of the Okta IDX flow
 }

--- a/src/shared/model/Errors.ts
+++ b/src/shared/model/Errors.ts
@@ -35,6 +35,7 @@ export enum RegistrationErrors {
 	GENERIC = 'There was a problem registering, please try again.',
 	EMAIL_INVALID = 'Please enter a valid email address.',
 	PROVISIONING_FAILURE = 'Your account has been created but there was a problem signing you in.',
+	PASSCODE_INVALID = 'Incorrect code',
 }
 
 // shown at the top of the change password page when something goes wrong

--- a/src/shared/model/Routes.ts
+++ b/src/shared/model/Routes.ts
@@ -30,6 +30,9 @@ export const ValidRoutePathsArray = [
 	'/oauth/authorization-code/interaction-code-callback',
 	'/reauthenticate',
 	'/register',
+	'/register/code',
+	'/register/code/expired',
+	'/register/code/resend',
 	'/register/email',
 	'/register/email-sent',
 	'/register/email-sent/resend',
@@ -73,6 +76,7 @@ export const ValidRoutePathsArray = [
 	'/welcome/social',
 	'/welcome/review',
 	'/welcome/newsletters',
+	'/welcome/password',
 ] as const;
 
 export type RoutePaths = (typeof ValidRoutePathsArray)[number];


### PR DESCRIPTION
## What does this change?

We've now upgraded to Okta Identity Engine. This unlocks a number of new features which previously weren't feasible. One of these is "passwordless", or the idea of eliminating, or reducing the need for passwords.

We also currently have an issue within our OAuth flows where users don't always end up signed in the same browser context that they registered from. This can occur if a user clicks a reset password/registration verification link in their on another browser or device, or if deeplinking/https interception isn't working properly on the user's device.

One way of fixing both these issues it to use One Time Passcodes (OTPs), where instead of a user clicking a link in an email, they have to type a 6 digit number into an input field which performs the same action of verifying the user. This means that the user always stays within the same browser device/context, while also securely verifying the user.

To begin with we're going to only implement OTPs for registration only, with the user still having to set a password, this is the focus of this PR. After this we will being rolling out passcodes for sign in and password reset too, thus eliminating passwords altogether, or at lease making them optional.

This PR builds on the work previously done in https://github.com/guardian/gateway/pull/2625 where the initial work to set up the IDX API was done, and https://github.com/guardian/gateway/pull/2637 where most of the APIs for passcodes were set up. The focus of this PR is to wire up the registration functionality to use the passcode API, and set up the frontend to handle this.

This PR however does not enable passcodes directly in `PROD`, the `usePasscodesRegistration` query parameter flag must be manually set in order to opt in, and the [switch](https://github.com/guardian/gateway/blob/3e221f52e6068ed8940212bf1cd502f44af7ee5d/src/shared/lib/featureSwitches.ts#L43) has to be enabled in `PROD`, it is currently set to `false`. This allows us to slowly opt in and first test on the CODE environment, followed by PROD behind the flag, followed by enabling it without the flag.

We're currently only enabling passcodes for new users who are registering. Existing users that are attempting to go through the registration flow will fallback to the legacy/current flow without passcodes for now until full passwordless is implemented. The full flowchart can be seen in https://github.com/guardian/gateway/issues/2567.

## The Journey

The steps to enable passcode registration are as follows:

1. User attempts to register with a new email, this calls `POST /register`
2. `POST /register`
	1. Checks if `registrationPasscodesEnabled` feature switch enabled and `usePasscodeRegistration` query parameter is set (this step is temporary before rolling out to all users) 
		1. If it is, attempt passcode registration flow
		2. Otherwise use classic flow
	2. Assuming 1) is stratified, first start the interaction code flow, and get the `interaction_handle` + `authState`
		1. See https://github.com/guardian/gateway/pull/2637 and https://github.com/guardian/gateway/pull/2625 for more details on specifics of what the interaction code flow/IDX API is doing
	3. Introspect the `interaction_handle` to get the `stateHandle`
	4. Encrypt any consents we need to preserve during the registration flow, and update the `authState` with the `stateToken` and `encryptedRegistrationConsents`
	5. Check if we have the `select-enroll-profile` remediation property which means registration is allowed using the IDX API
	6. Call the `/enroll` endpoint to attempt to start the registration process
	7. Call the `/enroll/new` endpoint to attempt to register the user with email
	8. If successful, the user will have been send an email with a passcode by Okta
	9. Set the encrypted state cookie to persist the `email` and `stateHandle` through the flow/between pages
	10. Finally redirect to the email sent page
	11. If at any point there is an error, we log the error and fallback to the classic registration flow
3. User shown the Email Sent page, but it has a passcode input field instead! User grabs the 6 digit passcode from their email. They type it in and click "Submit Passcode". This calls `POST /register/code`
4. `POST /register/code`
	1. Grab the `code` from the request body and read the `stateHandle` from the encrypted state cookie
	2. Check if the `stateHandle` is valid with the `introspect` endpoint
	3. Call the `/challenge/answer` endpoint with the `code` and `stateHandle`
		i. If valid continue
		ii. If invalid, we throw and handle a specific error case for invalid passcode: `api.authn.error.PASSCODE_INVALID`
	4. We need the user to set a password, so we need to enroll them in the "password" factor, find the `passwordAuthenticatorId`
	5. Call the `/credentials/enroll` method with the authenticator id and `methodType` set to `password`
	6. Redirect the user to the `/welcome/password` page where they'll set a password
5. `GET /welcome/password`
	1. This is intercepted as a `GET /welcome/:token` route, so we update the existing handler, which uses the `checkTokenInOkta` from `checkPasswordToken.ts`
	2. Checks if `registrationPasscodesEnabled` feature switch enabled and `usePasscodeRegistration` query parameter is set (this step is temporary before rolling out to all users) 
		1. If it is, attempt passcode registration flow
		2. Otherwise use classic flow, i.e assume the `token` parameter is a token
	3. If it is, read the encrypted state cookie for the email and state handle
	4. Check if the `stateHandle` is valid with the `introspect` endpoint and making sure it has the `enroll-authenticator` object so we know it's in the correct state
	5. Show the set password page
6. User enters a new password and submits, calls `POST /welcome/password`
	1. This is intercepted as a `POST /welcome/:token` route, so we update the existing handler, which uses the `changePasswordInOkta` from `changePassword.ts`
	2. Checks if `registrationPasscodesEnabled` feature switch enabled and `usePasscodeRegistration` query parameter is set (this step is temporary before rolling out to all users) 
		1. If it is, attempt passcode registration flow
		2. Otherwise use classic flow, i.e assume the `token` parameter is a token
	3. If it is, read the encrypted state cookie for the email and state handle
	4. Check if the `stateHandle` is valid with the `introspect` endpoint and making sure it has the `enroll-authenticator` object so we know it's in the correct state
	5. Validate the password field and check if breached
	6. Call the `setPasswordAndRedirect` function, which uses the `/challenge/answer` endpoint to set a password. This sets a global okta session, and completes the flow by redirecting the user to the interaction code callback endpoint, but with a `code` parameter (not an `interaction_code`) and the `state`.
7. In this callback endpoint, use a standard OAuth library that supports Authorization Code Flow with PKCE, and complete the flow. The user is authenticated at this point, and everything else remains the same as what we currently have
8. At any point if there is an error, we catch the error, log it, and fallback to the existing flow.

## Demo

https://github.com/guardian/gateway/assets/13315440/d49a4a24-b2e9-44c8-bfa4-8e668767216e

## Plan

- Merge this PR in behind feature flag and switch
- Perform testing on CODE apps and web
  - The query flag is `usePasscodeRegistration=true`
- Enable switch on PROD
  - PR required
- Perform testing on PROD behind 
- Remove feature flag on PROD
  - Big PR required 

While improving/making refinements.

## Tested?

- [x] Cypress tests
- [x] CODE - New user web
- [x] CODE - Existing user web
- [x] CODE - New user app
- [x] CODE - Existing user app