### PR TITLE
New Account Flow |  Do not show newsletters page if no newsletters to show

### DIFF
--- a/cypress/integration/ete-okta/new_account_review.3.cy.ts
+++ b/cypress/integration/ete-okta/new_account_review.3.cy.ts
@@ -12,7 +12,7 @@ describe('New account review page', () => {
 			req.reply(200);
 		});
 	});
-	it.only('should show the profiling and personalised advertising checkboxes if CMP accepted', () => {
+	it('should show the profiling and personalised advertising checkboxes if CMP accepted', () => {
 		const encodedReturnUrl =
 			'https%3A%2F%2Fm.code.dev-theguardian.com%2Ftravel%2F2019%2Fdec%2F18%2Ffood-culture-tour-bethlehem-palestine-east-jerusalem-photo-essay';
 		const unregisteredEmail = randomMailosaurEmail();
@@ -191,6 +191,7 @@ describe('New account newsletters page', () => {
 			cy.url().should('contain', decodeURIComponent(encodedReturnUrl));
 		});
 	});
+
 	it('should redirect to the newsletters page if the geolocation is AU', () => {
 		const encodedReturnUrl =
 			'https%3A%2F%2Fm.code.dev-theguardian.com%2Ftravel%2F2019%2Fdec%2F18%2Ffood-culture-tour-bethlehem-palestine-east-jerusalem-photo-essay';
@@ -230,6 +231,7 @@ describe('New account newsletters page', () => {
 			cy.url().should('contain', decodeURIComponent(encodedReturnUrl));
 		});
 	});
+
 	it('should redirect to the newsletters page if the geolocation is US', () => {
 		const encodedReturnUrl =
 			'https%3A%2F%2Fm.code.dev-theguardian.com%2Ftravel%2F2019%2Fdec%2F18%2Ffood-culture-tour-bethlehem-palestine-east-jerusalem-photo-essay';

--- a/src/server/routes/welcome.ts
+++ b/src/server/routes/welcome.ts
@@ -343,6 +343,7 @@ router.get(
 	loginMiddlewareOAuth,
 	async (req: Request, res: ResponseWithRequestState) => {
 		const state = res.locals;
+		const { returnUrl } = state.queryParams;
 		const geolocation = state.pageData.geolocation;
 		const newsletters = await getUserNewsletterSubscriptions({
 			newslettersOnPage: NewsletterMap.get(geolocation) as string[],
@@ -351,6 +352,10 @@ router.get(
 			request_id: state.requestId,
 			accessToken: state.oauthState.accessToken?.toString(),
 		});
+
+		if (newsletters?.length === 0) {
+			return res.redirect(303, returnUrl);
+		}
 
 		const html = renderer('/welcome/newsletters', {
 			pageTitle: 'Choose Newsletters',


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

- If for some reason there aren't any newsletters to show a user on the newsletters page, we just continue immediately on from the newsletters page to the `returnUrl`, returning the user to their article. No point showing an empty page!
- Fixes an errant `.only` in a Cypress test suite.

## Tests

- [x] Tested in CODE