### PR TITLE
Feast | Set up Android Feast App links within Gateway

### DIFF
--- a/cypress/integration/ete-okta/registration_newsletter.5.cy.ts
+++ b/cypress/integration/ete-okta/registration_newsletter.5.cy.ts
@@ -135,8 +135,30 @@ describe('Saturday Edition Geolocation', () => {
 });
 
 describe('Feast newsletter for Feast app', () => {
-	it('should show the Feast newsletter if coming from feast', () => {
+	it('should show the Feast newsletter if coming from feast ios', () => {
 		cy.oktaGetApps('ios_feast_app').then(([app]) => {
+			cy.visit(`/register/email?appClientId=${app.id}`);
+			cy.contains('Feast newsletter').should('exist');
+
+			cy.createTestUser({
+				isUserEmailValidated: true,
+			}).then(({ emailAddress, finalPassword }) => {
+				cy.visit(
+					`/signin?returnUrl=${encodeURIComponent(
+						`https://${Cypress.env('BASE_URI')}/welcome/google?appClientId=${app.id}`,
+					)}`,
+				);
+				cy.get('input[name=email]').type(emailAddress);
+				cy.get('input[name=password]').type(finalPassword);
+				cy.get('[data-cy="main-form-submit-button"]').click();
+				cy.url().should('include', '/welcome/google');
+				cy.contains('Feast newsletter').should('exist');
+			});
+		});
+	});
+
+	it('should show the Feast newsletter if coming from feast android', () => {
+		cy.oktaGetApps('android_feast_app').then(([app]) => {
 			cy.visit(`/register/email?appClientId=${app.id}`);
 			cy.contains('Feast newsletter').should('exist');
 

--- a/cypress/integration/mocked/okta_sign_in.6.cy.ts
+++ b/cypress/integration/mocked/okta_sign_in.6.cy.ts
@@ -112,7 +112,7 @@ describe('Sign in flow', () => {
 			cy.contains('Sign in with a different email');
 		});
 
-		it('loads the "signed in as" page if user is already authenticated and coming from native app and oauth flow - feast app', function () {
+		it('loads the "signed in as" page if user is already authenticated and coming from native app and oauth flow - feast app ios', function () {
 			cy.mockPattern(
 				200,
 				{
@@ -139,6 +139,69 @@ describe('Sign in flow', () => {
 				{
 					id: '456',
 					label: 'ios_feast_app',
+					settings: {
+						oauthClient: {
+							redirect_uris: [],
+						},
+					},
+				},
+				'/api/v1/apps/456',
+			);
+
+			cy.setCookie('idx', `the_idx_cookie`);
+
+			// disable the cmp  on the redirect
+			cy.disableCMP();
+
+			cy.visit(
+				'/signin?appClientId=456&fromURI=/fromURI=/oauth2/v1/authorize/redirect?okta_key=oktaKey',
+			);
+
+			cy.contains('Sign in to the Feast app');
+			cy.contains('You are signed in with');
+			cy.contains('user@example.com');
+			cy.contains('Continue')
+				.should('have.attr', 'href')
+				.and(
+					'include',
+					'/fromURI=/oauth2/v1/authorize/redirect?okta_key=oktaKey',
+				);
+			cy.contains('a', 'Sign in')
+				.should('have.attr', 'href')
+				.and(
+					'include',
+					'/signout?returnUrl=https%253A%252F%252Fprofile.thegulocal.com%252Fsignin%253FappClientId%253D456%2526fromURI%253D%25252FfromURI%25253D%25252Foauth2%25252Fv1%25252Fauthorize%25252Fredirect%25253Fokta_key%25253DoktaKey%2526returnUrl%253Dhttps%25253A%25252F%25252Fm.code.dev-theguardian.com',
+				);
+			cy.contains('Sign in with a different email');
+		});
+
+		it('loads the "signed in as" page if user is already authenticated and coming from native app and oauth flow - feast app android', function () {
+			cy.mockPattern(
+				200,
+				{
+					id: 'test',
+					login: 'user@example.com',
+					userId: 'userId',
+					status: 'ACTIVE',
+					expiresAt: '2016-01-03T09:13:17.000Z',
+					lastPasswordVerification: '2016-01-03T07:02:00.000Z',
+					lastFactorVerification: null,
+					amr: ['pwd'],
+					idp: {
+						id: '01a2bcdef3GHIJKLMNOP',
+						type: 'OKTA',
+					},
+				},
+				'/api/v1/sessions/me',
+			);
+
+			cy.mockPattern(204, {}, '/api/v1/users/userId/sessions');
+
+			cy.mockPattern(
+				200,
+				{
+					id: '456',
+					label: 'android_feast_app',
 					settings: {
 						oauthClient: {
 							redirect_uris: [],

--- a/scripts/okta/__tests__/removePrefixFromToken.test.ts
+++ b/scripts/okta/__tests__/removePrefixFromToken.test.ts
@@ -17,6 +17,10 @@ describe('removePrefixFromToken', () => {
 		expect(removePrefixFromToken('if_test')).toEqual('test');
 	});
 
+	it('should return token without prefix if prefix is passed - af_', () => {
+		expect(removePrefixFromToken('af_test')).toEqual('test');
+	});
+
 	it('should return undefined if no token is passed', () => {
 		expect(removePrefixFromToken('')).toBeUndefined();
 		expect(removePrefixFromToken(undefined)).toBeUndefined();

--- a/scripts/okta/lib/helper.ts
+++ b/scripts/okta/lib/helper.ts
@@ -176,7 +176,7 @@ export const removePrefixFromToken = (
 		return undefined;
 	}
 
-	const prefix = ['al_', 'il_', 'if_'].find((prefix) =>
+	const prefix = ['al_', 'il_', 'af_', 'if_'].find((prefix) =>
 		token.startsWith(prefix),
 	);
 

--- a/src/shared/lib/appNameUtils.ts
+++ b/src/shared/lib/appNameUtils.ts
@@ -20,6 +20,7 @@ import { isOneOf } from '@guardian/libs';
 export const apps = [
 	['android_live_app', 'al_'],
 	['ios_live_app', 'il_'],
+	['android_feast_app', 'af_'],
 	['ios_feast_app', 'if_'],
 ] as const;
 
@@ -54,6 +55,8 @@ export const getAppName = (
 		case 'il_':
 		case 'ios_live_app':
 			return 'Guardian';
+		case 'af_':
+		case 'android_feast_app':
 		case 'if_':
 		case 'ios_feast_app':
 			return 'Feast';


### PR DESCRIPTION
## What does this change?

This updates gateway to make sure to add the new app prefix for the Android feast app (`af_`) and make sure that it's correctly decrypted too.

Gateway will already be aware that Feast is an iOS app due to this line as the label within Okta will be `android_feast_app`: https://github.com/guardian/gateway/blob/main/src/server/lib/middleware/requestState.ts#L61. In the future, especially if we're going to be serving different experiences to different apps, we may have to extend this functionality to use the app name instead.

Based on iOS equivalent: Feast | Set up iOS Feast App links within gateway