### PR TITLE
use `useId` in place of `generateSourceId`

### DIFF
--- a/src/client/components/CheckboxInput.tsx
+++ b/src/client/components/CheckboxInput.tsx
@@ -125,7 +125,8 @@ export const CheckboxInput = ({
 	cssOverrides,
 	onToggle,
 }: CheckboxInputProps): EmotionJSX.Element => {
-	const switchName = id ?? useId();
+	const defaultId = useId();
+	const switchName = id ?? defaultId;
 	const labelId = descriptionId(switchName);
 
 	return (

--- a/src/client/components/CheckboxInput.tsx
+++ b/src/client/components/CheckboxInput.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useId } from 'react';
 import type { EmotionJSX } from '@emotion/react/types/jsx-namespace';
 import { Checkbox } from '@guardian/source/react-components';
 import { SerializedStyles, css } from '@emotion/react';
@@ -6,7 +6,6 @@ import {
 	textSans,
 	focusHalo,
 	descriptionId,
-	generateSourceId,
 	space,
 	palette,
 	textSans12,
@@ -126,7 +125,7 @@ export const CheckboxInput = ({
 	cssOverrides,
 	onToggle,
 }: CheckboxInputProps): EmotionJSX.Element => {
-	const switchName = id ?? generateSourceId();
+	const switchName = id ?? useId();
 	const labelId = descriptionId(switchName);
 
 	return (

--- a/src/client/components/ToggleSwitchInput.tsx
+++ b/src/client/components/ToggleSwitchInput.tsx
@@ -173,7 +173,8 @@ export const ToggleSwitchInput = ({
 	imagePath,
 	cssOverrides,
 }: ToggleSwitchInputProps): EmotionJSX.Element => {
-	const switchName = id ?? useId();
+	const defaultId = useId();
+	const switchName = id ?? defaultId;
 	const labelId = descriptionId(switchName);
 
 	return (

--- a/src/client/components/ToggleSwitchInput.tsx
+++ b/src/client/components/ToggleSwitchInput.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useId } from 'react';
 import type { EmotionJSX } from '@emotion/react/types/jsx-namespace';
 import type { Props } from '@guardian/source/react-components';
 import { css } from '@emotion/react';
@@ -9,7 +9,6 @@ import {
 	focusHalo,
 	visuallyHidden,
 	descriptionId,
-	generateSourceId,
 	space,
 } from '@guardian/source/foundations';
 
@@ -174,7 +173,7 @@ export const ToggleSwitchInput = ({
 	imagePath,
 	cssOverrides,
 }: ToggleSwitchInputProps): EmotionJSX.Element => {
-	const switchName = id ?? generateSourceId();
+	const switchName = id ?? useId();
 	const labelId = descriptionId(switchName);
 
 	return (


### PR DESCRIPTION
## What does this change?

Replaces source's `generateSourceId` with react's `useId`. 

`useId` does not change between renders, and brings gateway into line with source ([which no longer uses `generateSourceId`](https://github.com/guardian/csnx/pull/1447)).

