### PR TITLE
Tracking  | Set up tracking for new account pages

### DIFF
--- a/src/client/components/CheckboxInput.tsx
+++ b/src/client/components/CheckboxInput.tsx
@@ -140,6 +140,7 @@ export const CheckboxInput = ({
 			<div css={inputWrapperStyles}>
 				<Checkbox
 					id={switchName}
+					name={switchName}
 					aria-label={label}
 					checked={defaultChecked}
 					onChange={onToggle}

--- a/src/client/lib/consentsTracking.ts
+++ b/src/client/lib/consentsTracking.ts
@@ -1,6 +1,6 @@
 import { sendOphanInteractionEvent } from './ophan';
 import { Consent, Consents } from '@/shared/model/Consent';
-import { Newsletters } from '@/shared/model/Newsletter';
+import { NewsLetter, Newsletters } from '@/shared/model/Newsletter';
 
 const trackInputElementInteraction = (
 	inputElem: HTMLInputElement,
@@ -22,11 +22,12 @@ const trackInputElementInteraction = (
 	}
 };
 
+// handle consents form submit event
 export const consentsFormSubmitOphanTracking = (
 	target: HTMLFormElement,
-	consents: Consent[],
-): void => {
-	if (!consents.length) {
+	consents?: Consent[],
+) => {
+	if (!consents?.length) {
 		return;
 	}
 
@@ -36,6 +37,33 @@ export const consentsFormSubmitOphanTracking = (
 
 		if (consent) {
 			trackInputElementInteraction(elem, 'consent', consent.name);
+		}
+	});
+};
+
+// handle newsletter form submit event
+export const newslettersFormSubmitOphanTracking = (
+	target: HTMLFormElement,
+	newsletters?: NewsLetter[],
+): void => {
+	if (!newsletters?.length) {
+		return;
+	}
+
+	const inputElems = target.querySelectorAll('input');
+	inputElems.forEach((elem) => {
+		const newsletter = newsletters.find(({ id }) => id === elem.name);
+
+		if (newsletter) {
+			// if previously subscribed AND now wants to unsubscribe
+			// OR if previously not subscribed AND wants to subscribe
+			// then do the trackInputElementInteraction
+			if (
+				(newsletter.subscribed && !elem.checked) ||
+				(!newsletter.subscribed && elem.checked)
+			) {
+				trackInputElementInteraction(elem, 'newsletter', newsletter.nameId);
+			}
 		}
 	});
 };
@@ -53,6 +81,12 @@ export const registrationFormSubmitOphanTracking = (
 			switch (elem.name) {
 				case Newsletters.SATURDAY_EDITION:
 					trackInputElementInteraction(elem, 'newsletter', 'saturday-edition');
+					break;
+				case Newsletters.AU_BUNDLE:
+					trackInputElementInteraction(elem, 'newsletter', 'au-bundle');
+					break;
+				case Newsletters.US_BUNDLE:
+					trackInputElementInteraction(elem, 'newsletter', 'us-bundle');
 					break;
 				case Consents.SIMILAR_GUARDIAN_PRODUCTS:
 					trackInputElementInteraction(

--- a/src/client/pages/NewAccountNewsletters.tsx
+++ b/src/client/pages/NewAccountNewsletters.tsx
@@ -14,7 +14,7 @@ import {
 } from '@/client/components/InformationBox';
 import { Link } from '@guardian/source-react-components';
 import { NEWSLETTER_IMAGES } from '@/client/models/Newsletter';
-import { newslettersFormSubmitOphanTracking } from '../lib/consentsTracking';
+import { newslettersFormSubmitOphanTracking } from '@/client/lib/consentsTracking';
 import { usePageLoadOphanInteraction } from '@/client/lib/hooks/usePageLoadOphanInteraction';
 
 const consentToggleCss = css`

--- a/src/client/pages/NewAccountNewsletters.tsx
+++ b/src/client/pages/NewAccountNewsletters.tsx
@@ -14,6 +14,8 @@ import {
 } from '@/client/components/InformationBox';
 import { Link } from '@guardian/source-react-components';
 import { NEWSLETTER_IMAGES } from '@/client/models/Newsletter';
+import { newslettersFormSubmitOphanTracking } from '../lib/consentsTracking';
+import { usePageLoadOphanInteraction } from '@/client/lib/hooks/usePageLoadOphanInteraction';
 
 const consentToggleCss = css`
 	display: flex;
@@ -53,6 +55,9 @@ export const NewAccountNewsletters = ({
 	queryParams,
 	accountManagementUrl = 'https://manage.theguardian.com',
 }: NewAccountNewslettersProps) => {
+	const formTrackingName = 'new-account-newsletters';
+	usePageLoadOphanInteraction(formTrackingName);
+
 	const [checkboxesChecked, setCheckboxesChecked] = React.useState<string[]>(
 		[],
 	);
@@ -82,6 +87,15 @@ export const NewAccountNewsletters = ({
 				submitButtonText={
 					checkboxesChecked.length ? 'Subscribe and continue' : 'Maybe later'
 				}
+				onSubmit={({ target: form }) => {
+					newslettersFormSubmitOphanTracking(
+						form as HTMLFormElement,
+						newsletters,
+					);
+					// onSubmit expects an error object or undefined
+					return undefined;
+				}}
+				formTrackingName={formTrackingName}
 			>
 				{newsletters?.length ? (
 					newsletters.map((newsletter: NewsLetter) => (

--- a/src/client/pages/NewAccountNewslettersPage.tsx
+++ b/src/client/pages/NewAccountNewslettersPage.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import useClientState from '@/client/lib/hooks/useClientState';
-import { NewAccountNewsletters } from './NewAccountNewsletters';
+import { NewAccountNewsletters } from '@/client/pages/NewAccountNewsletters';
 
 export const NewAccountNewslettersPage = () => {
 	const clientState = useClientState();

--- a/src/client/pages/NewAccountReview.tsx
+++ b/src/client/pages/NewAccountReview.tsx
@@ -16,6 +16,8 @@ import { buildUrlWithQueryParams } from '@/shared/lib/routeUtils';
 import { CsrfFormField } from '@/client/components/CsrfFormField';
 import { QueryParams } from '@/shared/model/QueryParams';
 import { consentsFormSubmitOphanTracking } from '@/client/lib/consentsTracking';
+import { usePageLoadOphanInteraction } from '@/client/lib/hooks/usePageLoadOphanInteraction';
+import { trackFormSubmit } from '@/client/lib/ophan';
 
 const consentToggleCss = css`
 	display: flex;
@@ -70,6 +72,9 @@ export const NewAccountReview = ({
 	advertising,
 	queryParams,
 }: NewAccountReviewProps) => {
+	const formTrackingName = 'new-account-review';
+	usePageLoadOphanInteraction(formTrackingName);
+
 	if (!profiling && !advertising) {
 		return (
 			<MainLayout pageHeader="You're signed in! Welcome to the Guardian.">
@@ -95,6 +100,7 @@ export const NewAccountReview = ({
 				action={buildUrlWithQueryParams('/welcome/review', {}, queryParams)}
 				method="post"
 				onSubmit={({ target: form }) => {
+					trackFormSubmit(formTrackingName);
 					consentsFormSubmitOphanTracking(
 						form as HTMLFormElement,
 						[profiling, advertising].filter(Boolean) as Consent[],


### PR DESCRIPTION
## What does this change?

- Adds Ophan tracking to track specific newsletter choices to `NewAccountNewsletters.tsx`, where it hadn't ended up after the major consents flow overhaul in https://github.com/guardian/gateway/pull/2653
- Adds tracking for the US and AU bundles introduced in https://github.com/guardian/gateway/pull/2730 to the existing registration newsletter tracking function
- Adds page load and submit tracking to `/welcome/review` and `/welcome/newsletters`.

## Testing

- [x] Tested in CODE