### PR TITLE
Passcodes | Use `{{CTA}}` as CTA format on RegistrationPasscode email

### DIFF
--- a/src/email/templates/RegistrationPasscode/RegistrationPasscode.tsx
+++ b/src/email/templates/RegistrationPasscode/RegistrationPasscode.tsx
@@ -20,7 +20,7 @@ export const RegistrationPasscode = () => {
 					code to verify your email.
 				</Text>
 				<Text largeText>
-					<strong>{`$\${oneTimePassword}`}</strong>
+					<strong>{`{{CTA}}`}</strong>
 				</Text>
 				<Text>
 					<strong>


### PR DESCRIPTION
## What does this change?

In https://github.com/guardian/gateway/pull/2729 we attempted a fix for the email CTA, but although this works a rogue `$` appears in the final email template.

So instead, we're just changing it to `{{CTA}}` like the `AccidentalEmail` template, and then use terraform to do a string substitution afterwards, as we do for anything using the `AccidentalEmail` template.

![Screenshot 2024-05-20 at 15 02 04](https://github.com/guardian/gateway/assets/13315440/d46bdcc8-79b1-4a9c-a7dd-d3148ddcb81f)
