### PR TITLE
Wait for Identity ID to be present in access token during OAuth callback

### DIFF
--- a/src/client/pages/SignIn.tsx
+++ b/src/client/pages/SignIn.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { SignInErrors } from '@/shared/model/Errors';
+import { RegistrationErrors, SignInErrors } from '@/shared/model/Errors';
 import { QueryParams } from '@/shared/model/QueryParams';
 import { generateSignInRegisterTabs } from '@/client/components/Nav';
 import { MainLayout } from '@/client/layouts/Main';
@@ -17,6 +17,8 @@ import { divider, socialButtonDivider } from '@/client/styles/Shared';
 import { GuardianTerms, JobsTerms } from '@/client/components/Terms';
 import { MainBodyText } from '@/client/components/MainBodyText';
 import { InformationBox } from '@/client/components/InformationBox';
+import locations from '@/shared/lib/locations';
+import { SUPPORT_EMAIL } from '@/shared/model/Configuration';
 
 export type SignInProps = {
 	queryParams: QueryParams;
@@ -60,6 +62,14 @@ const getErrorContext = (error: string | undefined) => {
 			<>
 				We cannot sign you in with your social account credentials. Please enter
 				your account password below to sign in.
+			</>
+		);
+	} else if (error === RegistrationErrors.PROVISIONING_FAILURE) {
+		return (
+			<>
+				Please try signing in with your new account. If you are still having
+				trouble, please contact our customer service team at{' '}
+				<a href={locations.SUPPORT_EMAIL_MAILTO}>{SUPPORT_EMAIL}</a>
 			</>
 		);
 	}

--- a/src/server/lib/okta/oauth.ts
+++ b/src/server/lib/okta/oauth.ts
@@ -25,7 +25,8 @@ export type Scopes =
 	| 'guardian.identity-api.newsletters.read.self'
 	| 'guardian.identity-api.newsletters.update.self'
 	| 'guardian.identity-api.user.delete.self.secure'
-	| 'id_token.profile.profile';
+	| 'id_token.profile.profile'
+	| 'offline_access';
 
 /**
  * @name scopesForAuthentication
@@ -39,6 +40,8 @@ export const scopesForAuthentication: Scopes[] = [
 	'guardian.members-data-api.read.self',
 	'guardian.identity-api.newsletters.read.self',
 	'guardian.identity-api.newsletters.update.self',
+	// Required to obtain refresh tokens for the 'wait for Identity ID' loop
+	'offline_access',
 ];
 
 /**

--- a/src/server/lib/okta/openid-connect.ts
+++ b/src/server/lib/okta/openid-connect.ts
@@ -51,12 +51,13 @@ export interface AuthorizationState {
  * @property `authorizationUrl` - Generate the `/authorize` url for the Authorization Code Flow (w or w/o PKCE)
  * @property `callbackParams` - Get OpenID Connect query parameters returned to the callback (redirect_uri)
  * @property `callback` - Method used in the callback (redirect_uri) endpoint to get OAuth tokens
+ * @property `refresh` - Method used to refresh the OAuth tokens using a refresh token
  *
  */
 
-type OpenIdClient = Pick<
+export type OpenIdClient = Pick<
 	Client,
-	'authorizationUrl' | 'callbackParams' | 'callback'
+	'authorizationUrl' | 'callbackParams' | 'callback' | 'refresh'
 >;
 
 /**

--- a/src/server/models/Metrics.ts
+++ b/src/server/models/Metrics.ts
@@ -79,6 +79,7 @@ type UnconditionalMetrics =
 	| 'LoginMiddlewareOAuth::OAuthTokensValid'
 	| 'LoginMiddlewareOAuth::SignedOutCookie'
 	| 'LoginMiddlewareOAuth::UseIdapi'
+	| 'OAuthAuthorization::ProvisioningFailure'
 	| 'OktaIDX::UnexpectedVersion'
 	| 'OktaIDXSocialSignIn::Redirect'
 	| 'OktaIDXSocialSignIn::Failure'

--- a/src/server/models/okta/User.ts
+++ b/src/server/models/okta/User.ts
@@ -25,6 +25,7 @@ const userProfileSchema = z.object({
 	isJobsUser: z.boolean().nullable().optional(),
 	firstName: z.string().nullable().optional(),
 	lastName: z.string().nullable().optional(),
+	legacyIdentityId: z.string().nullable().optional(),
 });
 
 // https://developer.okta.com/docs/reference/api/users/#password-object
@@ -57,6 +58,7 @@ export const userResponseSchema = z.object({
 		isJobsUser: true,
 		registrationLocation: true,
 		registrationPlatform: true,
+		legacyIdentityId: true,
 	}),
 	credentials: userCredentialsSchema,
 });

--- a/src/server/routes/signIn.ts
+++ b/src/server/routes/signIn.ts
@@ -12,6 +12,7 @@ import { decrypt } from '@/server/lib/idapi/decryptToken';
 import {
 	FederationErrors,
 	GenericErrors,
+	RegistrationErrors,
 	SignInErrors,
 } from '@/shared/model/Errors';
 import { ApiError } from '@/server/models/Error';
@@ -69,6 +70,10 @@ export const getErrorMessageFromQueryParams = (
 	// show error if account linking required
 	if (error === FederationErrors.SOCIAL_SIGNIN_BLOCKED) {
 		return SignInErrors.ACCOUNT_ALREADY_EXISTS;
+	}
+	// Show error if provisioning failed
+	if (error === RegistrationErrors.PROVISIONING_FAILURE) {
+		return error;
 	}
 	// TODO: we're propagating a generic error message for now until we know what we're doing with the error_description parameter
 	if (error_description) {

--- a/src/shared/model/Errors.ts
+++ b/src/shared/model/Errors.ts
@@ -34,6 +34,7 @@ export enum SignInErrors {
 export enum RegistrationErrors {
 	GENERIC = 'There was a problem registering, please try again.',
 	EMAIL_INVALID = 'Please enter a valid email address.',
+	PROVISIONING_FAILURE = 'Your account has been created but there was a problem signing you in.',
 }
 
 // shown at the top of the change password page when something goes wrong


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

In the Gateway authentication callback handler (used for sign in/registration OAuth callbacks), we need the access token to include the `legacy_identity_id` claim (the IDAPI ID). This is so we can call an IDAPI endpoint to create a Braze user record for newly created users who have not already had a Braze record created by virtue of signing up for a newsletter, a behaviour added in [this PR](https://github.com/guardian/gateway/pull/2627).

These users fall into two groups: (1) users who signed up via email and password, but opted out of the Saturday Edition registration newsletter; (2) all users who signed up via Google/Apple, who don't sign up for the Saturday Edition newsletter until _after_ they've been through the social authentication flow.

This is a simplified diagram of the existing registration flow:

```mermaid
sequenceDiagram
    App->>Gateway: Begin register
    Gateway->>Okta: Register new user
    Okta->>+IDAPI: Event hook to create IDAPI user
    Okta->>Gateway: Redirect to OAuth callback endpoint
    Gateway->>Okta: Exchange authorization code for OAuth tokens
    Okta->>Gateway: Return access token without IDAPI ID
    Note over Gateway: Complete callback flow, causing errors
    IDAPI->>-Okta: Update Okta user with IDAPI ID
    Note over Okta: Okta now has the IDAPI ID
```

As can be seen here, when the 'app' begins a registration journey, two things happen: (1) Okta calls IDAPI to create a new IDAPI user and then tell Okta what the new IDAPI ID is; (2) Okta calls the Gateway callback endpoint to complete the OAuth flow. Especially in the case of social registration, (1) can take longer than (2). In these cases, when Gateway asks Okta for an access token, Okta sends back an access token missing the `legacy_identity_id` claim. This access token is unusable by IDAPI because it doesn't know what to do with it - you can't link an IDAPI ID to a Braze record if you don't know the IDAPI ID! As a result, we've been seeing a lot of errors in the Gateway and IDAPI logs which show failures in the Braze provisioning process.

As a secondary effect, if the callback operation happens too quickly, the next step of the process, not shown here, may also fail. For apps in particular, once the web view closes, the Okta SDK calls Okta for a user info package which contains the IDAPI ID, the Braze ID, and access and ID tokens, among other data. If _this_ operation happens before IDAPI has updated Okta, it will _also_ return unusable data.

For this reason, we need to wait in the callback endpoint handler until the IDAPI operation completes and the Okta user is updated before we can proceed. The logic broadly is:

1. Check if the original access token is missing the `legacy_identity_id` claim.
2. If it is, use the refresh token we also got from the callback to get a new access token, and check that.
3. Once the claim is present, pass the new access token along and proceed with the rest of the callback logic.
4. If the claim is not present after a timeout, return an error to the user.

### New flow

```mermaid
sequenceDiagram
    App->>Gateway: Begin register
    Gateway->>Okta: Register new user
    Okta->>+IDAPI: Event hook to create IDAPI user
    Okta->>Gateway: Redirect to OAuth callback endpoint
    Gateway->>Okta: Exchange authorization code for OAuth tokens
    Okta->>Gateway: Return refresh token + access token without IDAPI ID
    loop Until access token contains IDAPI ID, or 30s timeout
        Gateway->>Okta: Exchange refresh token for OAuth tokens
        alt New access token has IDAPI ID
            IDAPI->>-Okta: Update Okta user with IDAPI ID
            Note over Okta: Okta now has the IDAPI ID
            Okta->>Gateway: Return refresh token + new access token
            Note over Gateway: Complete callback flow
        else New access token missing IDAPI ID
            Okta->>Gateway: Return refresh token + new access token
            Note over Gateway: Keep looping
        end
    end
    Note over Gateway: Timeout, redirect to /signin with error message
```

### Edge case notes

**Given** I am a social registration user
**When** my `legacy_identity_id` fetch times out (because Okta never called IDAPI, or IDAPI never updated Okta for some reason)
**Then** I am sent back to `/reauthenticate`.
**Given** I try to sign in again
**When** my Okta profile has been fixed
**Then** I will have my Braze account created and be shown the `/welcome/social` screen, where I can set my registration newsletter consents.

**Given** I am an email and password registration user
**When** my `legacy_identity_id` fetch times out (because Okta never called IDAPI, or IDAPI never updated Okta for some reason)
**Then** I am sent back to `/reauthenticate`.
**Given** I try to sign in again
**When** my Okta profile has been fixed
**Then** I will have my Braze account created. Any consents I set on the email/password screen will be lost - by default, I'll be registered for Saturday Edition.

## Testing

- [x] Registration - Email
- [x] Registration - Google
- [x] Registration - Apple
- [x] Reset password
- [x] Delete account
