### PR TITLE
OAuth | Do not redirect user to /reauthenticate on missing IDAPI ID

### DIFF
--- a/src/server/routes/oauth.ts
+++ b/src/server/routes/oauth.ts
@@ -17,7 +17,6 @@ import { setIDAPICookies } from '@/server/lib/idapi/IDAPICookies';
 import {
 	FederationErrors,
 	GenericErrors,
-	RegistrationErrors,
 	SignInErrors,
 } from '@/shared/model/Errors';
 import { addQueryParamsToPath } from '@/shared/lib/queryParams';
@@ -278,18 +277,14 @@ const authenticationHandler = async (
 					openIdClient,
 				);
 			} catch (error) {
-				// Something went wrong, so send the user to /reauthenticate with an error.
+				// Something went wrong, so long an error and continue to the rest of the callback function
+				// This may result in Gateway errors but won't prevent the user from signing in.
 				trackMetric('OAuthAuthorization::ProvisioningFailure');
 				trackMetric('OAuthAuthenticationCallback::Failure');
 				logger.error(`Failed to fix Okta profile for ${sub}`, error, {
 					request_id: res.locals.requestId,
 					oktaId: sub,
 				});
-				return res.redirect(
-					addQueryParamsToPath('/reauthenticate', authState.queryParams, {
-						error: RegistrationErrors.PROVISIONING_FAILURE,
-					}),
-				);
 			}
 		}
 


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

In https://github.com/guardian/gateway/pull/2722, we prevented users from logging in (by sending them to `/reauthenticate`) if they didn't have an IDAPI ID in their Okta profile and their IDAPI account doesn't appear to exist. This PR reverts this behaviour to the previous functionality, which allows them to continue logging in, despite their access tokens not being valid. We're doing this so we don't degrade the user experience for users who could previously log in but now can't.