### PR TITLE
Recaptcha | Always show detailed recaptcha message and update copy

### DIFF
--- a/cypress/integration/ete/registration/register.2.cy.ts
+++ b/cypress/integration/ete/registration/register.2.cy.ts
@@ -274,26 +274,11 @@ describe('Registration flow', () => {
 		cy.interceptRecaptcha();
 
 		cy.get('input[name=email').type(unregisteredEmail);
-		cy.get('[data-cy="main-form-submit-button"]').click();
-		cy.contains('Google reCAPTCHA verification failed. Please try again.');
-
-		// On second click, an expanded error is shown.
-		cy.get('[data-cy="main-form-submit-button"]').click();
-
-		cy.contains('Google reCAPTCHA verification failed.');
-		cy.contains('Report this error').should(
-			'have.attr',
-			'href',
-			'https://manage.theguardian.com/help-centre/contact-us',
-		);
-		cy.contains('If the problem persists please try the following:');
 
 		const timeRequestWasMade = new Date();
 		cy.get('[data-cy="main-form-submit-button"]').click();
 
-		cy.contains(
-			'Google reCAPTCHA verification failed. Please try again.',
-		).should('not.exist');
+		cy.contains('Google reCAPTCHA verification failed.').should('not.exist');
 
 		cy.contains('Check your email inbox');
 		cy.contains(unregisteredEmail);

--- a/cypress/integration/ete/registration/register_email_sent.3.cy.ts
+++ b/cypress/integration/ete/registration/register_email_sent.3.cy.ts
@@ -1,6 +1,5 @@
 import { injectAndCheckAxe } from '../../../support/cypress-axe';
 import { randomMailosaurEmail } from '../../../support/commands/testUser';
-import { SUPPORT_EMAIL } from '../../../../src/shared/model/Configuration';
 
 describe('Registration email sent page', () => {
 	context('A11y checks', () => {
@@ -175,21 +174,15 @@ describe('Registration email sent page', () => {
 				cy.interceptRecaptcha();
 
 				cy.contains('send again').click();
-				cy.contains('Google reCAPTCHA verification failed. Please try again.');
-
-				// On second click, an expanded error is shown.
-				cy.contains('send again').click();
-
 				cy.contains('Google reCAPTCHA verification failed.');
 				cy.contains('If the problem persists please try the following:');
-				cy.contains(SUPPORT_EMAIL);
 
 				const timeRequestWasMade = new Date();
 				cy.contains('send again').click();
 
-				cy.contains(
-					'Google reCAPTCHA verification failed. Please try again.',
-				).should('not.exist');
+				cy.contains('Google reCAPTCHA verification failed.').should(
+					'not.exist',
+				);
 
 				cy.contains('Check your email inbox');
 				cy.contains(emailAddress);

--- a/cypress/integration/ete/reset_password/reset_password.4.cy.ts
+++ b/cypress/integration/ete/reset_password/reset_password.4.cy.ts
@@ -1,4 +1,3 @@
-import { SUPPORT_EMAIL } from '../../../../src/shared/model/Configuration';
 import { randomPassword } from '../../../support/commands/testUser';
 
 describe('Password reset flow', () => {
@@ -25,13 +24,8 @@ describe('Password reset flow', () => {
 
 					// Check that both reCAPTCHA errors are shown.
 					cy.get('[data-cy="main-form-submit-button"]').click();
-					cy.contains(
-						'Google reCAPTCHA verification failed. Please try again.',
-					);
-					cy.get('[data-cy="main-form-submit-button"]').click();
 					cy.contains('Google reCAPTCHA verification failed.');
 					cy.contains('If the problem persists please try the following:');
-					cy.contains(SUPPORT_EMAIL);
 
 					// Continue checking the password reset flow after reCAPTCHA assertions above.
 					cy.get('[data-cy="main-form-submit-button"]').click();
@@ -76,13 +70,8 @@ describe('Password reset flow', () => {
 
 					// Check that both reCAPTCHA errors are shown.
 					cy.get('[data-cy="main-form-submit-button"]').click();
-					cy.contains(
-						'Google reCAPTCHA verification failed. Please try again.',
-					);
-					cy.get('[data-cy="main-form-submit-button"]').click();
 					cy.contains('Google reCAPTCHA verification failed.');
 					cy.contains('If the problem persists please try the following:');
-					cy.contains(SUPPORT_EMAIL);
 
 					// Continue checking the password reset flow after reCAPTCHA assertions above.
 					cy.get('[data-cy="main-form-submit-button"]').click();
@@ -133,14 +122,8 @@ describe('Password set flow', () => {
 
 					// Check that both reCAPTCHA errors are shown.
 					cy.contains('Send me a link').click();
-					cy.contains(
-						'Google reCAPTCHA verification failed. Please try again.',
-					);
-
-					cy.contains('Send me a link').click();
 					cy.contains('Google reCAPTCHA verification failed.');
 					cy.contains('If the problem persists please try the following:');
-					cy.contains(SUPPORT_EMAIL);
 
 					// Continue checking the password reset flow after reCAPTCHA assertions above.
 					cy.contains('Send me a link').click();

--- a/cypress/integration/mocked/register.6.cy.ts
+++ b/cypress/integration/mocked/register.6.cy.ts
@@ -66,35 +66,8 @@ describe('Registration flow', () => {
 				statusCode: 500,
 			});
 			cy.get('[data-cy=main-form-submit-button]').click();
-			cy.contains('Google reCAPTCHA verification failed. Please try again.');
-		});
-
-		it('shows detailed recaptcha error message when reCAPTCHA token request fails two times', () => {
-			// Intercept "Report this error" link because we just check it is linked to.
-			cy.intercept(
-				'GET',
-				'https://manage.theguardian.com/help-centre/contact-us',
-				{
-					statusCode: 200,
-				},
-			);
-			cy.visit(
-				'/register/email?returnUrl=https%3A%2F%2Fwww.theguardian.com%2Fabout&useIdapi=true',
-			);
-			cy.get('input[name="email"]').type('placeholder@example.com');
-			cy.intercept('POST', 'https://www.google.com/recaptcha/api2/**', {
-				statusCode: 500,
-			});
-			cy.get('[data-cy=main-form-submit-button]').click();
-			cy.contains('Google reCAPTCHA verification failed. Please try again.');
-			cy.get('[data-cy=main-form-submit-button]').click();
 			cy.contains('Google reCAPTCHA verification failed.');
 			cy.contains('If the problem persists please try the following:');
-			cy.contains('Report this error').click();
-			cy.url().should(
-				'eq',
-				'https://manage.theguardian.com/help-centre/contact-us',
-			);
 		});
 
 		it('redirects to email sent page upon successful guest registration', () => {

--- a/cypress/integration/mocked/reset_password.5.cy.ts
+++ b/cypress/integration/mocked/reset_password.5.cy.ts
@@ -1,4 +1,3 @@
-import { SUPPORT_EMAIL } from '../../../src/shared/model/Configuration';
 import { injectAndCheckAxe } from '../../support/cypress-axe';
 import PageResetPassword from '../../support/pages/reset_password_page';
 
@@ -73,21 +72,8 @@ describe('Password reset flow', () => {
 			});
 			const { email } = this.users.emailNotRegistered;
 			page.submitEmailAddress(email);
-			cy.contains('Google reCAPTCHA verification failed. Please try again.');
-		});
-
-		it('shows detailed recaptcha error message when reCAPTCHA token request fails two times', function () {
-			cy.intercept('POST', 'https://www.google.com/recaptcha/api2/**', {
-				statusCode: 500,
-			});
-			const { email } = this.users.emailNotRegistered;
-			page.submitEmailAddress(email);
-			cy.contains('Google reCAPTCHA verification failed. Please try again.');
-			page.emailAddressField().clear();
-			page.submitEmailAddress(email);
 			cy.contains('Google reCAPTCHA verification failed.');
 			cy.contains('If the problem persists please try the following:');
-			cy.contains(SUPPORT_EMAIL);
 		});
 	});
 });

--- a/cypress/integration/mocked/set_password.5.cy.ts
+++ b/cypress/integration/mocked/set_password.5.cy.ts
@@ -1,6 +1,5 @@
 /// <reference types="cypress" />
 
-import { SUPPORT_EMAIL } from '../../../src/shared/model/Configuration';
 import { injectAndCheckAxe } from '../../support/cypress-axe';
 
 describe('Password set/create flow', () => {
@@ -123,11 +122,8 @@ describe('Password set/create flow', () => {
 				statusCode: 500,
 			});
 			cy.get('button[type="submit"]').click();
-			cy.contains('Google reCAPTCHA verification failed. Please try again.');
-			cy.get('button[type="submit"]').click();
 			cy.contains('Google reCAPTCHA verification failed.');
 			cy.contains('If the problem persists please try the following:');
-			cy.contains(SUPPORT_EMAIL);
 		});
 
 		it('shows the session time out page if the token expires while on the set password page', () => {

--- a/cypress/integration/mocked/sign_in.2.cy.ts
+++ b/cypress/integration/mocked/sign_in.2.cy.ts
@@ -112,19 +112,6 @@ describe('Sign in flow', () => {
 		});
 
 		it('shows recaptcha error message when reCAPTCHA token request fails', () => {
-			cy.visit(
-				'/signin?returnUrl=https%3A%2F%2Fwww.theguardian.com%2Fabout&useIdapi=true',
-			);
-			cy.get('input[name="email"]').type('placeholder@example.com');
-			cy.get('input[name="password"]').type('definitelynotarealpassword');
-			cy.intercept('POST', 'https://www.google.com/recaptcha/api2/**', {
-				statusCode: 500,
-			});
-			cy.get('[data-cy=main-form-submit-button]').click();
-			cy.contains('Google reCAPTCHA verification failed. Please try again.');
-		});
-
-		it('shows detailed recaptcha error message when reCAPTCHA token request fails two times', () => {
 			// Intercept "Report this error" link because we just check it is linked to.
 			cy.intercept(
 				'GET',
@@ -142,15 +129,8 @@ describe('Sign in flow', () => {
 				statusCode: 500,
 			});
 			cy.get('[data-cy=main-form-submit-button]').click();
-			cy.contains('Google reCAPTCHA verification failed. Please try again.');
-			cy.get('[data-cy=main-form-submit-button]').click();
 			cy.contains('Google reCAPTCHA verification failed.');
 			cy.contains('If the problem persists please try the following:');
-			cy.contains('Report this error').click();
-			cy.url().should(
-				'eq',
-				'https://manage.theguardian.com/help-centre/contact-us',
-			);
 		});
 
 		it('redirects to homepage when user with existing valid session visits signin page', () => {

--- a/cypress/integration/mocked/verify_email.4.cy.ts
+++ b/cypress/integration/mocked/verify_email.4.cy.ts
@@ -1,5 +1,4 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
-import { SUPPORT_EMAIL } from '../../../src/shared/model/Configuration';
 import { injectAndCheckAxe } from '../../support/cypress-axe';
 import { authRedirectSignInRecentlyEmailValidated } from '../../support/idapi/auth';
 import { CONSENTS_ENDPOINT, allConsents } from '../../support/idapi/consent';
@@ -314,13 +313,8 @@ describe('Verify email flow', () => {
 			});
 
 			cy.contains(VerifyEmail.CONTENT.SEND_LINK).click();
-			cy.contains('Google reCAPTCHA verification failed. Please try again.');
-
-			// show extended reCaptcha message on the second failure
-			cy.contains(VerifyEmail.CONTENT.SEND_LINK).click();
 			cy.contains('Google reCAPTCHA verification failed.');
 			cy.contains('If the problem persists please try the following:');
-			cy.contains(SUPPORT_EMAIL);
 		});
 	});
 });

--- a/cypress/integration/mocked/welcome.4.cy.ts
+++ b/cypress/integration/mocked/welcome.4.cy.ts
@@ -1,4 +1,3 @@
-import { SUPPORT_EMAIL } from '../../../src/shared/model/Configuration';
 import { injectAndCheckAxe } from '../../support/cypress-axe';
 
 describe('Welcome and set password page', () => {
@@ -165,11 +164,8 @@ describe('Welcome and set password page', () => {
 				statusCode: 500,
 			});
 			cy.get('button[type="submit"]').click();
-			cy.contains('Google reCAPTCHA verification failed. Please try again.');
-			cy.get('button[type="submit"]').click();
 			cy.contains('Google reCAPTCHA verification failed.');
 			cy.contains('If the problem persists please try the following:');
-			cy.contains(SUPPORT_EMAIL);
 		});
 
 		it('takes user back to link expired page if "try another address" clicked', () => {

--- a/cypress/integration/shared/sign_in.shared.ts
+++ b/cypress/integration/shared/sign_in.shared.ts
@@ -413,26 +413,15 @@ export const showsRecaptchaErrorsWhenTheUserTriesToSignInOfflineAndAllowsSignInW
 						cy.get('input[name=email]').type(emailAddress);
 						cy.get('input[name=password]').type(finalPassword);
 						cy.get('[data-cy="main-form-submit-button"]').click();
-						cy.contains(
-							'Google reCAPTCHA verification failed. Please try again.',
-						);
-
-						// On second click, an expanded error is shown.
-						cy.get('[data-cy="main-form-submit-button"]').click();
 
 						cy.contains('Google reCAPTCHA verification failed.');
-						cy.contains('Report this error').should(
-							'have.attr',
-							'href',
-							'https://manage.theguardian.com/help-centre/contact-us',
-						);
 						cy.contains('If the problem persists please try the following:');
 
 						cy.get('[data-cy="main-form-submit-button"]').click();
 
-						cy.contains(
-							'Google reCAPTCHA verification failed. Please try again.',
-						).should('not.exist');
+						cy.contains('Google reCAPTCHA verification failed.').should(
+							'not.exist',
+						);
 
 						cy.url().should('include', 'https://m.code.dev-theguardian.com/');
 					});

--- a/src/client/__tests__/MainForm.test.tsx
+++ b/src/client/__tests__/MainForm.test.tsx
@@ -80,7 +80,7 @@ test('calls method to set an error message when reCAPTCHA does not load correctl
 	});
 	await waitFor(() => {
 		expect(setRecaptchaErrorMessage).toHaveBeenCalledWith(
-			'Google reCAPTCHA verification failed. Please try again.',
+			'Google reCAPTCHA verification failed.',
 		);
 	});
 });
@@ -227,9 +227,12 @@ test('sets error message and context and prevents form submission when the reCAP
 
 		expect(setRecaptchaErrorMessage).toBeCalledTimes(1);
 		expect(setRecaptchaErrorMessage).toHaveBeenCalledWith(
-			'Google reCAPTCHA verification failed. Please try again.',
+			'Google reCAPTCHA verification failed.',
 		);
-		expect(setRecaptchaErrorContext).not.toBeCalled();
+		expect(setRecaptchaErrorContext).toBeCalledTimes(1);
+		expect(setRecaptchaErrorContext).toHaveBeenCalledWith(
+			expect.objectContaining({ type: DetailedRecaptchaError }),
+		);
 	});
 
 	void act(() => {
@@ -248,7 +251,7 @@ test('sets error message and context and prevents form submission when the reCAP
 		expect(setRecaptchaErrorMessage).toHaveBeenCalledWith(
 			'Google reCAPTCHA verification failed.',
 		);
-		expect(setRecaptchaErrorContext).toBeCalledTimes(1);
+		expect(setRecaptchaErrorContext).toBeCalledTimes(2);
 		expect(setRecaptchaErrorContext).toHaveBeenCalledWith(
 			expect.objectContaining({ type: DetailedRecaptchaError }),
 		);

--- a/src/client/components/DetailedRecaptchaError.tsx
+++ b/src/client/components/DetailedRecaptchaError.tsx
@@ -10,8 +10,9 @@ export const DetailedRecaptchaError = () => (
 			If the problem persists please try the following:
 		</p>
 		<ul css={errorContextSpacing}>
-			<li>Disable your browser plugins</li>
 			<li>Ensure that JavaScript is enabled</li>
+			<li>Temporarily disable VPNs and content blockers</li>
+			<li>Disable your browser plugins</li>
 			<li>Update your browser</li>
 		</ul>
 		<p css={[errorContextSpacing, { marginBottom: `${space[3]}px` }]}>

--- a/src/client/components/MainForm.tsx
+++ b/src/client/components/MainForm.tsx
@@ -26,7 +26,6 @@ import { RefTrackingFormFields } from '@/client/components/RefTrackingFormFields
 import { trackFormFocusBlur, trackFormSubmit } from '@/client/lib/ophan';
 import { logger } from '@/client/lib/clientSideLogger';
 import { ErrorSummary } from '@guardian/source-react-components-development-kitchen';
-import locations from '@/shared/lib/locations';
 import {
 	InformationBox,
 	InformationBoxText,
@@ -147,7 +146,6 @@ export const MainForm = ({
 	const [isFormDisabled, setIsFormDisabled] = useState(false);
 
 	const formLevelErrorMargin = !!formLevelErrorMessage;
-	const showFormLevelReportUrl = !!formLevelErrorContext;
 
 	/**
 	 * Executes the reCAPTCHA check and form submit tracking.
@@ -230,20 +228,14 @@ export const MainForm = ({
 				logger.info('reCAPTCHA check failed');
 			}
 
-			// Used to show a more detailed reCAPTCHA error if
-			// the user has requested a check more than once.
-			const showErrorContext =
-				recaptchaCheckFailed && recaptchaState?.requestCount > 1;
+			// Used to show a more detailed reCAPTCHA error
+			const showErrorContext = recaptchaCheckFailed;
 
 			// Default to generic reCAPTCHA error message.
 			// Show the retry message if the user has requested a check more than once.
-			const recaptchaErrorMessage = showErrorContext
-				? CaptchaErrors.RETRY
-				: CaptchaErrors.GENERIC;
+			const recaptchaErrorMessage = CaptchaErrors.GENERIC;
 
-			const recaptchaErrorContext = showErrorContext ? (
-				<DetailedRecaptchaError />
-			) : undefined;
+			const recaptchaErrorContext = <DetailedRecaptchaError />;
 
 			// Don't show the reCAPTCHA error if the key is set to 'test'
 			const isTestKey = recaptchaSiteKey === 'test';
@@ -301,9 +293,6 @@ export const MainForm = ({
 					cssOverrides={summaryStyles(formLevelErrorMargin)}
 					message={errorMessage}
 					context={errorContext}
-					errorReportUrl={
-						showFormLevelReportUrl ? locations.REPORT_ISSUE : undefined
-					}
 				/>
 			)}
 			{recaptchaEnabled && (

--- a/src/shared/model/Errors.ts
+++ b/src/shared/model/Errors.ts
@@ -84,8 +84,7 @@ export enum CsrfErrors {
 }
 
 export enum CaptchaErrors {
-	GENERIC = 'Google reCAPTCHA verification failed. Please try again.',
-	RETRY = 'Google reCAPTCHA verification failed.',
+	GENERIC = 'Google reCAPTCHA verification failed.',
 }
 
 export enum RateLimitErrors {


### PR DESCRIPTION
## What does this change?

Always show the detailed recaptcha message on a recaptcha related error. This gives additional context to help the user why they are in this scenario. We also update the message to include "Temporarily disable VPNs and content blockers" which we find can block recaptcha.

Since we were previously showing this error message when this error occurred more than once on the same page, we've now changed this to always show the detailed message.

![localhost_6006_iframe html_args= globals=viewport_MOBILE id=pages-signin--invalid-recaptcha viewMode=story(iPhone 12 Pro)](https://github.com/guardian/gateway/assets/13315440/007ffc56-e178-4334-bd71-d366257d6eab)

## Tested

- [x] CODE