### PR TITLE
Feast | Add Feast newsletter to registration, hide nav bar on `/welcome/:token`

### DIFF
--- a/cypress/integration/ete-okta/registration_newsletter.5.cy.ts
+++ b/cypress/integration/ete-okta/registration_newsletter.5.cy.ts
@@ -133,3 +133,27 @@ describe('Saturday Edition Geolocation', () => {
 		});
 	});
 });
+
+describe('Feast newsletter for Feast app', () => {
+	it('should show the Feast newsletter if coming from feast', () => {
+		cy.oktaGetApps('ios_feast_app').then(([app]) => {
+			cy.visit(`/register/email?appClientId=${app.id}`);
+			cy.contains('Feast newsletter').should('exist');
+
+			cy.createTestUser({
+				isUserEmailValidated: true,
+			}).then(({ emailAddress, finalPassword }) => {
+				cy.visit(
+					`/signin?returnUrl=${encodeURIComponent(
+						`https://${Cypress.env('BASE_URI')}/welcome/google?appClientId=${app.id}`,
+					)}`,
+				);
+				cy.get('input[name=email]').type(emailAddress);
+				cy.get('input[name=password]').type(finalPassword);
+				cy.get('[data-cy="main-form-submit-button"]').click();
+				cy.url().should('include', '/welcome/google');
+				cy.contains('Feast newsletter').should('exist');
+			});
+		});
+	});
+});

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -38,6 +38,7 @@ import {
 	sendConsentEmail,
 } from './commands/testUser';
 import { interceptRecaptcha } from './commands/recaptcha';
+import { oktaGetApps } from './commands/oktaManagementApi';
 
 Cypress.Commands.add('mockNext', mockNext);
 Cypress.Commands.add('mockPattern', mockPattern); // unused, candidate for removal
@@ -79,3 +80,4 @@ Cypress.Commands.add(
 );
 Cypress.Commands.add('sendConsentEmail', sendConsentEmail);
 Cypress.Commands.add('interceptRecaptcha', interceptRecaptcha);
+Cypress.Commands.add('oktaGetApps', oktaGetApps);

--- a/cypress/support/commands/oktaManagementApi.ts
+++ b/cypress/support/commands/oktaManagementApi.ts
@@ -1,0 +1,30 @@
+import { AppResponse } from '../../../src/server/models/okta/App';
+
+declare global {
+	// eslint-disable-next-line @typescript-eslint/no-namespace
+	namespace Cypress {
+		interface Chainable {
+			oktaGetApps: typeof oktaGetApps;
+		}
+	}
+}
+
+export const oktaGetApps = (label?: string) => {
+	try {
+		return cy
+			.request({
+				url: `${Cypress.env('OKTA_ORG_URL')}/api/v1/apps${label ? `?q=${label}` : ''}`,
+				method: 'GET',
+				headers: {
+					Authorization: `SSWS ${Cypress.env('OKTA_API_TOKEN')}`,
+				},
+				retryOnStatusCodeFailure: true,
+			})
+			.then((res) => {
+				const user = res.body as AppResponse[];
+				return cy.wrap(user);
+			});
+	} catch (error) {
+		throw new Error('Failed to lost okta apps: ' + error);
+	}
+};

--- a/src/client/components/RegistrationConsents.tsx
+++ b/src/client/components/RegistrationConsents.tsx
@@ -6,11 +6,13 @@ import { space } from '@guardian/source-foundations';
 import { RegistrationMarketingConsentFormField } from './RegistrationMarketingConsentFormField';
 import { RegistrationNewsletterFormField } from './RegistrationNewsletterFormField';
 import { GeoLocation } from '@/shared/model/Geolocation';
+import { AppName } from '@/shared/lib/appNameUtils';
 
 interface RegistrationConsentsProps {
 	geolocation?: string;
 	useIdapi?: boolean;
 	noMarginBottom?: boolean;
+	appName?: AppName;
 }
 
 const consentToggleCss = (noMarginBottom = false) => css`
@@ -25,11 +27,25 @@ export const RegistrationConsents = ({
 	geolocation,
 	useIdapi,
 	noMarginBottom,
+	appName,
 }: RegistrationConsentsProps) => {
-	// don't show the Saturday Edition newsletter option for US and AUS
-	const showSaturdayEdition = !(['US', 'AU'] as GeoLocation[]).some(
-		(location: GeoLocation) => location === geolocation,
-	);
+	// check if the app is Feast or not
+	const isFeast = appName === 'Feast';
+
+	// don't show the Saturday Edition newsletter option for US and AUS or if using Feast app
+	const showSaturdayEdition = (() => {
+		const isValidLocation = !(['US', 'AU'] satisfies GeoLocation[]).some(
+			(location: GeoLocation) => location === geolocation,
+		);
+
+		return isValidLocation && !isFeast;
+	})();
+
+	// show the Feast newsletter option if the app is Feast and Saturday Edition is not shown
+	const showFeast = isFeast && !showSaturdayEdition;
+
+	// Show marketing consent if not showing Feast
+	const showMarketingConsent = !showFeast;
 
 	if (useIdapi) {
 		return <></>;
@@ -44,10 +60,19 @@ export const RegistrationConsents = ({
 					context={RegistrationNewslettersFormFields.saturdayEdition.context}
 				/>
 			)}
-			<RegistrationMarketingConsentFormField
-				id={RegistrationConsentsFormFields.similarGuardianProducts.id}
-				label={RegistrationConsentsFormFields.similarGuardianProducts.label}
-			/>
+			{showFeast && (
+				<RegistrationNewsletterFormField
+					id={RegistrationNewslettersFormFields.feast.id}
+					label={`${RegistrationNewslettersFormFields.feast.label} newsletter`}
+					context={RegistrationNewslettersFormFields.feast.context}
+				/>
+			)}
+			{showMarketingConsent && (
+				<RegistrationMarketingConsentFormField
+					id={RegistrationConsentsFormFields.similarGuardianProducts.id}
+					label={RegistrationConsentsFormFields.similarGuardianProducts.label}
+				/>
+			)}
 		</div>
 	);
 };

--- a/src/client/pages/ConsentsNewsletters.tsx
+++ b/src/client/pages/ConsentsNewsletters.tsx
@@ -14,7 +14,10 @@ import { ConsentsNavigation } from '@/client/components/ConsentsNavigation';
 import { greyBorderTop, heading, text } from '@/client/styles/Consents';
 import { ConsentsLayout } from '@/client/layouts/ConsentsLayout';
 import { Consent } from '@/shared/model/Consent';
-import { NewsLetter } from '@/shared/model/Newsletter';
+import {
+	NewsLetter,
+	newsletterAdditionalTerms,
+} from '@/shared/model/Newsletter';
 import {
 	NEWSLETTER_COLOURS,
 	NEWSLETTER_IMAGES,
@@ -84,8 +87,7 @@ export const ConsentsNewsletters = ({ consents }: ConsentsNewslettersProps) => {
 				journalism.
 			</p>
 			<p css={[text, paragraphSpacing, autoRow()]}>
-				Newsletters may contain information about Guardian products, services
-				and chosen charities or online advertisements.
+				{newsletterAdditionalTerms}
 			</p>
 			<ConsentsForm cssOverrides={autoRow()}>
 				{consents.map(({ type, consent }, i) => {

--- a/src/client/pages/RegisterWithEmail.stories.tsx
+++ b/src/client/pages/RegisterWithEmail.stories.tsx
@@ -61,3 +61,10 @@ export const USGeolocation = (args: RegistrationProps) => (
 USGeolocation.story = {
 	name: 'with US geolocation',
 };
+
+export const FeastApp = (args: RegistrationProps) => (
+	<RegisterWithEmail {...args} appName="Feast" />
+);
+FeastApp.story = {
+	name: 'with Feast app',
+};

--- a/src/client/pages/RegisterWithEmail.tsx
+++ b/src/client/pages/RegisterWithEmail.tsx
@@ -12,6 +12,7 @@ import { GeoLocation } from '@/shared/model/Geolocation';
 import { registrationFormSubmitOphanTracking } from '@/client/lib/consentsTracking';
 import { RegistrationConsents } from '@/client/components/RegistrationConsents';
 import { AppName } from '@/shared/lib/appNameUtils';
+import { newsletterAdditionalTerms } from '@/shared/model/Newsletter';
 
 type RegisterWithEmailProps = RegistrationProps & {
 	geolocation?: GeoLocation;
@@ -52,7 +53,7 @@ export const RegisterWithEmail = ({
 					registrationFormSubmitOphanTracking(e.target as HTMLFormElement);
 					return undefined;
 				}}
-				additionalTerms="Newsletters may contain info about charities, online ads, and content funded by outside parties."
+				additionalTerms={newsletterAdditionalTerms}
 			>
 				<EmailInput defaultValue={email} autoComplete="off" />
 				<CmpConsentedStateHiddenInput cmpConsentedState={hasCmpConsent} />

--- a/src/client/pages/RegisterWithEmail.tsx
+++ b/src/client/pages/RegisterWithEmail.tsx
@@ -11,9 +11,11 @@ import { generateSignInRegisterTabs } from '@/client/components/Nav';
 import { GeoLocation } from '@/shared/model/Geolocation';
 import { registrationFormSubmitOphanTracking } from '@/client/lib/consentsTracking';
 import { RegistrationConsents } from '@/client/components/RegistrationConsents';
+import { AppName } from '@/shared/lib/appNameUtils';
 
 type RegisterWithEmailProps = RegistrationProps & {
 	geolocation?: GeoLocation;
+	appName?: AppName;
 };
 
 export const RegisterWithEmail = ({
@@ -22,6 +24,7 @@ export const RegisterWithEmail = ({
 	queryParams,
 	formError,
 	geolocation,
+	appName,
 }: RegisterWithEmailProps) => {
 	const formTrackingName = 'register';
 
@@ -54,7 +57,11 @@ export const RegisterWithEmail = ({
 				<EmailInput defaultValue={email} autoComplete="off" />
 				<CmpConsentedStateHiddenInput cmpConsentedState={hasCmpConsent} />
 
-				<RegistrationConsents useIdapi={useIdapi} geolocation={geolocation} />
+				<RegistrationConsents
+					useIdapi={useIdapi}
+					geolocation={geolocation}
+					appName={appName}
+				/>
 			</MainForm>
 		</MainLayout>
 	);

--- a/src/client/pages/RegisterWithEmailPage.tsx
+++ b/src/client/pages/RegisterWithEmailPage.tsx
@@ -15,6 +15,7 @@ export const RegisterWithEmailPage = () => {
 			recaptchaSiteKey={recaptchaSiteKey}
 			queryParams={queryParams}
 			geolocation={pageData.geolocation}
+			appName={pageData.appName}
 		/>
 	);
 };

--- a/src/client/pages/WelcomeSocial.stories.tsx
+++ b/src/client/pages/WelcomeSocial.stories.tsx
@@ -50,3 +50,10 @@ export const USGeolocation = (args: WelcomeSocialProps) => (
 USGeolocation.story = {
 	name: 'with US geolocation',
 };
+
+export const FeastApp = (args: WelcomeSocialProps) => (
+	<WelcomeSocial {...args} appName="Feast" />
+);
+FeastApp.story = {
+	name: 'with Feast app',
+};

--- a/src/client/pages/WelcomeSocial.tsx
+++ b/src/client/pages/WelcomeSocial.tsx
@@ -23,6 +23,7 @@ import { GeoLocation } from '@/shared/model/Geolocation';
 import { registrationFormSubmitOphanTracking } from '@/client/lib/consentsTracking';
 import { RegistrationConsents } from '@/client/components/RegistrationConsents';
 import { AppName } from '@/shared/lib/appNameUtils';
+import { newsletterAdditionalTerms } from '@/shared/model/Newsletter';
 
 const inlineMessage = (socialProvider: SocialProvider) => css`
 	display: flex;
@@ -94,7 +95,7 @@ export const WelcomeSocial = ({
 					registrationFormSubmitOphanTracking(e.target as HTMLFormElement);
 					return undefined;
 				}}
-				additionalTerms="Newsletters may contain info about charities, online ads, and content funded by outside parties."
+				additionalTerms={newsletterAdditionalTerms}
 			>
 				{socialProvider === 'google' && (
 					<MainBodyText cssOverrides={inlineMessage(socialProvider)}>

--- a/src/client/pages/WelcomeSocial.tsx
+++ b/src/client/pages/WelcomeSocial.tsx
@@ -22,6 +22,7 @@ import { SocialProvider } from '@/shared/model/Social';
 import { GeoLocation } from '@/shared/model/Geolocation';
 import { registrationFormSubmitOphanTracking } from '@/client/lib/consentsTracking';
 import { RegistrationConsents } from '@/client/components/RegistrationConsents';
+import { AppName } from '@/shared/lib/appNameUtils';
 
 const inlineMessage = (socialProvider: SocialProvider) => css`
 	display: flex;
@@ -66,6 +67,7 @@ const inlineMessage = (socialProvider: SocialProvider) => css`
 export type WelcomeSocialProps = RegistrationProps & {
 	socialProvider: SocialProvider;
 	geolocation?: GeoLocation;
+	appName?: AppName;
 };
 
 export const WelcomeSocial = ({
@@ -73,6 +75,7 @@ export const WelcomeSocial = ({
 	formError,
 	socialProvider,
 	geolocation,
+	appName,
 }: WelcomeSocialProps) => {
 	const formTrackingName = 'register';
 
@@ -91,6 +94,7 @@ export const WelcomeSocial = ({
 					registrationFormSubmitOphanTracking(e.target as HTMLFormElement);
 					return undefined;
 				}}
+				additionalTerms="Newsletters may contain info about charities, online ads, and content funded by outside parties."
 			>
 				{socialProvider === 'google' && (
 					<MainBodyText cssOverrides={inlineMessage(socialProvider)}>
@@ -106,7 +110,11 @@ export const WelcomeSocial = ({
 						<SvgTickRound />
 					</MainBodyText>
 				)}
-				<RegistrationConsents geolocation={geolocation} noMarginBottom />
+				<RegistrationConsents
+					geolocation={geolocation}
+					noMarginBottom
+					appName={appName}
+				/>
 			</MainForm>
 		</MainLayout>
 	);

--- a/src/client/pages/WelcomeSocialPage.tsx
+++ b/src/client/pages/WelcomeSocialPage.tsx
@@ -20,6 +20,7 @@ export const WelcomeSocialPage = ({
 			queryParams={queryParams}
 			socialProvider={socialProvider}
 			geolocation={pageData.geolocation}
+			appName={pageData.appName}
 		/>
 	);
 };

--- a/src/server/controllers/checkPasswordToken.ts
+++ b/src/server/controllers/checkPasswordToken.ts
@@ -25,6 +25,7 @@ import { PersistableQueryParams } from '@/shared/model/QueryParams';
 import { validateReturnUrl } from '@/server/lib/validateUrl';
 import { mergeRequestState } from '@/server/lib/requestState';
 import { decryptOktaRecoveryToken } from '@/server/lib/deeplink/oktaRecoveryToken';
+import { getAppName, getAppPrefix } from '@/shared/lib/appNameUtils';
 
 const { okta, defaultReturnUri } = getConfiguration();
 
@@ -154,6 +155,9 @@ export const checkTokenInOkta = async (
 	const { token } = req.params;
 
 	try {
+		// check if the token is prefixed with an app prefix
+		const prefix = getAppPrefix(token);
+
 		// decrypt the recovery token
 		const decryptedRecoveryToken = decryptOktaRecoveryToken({
 			encryptedToken: token,
@@ -213,6 +217,12 @@ export const checkTokenInOkta = async (
 						fieldErrors,
 						formError: error,
 						token,
+						isNativeApp: prefix
+							? prefix.startsWith('a')
+								? 'android'
+								: 'ios'
+							: undefined,
+						appName: prefix ? getAppName(prefix) : undefined,
 					},
 				}),
 			},

--- a/src/server/lib/middleware/requestState.ts
+++ b/src/server/lib/middleware/requestState.ts
@@ -12,7 +12,7 @@ import Bowser from 'bowser';
 import { logger } from '@/server/lib/serverSideLogger';
 import { getApp } from '@/server/lib/okta/api/apps';
 import { IsNativeApp } from '@/shared/model/ClientState';
-import { getAppName, isAppLabel } from '@/shared/lib/appNameUtils';
+import { AppName, getAppName, isAppLabel } from '@/shared/lib/appNameUtils';
 
 const {
 	idapiBaseUrl,
@@ -53,7 +53,7 @@ const getRequestState = async (
 
 	// it is also useful to know the app name
 	// eslint-disable-next-line functional/no-let
-	let appName;
+	let appName: AppName | undefined;
 
 	try {
 		if (!!queryParams.appClientId) {

--- a/src/shared/lib/appNameUtils.ts
+++ b/src/shared/lib/appNameUtils.ts
@@ -42,7 +42,7 @@ export type AppName = 'Guardian' | 'Feast';
  * @param token	- string that may or may not have a prefix representing an native application
  * @returns	- boolean representing if the string has a prefix representing an native application
  */
-export const getAppPrefix = (token: string): string | undefined =>
+export const getAppPrefix = (token: string): AppPrefix | undefined =>
 	appPrefixes.find((prefix) => token.startsWith(prefix));
 
 export const getAppName = (

--- a/src/shared/lib/appNameUtils.ts
+++ b/src/shared/lib/appNameUtils.ts
@@ -33,6 +33,8 @@ export const isAppPrefix = isOneOf(appPrefixes);
 const appLabels = apps.map(([label]) => label);
 export const isAppLabel = isOneOf(appLabels);
 
+export type AppName = 'Guardian' | 'Feast';
+
 /**
  * @name getAppPrefix
  * @description To check and get a string has a prefix representing an native application.
@@ -45,7 +47,7 @@ export const getAppPrefix = (token: string): string | undefined =>
 
 export const getAppName = (
 	labelOrPrefix: AppLabel | AppPrefix,
-): string | undefined => {
+): AppName | undefined => {
 	switch (labelOrPrefix) {
 		case 'al_':
 		case 'android_live_app':

--- a/src/shared/model/ClientState.ts
+++ b/src/shared/model/ClientState.ts
@@ -7,6 +7,7 @@ import { Participations } from '@guardian/ab-core';
 import { ConsentPath, RoutePaths } from '@/shared/model/Routes';
 import { UserAttributesResponse } from '@/shared/lib/members-data-api';
 import { Stage } from '@/shared/model/Configuration';
+import { AppName } from '@/shared/lib/appNameUtils';
 
 export interface FieldError {
 	field: string;
@@ -36,7 +37,7 @@ export interface PageData {
 	browserName?: string;
 	isNativeApp?: IsNativeApp;
 	accountManagementUrl?: string;
-	appName?: string;
+	appName?: AppName;
 
 	// token
 	token?: string;

--- a/src/shared/model/Newsletter.ts
+++ b/src/shared/model/Newsletter.ts
@@ -49,3 +49,6 @@ export const RegistrationNewslettersFormFields = {
 			'A weekly email from Yotam Ottolenghi, Ravinder Bhogal, Felicity Cloake and Rachel Roddy, featuring the latest recipes and seasonal eating ideas',
 	},
 };
+
+export const newsletterAdditionalTerms =
+	'Newsletters may contain information about Guardian products, services and chosen charities or online advertisements.';

--- a/src/shared/model/Newsletter.ts
+++ b/src/shared/model/Newsletter.ts
@@ -25,10 +25,12 @@ export enum Newsletters {
 	THIS_IS_EUROPE = '4234',
 	// Registration Newsletter
 	SATURDAY_EDITION = '6031',
+	FEAST = '6002',
 }
 
 export const REGISTRATION_NEWSLETTERS: string[] = [
 	Newsletters.SATURDAY_EDITION,
+	Newsletters.FEAST,
 ];
 
 export const ALL_NEWSLETTER_IDS = Object.values(Newsletters);
@@ -39,5 +41,11 @@ export const RegistrationNewslettersFormFields = {
 		label: 'Saturday Edition',
 		context:
 			'An exclusive email highlighting the week’s best Guardian journalism from the editor-in-chief, Katharine Viner.',
+	},
+	feast: {
+		id: Newsletters.FEAST,
+		label: 'Feast',
+		context:
+			'A weekly email from Yotam Ottolenghi, Ravinder Bhogal, Felicity Cloake and Rachel Roddy, featuring the latest recipes and seasonal eating ideas',
 	},
 };


### PR DESCRIPTION
## What does this change?

This PR contains changes that we need to make to our sign in and registration flows to support the Feast app launch.

There are 2 changes

- Show the Feast newsletter on the email / social registration pages
  - This is in place of the Saturday Edition and marketing consent
  - Also added the missing `additionalTerms` ("Newsletter may contain...") text to the social registration page
- Hide the nav bar on the `/welcome/:token` page when setting a password, and coming from a native app
  - This has been a long standing bug also affecting the live apps

In both cases we determine if the user is coming from an app in the following ways
- If there is an `appClientId` query parameter and it matches a native app.
- If there is a `token` parameter and it's prefixed
- Using these or a combination of these we can get the `AppName` to determine this two

## Screenshots

<table>
<tr>
<th> Register with Email
<th> Social Google
<th> Social Apple
<th> Set password
<tr>
 <td>

![profile code dev-theguardian com_register_email_appClientId=0oa6xgaxgsweAnGNH0x7 returnUrl=https%3A%2F%2Fm code dev-theguardian com%2F(iPhone 12 Pro)](https://github.com/guardian/gateway/assets/13315440/0266ce4a-41d7-414b-aa53-1ef705dedb5a)

 <td>

![profile code dev-theguardian com_welcome_google_componentEventParams=componentType%3Didentityauthentication%26componentId%3Dguardian_signin_header returnUrl=https%3A%2F%2Fm code dev-theguardian com%2Fuk appClientId=0oa6xgaxgsweAnGNH0x7(iPho](https://github.com/guardian/gateway/assets/13315440/20abadfa-3205-4f43-89c0-8ea6659d1f80)

 <td>

![profile code dev-theguardian com_welcome_apple_appClientId=0oa6xgaxgsweAnGNH0x7 componentEventParams=componentType%3Didentityauthentication%26componentId%3Dguardian_signin_header returnUrl=https%3A%2F%2Fm code dev-theguardian com%2Fuk(iPhon](https://github.com/guardian/gateway/assets/13315440/47f28367-9295-40b7-8bb1-889f3d7e65b5)

 <td>

![profile code dev-theguardian com_welcome_if_cqU-lvud3INsNDBj9MI5gA oTonwQFuiJY830xZ 3y0z6Jy8RuI0yWEnr0HUnVdI9hE_ref=https%3A%2F%2Fprofile code dev-theguardian com%2Freset-password%2FXlhwFe6cbzKPxUpr7Fbw7Q Xa4HdqvtTTdqGz2y M-snWs6d9OCzWOl0Ug](https://github.com/guardian/gateway/assets/13315440/d1f6a626-f323-4a33-84d1-cb66bd8e218e)

</table>

## Tested
- [x] CODE