### PR TITLE
Passcodes | Use correct CTA format on RegistrationPasscode email

### DIFF
--- a/src/email/templates/RegistrationPasscode/RegistrationPasscode.tsx
+++ b/src/email/templates/RegistrationPasscode/RegistrationPasscode.tsx
@@ -20,7 +20,7 @@ export const RegistrationPasscode = () => {
 					code to verify your email.
 				</Text>
 				<Text largeText>
-					<strong>{`\${oneTimePassword}`}</strong>
+					<strong>{`$\${oneTimePassword}`}</strong>
 				</Text>
 				<Text>
 					<strong>


### PR DESCRIPTION
## What does this change?

When trying to apply terraform for this email template in https://github.com/guardian/identity-platform, we kept getting unhelpful 400, 404, or 409 errors.

After much debugging and using the following command when trying to apply terraform, I was able to output the terraform raw logs to a file.

```
TF_LOG=DEBUG TF_LOG_PATH=tf.log terraform apply -auto-approve
```

This helpfully returns a full error message rather than just the status code. After much digging, the reason this template wasn't getting applied is that the CTA for the one time passcode had to be in the following format

`$${oneTimePasscode}`

which it then shortens to the format it needs, i.e the one that we tried using (`${oneTimePasscode}`).

This PR updates that CTA, and a separate PR will be created in identity-platform for applying the terraform configuration once this one is merged in.
