### PR TITLE
IDAPI | Redirect to sign in after setting password

### DIFF
--- a/cypress/integration/ete/reset_password/reset_password.4.cy.ts
+++ b/cypress/integration/ete/reset_password/reset_password.4.cy.ts
@@ -47,8 +47,7 @@ describe('Password reset flow', () => {
 						cy.get('[data-cy="main-form-submit-button"]')
 							.click()
 							.should('be.disabled');
-						cy.contains('Password updated');
-						cy.contains(emailAddress.toLowerCase());
+						cy.contains('Sign in');
 					});
 				});
 		});
@@ -97,8 +96,7 @@ describe('Password reset flow', () => {
 						cy.get('input[name=password]').type(randomPassword());
 						cy.wait('@breachCheck');
 						cy.get('[data-cy="main-form-submit-button"]').click();
-						cy.contains('Password updated');
-						cy.contains(emailAddress.toLowerCase());
+						cy.contains('Sign in');
 					});
 				});
 		});

--- a/cypress/integration/mocked/change_password.3.cy.ts
+++ b/cypress/integration/mocked/change_password.3.cy.ts
@@ -164,7 +164,7 @@ describe('Password change flow', () => {
 	});
 
 	context('Valid password entered', () => {
-		it('shows password change success screen, with a default redirect button.', () => {
+		it('shows password change success screen, with a default return url', () => {
 			cy.mockNext(200);
 			cy.mockNext(200, fakeSuccessResponse);
 			cy.intercept({
@@ -178,40 +178,18 @@ describe('Password change flow', () => {
 			// Submit the button
 			cy.contains('Valid password');
 			cy.get('button[type="submit"]').click();
-			cy.contains('Password updated');
-			cy.contains('Continue to the Guardian').should(
-				'have.attr',
-				'href',
-				`${Cypress.env('DEFAULT_RETURN_URI')}/`,
+			cy.contains('Sign in');
+			cy.url().should(
+				'include',
+				`returnUrl=https%3A%2F%2Fm.code.dev-theguardian.com`,
 			);
+			cy.url().should('not.include', 'useIdapi=true');
 
 			// Not currently possible to test login cookie,
 			// Cookie is not set to domain we can access, even in cypress.
 			// e.g.
 			// cy.getCookie('GU_U')
 			//  .should('have.property', 'value', 'FAKE_VALUE_0');
-		});
-
-		it('shows password change success screen, with default redirect button, and users email', () => {
-			cy.mockNext(200, fakeValidationResponse());
-			cy.mockNext(200, fakeSuccessResponse);
-			cy.intercept({
-				method: 'GET',
-				url: 'https://api.pwnedpasswords.com/range/*',
-			}).as('breachCheck');
-			cy.visit(`/reset-password/fake_token?useIdapi=true`);
-			cy.contains(fakeValidationResponse().user.primaryEmailAddress);
-
-			cy.get('input[name="password"]').type('thisisalongandunbreachedpassword');
-			cy.wait('@breachCheck');
-			cy.get('button[type="submit"]').click();
-			cy.contains('Password updated');
-			cy.contains('Continue to the Guardian').should(
-				'have.attr',
-				'href',
-				`${Cypress.env('DEFAULT_RETURN_URI')}/`,
-			);
-			cy.contains(fakeValidationResponse().user.primaryEmailAddress);
 		});
 	});
 
@@ -233,12 +211,12 @@ describe('Password change flow', () => {
 				);
 				cy.wait('@breachCheck');
 				cy.get('button[type="submit"]').click();
-				cy.contains('Password updated');
-				cy.contains('Continue to the Guardian').should(
-					'have.attr',
-					'href',
-					'https://news.theguardian.com/',
+				cy.contains('Sign in');
+				cy.url().should(
+					'include',
+					`returnUrl=${encodeURIComponent('https://news.theguardian.com')}`,
 				);
+				cy.url().should('not.include', 'useIdapi=true');
 			});
 		},
 	);
@@ -261,12 +239,12 @@ describe('Password change flow', () => {
 				);
 				cy.wait('@breachCheck');
 				cy.get('button[type="submit"]').click();
-				cy.contains('Password updated');
-				cy.contains('Continue to the Guardian').should(
-					'have.attr',
-					'href',
-					`${Cypress.env('DEFAULT_RETURN_URI')}/`,
+				cy.contains('Sign in');
+				cy.url().should(
+					'include',
+					`returnUrl=https%3A%2F%2Fm.code.dev-theguardian.com`,
 				);
+				cy.url().should('not.include', 'useIdapi=true');
 			});
 		},
 	);

--- a/cypress/integration/mocked/set_password.5.cy.ts
+++ b/cypress/integration/mocked/set_password.5.cy.ts
@@ -158,34 +158,12 @@ describe('Password set/create flow', () => {
 			cy.get('input[name="password"]').type('thisisalongandunbreachedpassword');
 			cy.wait('@breachCheck');
 			cy.get('button[type="submit"]').click();
-			cy.contains('Password created');
-			cy.contains('Continue to the Guardian').should(
-				'have.attr',
-				'href',
-				`${Cypress.env('DEFAULT_RETURN_URI')}/`,
+			cy.contains('Sign in');
+			cy.url().should(
+				'include',
+				`returnUrl=https%3A%2F%2Fm.code.dev-theguardian.com`,
 			);
-		});
-
-		it('shows password change success screen, with default redirect button, and users email', () => {
-			cy.mockNext(200, fakeValidationRespone());
-			cy.mockNext(200, fakeSuccessResponse);
-			cy.intercept({
-				method: 'GET',
-				url: 'https://api.pwnedpasswords.com/range/*',
-			}).as('breachCheck');
-			cy.visit('/set-password/fake_token?useIdapi=true');
-			cy.contains(fakeValidationRespone().user.primaryEmailAddress);
-
-			cy.get('input[name="password"]').type('thisisalongandunbreachedpassword');
-			cy.wait('@breachCheck');
-			cy.get('button[type="submit"]').click();
-			cy.contains('Password created');
-			cy.contains('Continue to the Guardian').should(
-				'have.attr',
-				'href',
-				`${Cypress.env('DEFAULT_RETURN_URI')}/`,
-			);
-			cy.contains(fakeValidationRespone().user.primaryEmailAddress);
+			cy.url().should('not.include', 'useIdapi=true');
 		});
 	});
 
@@ -207,12 +185,12 @@ describe('Password set/create flow', () => {
 				);
 				cy.wait('@breachCheck');
 				cy.get('button[type="submit"]').click();
-				cy.contains('Password created');
-				cy.contains('Continue to the Guardian').should(
-					'have.attr',
-					'href',
-					'https://news.theguardian.com/',
+				cy.contains('Sign in');
+				cy.url().should(
+					'include',
+					`returnUrl=${encodeURIComponent('https://news.theguardian.com')}`,
 				);
+				cy.url().should('not.include', 'useIdapi=true');
 			});
 		},
 	);
@@ -235,12 +213,12 @@ describe('Password set/create flow', () => {
 				);
 				cy.wait('@breachCheck');
 				cy.get('button[type="submit"]').click();
-				cy.contains('Password created');
-				cy.contains('Continue to the Guardian').should(
-					'have.attr',
-					'href',
-					`${Cypress.env('DEFAULT_RETURN_URI')}/`,
+				cy.contains('Sign in');
+				cy.url().should(
+					'include',
+					`returnUrl=https%3A%2F%2Fm.code.dev-theguardian.com`,
 				);
+				cy.url().should('not.include', 'useIdapi=true');
 			});
 		},
 	);


### PR DESCRIPTION
## What does this change?

Support is currently using the Identity API `/guest` endpoint to create a new user. This endpoint will send the user an email saying to confirm their account and set a password. 

However this endpoint doesn't support Okta, it's still using legacy identity authentication. Now that across our website we're using Okta to authenticate the user, and not IDAPI.

So after the user sets a password they will only be given IDAPI credentials, which are no longer used, so will appear signed out.

The long term solution to this is to migrate the `/guest` endpoint to https://github.com/guardian/gatehouse, but until this happens we need an interim solution.

So for the time being, when a user sets a password using the `useIdapi` flag, we don't set any cookies, and instead redirect the user to the `/signin` page, and have them authenticate with Okta instead!

## Tested
- [x] CODE