### PR TITLE
Fix Cypress tests to work with new CMP banner

### DIFF
--- a/cypress/support/commands/manageCmp.ts
+++ b/cypress/support/commands/manageCmp.ts
@@ -27,23 +27,10 @@ const cmpIframe = () => {
 		.then(cy.wrap);
 };
 
-const privacySettingsIframe = () => {
-	return cy
-		.get('[src*="https://cdn.privacy-mgmt.com/privacy-manager"]')
-		.its('0.contentDocument.body')
-		.should('not.be.empty')
-		.then(cy.wrap);
-};
-
 export const acceptCMP = () => {
 	cmpIframe().find("[title='Yes, I’m happy']").click().wait(2000);
 };
 
 export const declineCMP = () => {
-	cmpIframe().find("[title='Manage or reject cookies']").click();
-	privacySettingsIframe().contains('Privacy settings');
-	privacySettingsIframe()
-		.find("[title='Reject all']", { timeout: 2000 })
-		.click()
-		.wait(2000);
+	cmpIframe().find("[title='No, thank you']").click().wait(2000);
 };


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Recent changes to the CMP banner (namely the addition of a 'No thank you' reject all button) have broken some of our Cypress tests. This updates the tests to work with the new banner layout.