### PR TITLE
CI | Fix Synk Action

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -14,5 +14,6 @@ jobs:
       ORG: guardian-identity
       SKIP_NODE: false
       SKIP_SBT: true
+      NODE_PACKAGE_JSON_FILES_MISSING_LOCK: ./package.json
     secrets:
       SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}


### PR DESCRIPTION
## What does this change?

Snyk doesn't support PNPM directly. So in order to get snyk to validate dependencies we need to install a `node_modules` folder when running the action.

The `NODE_PACKAGE_JSON_FILES_MISSING_LOCK` does just this. We add `package.json` to this, so that it installs the dependencies, and then snyk can check our dependencies.