### PR TITLE
Passcodes | Add email template for RegistrationPasscode

### DIFF
--- a/src/email/components/Text.tsx
+++ b/src/email/components/Text.tsx
@@ -7,12 +7,14 @@ type Props = {
 	children: React.ReactNode;
 	noPaddingBottom?: boolean;
 	cssClass?: string;
+	largeText?: boolean;
 };
 
 export const Text = ({
 	children,
 	noPaddingBottom = false,
 	cssClass,
+	largeText = false,
 }: Props) => (
 	<MjmlSection
 		background-color={background.primary}
@@ -22,7 +24,7 @@ export const Text = ({
 		<MjmlColumn>
 			<MjmlText
 				padding="0"
-				fontSize="17px"
+				fontSize={largeText ? '20px' : '17px'}
 				lineHeight="1.35"
 				letterSpacing="-0.02px"
 				fontFamily="Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif"

--- a/src/email/templates/RegistrationPasscode/RegistrationPasscode.stories.tsx
+++ b/src/email/templates/RegistrationPasscode/RegistrationPasscode.stories.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { Meta } from '@storybook/react';
+
+import { RegistrationPasscode } from './RegistrationPasscode';
+import { renderMJML } from '../../testUtils';
+
+export default {
+	title: 'Email/Templates/RegistrationPasscode',
+	component: RegistrationPasscode,
+	parameters: { layout: 'fullscreen' },
+} as Meta;
+
+export const Default = () => {
+	return renderMJML(<RegistrationPasscode />);
+};
+Default.storyName = 'with defaults';

--- a/src/email/templates/RegistrationPasscode/RegistrationPasscode.tsx
+++ b/src/email/templates/RegistrationPasscode/RegistrationPasscode.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+
+import { Mjml, MjmlBody, MjmlHead, MjmlTitle } from '@faire/mjml-react';
+import { Header } from '@/email/components/Header';
+import { SubHeader } from '@/email/components/SubHeader';
+import { Text } from '@/email/components/Text';
+import { Footer } from '@/email/components/Footer';
+
+export const RegistrationPasscode = () => {
+	return (
+		<Mjml>
+			<MjmlHead>
+				<MjmlTitle>One-time verification code | The Guardian</MjmlTitle>
+			</MjmlHead>
+			<MjmlBody width={600}>
+				<Header />
+				<SubHeader>Your verification code</SubHeader>
+				<Text>
+					Thank you for creating an account with the Guardian. Use the following
+					code to verify your email.{' '}
+				</Text>
+				<Text largeText>
+					<strong>{`\${oneTimePassword}`}</strong>
+				</Text>
+				<Text>
+					<strong>
+						Do not share this code with anyone. This code will expire in 30
+						minutes.
+					</strong>
+				</Text>
+				<Text>
+					<strong>
+						If your code has expired, create your Guardian again.{' '}
+					</strong>
+				</Text>
+				<Footer
+					mistakeParagraphComponent={
+						'If you received this email by mistake, please delete it. You won’t be registered if you don’t do anything'
+					}
+				/>
+			</MjmlBody>
+		</Mjml>
+	);
+};

--- a/src/email/templates/RegistrationPasscode/RegistrationPasscode.tsx
+++ b/src/email/templates/RegistrationPasscode/RegistrationPasscode.tsx
@@ -17,7 +17,7 @@ export const RegistrationPasscode = () => {
 				<SubHeader>Your verification code</SubHeader>
 				<Text>
 					Thank you for creating an account with the Guardian. Use the following
-					code to verify your email.{' '}
+					code to verify your email.
 				</Text>
 				<Text largeText>
 					<strong>{`\${oneTimePassword}`}</strong>
@@ -30,12 +30,12 @@ export const RegistrationPasscode = () => {
 				</Text>
 				<Text>
 					<strong>
-						If your code has expired, create your Guardian again.{' '}
+						If your code has expired, create your Guardian account again.
 					</strong>
 				</Text>
 				<Footer
 					mistakeParagraphComponent={
-						'If you received this email by mistake, please delete it. You won’t be registered if you don’t do anything'
+						'If you received this email by mistake, please delete it. You won’t be registered if you don’t do anything.'
 					}
 				/>
 			</MjmlBody>

--- a/src/email/templates/RegistrationPasscode/RegistrationPasscodeText.ts
+++ b/src/email/templates/RegistrationPasscode/RegistrationPasscodeText.ts
@@ -1,0 +1,15 @@
+import { SUPPORT_EMAIL } from '@/shared/model/Configuration';
+
+export const RegistrationPasscodeText = () => `
+Thank you for creating an account with the Guardian.
+
+Here is your Guardian Live discount code, allowing 20% off all livestreamed events:
+
+LIVEREG20
+
+Visit Guardian Live: https://www.theguardian.com/guardian-live-events
+
+If you have any queries about why you are receiving this email, please contact our customer service team at ${SUPPORT_EMAIL}
+
+Guardian News and Media Limited, Kings Place, 90 York Way, London, N1 9GU, United Kingdom
+`;

--- a/src/email/templates/RegistrationPasscode/RegistrationPasscodeText.ts
+++ b/src/email/templates/RegistrationPasscode/RegistrationPasscodeText.ts
@@ -1,15 +1,13 @@
-import { SUPPORT_EMAIL } from '@/shared/model/Configuration';
-
 export const RegistrationPasscodeText = () => `
-Thank you for creating an account with the Guardian.
+Thank you for creating an account with the Guardian. Use the following code to verify your email.
 
-Here is your Guardian Live discount code, allowing 20% off all livestreamed events:
+\${oneTimePassword}
 
-LIVEREG20
+Do not share this code with anyone. This code will expire in 30 minutes.
 
-Visit Guardian Live: https://www.theguardian.com/guardian-live-events
+If your code has expired, create your Guardian account again.
 
-If you have any queries about why you are receiving this email, please contact our customer service team at ${SUPPORT_EMAIL}
+If you received this email by mistake, please delete it. You won't be registered if you don't do anything.
 
 Guardian News and Media Limited, Kings Place, 90 York Way, London, N1 9GU, United Kingdom
 `;

--- a/src/email/templates/RegistrationPasscode/sendRegistrationPasscode.ts
+++ b/src/email/templates/RegistrationPasscode/sendRegistrationPasscode.ts
@@ -1,0 +1,25 @@
+import { render } from '@faire/mjml-react/utils/render';
+import { send } from '@/email/lib/send';
+
+import { RegistrationPasscode } from './RegistrationPasscode';
+import { RegistrationPasscodeText } from './RegistrationPasscodeText';
+
+type Props = {
+	to: string;
+	subject?: string;
+};
+
+const plainText = RegistrationPasscodeText();
+const { html } = render(RegistrationPasscode());
+
+export const sendRegistrationPasscodeEmail = ({
+	to,
+	subject = 'Your Guardian account and discount code',
+}: Props) => {
+	return send({
+		html,
+		plainText,
+		subject,
+		to,
+	});
+};

--- a/src/email/templates/renderedTemplates.ts
+++ b/src/email/templates/renderedTemplates.ts
@@ -16,6 +16,8 @@ import { CompleteRegistration } from './CompleteRegistration/CompleteRegistratio
 import { CompleteRegistrationText } from './CompleteRegistration/CompleteRegistrationText';
 
 import { render } from '@faire/mjml-react/utils/render';
+import { RegistrationPasscode } from './RegistrationPasscode/RegistrationPasscode';
+import { RegistrationPasscodeText } from './RegistrationPasscode/RegistrationPasscodeText';
 
 type EmailRenderResult = {
 	plain: string;
@@ -60,4 +62,9 @@ export const renderedUnvalidatedEmailResetPassword = {
 export const renderedCompleteRegistration = {
 	plain: CompleteRegistrationText(),
 	html: render(CompleteRegistration()).html,
+} as EmailRenderResult;
+
+export const renderedRegistrationPasscode = {
+	plain: RegistrationPasscodeText(),
+	html: render(RegistrationPasscode()).html,
 } as EmailRenderResult;

--- a/src/server/routes/emailTemplates.ts
+++ b/src/server/routes/emailTemplates.ts
@@ -2,9 +2,15 @@ import { Request } from 'express';
 import { ResponseWithRequestState } from '@/server/models/Express';
 import { rateLimitedTypedRouter as router } from '@/server/lib/typedRoutes';
 
-import { renderedAccidentalEmail } from '@/email/templates/renderedTemplates';
+import {
+	renderedAccidentalEmail,
+	renderedRegistrationPasscode,
+} from '@/email/templates/renderedTemplates';
 
-const emailTemplateTypes = ['accidental-email'] as const;
+const emailTemplateTypes = [
+	'accidental-email',
+	'registration-passcode',
+] as const;
 type EmailTemplateType = (typeof emailTemplateTypes)[number];
 
 type EmailRenderResult = {
@@ -18,6 +24,8 @@ const renderEmailTemplate = (
 	switch (template) {
 		case 'accidental-email':
 			return renderedAccidentalEmail;
+		case 'registration-passcode':
+			return renderedRegistrationPasscode;
 		default:
 			// We don't want to do anything for invalid template names
 			return undefined;


### PR DESCRIPTION
## What does this change?

Adds an email template which will be consumed by Okta for the registration via passcodes process.

The template will also be available at the `/email/registration-passcode` endpoint

## Screenshot

<table>
<tr><th> Mobile Email
<tr><td> 

![localhost_6006_iframe html_globals=viewport_MOBILE id=email-templates-registrationpasscode--default viewMode=story(iPhone 12 Pro)](https://github.com/guardian/gateway/assets/13315440/0a97ffc8-9cc3-4340-b34c-9fb668b7260a)


</table>