### PR TITLE
Feast | Update copy after marketing review

### DIFF
--- a/src/shared/model/Newsletter.ts
+++ b/src/shared/model/Newsletter.ts
@@ -46,7 +46,7 @@ export const RegistrationNewslettersFormFields = {
 		id: Newsletters.FEAST,
 		label: 'Feast',
 		context:
-			'A weekly email from Yotam Ottolenghi, Ravinder Bhogal, Felicity Cloake and Rachel Roddy, featuring the latest recipes and seasonal eating ideas',
+			'A weekly email from Yotam Ottolenghi, Meera Sodha, Felicity Cloake and Rachel Roddy, featuring the latest recipes and seasonal eating ideas.',
 	},
 };
 


### PR DESCRIPTION
## What does this change?

Change the marketing copy for the newsletter text from

`A weekly email from Yotam Ottolenghi, Ravinder Bhogal, Felicity Cloake and Rachel Roddy, featuring the latest recipes and seasonal eating ideas.`

to

`A weekly email from Yotam Ottolenghi, Meera Sodha, Felicity Cloake and Rachel Roddy, featuring the latest recipes and seasonal eating ideas.`

after marketing review.