### PR TITLE
Show account linking page for social sign in guest users

### DIFF
--- a/cypress/integration/shared/sign_in.shared.ts
+++ b/cypress/integration/shared/sign_in.shared.ts
@@ -368,9 +368,9 @@ export const showsAnErrorMessageAndInformationParagraphWhenAccountLinkingRequire
 					: '/signin?error=accountLinkingRequired';
 				cy.visit(visitUrl);
 				cy.contains(
-					'We cannot sign you in with your social account credentials. Please enter your account password below to sign in.',
+					'We could not sign you in with your social account credentials. Please sign in with your email below.',
 				);
-				cy.contains('Account already exists');
+				cy.contains('Social sign-in unsuccessful');
 			},
 		] as const;
 	};

--- a/src/client/pages/SignIn.stories.tsx
+++ b/src/client/pages/SignIn.stories.tsx
@@ -47,7 +47,7 @@ WithPageLevelErrorAndEmail.story = {
 export const SocialSigninBlocked = (args: SignInProps) => (
 	<SignIn
 		{...args}
-		pageError={SignInErrors.ACCOUNT_ALREADY_EXISTS}
+		pageError={SignInErrors.SOCIAL_SIGNIN_ERROR}
 		email="someone@theguardian.com"
 	/>
 );
@@ -72,7 +72,7 @@ WithFormLevelErrorAndEmail.story = {
 export const WithFormLevelErrorAndSocialSigninBlocked = (args: SignInProps) => (
 	<SignIn
 		{...args}
-		pageError={SignInErrors.ACCOUNT_ALREADY_EXISTS}
+		pageError={SignInErrors.SOCIAL_SIGNIN_ERROR}
 		formError="This is an error"
 		email="someone@theguardian.com"
 	/>
@@ -107,7 +107,7 @@ WithJobs.story = {
 export const WithJobsAndSocialSigninBlocked = (args: SignInProps) => (
 	<SignIn
 		{...{ ...args, queryParams: { ...args.queryParams, clientId: 'jobs' } }}
-		pageError={SignInErrors.ACCOUNT_ALREADY_EXISTS}
+		pageError={SignInErrors.SOCIAL_SIGNIN_ERROR}
 		email="someone@theguardian.com"
 	/>
 );

--- a/src/client/pages/SignIn.tsx
+++ b/src/client/pages/SignIn.tsx
@@ -56,12 +56,30 @@ const Links = ({ children }: { children: React.ReactNode }) => (
 	</div>
 );
 
-const getErrorContext = (error: string | undefined) => {
-	if (error === SignInErrors.ACCOUNT_ALREADY_EXISTS) {
+const getErrorContext = (
+	error: string | undefined,
+	queryParams: QueryParams,
+) => {
+	if (error === SignInErrors.SOCIAL_SIGNIN_ERROR) {
 		return (
 			<>
-				We cannot sign you in with your social account credentials. Please enter
-				your account password below to sign in.
+				<div>
+					We could not sign you in with your social account credentials. Please
+					sign in with your email below. If you do not know your password, you
+					can{' '}
+					<Link
+						href={buildUrlWithQueryParams('/reset-password', {}, queryParams)}
+					>
+						reset it here
+					</Link>
+					.
+				</div>
+				<br />
+				<div>
+					If you are still having trouble, please contact our customer service
+					team at{' '}
+					<Link href={locations.SUPPORT_EMAIL_MAILTO}>{SUPPORT_EMAIL}</Link>.
+				</div>
 			</>
 		);
 	} else if (error === RegistrationErrors.PROVISIONING_FAILURE) {
@@ -113,7 +131,7 @@ export const SignIn = ({
 	const formTrackingName = 'sign-in';
 
 	// The page level error is equivalent to this enum if social signin has been blocked.
-	const socialSigninBlocked = pageError === SignInErrors.ACCOUNT_ALREADY_EXISTS;
+	const socialSigninBlocked = pageError === SignInErrors.SOCIAL_SIGNIN_ERROR;
 
 	const { clientId } = queryParams;
 	const isJobs = clientId === 'jobs';
@@ -129,7 +147,7 @@ export const SignIn = ({
 	return (
 		<MainLayout
 			errorOverride={pageError}
-			errorContext={getErrorContext(pageError)}
+			errorContext={getErrorContext(pageError, queryParams)}
 			tabs={tabs}
 			errorSmallMarginBottom={!!pageError}
 			pageHeader="Sign in"
@@ -139,7 +157,7 @@ export const SignIn = ({
 			{showAuthProviderButtons(socialSigninBlocked, queryParams, isJobs)}
 			<MainForm
 				formErrorMessageFromParent={formError}
-				formErrorContextFromParent={getErrorContext(formError)}
+				formErrorContextFromParent={getErrorContext(formError, queryParams)}
 				formAction={buildUrlWithQueryParams(
 					isReauthenticate ? '/reauthenticate' : '/signin',
 					{},

--- a/src/server/routes/oauth.ts
+++ b/src/server/routes/oauth.ts
@@ -801,8 +801,9 @@ router.get(
 			// and redirect to the sign in page with the social sign in blocked error
 			if (
 				callbackParams.error === OpenIdErrors.ACCESS_DENIED &&
-				callbackParams.error_description ===
-					OpenIdErrorDescriptions.ACCOUNT_LINKING_DENIED_GROUPS
+				(callbackParams.error_description ===
+					OpenIdErrorDescriptions.ACCOUNT_LINKING_DENIED_GROUPS ||
+					OpenIdErrorDescriptions.USER_STATUS_INVALID)
 			) {
 				trackMetric('OAuthAuthorization::Failure');
 				return res.redirect(
@@ -811,6 +812,9 @@ router.get(
 					}),
 				);
 			}
+
+			// handle the rest of the errors generically
+			return redirectForGenericError(req, res);
 		}
 
 		// exchange the auth code for access token + id token

--- a/src/server/routes/signIn.ts
+++ b/src/server/routes/signIn.ts
@@ -69,7 +69,7 @@ export const getErrorMessageFromQueryParams = (
 ) => {
 	// show error if account linking required
 	if (error === FederationErrors.SOCIAL_SIGNIN_BLOCKED) {
-		return SignInErrors.ACCOUNT_ALREADY_EXISTS;
+		return SignInErrors.SOCIAL_SIGNIN_ERROR;
 	}
 	// Show error if provisioning failed
 	if (error === RegistrationErrors.PROVISIONING_FAILURE) {

--- a/src/shared/model/Errors.ts
+++ b/src/shared/model/Errors.ts
@@ -28,7 +28,7 @@ export enum ResetPasswordErrors {
 export enum SignInErrors {
 	GENERIC = 'There was a problem signing in, please try again.',
 	AUTHENTICATION_FAILED = "Email and password don't match",
-	ACCOUNT_ALREADY_EXISTS = 'Account already exists',
+	SOCIAL_SIGNIN_ERROR = 'Social sign-in unsuccessful',
 }
 
 export enum RegistrationErrors {

--- a/src/shared/model/OpenIdErrors.ts
+++ b/src/shared/model/OpenIdErrors.ts
@@ -17,4 +17,5 @@ export enum OpenIdErrors {
 
 export enum OpenIdErrorDescriptions {
 	ACCOUNT_LINKING_DENIED_GROUPS = 'User linking was denied because the user is not in any of the specified groups.',
+	USER_STATUS_INVALID = 'User status is invalid.',
 }


### PR DESCRIPTION
## What does this change?

Currently users who are "guest" accounts (i.e users in Okta who are not in the `ACTIVE` state) get blocked from authenticating with a social identity provider by Okta. Okta returns an error to us with the `error=access_denied&error_description=User+status+is+invalid.` query parameters, however this error was not being handled correctly, and users were either being show a "Not Found" or "Error" page, which wasn't proving to be great UX.

Ideally we'd rectify the issue when the user authenticates, however all of social authentication happens through Okta, and all we get back from Okta is either a success (user created and authenticated) or failure (something went wrong). We're still investigating how best we should manage this.

For now we should improve the user experience. In Gateway we already have the "Account Linking" failed page for social users for a different purpose (if the user wasn't in the correct group). This page doesn't have social buttons, only email and password, and an error message explaining that we were unable to sign in with social and to use email and password instead.

This PR now handles the specific error correctly, and we also redirect to this account linking denied page. We also expand the error message to suggest reseting their password, or contacting support. We also handle any other OAuth errors using our generic handler.

<table>
<tr>
 <th>
Screenshot
 <th>
Video
<tr>
 <td>

![localhost_6006_iframe html_globals=viewport_MOBILE id=pages-signin--social-signin-blocked viewMode=story(iPhone 14 Pro Max) (1)](https://github.com/guardian/gateway/assets/13315440/4fa6b06a-a3cb-4810-a7c9-0109a24c03fe)

 <td>

https://github.com/guardian/gateway/assets/13315440/226408e9-7e9c-44d7-bae5-922bfe8cad4f

</table>

## Tested
- [x] CODE