### PR TITLE
OAuth | Fix authentication handler delay issues

### DIFF
--- a/cypress/support/commands/testUser.ts
+++ b/cypress/support/commands/testUser.ts
@@ -66,6 +66,7 @@ interface OktaUserProfile {
 	isJobsUser?: boolean;
 	firstName?: string;
 	lastName?: string;
+	legacyIdentityId?: string | null;
 }
 
 type IDAPITestUserResponse = [

--- a/src/server/lib/okta/fixProfile.ts
+++ b/src/server/lib/okta/fixProfile.ts
@@ -1,6 +1,7 @@
 import { logger } from '@/server/lib/serverSideLogger';
 import { getUserByEmailAddress } from '@/server/lib/idapi/user';
 import { getUser, updateUser } from '@/server/lib/okta/api/users';
+import { sha256 } from '@/server/lib/crypto';
 
 export const fixOktaProfile = async ({
 	oktaId,
@@ -30,6 +31,7 @@ export const fixOktaProfile = async ({
 		await updateUser(oktaId, {
 			profile: {
 				legacyIdentityId: idapiUser.id,
+				searchPartitionKey: sha256(idapiUser.id),
 			},
 		});
 		return true;

--- a/src/server/lib/okta/fixProfile.ts
+++ b/src/server/lib/okta/fixProfile.ts
@@ -1,0 +1,40 @@
+import { logger } from '@/server/lib/serverSideLogger';
+import { getUserByEmailAddress } from '@/server/lib/idapi/user';
+import { getUser, updateUser } from '@/server/lib/okta/api/users';
+
+export const fixOktaProfile = async ({
+	oktaId,
+	email,
+	ip,
+	request_id,
+}: {
+	oktaId: string;
+	email?: string;
+	ip: string;
+	request_id?: string;
+}): Promise<boolean> => {
+	try {
+		const oktaUser = await getUser(oktaId);
+		// Check the legacyIdentityId field. If it's set, we don't need to do anything.
+		if (oktaUser.profile.legacyIdentityId) {
+			return true;
+		}
+		// If the email is not provided, we can't fix the profile.
+		if (!email) {
+			throw new Error(`fixOktaProfile - Email is required to fix Okta profile`);
+		}
+		const idapiUser = await getUserByEmailAddress(email, ip, request_id);
+		if (!idapiUser.id) {
+			throw new Error(`fixOktaProfile - IDAPI profile missing ID`);
+		}
+		await updateUser(oktaId, {
+			profile: {
+				legacyIdentityId: idapiUser.id,
+			},
+		});
+		return true;
+	} catch (error) {
+		logger.warn('fixOktaProfile - Could not fix Okta profile', error);
+		return false;
+	}
+};

--- a/src/server/models/okta/User.ts
+++ b/src/server/models/okta/User.ts
@@ -26,6 +26,7 @@ const userProfileSchema = z.object({
 	firstName: z.string().nullable().optional(),
 	lastName: z.string().nullable().optional(),
 	legacyIdentityId: z.string().nullable().optional(),
+	searchPartitionKey: z.string().nullable().optional(),
 });
 
 // https://developer.okta.com/docs/reference/api/users/#password-object

--- a/src/shared/model/Routes.ts
+++ b/src/shared/model/Routes.ts
@@ -100,6 +100,7 @@ export type ApiRoutePaths =
 	| '/user/change-email'
 	| '/unsubscribe'
 	| '/subscribe'
+	| '/user'
 	| '/user/me'
 	| '/user/me/consents'
 	| '/user/me/group/:groupCode'

--- a/src/shared/model/User.ts
+++ b/src/shared/model/User.ts
@@ -4,6 +4,7 @@ import { UserConsent } from '@/shared/model/UserConsents';
 export default interface User {
 	consents: UserConsent[];
 	primaryEmailAddress: string;
+	id: string;
 	statusFields: UserStatusFields;
 	privateFields: PrivateFields;
 	userGroups: Group[];


### PR DESCRIPTION
## What does this change?

- Moves the checks for `legacyIdentityId` introduced in https://github.com/guardian/gateway/pull/2694/ from the main OAuth callback endpoint to the authentication handler, so they only run during authentication activities
- Adds a function to attempt to fix an Okta profile missing a `legacyIdentityId` field by fetching the correct ID from IDAPI.
- Changes the check function to instead attempt to run this fix, and if that succeeds, return fresh tokens which will be used in another invocation of the `authenticationHandler()` function. If the fix or token fetching fails, the user is sent back to `/reauthenticate` with a hopefully useful error, as before.
- The timeout for the fix function is reduced from 30 to 10 seconds, which is under the 30 seconds specified as the TTFB timeout in our Fastly config (this may have been causing users to see 503 errors).
- Adds a Cypress test to check that this fix function works.

Thank you @coldlink for pairing on this with me for 2 hours!

### Flowchart

```mermaid
flowchart TD
    start(["START: Receive a token set"])
    start --> hasId{Does token set\ncontain legacy\nIdentity ID?}
    hasId -- Yes --> returnTokenSet([Return valid token set!])
    hasId -- No --> timedOut{Have we reached\nmaximum wait time?}
    timedOut -- Yes --> returnNull([Return null])
    timedOut -- No --> attemptFix[Attempt to fix Okta\nuser profile]
    attemptFix --> hasFixSucceeded{Did the fix\nsucceed?}
    hasFixSucceeded -- Yes --> refreshTokens[Get new tokens using\nrefresh token]
    refreshTokens -- Pass new tokens --> start
    hasFixSucceeded -- "No - pass\nold tokens" --> start
```

## Tests

- [x] Tested on CODE