### PR TITLE
Add /unsubscribe-all endpoint

### DIFF
--- a/cypress/integration/ete/unsubscribe/unsubscribe.3.cy.ts
+++ b/cypress/integration/ete/unsubscribe/unsubscribe.3.cy.ts
@@ -62,6 +62,28 @@ describe('Unsubscribe newsletter/marketing email', () => {
 		});
 	});
 
+	it.only('should be able to unsubscribe from all emails', () => {
+		cy.createTestUser({
+			isUserEmailValidated: true,
+		}).then(({ cookies }) => {
+			// SC_GU_U is required for the cy.getTestUserDetails
+			const scGuU = cookies.find((cookie) => cookie.key === 'SC_GU_U');
+			if (!scGuU) throw new Error('SC_GU_U cookie not found');
+			cy.setCookie('SC_GU_U', scGuU?.value);
+
+			cy.getTestUserDetails().then(({ user }) => {
+				const userId = user.id;
+				const data = `${userId}:${Math.floor(Date.now() / 1000)}`;
+				cy.request(
+					'POST',
+					`/unsubscribe-all/${encodeURIComponent(data)}/${createToken(data)}`,
+				).then((response) => {
+					expect(response.status).to.eq(200);
+				});
+			});
+		});
+	});
+
 	it('should be able to handle a unsubscribe error if emailType is not newsletter/marketing', () => {
 		cy.createTestUser({
 			isUserEmailValidated: true,

--- a/cypress/integration/ete/unsubscribe/unsubscribe.3.cy.ts
+++ b/cypress/integration/ete/unsubscribe/unsubscribe.3.cy.ts
@@ -62,7 +62,7 @@ describe('Unsubscribe newsletter/marketing email', () => {
 		});
 	});
 
-	it.only('should be able to unsubscribe from all emails', () => {
+	it('should be able to unsubscribe from all emails', () => {
 		cy.createTestUser({
 			isUserEmailValidated: true,
 		}).then(({ cookies }) => {

--- a/cypress/integration/mocked/unsubscribe.5.cy.ts
+++ b/cypress/integration/mocked/unsubscribe.5.cy.ts
@@ -32,6 +32,15 @@ describe('Unsubscribe newsletter/marketing email', () => {
 			cy.contains('You have been unsubscribed.');
 		});
 
+		it('should be able to unsubscribe from a newsletter', () => {
+			cy.mockNext(200);
+			cy.request('POST', '/unsubscribe-all/1000000%3A1677075570/token').then(
+				(response) => {
+					expect(response.status).to.eq(200);
+				},
+			);
+		});
+
 		it('should be able to unsubscribe from a marketing email', () => {
 			cy.mockNext(200);
 			cy.visit('/unsubscribe/marketing/supporter%3A1000000%3A1677075570/token');

--- a/cypress/integration/mocked/unsubscribe.5.cy.ts
+++ b/cypress/integration/mocked/unsubscribe.5.cy.ts
@@ -32,7 +32,7 @@ describe('Unsubscribe newsletter/marketing email', () => {
 			cy.contains('You have been unsubscribed.');
 		});
 
-		it('should be able to unsubscribe from a newsletter', () => {
+		it('should be able to unsubscribe from all marketing consents and newsletters', () => {
 			cy.mockNext(200);
 			cy.request('POST', '/unsubscribe-all/1000000%3A1677075570/token').then(
 				(response) => {

--- a/src/server/lib/__tests__/middleware/csrf.test.ts
+++ b/src/server/lib/__tests__/middleware/csrf.test.ts
@@ -1,0 +1,47 @@
+import { csrfMiddleware } from '../../middleware/csrf';
+import type { ResponseWithRequestState } from '@/server/models/Express';
+import type { Request } from 'express';
+
+const csrfSpy = jest.fn();
+jest.mock('csurf', () => {
+	// There's an extra level of function application here, without it I get the
+	// following error:
+	// ReferenceError: Cannot access 'csrfSpy' before initialization
+	return () => () => csrfSpy();
+});
+jest.mock('@/server/lib/getConfiguration', () => {
+	return {
+		getConfiguration: () => ({
+			isHttps: true,
+		}),
+	};
+});
+
+beforeEach(() => {
+	csrfSpy.mockClear();
+});
+
+describe('csrfMiddleware', () => {
+	it('does not call the underlying csrf middleware for routes which have been excluded', () => {
+		const req = {
+			path: '/unsubscribe-all/data/token',
+		} as unknown as Request;
+		const res = {} as unknown as ResponseWithRequestState;
+		const next = jest.fn();
+
+		csrfMiddleware(req, res, next);
+
+		expect(next).toHaveBeenCalled();
+		expect(csrfSpy).not.toHaveBeenCalled();
+	});
+
+	it('does call the underlying csrf middleware for routes which have not been excluded', () => {
+		const req = { path: '/some-other-path' } as unknown as Request;
+		const res = {} as unknown as ResponseWithRequestState;
+		const next = jest.fn();
+
+		csrfMiddleware(req, res, next);
+
+		expect(csrfSpy).toHaveBeenCalledTimes(1);
+	});
+});

--- a/src/server/lib/idapi/subscriptions.ts
+++ b/src/server/lib/idapi/subscriptions.ts
@@ -119,7 +119,6 @@ export const makeUnsubscribeAllRequest = async (
 			request_id,
 		});
 
-		// Maybe we don't return an error message here? There's nothing user facing
 		throw new IdapiError({ message: 'Unsubscribe all failed', status: 500 });
 	}
 };

--- a/src/server/lib/idapi/subscriptions.ts
+++ b/src/server/lib/idapi/subscriptions.ts
@@ -17,6 +17,11 @@ interface SubscriptionData {
 	timestamp: number;
 }
 
+interface UnsubscribeAllData {
+	userId: string;
+	timestamp: number;
+}
+
 export const isValidEmailType = (emailType: string): emailType is EmailType => {
 	return ['newsletter', 'marketing'].includes(emailType);
 };
@@ -30,6 +35,19 @@ export const parseSubscriptionData = (data: string): SubscriptionData => {
 
 	return {
 		emailId,
+		userId,
+		timestamp: +timestamp,
+	};
+};
+
+export const parseUnsubscribeAllData = (data: string): UnsubscribeAllData => {
+	const [userId, timestamp] = data.split(':');
+
+	if (!userId || !timestamp) {
+		throw new Error('Invalid unsubscribe-all data');
+	}
+
+	return {
 		userId,
 		timestamp: +timestamp,
 	};
@@ -74,5 +92,34 @@ export const makeSubscriptionRequest = async (
 			},
 		);
 		return handleError(subscriptionAction, error as IDAPIError);
+	}
+};
+
+const unsubscribeAllPath = '/unsubscribe-all';
+export const makeUnsubscribeAllRequest = async (
+	unsubscribeData: UnsubscribeAllData,
+	token: string,
+	ip: string,
+	request_id?: string,
+) => {
+	const body = {
+		...unsubscribeData,
+		token,
+	};
+
+	const options = APIAddClientAccessToken(APIPostOptions(body), ip);
+
+	try {
+		await idapiFetch({
+			path: unsubscribeAllPath,
+			options,
+		});
+	} catch (error) {
+		logger.error(`IDAPI Error '${unsubscribeAllPath}'`, error, {
+			request_id,
+		});
+
+		// Maybe we don't return an error message here? There's nothing user facing
+		throw new IdapiError({ message: 'Unsubscribe all failed', status: 500 });
 	}
 };

--- a/src/server/lib/middleware/csrf.ts
+++ b/src/server/lib/middleware/csrf.ts
@@ -1,9 +1,11 @@
 import csrf from 'csurf';
 import { getConfiguration } from '@/server/lib/getConfiguration';
+import { ResponseWithRequestState } from '@/server/models/Express';
+import { NextFunction, Request } from 'express';
 
 const { isHttps } = getConfiguration();
 
-export const csrfMiddleware = csrf({
+const baseCsrfMiddleware = csrf({
 	cookie: {
 		key: '_csrf',
 		sameSite: true,
@@ -12,3 +14,17 @@ export const csrfMiddleware = csrf({
 		signed: true,
 	},
 });
+
+const SKIP_CSRF_ROUTE_PREFIXES = ['/unsubscribe-all/'];
+
+export const csrfMiddleware = (
+	req: Request,
+	res: ResponseWithRequestState,
+	next: NextFunction,
+) => {
+	if (SKIP_CSRF_ROUTE_PREFIXES.find((path) => req.path.startsWith(path))) {
+		next();
+	} else {
+		baseCsrfMiddleware(req, res, next);
+	}
+};

--- a/src/server/lib/middleware/csrf.ts
+++ b/src/server/lib/middleware/csrf.ts
@@ -1,7 +1,7 @@
 import csrf from 'csurf';
 import { getConfiguration } from '@/server/lib/getConfiguration';
-import { ResponseWithRequestState } from '@/server/models/Express';
-import { NextFunction, Request } from 'express';
+import type { ResponseWithRequestState } from '@/server/models/Express';
+import type { NextFunction, Request } from 'express';
 
 const { isHttps } = getConfiguration();
 

--- a/src/server/lib/middleware/requestState.ts
+++ b/src/server/lib/middleware/requestState.ts
@@ -86,6 +86,9 @@ const getRequestState = async (
 		},
 		globalMessage: {},
 		csrf: {
+			// This isn't guaranteed to exist as there are some endpoints where
+			// we do not have CSRF protection e.g. /unsubscribe-all which is a
+			// POST but called by external clients.
 			token: req.csrfToken?.(),
 		},
 		abTesting: abTesting,

--- a/src/server/lib/middleware/requestState.ts
+++ b/src/server/lib/middleware/requestState.ts
@@ -86,7 +86,7 @@ const getRequestState = async (
 		},
 		globalMessage: {},
 		csrf: {
-			token: req.csrfToken(),
+			token: req.csrfToken?.(),
 		},
 		abTesting: abTesting,
 		abTestAPI: abTestAPI,

--- a/src/server/models/Metrics.ts
+++ b/src/server/models/Metrics.ts
@@ -60,6 +60,7 @@ type ConditionalMetrics =
 	| 'SignOut'
 	| 'SignOutGlobal'
 	| 'Unsubscribe'
+	| 'UnsubscribeAll'
 	| 'Subscribe'
 	| 'UpdatePassword'
 	| 'RecaptchaMiddleware'

--- a/src/server/routes/subscriptions.ts
+++ b/src/server/routes/subscriptions.ts
@@ -102,15 +102,7 @@ router.post(
 				res.locals.requestId,
 			);
 
-			// TODO: metrics?
-			// trackMetric(`${subscriptionActionName(action)}::Success`);
-
-			// const html = renderer(`/${action}/success`, {
-			// 	requestState: mergeRequestState(res.locals, {
-			// 		pageData: buildPageData(emailType, subscriptionData.emailId),
-			// 	}),
-			// 	pageTitle: `${subscriptionActionName(action)} Confirmation`,
-			// });
+			trackMetric(`UnsubscribeAll::Success`);
 
 			return res.status(200).send();
 		} catch (error) {
@@ -118,16 +110,7 @@ router.post(
 				request_id: res.locals.requestId,
 			});
 
-			// trackMetric(`${subscriptionActionName(action)}::Failure`);
-
-			// const html = renderer(`/${action}/error`, {
-			// 	requestState: mergeRequestState(res.locals, {
-			// 		pageData: {
-			// 			accountManagementUrl,
-			// 		},
-			// 	}),
-			// 	pageTitle: `${subscriptionActionName(action)} Error`,
-			// });
+			trackMetric(`UnsubscribeAll::Failure`);
 
 			return res.status(500).send();
 		}

--- a/src/shared/model/Routes.ts
+++ b/src/shared/model/Routes.ts
@@ -61,6 +61,7 @@ export const ValidRoutePathsArray = [
 	'/unsubscribe/:emailType/:data/:token',
 	'/unsubscribe/success',
 	'/unsubscribe/error',
+	'/unsubscribe-all/:data/:token',
 	'/subscribe/:emailType/:data/:token',
 	'/subscribe/success',
 	'/subscribe/error',
@@ -100,6 +101,7 @@ export type ApiRoutePaths =
 	| '/user/change-email'
 	| '/unsubscribe'
 	| '/subscribe'
+	| '/unsubscribe-all'
 	| '/user'
 	| '/user/me'
 	| '/user/me/consents'


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Adds a new `/unsubscribe-all` endpoint, to be used in the `List-Unsubscribe` header of emails.

According to [the spec](https://datatracker.ietf.org/doc/html/rfc8058) this must be a `POST` endpoint. By default CSRF protection is enabled on all `POST`s, but that's not appropriate in this case as the request is made from an external location. So I've had to modify the middleware to allow `POST`s to this endpoint with no CSRF token.

See also guardian/identity#2514.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

I've done some end to end testing in CODE. I configured the List-Unsubscribe header in Braze B2C - Dev, and manually posted to the CODE url to simulate the email client making that request. It unsubscribed me from all newsletters and marketing email consents as expected.

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
