### PR TITLE
Passcodes | Remove `usePasscodeRegistration` query parameter and make passcode registration default

### DIFF
--- a/cypress/fixtures/okta-responses/error/idx-enroll-new-existing-user-response.json
+++ b/cypress/fixtures/okta-responses/error/idx-enroll-new-existing-user-response.json
@@ -1,0 +1,94 @@
+{
+	"code": 400,
+	"response": {
+		"version": "1.0.0",
+		"stateHandle": "02.id.state~c.handle",
+		"expiresAt": "2099-12-31T23:59:59.000Z",
+		"remediation": {
+			"type": "array",
+			"value": [
+				{
+					"rel": ["create-form"],
+					"name": "enroll-profile",
+					"href": "https://profile.code.dev-theguardian.com/idp/idx/enroll/new",
+					"method": "POST",
+					"produces": "application/ion+json; okta-version=1.0.0",
+					"value": [
+						{
+							"name": "userProfile",
+							"form": {
+								"value": [
+									{
+										"name": "email",
+										"type": "string",
+										"label": "Primary email",
+										"required": true,
+										"messages": {
+											"type": "array",
+											"value": [
+												{
+													"message": "A user with this Primary email already exists",
+													"i18n": {
+														"key": "registration.error.notUniqueWithinOrg",
+														"params": ["Primary email"]
+													},
+													"class": "ERROR"
+												}
+											]
+										},
+										"maxLength": 100
+									},
+									{
+										"name": "isGuardianUser",
+										"type": "boolean",
+										"label": "isGuardianUser",
+										"required": true
+									},
+									{
+										"name": "registrationPlatform",
+										"type": "string",
+										"label": "registrationPlatform",
+										"required": false,
+										"maxLength": 50
+									},
+									{
+										"name": "registrationLocation",
+										"type": "string",
+										"label": "registrationLocation",
+										"required": false,
+										"maxLength": 50
+									}
+								]
+							}
+						},
+						{
+							"name": "stateHandle",
+							"required": true,
+							"value": "02.id.state~c.handle",
+							"visible": false,
+							"mutable": false
+						}
+					],
+					"accepts": "application/json; okta-version=1.0.0"
+				},
+				{
+					"rel": ["create-form"],
+					"name": "select-identify",
+					"href": "https://profile.code.dev-theguardian.com/idp/idx/identify/select",
+					"method": "POST",
+					"produces": "application/ion+json; okta-version=1.0.0",
+					"value": [
+						{
+							"name": "stateHandle",
+							"required": true,
+							"value": "02.id.state~c.handle",
+							"visible": false,
+							"mutable": false
+						}
+					],
+					"accepts": "application/json; okta-version=1.0.0"
+				}
+			]
+		}
+	}
+}

--- a/cypress/fixtures/okta-responses/success/idx-enroll-new-response.json
+++ b/cypress/fixtures/okta-responses/success/idx-enroll-new-response.json
@@ -1,0 +1,123 @@
+{
+	"code": 200,
+	"response": {
+		"version": "1.0.0",
+		"stateHandle": "02.id.state~c.handle",
+		"expiresAt": "2099-12-31T23:59:59.000Z",
+		"remediation": {
+			"type": "array",
+			"value": [
+				{
+					"rel": ["create-form"],
+					"name": "enroll-authenticator",
+					"relatesTo": ["$.currentAuthenticator"],
+					"href": "https://profile.code.dev-theguardian.com/idp/idx/challenge/answer",
+					"method": "POST",
+					"produces": "application/ion+json; okta-version=1.0.0",
+					"value": [
+						{
+							"name": "credentials",
+							"type": "object",
+							"form": {
+								"value": [
+									{
+										"name": "passcode",
+										"label": "Enter code"
+									}
+								]
+							},
+							"required": true
+						},
+						{
+							"name": "stateHandle",
+							"required": true,
+							"value": "02.id.state~c.handle",
+							"visible": false,
+							"mutable": false
+						}
+					],
+					"accepts": "application/json; okta-version=1.0.0"
+				},
+				{
+					"rel": ["create-form"],
+					"name": "select-authenticator-enroll",
+					"href": "https://profile.code.dev-theguardian.com/idp/idx/credential/enroll",
+					"method": "POST",
+					"produces": "application/ion+json; okta-version=1.0.0",
+					"value": [
+						{
+							"name": "authenticator",
+							"type": "object",
+							"options": [
+								{
+									"label": "Email",
+									"value": {
+										"form": {
+											"value": [
+												{
+													"name": "id",
+													"required": true,
+													"value": "id",
+													"mutable": false
+												},
+												{
+													"name": "methodType",
+													"required": false,
+													"value": "email",
+													"mutable": false
+												}
+											]
+										}
+									},
+									"relatesTo": "$.authenticators.value[0]"
+								}
+							]
+						},
+						{
+							"name": "stateHandle",
+							"required": true,
+							"value": "02.id.state~c.handle",
+							"visible": false,
+							"mutable": false
+						}
+					],
+					"accepts": "application/json; okta-version=1.0.0"
+				}
+			]
+		},
+		"currentAuthenticator": {
+			"type": "object",
+			"value": {
+				"resend": {
+					"rel": ["create-form"],
+					"name": "resend",
+					"href": "https://profile.code.dev-theguardian.com/idp/idx/challenge/resend",
+					"method": "POST",
+					"produces": "application/ion+json; okta-version=1.0.0",
+					"value": [
+						{
+							"name": "stateHandle",
+							"required": true,
+							"value": "02.id.state~c.handle",
+							"visible": false,
+							"mutable": false
+						}
+					],
+					"accepts": "application/json; okta-version=1.0.0"
+				},
+				"contextualData": {
+					"useEmailMagicLink": false
+				},
+				"type": "email",
+				"key": "okta_email",
+				"id": "emailId",
+				"displayName": "Email",
+				"methods": [
+					{
+						"type": "email"
+					}
+				]
+			}
+		}
+	}
+}

--- a/cypress/fixtures/okta-responses/success/idx-enroll-response.json
+++ b/cypress/fixtures/okta-responses/success/idx-enroll-response.json
@@ -1,0 +1,81 @@
+{
+	"code": 200,
+	"response": {
+		"version": "1.0.0",
+		"stateHandle": "02.id.state~c.handle",
+		"expiresAt": "2099-12-31T23:59:59.000Z",
+		"remediation": {
+			"type": "array",
+			"value": [
+				{
+					"rel": ["create-form"],
+					"name": "enroll-profile",
+					"href": "https://profile.code.dev-theguardian.com/idp/idx/enroll/new",
+					"method": "POST",
+					"produces": "application/ion+json; okta-version=1.0.0",
+					"value": [
+						{
+							"name": "userProfile",
+							"form": {
+								"value": [
+									{
+										"name": "email",
+										"type": "string",
+										"label": "Primary email",
+										"required": true,
+										"maxLength": 100
+									},
+									{
+										"name": "isGuardianUser",
+										"type": "boolean",
+										"label": "isGuardianUser",
+										"required": true
+									},
+									{
+										"name": "registrationPlatform",
+										"type": "string",
+										"label": "registrationPlatform",
+										"required": false,
+										"maxLength": 50
+									},
+									{
+										"name": "registrationLocation",
+										"type": "string",
+										"label": "registrationLocation",
+										"required": false,
+										"maxLength": 50
+									}
+								]
+							}
+						},
+						{
+							"name": "stateHandle",
+							"required": true,
+							"value": "02.id.state~c.handle",
+							"visible": false,
+							"mutable": false
+						}
+					],
+					"accepts": "application/json; okta-version=1.0.0"
+				},
+				{
+					"rel": ["create-form"],
+					"name": "select-identify",
+					"href": "https://profile.code.dev-theguardian.com/idp/idx/identify/select",
+					"method": "POST",
+					"produces": "application/ion+json; okta-version=1.0.0",
+					"value": [
+						{
+							"name": "stateHandle",
+							"required": true,
+							"value": "02.id.state~c.handle",
+							"visible": false,
+							"mutable": false
+						}
+					],
+					"accepts": "application/json; okta-version=1.0.0"
+				}
+			]
+		}
+	}
+}

--- a/cypress/fixtures/okta-responses/success/idx-interact-response.json
+++ b/cypress/fixtures/okta-responses/success/idx-interact-response.json
@@ -1,0 +1,6 @@
+{
+	"code": 200,
+	"response": {
+		"interaction_handle": "someInteractionHandle"
+	}
+}

--- a/cypress/fixtures/okta-responses/success/idx-introspect-default-response.json
+++ b/cypress/fixtures/okta-responses/success/idx-introspect-default-response.json
@@ -1,0 +1,94 @@
+{
+	"code": 200,
+	"response": {
+		"version": "1.0.0",
+		"stateHandle": "02.id.state~c.handle",
+		"expiresAt": "2099-12-31T23:59:59.000Z",
+		"remediation": {
+			"type": "array",
+			"value": [
+				{
+					"rel": ["create-form"],
+					"name": "identify",
+					"href": "https://profile.thegulocal.com/idp/idx/identify",
+					"method": "POST",
+					"produces": "application/ion+json; okta-version=1.0.0",
+					"value": [
+						{
+							"name": "identifier",
+							"label": "Username",
+							"required": true
+						},
+						{
+							"name": "rememberMe",
+							"type": "boolean",
+							"label": "Remember this device"
+						},
+						{
+							"name": "stateHandle",
+							"required": true,
+							"value": "02.id.state~c.handle",
+							"visible": false,
+							"mutable": false
+						}
+					],
+					"accepts": "application/json; okta-version=1.0.0"
+				},
+				{
+					"rel": ["create-form"],
+					"name": "select-enroll-profile",
+					"href": "https://profile.thegulocal.com/idp/idx/enroll",
+					"method": "POST",
+					"produces": "application/ion+json; okta-version=1.0.0",
+					"value": [
+						{
+							"name": "stateHandle",
+							"required": true,
+							"value": "02.id.state~c.handle",
+							"visible": false,
+							"mutable": false
+						}
+					],
+					"accepts": "application/json; okta-version=1.0.0"
+				},
+				{
+					"rel": ["create-form"],
+					"name": "unlock-account",
+					"href": "https://profile.thegulocal.com/idp/idx/unlock-account",
+					"method": "POST",
+					"produces": "application/ion+json; okta-version=1.0.0",
+					"value": [
+						{
+							"name": "stateHandle",
+							"required": true,
+							"value": "02.id.state~c.handle",
+							"visible": false,
+							"mutable": false
+						}
+					],
+					"accepts": "application/json; okta-version=1.0.0"
+				},
+				{
+					"name": "redirect-idp",
+					"type": "APPLE",
+					"idp": {
+						"id": "apple",
+						"name": "Apple Auth"
+					},
+					"href": "https://profile.thegulocal.com/oauth2/aus3v9gla95Toj0EE0x7/v1/authorize?client_id=0oa4iyjx692Aj8SlZ0x7&request_uri=urn:okta:VHpUbjZjSUtKLVBQaUs2M0pXaWFhTFM2Tm5feVA0eWRiTm9QLVV3U2gzSTowb2ExcXc3MjRmZ3JMSjQ2YjB4Nw",
+					"method": "GET"
+				},
+				{
+					"name": "redirect-idp",
+					"type": "GOOGLE",
+					"idp": {
+						"id": "google",
+						"name": "Google Auth"
+					},
+					"href": "https://profile.thegulocal.com/oauth2/aus3v9gla95Toj0EE0x7/v1/authorize?client_id=0oa4iyjx692Aj8SlZ0x7&request_uri=urn:okta:VHpUbjZjSUtKLVBQaUs2M0pXaWFhTFM2Tm5feVA0eWRiTm9QLVV3U2gzSTowb2ExcXdhZGJtd3BGZXhvUTB4Nw",
+					"method": "GET"
+				}
+			]
+		}
+	}
+}

--- a/cypress/integration/ete-okta/new_account_review.3.cy.ts
+++ b/cypress/integration/ete-okta/new_account_review.3.cy.ts
@@ -29,69 +29,80 @@ describe('New account review page', () => {
 		cy.get('input[name=email]').type(unregisteredEmail);
 		cy.get('[data-cy="main-form-submit-button"]').click();
 
-		cy.contains('Check your inbox');
+		cy.contains('Enter your code');
 		cy.contains(unregisteredEmail);
 		cy.contains('send again');
 		cy.contains('try another address');
 
-		cy.checkForEmailAndGetDetails(
-			unregisteredEmail,
-			timeRequestWasMade,
-			/welcome\/([^"]*)/,
-		).then(({ body, token }) => {
-			expect(body).to.have.string('Complete registration');
-			cy.visit(`/welcome/${token}`);
-			cy.contains('Complete creating account');
-			cy.get('input[name="password"]').type(randomPassword());
-			cy.get('button[type="submit"]').click();
+		cy.checkForEmailAndGetDetails(unregisteredEmail, timeRequestWasMade).then(
+			({ body, codes }) => {
+				// email
+				expect(body).to.have.string('Your verification code');
+				expect(codes?.length).to.eq(1);
+				const code = codes?.[0].value;
+				expect(code).to.match(/^\d{6}$/);
 
-			cy.url().should('contain', '/welcome/review');
+				// passcode page
+				cy.url().should('include', '/register/email-sent');
+				cy.get('input[name=code]').type(code!);
 
-			// Always shown
-			cy.get('label').contains(
-				'Allow the Guardian to analyse my signed-in data to improve marketing content',
-			);
-			cy.contains('What we mean by signed-in data');
+				cy.contains('Submit verification code').click();
 
-			// Only shown when CMP consented
-			cy.get('label').contains(
-				'Allow personalised advertising with my signed-in data',
-			);
-			cy.contains('Advertising is a crucial source of our funding');
+				cy.contains('Complete creating account');
+				cy.get('input[name="password"]').type(randomPassword());
+				cy.get('button[type="submit"]').click();
 
-			// Flip the switches so personalised advertising is on
-			// and profiling is off
-			cy.get(`label#${Consents.ADVERTISING}_description`).click();
-			cy.get(`label#${Consents.PROFILING}_description`).click();
-			cy.get('button[type="submit"]').click();
+				cy.url().should('contain', '/welcome/review');
 
-			cy.url().should('contain', decodeURIComponent(encodedReturnUrl));
-
-			// Return to Gateway so we can access the user cookie
-			cy.visit('/signin');
-
-			cy.getTestUserDetails().then((response) => {
-				const consentIds = response.user.consents.filter(
-					(consent) =>
-						consent.id === 'profiling_optout' ||
-						consent.id === 'personalised_advertising',
+				// Always shown
+				cy.get('label').contains(
+					'Allow the Guardian to analyse my signed-in data to improve marketing content',
 				);
-				expect(consentIds).to.have.length(2);
-				response.user.consents.map((consent) => {
-					if (consent.id === 'profiling_optout') {
-						// Profiling is modelled as an optout so we now expect it to be true
-						expect(consent.consented).to.be.true;
-					}
-					if (consent.id === 'personalised_advertising') {
-						expect(consent.consented).to.be.true;
-					}
+				cy.contains('What we mean by signed-in data');
+
+				// Only shown when CMP consented
+				cy.get('label').contains(
+					'Allow personalised advertising with my signed-in data',
+				);
+				cy.contains('Advertising is a crucial source of our funding');
+
+				// Flip the switches so personalised advertising is on
+				// and profiling is off
+				cy.get(`label#${Consents.ADVERTISING}_description`).click();
+				cy.get(`label#${Consents.PROFILING}_description`).click();
+				cy.get('button[type="submit"]').click();
+
+				cy.url().should('contain', decodeURIComponent(encodedReturnUrl));
+
+				// Return to Gateway so we can access the user cookie
+				cy.visit('/signin');
+
+				cy.getTestUserDetails().then((response) => {
+					const consentIds = response.user.consents.filter(
+						(consent) =>
+							consent.id === 'profiling_optout' ||
+							consent.id === 'personalised_advertising',
+					);
+					expect(consentIds).to.have.length(2);
+					response.user.consents.map((consent) => {
+						if (consent.id === 'profiling_optout') {
+							// Profiling is modelled as an optout so we now expect it to be true
+							expect(consent.consented).to.be.true;
+						}
+						if (consent.id === 'personalised_advertising') {
+							expect(consent.consented).to.be.true;
+						}
+					});
+					cy.getTestOktaUser(unregisteredEmail).then((user) => {
+						expect(user.profile.registrationLocation).to.equal(
+							'United Kingdom',
+						);
+					});
 				});
-				cy.getTestOktaUser(unregisteredEmail).then((user) => {
-					expect(user.profile.registrationLocation).to.equal('United Kingdom');
-				});
-			});
-		});
+			},
+		);
 	});
+
 	it('should show only the profiling checkbox if CMP is not accepted', () => {
 		const encodedReturnUrl =
 			'https%3A%2F%2Fm.code.dev-theguardian.com%2Ftravel%2F2019%2Fdec%2F18%2Ffood-culture-tour-bethlehem-palestine-east-jerusalem-photo-essay';
@@ -103,50 +114,57 @@ describe('New account review page', () => {
 		cy.get('input[name=email]').type(unregisteredEmail);
 		cy.get('[data-cy="main-form-submit-button"]').click();
 
-		cy.contains('Check your inbox');
+		cy.contains('Enter your code');
 		cy.contains(unregisteredEmail);
 		cy.contains('send again');
 		cy.contains('try another address');
 
-		cy.checkForEmailAndGetDetails(
-			unregisteredEmail,
-			timeRequestWasMade,
-			/welcome\/([^"]*)/,
-		).then(({ body, token }) => {
-			expect(body).to.have.string('Complete registration');
-			cy.visit(`/welcome/${token}`);
-			cy.contains('Complete creating account');
-			cy.get('input[name="password"]').type(randomPassword());
-			cy.get('button[type="submit"]').click();
+		cy.checkForEmailAndGetDetails(unregisteredEmail, timeRequestWasMade).then(
+			({ body, codes }) => {
+				// email
+				expect(body).to.have.string('Your verification code');
+				expect(codes?.length).to.eq(1);
+				const code = codes?.[0].value;
+				expect(code).to.match(/^\d{6}$/);
 
-			cy.url().should('contain', '/welcome/review');
+				// passcode page
+				cy.url().should('include', '/register/email-sent');
+				cy.get('input[name=code]').type(code!);
 
-			cy.get('label').contains(
-				'Allow the Guardian to analyse my signed-in data to improve marketing content',
-			);
-			cy.contains('What we mean by signed-in data');
+				cy.contains('Submit verification code').click();
+				cy.contains('Complete creating account');
+				cy.get('input[name="password"]').type(randomPassword());
+				cy.get('button[type="submit"]').click();
 
-			cy.get('label').should(
-				'not.contain',
-				'Allow personalised advertising with my signed-in data',
-			);
-			cy.should(
-				'not.contain',
-				'Advertising is a crucial source of our funding',
-			);
+				cy.url().should('contain', '/welcome/review');
 
-			cy.get('button[type="submit"]').click();
+				cy.get('label').contains(
+					'Allow the Guardian to analyse my signed-in data to improve marketing content',
+				);
+				cy.contains('What we mean by signed-in data');
 
-			cy.url().should('contain', decodeURIComponent(encodedReturnUrl));
+				cy.get('label').should(
+					'not.contain',
+					'Allow personalised advertising with my signed-in data',
+				);
+				cy.should(
+					'not.contain',
+					'Advertising is a crucial source of our funding',
+				);
 
-			// Return to Gateway so we can access the user cookie
-			cy.visit('/signin');
+				cy.get('button[type="submit"]').click();
 
-			// Check that the user does not have their registration location set
-			cy.getTestOktaUser(unregisteredEmail).then((user) => {
-				expect(user.profile.registrationLocation).to.be.undefined;
-			});
-		});
+				cy.url().should('contain', decodeURIComponent(encodedReturnUrl));
+
+				// Return to Gateway so we can access the user cookie
+				cy.visit('/signin');
+
+				// Check that the user does not have their registration location set
+				cy.getTestOktaUser(unregisteredEmail).then((user) => {
+					expect(user.profile.registrationLocation).to.be.undefined;
+				});
+			},
+		);
 	});
 });
 
@@ -167,29 +185,36 @@ describe('New account newsletters page', () => {
 		cy.get('input[name=email]').type(unregisteredEmail);
 		cy.get('[data-cy="main-form-submit-button"]').click();
 
-		cy.contains('Check your inbox');
+		cy.contains('Enter your code');
 		cy.contains(unregisteredEmail);
 		cy.contains('send again');
 		cy.contains('try another address');
 
-		cy.checkForEmailAndGetDetails(
-			unregisteredEmail,
-			timeRequestWasMade,
-			/welcome\/([^"]*)/,
-		).then(({ body, token }) => {
-			expect(body).to.have.string('Complete registration');
-			cy.visit(`/welcome/${token}`);
-			cy.contains('Complete creating account');
-			cy.get('input[name="password"]').type(randomPassword());
-			cy.get('button[type="submit"]').click();
+		cy.checkForEmailAndGetDetails(unregisteredEmail, timeRequestWasMade).then(
+			({ body, codes }) => {
+				// email
+				expect(body).to.have.string('Your verification code');
+				expect(codes?.length).to.eq(1);
+				const code = codes?.[0].value;
+				expect(code).to.match(/^\d{6}$/);
 
-			cy.url().should('contain', '/welcome/review');
-			cy.get('button[type="submit"]').click();
-			cy.contains(
-				'Our newsletters help you get closer to our quality, independent journalism.',
-			).should('not.exist');
-			cy.url().should('contain', decodeURIComponent(encodedReturnUrl));
-		});
+				// passcode page
+				cy.url().should('include', '/register/email-sent');
+				cy.get('input[name=code]').type(code!);
+
+				cy.contains('Submit verification code').click();
+				cy.contains('Complete creating account');
+				cy.get('input[name="password"]').type(randomPassword());
+				cy.get('button[type="submit"]').click();
+
+				cy.url().should('contain', '/welcome/review');
+				cy.get('button[type="submit"]').click();
+				cy.contains(
+					'Our newsletters help you get closer to our quality, independent journalism.',
+				).should('not.exist');
+				cy.url().should('contain', decodeURIComponent(encodedReturnUrl));
+			},
+		);
 	});
 
 	it('should redirect to the newsletters page if the geolocation is AU', () => {
@@ -205,31 +230,38 @@ describe('New account newsletters page', () => {
 		cy.get('input[name=email]').type(unregisteredEmail);
 		cy.get('[data-cy="main-form-submit-button"]').click();
 
-		cy.contains('Check your inbox');
+		cy.contains('Enter your code');
 		cy.contains(unregisteredEmail);
 		cy.contains('send again');
 		cy.contains('try another address');
 
-		cy.checkForEmailAndGetDetails(
-			unregisteredEmail,
-			timeRequestWasMade,
-			/welcome\/([^"]*)/,
-		).then(({ body, token }) => {
-			expect(body).to.have.string('Complete registration');
-			cy.visit(`/welcome/${token}`);
-			cy.contains('Complete creating account');
-			cy.get('input[name="password"]').type(randomPassword());
-			cy.get('button[type="submit"]').click();
+		cy.checkForEmailAndGetDetails(unregisteredEmail, timeRequestWasMade).then(
+			({ body, codes }) => {
+				// email
+				expect(body).to.have.string('Your verification code');
+				expect(codes?.length).to.eq(1);
+				const code = codes?.[0].value;
+				expect(code).to.match(/^\d{6}$/);
 
-			cy.url().should('contain', '/welcome/review');
-			cy.get('button[type="submit"]').click();
-			cy.url().should('contain', '/welcome/newsletters');
-			cy.contains(
-				'Our newsletters help you get closer to our quality, independent journalism.',
-			);
-			cy.get('button[type="submit"]').click();
-			cy.url().should('contain', decodeURIComponent(encodedReturnUrl));
-		});
+				// passcode page
+				cy.url().should('include', '/register/email-sent');
+				cy.get('input[name=code]').type(code!);
+
+				cy.contains('Submit verification code').click();
+				cy.contains('Complete creating account');
+				cy.get('input[name="password"]').type(randomPassword());
+				cy.get('button[type="submit"]').click();
+
+				cy.url().should('contain', '/welcome/review');
+				cy.get('button[type="submit"]').click();
+				cy.url().should('contain', '/welcome/newsletters');
+				cy.contains(
+					'Our newsletters help you get closer to our quality, independent journalism.',
+				);
+				cy.get('button[type="submit"]').click();
+				cy.url().should('contain', decodeURIComponent(encodedReturnUrl));
+			},
+		);
 	});
 
 	it('should redirect to the newsletters page if the geolocation is US', () => {
@@ -245,30 +277,37 @@ describe('New account newsletters page', () => {
 		cy.get('input[name=email]').type(unregisteredEmail);
 		cy.get('[data-cy="main-form-submit-button"]').click();
 
-		cy.contains('Check your inbox');
+		cy.contains('Enter your code');
 		cy.contains(unregisteredEmail);
 		cy.contains('send again');
 		cy.contains('try another address');
 
-		cy.checkForEmailAndGetDetails(
-			unregisteredEmail,
-			timeRequestWasMade,
-			/welcome\/([^"]*)/,
-		).then(({ body, token }) => {
-			expect(body).to.have.string('Complete registration');
-			cy.visit(`/welcome/${token}`);
-			cy.contains('Complete creating account');
-			cy.get('input[name="password"]').type(randomPassword());
-			cy.get('button[type="submit"]').click();
+		cy.checkForEmailAndGetDetails(unregisteredEmail, timeRequestWasMade).then(
+			({ body, codes }) => {
+				// email
+				expect(body).to.have.string('Your verification code');
+				expect(codes?.length).to.eq(1);
+				const code = codes?.[0].value;
+				expect(code).to.match(/^\d{6}$/);
 
-			cy.url().should('contain', '/welcome/review');
-			cy.get('button[type="submit"]').click();
-			cy.url().should('contain', '/welcome/newsletters');
-			cy.contains(
-				'Our newsletters help you get closer to our quality, independent journalism.',
-			);
-			cy.get('button[type="submit"]').click();
-			cy.url().should('contain', decodeURIComponent(encodedReturnUrl));
-		});
+				// passcode page
+				cy.url().should('include', '/register/email-sent');
+				cy.get('input[name=code]').type(code!);
+
+				cy.contains('Submit verification code').click();
+				cy.contains('Complete creating account');
+				cy.get('input[name="password"]').type(randomPassword());
+				cy.get('button[type="submit"]').click();
+
+				cy.url().should('contain', '/welcome/review');
+				cy.get('button[type="submit"]').click();
+				cy.url().should('contain', '/welcome/newsletters');
+				cy.contains(
+					'Our newsletters help you get closer to our quality, independent journalism.',
+				);
+				cy.get('button[type="submit"]').click();
+				cy.url().should('contain', decodeURIComponent(encodedReturnUrl));
+			},
+		);
 	});
 });

--- a/cypress/integration/ete-okta/registration_2.6.cy.ts
+++ b/cypress/integration/ete-okta/registration_2.6.cy.ts
@@ -652,7 +652,7 @@ describe('Registration flow - Split 2/2', () => {
 
 	// a few tests to check if the Okta Classic flow is still working using the useOktaClassic flag
 	context('Okta Classic Flow', () => {
-		it('successfully registers using an email with no existing account', () => {
+		it('create account - successfully registers using an email with no existing account', () => {
 			const encodedReturnUrl =
 				'https%3A%2F%2Fm.code.dev-theguardian.com%2Ftravel%2F2019%2Fdec%2F18%2Ffood-culture-tour-bethlehem-palestine-east-jerusalem-photo-essay';
 			const unregisteredEmail = randomMailosaurEmail();

--- a/cypress/integration/ete-okta/registration_2.6.cy.ts
+++ b/cypress/integration/ete-okta/registration_2.6.cy.ts
@@ -290,31 +290,39 @@ describe('Registration flow - Split 2/2', () => {
 			cy.get('input[name=email]').type(unregisteredEmail);
 			cy.get('[data-cy="main-form-submit-button"]').click();
 
-			cy.contains('Check your inbox');
+			cy.contains('Enter your code');
 			cy.contains(unregisteredEmail);
 			cy.contains('send again');
 			cy.contains('try another address');
 
-			cy.checkForEmailAndGetDetails(
-				unregisteredEmail,
-				timeRequestWasMade,
-				/welcome\/([^"]*)/,
-			).then(({ body, token }) => {
-				expect(body).to.have.string('Complete registration');
-				cy.visit(`/welcome/${token}`);
-				cy.contains('Complete creating account');
+			cy.checkForEmailAndGetDetails(unregisteredEmail, timeRequestWasMade).then(
+				({ body, codes }) => {
+					// email
+					expect(body).to.have.string('Your verification code');
+					expect(codes?.length).to.eq(1);
+					const code = codes?.[0].value;
+					expect(code).to.match(/^\d{6}$/);
 
-				cy.get('form')
-					.should('have.attr', 'action')
-					.and('match', new RegExp(encodedReturnUrl));
+					// passcode page
+					cy.url().should('include', '/register/email-sent');
+					cy.get('input[name=code]').type(code!);
 
-				//we are reloading here to make sure the params are persisted even on page refresh
-				cy.reload();
+					cy.contains('Submit verification code').click();
 
-				cy.get('input[name="password"]').type(randomPassword());
-				cy.get('button[type="submit"]').click();
-				cy.url().should('contain', encodedReturnUrl);
-			});
+					cy.contains('Complete creating account');
+
+					cy.get('form')
+						.should('have.attr', 'action')
+						.and('match', new RegExp(encodedReturnUrl));
+
+					//we are reloading here to make sure the params are persisted even on page refresh
+					cy.reload();
+
+					cy.get('input[name="password"]').type(randomPassword());
+					cy.get('button[type="submit"]').click();
+					cy.url().should('contain', encodedReturnUrl);
+				},
+			);
 		});
 
 		it('should resend a STAGED user a set password email with an Okta activation token', () => {
@@ -642,18 +650,26 @@ describe('Registration flow - Split 2/2', () => {
 		});
 	});
 
-	context('Temp Fix: Registration when token is prefixed with app', () => {
-		beforeEach(() => {
-			// Intercept the external redirect page.
-			// We just want to check that the redirect happens, not that the page loads.
-			cy.intercept('GET', 'https://m.code.dev-theguardian.com/', (req) => {
-				req.reply(200);
-			});
-		});
-
-		it('should redirect to the guardian homepage when registering with a token prefixed with app prefix and it did not get intercepted by app', () => {
+	// a few tests to check if the Okta Classic flow is still working using the useOktaClassic flag
+	context('Okta Classic Flow', () => {
+		it('successfully registers using an email with no existing account', () => {
+			const encodedReturnUrl =
+				'https%3A%2F%2Fm.code.dev-theguardian.com%2Ftravel%2F2019%2Fdec%2F18%2Ffood-culture-tour-bethlehem-palestine-east-jerusalem-photo-essay';
 			const unregisteredEmail = randomMailosaurEmail();
-			cy.visit(`/register/email`);
+			const encodedRef = 'https%3A%2F%2Fm.theguardian.com';
+			const refViewId = 'testRefViewId';
+			const clientId = 'jobs';
+
+			// these params should *not* persist between initial registration and welcome page
+			// despite the fact that they PersistableQueryParams, as these are set by the Okta SDK sign in method
+			// and subsequent interception, and not by gateway
+			const appClientId = 'appClientId1';
+			const fromURI = 'fromURI1';
+
+			cy.visit(
+				`/register/email?returnUrl=${encodedReturnUrl}&ref=${encodedRef}&refViewId=${refViewId}&clientId=${clientId}&appClientId=${appClientId}&fromURI=${fromURI}&useOktaClassic=true`,
+			);
+
 			const timeRequestWasMade = new Date();
 			cy.get('input[name=email]').type(unregisteredEmail);
 			cy.get('[data-cy="main-form-submit-button"]').click();
@@ -669,24 +685,44 @@ describe('Registration flow - Split 2/2', () => {
 				/welcome\/([^"]*)/,
 			).then(({ body, token }) => {
 				expect(body).to.have.string('Complete registration');
-				const appClientId = Cypress.env('OKTA_ANDROID_CLIENT_ID');
-				// manually adding the app prefix to the token
-				cy.visit(`/welcome/al_${token}&appClientId=${appClientId}`);
+				cy.visit(`/welcome/${token}`);
 				cy.contains('Complete creating account');
 
+				cy.get('form')
+					.should('have.attr', 'action')
+					.and('match', new RegExp(encodedReturnUrl))
+					.and('match', new RegExp(refViewId))
+					.and('match', new RegExp(encodedRef))
+					.and('match', new RegExp(clientId))
+					.and('not.match', new RegExp(appClientId))
+					.and('not.match', new RegExp(fromURI));
+
+				//we are reloading here to make sure the params are persisted even on page refresh
+				cy.reload();
+
+				cy.get('input[name="firstName"]').type('First Name');
+				cy.get('input[name="secondName"]').type('Last Name');
 				cy.get('input[name="password"]').type(randomPassword());
 				cy.get('button[type="submit"]').click();
+				cy.url().should('contain', encodedReturnUrl);
+				cy.url().should('contain', refViewId);
+				cy.url().should('contain', encodedRef);
+				cy.url().should('contain', clientId);
+				cy.url().should('not.contain', appClientId);
+				cy.url().should('not.contain', fromURI);
 
-				cy.url().should('contain', '/welcome/al_/complete');
-				cy.contains(unregisteredEmail);
-				cy.contains('Guardian app');
+				// test the registration platform is set correctly
+				cy.getTestOktaUser(unregisteredEmail).then((oktaUser) => {
+					expect(oktaUser.status).to.eq(Status.ACTIVE);
+					expect(oktaUser.profile.registrationPlatform).to.eq('profile');
+				});
 			});
 		});
-	});
 
-	// TODO: These tests should be merged into the existing registration tests when the passcode registration feature flag is removed
-	context('Passcode registration temporary tests', () => {
-		it('successfully registers using an email with no existing account using a passcode', () => {
+		it('create account - successfully registers using an email with no existing account, and has a prefixed activation token when using a native app', () => {
+			cy.intercept('GET', 'https://m.code.dev-theguardian.com/', (req) => {
+				req.reply(200);
+			});
 			const encodedReturnUrl =
 				'https%3A%2F%2Fm.code.dev-theguardian.com%2Ftravel%2F2019%2Fdec%2F18%2Ffood-culture-tour-bethlehem-palestine-east-jerusalem-photo-essay';
 			const unregisteredEmail = randomMailosaurEmail();
@@ -694,352 +730,112 @@ describe('Registration flow - Split 2/2', () => {
 			const refViewId = 'testRefViewId';
 			const clientId = 'jobs';
 
-			cy.visit(
-				`/register/email?returnUrl=${encodedReturnUrl}&ref=${encodedRef}&refViewId=${refViewId}&clientId=${clientId}&usePasscodeRegistration=true`,
-			);
-
-			const timeRequestWasMade = new Date();
-			cy.get('input[name=email]').type(unregisteredEmail);
-			cy.get('[data-cy="main-form-submit-button"]').click();
-
-			cy.contains('Enter your code');
-			cy.contains(unregisteredEmail);
-			cy.contains('send again');
-			cy.contains('try another address');
-
-			cy.checkForEmailAndGetDetails(unregisteredEmail, timeRequestWasMade).then(
-				({ body, codes }) => {
-					// email
-					expect(body).to.have.string('Your verification code');
-					expect(codes?.length).to.eq(1);
-					const code = codes?.[0].value;
-					expect(code).to.match(/^\d{6}$/);
-
-					// passcode page
-					cy.url().should('include', '/register/email-sent');
-					cy.get('input[name=code]').type(code!);
-
-					cy.get('form')
-						.should('have.attr', 'action')
-						.and('match', new RegExp(encodedReturnUrl))
-						.and('match', new RegExp(refViewId))
-						.and('match', new RegExp(encodedRef))
-						.and('match', new RegExp(clientId));
-
-					cy.contains('Submit verification code').click();
-
-					// password page
-					cy.url().should('include', '/welcome/password');
-					cy.get('form')
-						.should('have.attr', 'action')
-						.and('match', new RegExp(encodedReturnUrl))
-						.and('match', new RegExp(refViewId))
-						.and('match', new RegExp(encodedRef))
-						.and('match', new RegExp(clientId));
-
-					cy.get('input[name="firstName"]').type('First Name');
-					cy.get('input[name="secondName"]').type('Last Name');
-					cy.get('input[name="password"]').type(randomPassword());
-					cy.get('button[type="submit"]').click();
-
-					// test the registration platform is set correctly
-					cy.getTestOktaUser(unregisteredEmail).then((oktaUser) => {
-						expect(oktaUser.status).to.eq(Status.ACTIVE);
-						expect(oktaUser.profile.registrationPlatform).to.eq('profile');
-					});
-
-					cy.url().should('contain', '/welcome/review');
-				},
-			);
-		});
-
-		it('successfully registers using an email with no existing account using a passcode and redirects to fromURI', () => {
-			const appClientId = 'appClientId1';
-			const fromURI = '%2FfromURI1';
-
-			// Intercept the external redirect page.
-			// We just want to check that the redirect happens, not that the page loads.
-			cy.intercept(
-				'GET',
-				`https://${Cypress.env('BASE_URI')}${decodeURIComponent(fromURI)}`,
-				(req) => {
-					req.reply(200);
-				},
-			);
-
-			const encodedReturnUrl =
-				'https%3A%2F%2Fm.code.dev-theguardian.com%2Ftravel%2F2019%2Fdec%2F18%2Ffood-culture-tour-bethlehem-palestine-east-jerusalem-photo-essay';
-			const unregisteredEmail = randomMailosaurEmail();
-			const encodedRef = 'https%3A%2F%2Fm.theguardian.com';
-			const refViewId = 'testRefViewId';
+			// these params should *not* persist between initial registration and welcome page
+			// despite the fact that they PersistableQueryParams, as these are set by the Okta SDK sign in method
+			// and subsequent interception, and not by gateway
+			const appClientId = Cypress.env('OKTA_ANDROID_CLIENT_ID');
+			const fromURI = 'fromURI1';
 
 			cy.visit(
-				`/register/email?returnUrl=${encodedReturnUrl}&ref=${encodedRef}&refViewId=${refViewId}&appClientId=${appClientId}&fromURI=${fromURI}&usePasscodeRegistration=true`,
+				`/register/email?returnUrl=${encodedReturnUrl}&ref=${encodedRef}&refViewId=${refViewId}&clientId=${clientId}&appClientId=${appClientId}&fromURI=${fromURI}&useOktaClassic=true`,
 			);
 
 			const timeRequestWasMade = new Date();
 			cy.get('input[name=email]').type(unregisteredEmail);
 			cy.get('[data-cy="main-form-submit-button"]').click();
 
-			cy.contains('Enter your code');
-			cy.contains(unregisteredEmail);
-			cy.contains('send again');
-			cy.contains('try another address');
-
-			cy.checkForEmailAndGetDetails(unregisteredEmail, timeRequestWasMade).then(
-				({ body, codes }) => {
-					// email
-					expect(body).to.have.string('Your verification code');
-					expect(codes?.length).to.eq(1);
-					const code = codes?.[0].value;
-					expect(code).to.match(/^\d{6}$/);
-
-					// passcode page
-					cy.url().should('include', '/register/email-sent');
-					cy.get('input[name=code]').type(code!);
-
-					cy.get('form')
-						.should('have.attr', 'action')
-						.and('match', new RegExp(encodedReturnUrl))
-						.and('match', new RegExp(refViewId))
-						.and('match', new RegExp(encodedRef))
-						.and('match', new RegExp(appClientId))
-						.and('match', new RegExp(fromURI));
-
-					cy.contains('Submit verification code').click();
-
-					// password page
-					cy.url().should('include', '/welcome/password');
-					cy.get('form')
-						.should('have.attr', 'action')
-						.and('match', new RegExp(encodedReturnUrl))
-						.and('match', new RegExp(refViewId))
-						.and('match', new RegExp(encodedRef))
-						.and('match', new RegExp(appClientId))
-						.and('match', new RegExp(fromURI));
-
-					cy.get('input[name="password"]').type(randomPassword());
-					cy.get('button[type="submit"]').click();
-
-					// test the registration platform is set correctly
-					cy.getTestOktaUser(unregisteredEmail).then((oktaUser) => {
-						expect(oktaUser.status).to.eq(Status.ACTIVE);
-						expect(oktaUser.profile.registrationPlatform).to.eq('profile');
-					});
-
-					cy.url().should('contain', decodeURIComponent(fromURI));
-				},
-			);
-		});
-
-		it('passcode used functionality', () => {
-			const unregisteredEmail = randomMailosaurEmail();
-			cy.visit(`/register/email?usePasscodeRegistration=true`);
-
-			const timeRequestWasMade = new Date();
-			cy.get('input[name=email]').type(unregisteredEmail);
-			cy.get('[data-cy="main-form-submit-button"]').click();
-
-			cy.contains('Enter your code');
-			cy.contains(unregisteredEmail);
-			cy.contains('send again');
-			cy.contains('try another address');
-
-			cy.checkForEmailAndGetDetails(unregisteredEmail, timeRequestWasMade).then(
-				({ body, codes }) => {
-					// email
-					expect(body).to.have.string('Your verification code');
-					expect(codes?.length).to.eq(1);
-					const code = codes?.[0].value;
-					expect(code).to.match(/^\d{6}$/);
-
-					// passcode page
-					cy.get('input[name=code]').clear().type(code!);
-					cy.contains('Submit verification code').click();
-
-					cy.url().should('contain', '/welcome/password');
-
-					cy.go('back');
-					cy.url().should('contain', '/register/email');
-					cy.contains('Email verified');
-					cy.contains('Complete creating account').click();
-
-					cy.url().should('contain', '/welcome/password');
-
-					cy.get('input[name="password"]').type(randomPassword());
-					cy.get('button[type="submit"]').click();
-
-					cy.url().should('contain', '/welcome/review');
-				},
-			);
-		});
-
-		it('passcode incorrect functionality', () => {
-			const unregisteredEmail = randomMailosaurEmail();
-			cy.visit(`/register/email?usePasscodeRegistration=true`);
-
-			const timeRequestWasMade = new Date();
-			cy.get('input[name=email]').type(unregisteredEmail);
-			cy.get('[data-cy="main-form-submit-button"]').click();
-
-			cy.contains('Enter your code');
-			cy.contains(unregisteredEmail);
-			cy.contains('send again');
-			cy.contains('try another address');
-
-			cy.checkForEmailAndGetDetails(unregisteredEmail, timeRequestWasMade).then(
-				({ body, codes }) => {
-					// email
-					expect(body).to.have.string('Your verification code');
-					expect(codes?.length).to.eq(1);
-					const code = codes?.[0].value;
-					expect(code).to.match(/^\d{6}$/);
-
-					// passcode page
-					cy.url().should('include', '/register/email-sent');
-					cy.get('input[name=code]').type(`${+code! + 1}`);
-
-					cy.contains('Submit verification code').click();
-
-					cy.url().should('include', '/register/code');
-
-					cy.contains('Incorrect code');
-
-					cy.get('input[name=code]').clear().type(code!);
-					cy.contains('Submit verification code').click();
-
-					cy.url().should('contain', '/welcome/password');
-				},
-			);
-		});
-
-		it('resend email functionality', () => {
-			const unregisteredEmail = randomMailosaurEmail();
-			cy.visit(`/register/email?usePasscodeRegistration=true`);
-
-			const timeRequestWasMade1 = new Date();
-			cy.get('input[name=email]').type(unregisteredEmail);
-			cy.get('[data-cy="main-form-submit-button"]').click();
-
-			cy.contains('Enter your code');
+			cy.contains('Check your inbox');
 			cy.contains(unregisteredEmail);
 			cy.contains('send again');
 			cy.contains('try another address');
 
 			cy.checkForEmailAndGetDetails(
 				unregisteredEmail,
-				timeRequestWasMade1,
-			).then(({ body, codes }) => {
-				// email
-				expect(body).to.have.string('Your verification code');
-				expect(codes?.length).to.eq(1);
-				const code = codes?.[0].value;
-				expect(code).to.match(/^\d{6}$/);
+				timeRequestWasMade,
+				/welcome\/([^"]*)/,
+			).then(({ body, token }) => {
+				expect(body).to.have.string('Complete registration');
+				expect(token).to.have.string('al_');
+				cy.visit(`/welcome/${token}`);
+				cy.contains('Complete creating account');
 
-				// passcode page
-				cy.url().should('include', '/register/email-sent');
-				const timeRequestWasMade2 = new Date();
-				cy.contains('send again').click();
-				cy.checkForEmailAndGetDetails(
-					unregisteredEmail,
-					timeRequestWasMade2,
-				).then(({ body, codes }) => {
-					// email
-					expect(body).to.have.string('Your verification code');
-					expect(codes?.length).to.eq(1);
-					const code = codes?.[0].value;
-					expect(code).to.match(/^\d{6}$/);
+				cy.get('form')
+					.should('have.attr', 'action')
+					.and('match', new RegExp(encodedReturnUrl))
+					.and('match', new RegExp(refViewId))
+					.and('match', new RegExp(encodedRef))
+					.and('match', new RegExp(clientId))
+					.and('not.match', new RegExp(appClientId))
+					.and('not.match', new RegExp(fromURI));
 
-					// passcode page
-					cy.url().should('include', '/register/email-sent');
-					cy.contains('Email with verification code sent');
+				//we are reloading here to make sure the params are persisted even on page refresh
+				cy.reload();
 
-					cy.get('input[name=code]').type(code!);
-					cy.contains('Submit verification code').click();
+				cy.get('form')
+					.should('have.attr', 'action')
+					.and('match', new RegExp(encodedReturnUrl))
+					.and('match', new RegExp(refViewId))
+					.and('match', new RegExp(encodedRef))
+					.and('match', new RegExp(clientId))
+					.and('not.match', new RegExp(appClientId))
+					.and('not.match', new RegExp(fromURI));
 
-					cy.url().should('contain', '/welcome/password');
+				cy.get('input[name="firstName"]').type('First Name');
+				cy.get('input[name="secondName"]').type('Last Name');
+				cy.get('input[name="password"]').type(randomPassword());
+				cy.get('button[type="submit"]').click();
+				cy.url().should('contain', '/welcome/al_/complete');
+				cy.contains(unregisteredEmail);
+				cy.contains('Guardian app');
+
+				// test the registration platform is set correctly
+				cy.getTestOktaUser(unregisteredEmail).then((oktaUser) => {
+					expect(oktaUser.status).to.eq(Status.ACTIVE);
+					expect(oktaUser.profile.registrationPlatform).to.eq(
+						'android_live_app',
+					);
 				});
 			});
 		});
 
-		it('change email functionality', () => {
+		it('welcome expired - send an email for user with no existing account', () => {
+			const encodedReturnUrl =
+				'https%3A%2F%2Fm.code.dev-theguardian.com%2Ftravel%2F2019%2Fdec%2F18%2Ffood-culture-tour-bethlehem-palestine-east-jerusalem-photo-essay';
 			const unregisteredEmail = randomMailosaurEmail();
-			cy.visit(`/register/email?usePasscodeRegistration=true`);
+
+			cy.visit(
+				`/welcome/resend?returnUrl=${encodedReturnUrl}&useOktaClassic=true`,
+			);
 
 			const timeRequestWasMade = new Date();
 			cy.get('input[name=email]').type(unregisteredEmail);
 			cy.get('[data-cy="main-form-submit-button"]').click();
 
-			cy.contains('Enter your code');
+			cy.contains('Check your inbox');
 			cy.contains(unregisteredEmail);
 			cy.contains('send again');
 			cy.contains('try another address');
 
-			cy.checkForEmailAndGetDetails(unregisteredEmail, timeRequestWasMade).then(
-				({ body, codes }) => {
-					// email
-					expect(body).to.have.string('Your verification code');
-					expect(codes?.length).to.eq(1);
-					const code = codes?.[0].value;
-					expect(code).to.match(/^\d{6}$/);
+			cy.checkForEmailAndGetDetails(
+				unregisteredEmail,
+				timeRequestWasMade,
+				/welcome\/([^"]*)/,
+			).then(({ body, token }) => {
+				expect(body).to.have.string('Complete registration');
+				cy.visit(`/welcome/${token}`);
+				cy.contains('Complete creating account');
 
-					// passcode page
-					cy.url().should('include', '/register/email-sent');
-					cy.contains('try another address').click();
+				cy.get('form')
+					.should('have.attr', 'action')
+					.and('match', new RegExp(encodedReturnUrl));
 
-					cy.url().should('include', '/register/email');
-				},
-			);
-		});
+				//we are reloading here to make sure the params are persisted even on page refresh
+				cy.reload();
 
-		it('existing users should fallback to the standard registration flow without passcodes', () => {
-			// Set up an existing user using the test user endpoint
-			cy
-				.createTestUser({
-					isGuestUser: true,
-					isUserEmailValidated: true,
-				})
-				?.then(({ emailAddress }) => {
-					cy.getTestOktaUser(emailAddress).then((oktaUser) => {
-						expect(oktaUser.status).to.eq(Status.STAGED);
-
-						const appClientId = Cypress.env('OKTA_ANDROID_CLIENT_ID');
-						const fromURI = 'fromURI1';
-
-						cy.visit(
-							`/register/email?appClientId=${appClientId}&fromURI=${fromURI}&usePasscodeRegistration=true`,
-						);
-						const timeRequestWasMade = new Date();
-
-						cy.get('input[name=email]').type(emailAddress);
-						cy.get('[data-cy="main-form-submit-button"]').click();
-
-						cy.contains('Check your inbox');
-						cy.contains(emailAddress);
-						cy.contains('send again');
-						cy.contains('try another address');
-
-						cy.checkForEmailAndGetDetails(
-							emailAddress,
-							timeRequestWasMade,
-							/\/set-password\/([^"]*)/,
-						).then(({ links, body }) => {
-							expect(body).to.have.string('This account already exists');
-
-							expect(body).to.have.string('Create password');
-							expect(links.length).to.eq(2);
-							const setPasswordLink = links.find((s) =>
-								s.text?.includes('Create password'),
-							);
-							expect(setPasswordLink?.href ?? '')
-								.to.have.string('al_')
-								.and.not.to.have.string('useOkta=true');
-							cy.visit(setPasswordLink?.href as string);
-							cy.contains('Create password');
-							cy.contains(emailAddress);
-						});
-					});
-				});
+				cy.get('input[name="password"]').type(randomPassword());
+				cy.get('button[type="submit"]').click();
+				cy.url().should('contain', encodedReturnUrl);
+			});
 		});
 	});
 });

--- a/cypress/integration/mocked-okta/rateLimit.1.cy.ts
+++ b/cypress/integration/mocked-okta/rateLimit.1.cy.ts
@@ -73,7 +73,7 @@ describe('POST requests return a user-facing error message when encountering a r
 			errorCauses: [],
 		});
 		cy.get('button[type=submit]').click();
-		cy.contains('Sorry, something went wrong. Please try again.');
+		cy.contains('There was a problem registering, please try again.');
 	});
 
 	specify('Submit /welcome/expired', () => {
@@ -88,7 +88,7 @@ describe('POST requests return a user-facing error message when encountering a r
 			errorCauses: [],
 		});
 		cy.get('button[type=submit]').click();
-		cy.contains('Sorry, something went wrong. Please try again.');
+		cy.contains('There was a problem registering, please try again.');
 	});
 
 	specify('Submit /reset-password/resend', () => {

--- a/cypress/integration/mocked-okta/registerController.1.cy.ts
+++ b/cypress/integration/mocked-okta/registerController.1.cy.ts
@@ -5,12 +5,35 @@ import socialUserResponse from '../../fixtures/okta-responses/success/social-use
 import userExistsError from '../../fixtures/okta-responses/error/user-exists.json';
 import successTokenResponse from '../../fixtures/okta-responses/success/token.json';
 import resetPasswordResponse from '../../fixtures/okta-responses/success/reset-password.json';
+import idxInteractResponse from '../../fixtures/okta-responses/success/idx-interact-response.json';
+import idxIntrospectDefaultResponse from '../../fixtures/okta-responses/success/idx-introspect-default-response.json';
+import idxEnrollResponse from '../../fixtures/okta-responses/success/idx-enroll-response.json';
+import idxEnrollNewResponse from '../../fixtures/okta-responses/success/idx-enroll-new-response.json';
+import idxEnrollNewExistingUserResponse from '../../fixtures/okta-responses/error/idx-enroll-new-existing-user-response.json';
 
 beforeEach(() => {
 	cy.mockPurge();
 });
+
 const verifyInRegularEmailSentPage = () => {
 	cy.contains('Check your inbox');
+	cy.contains('send again');
+};
+
+const baseIdxPasscodeRegistrationMocks = () => {
+	// interact
+	cy.mockNext(idxInteractResponse.code, idxInteractResponse.response);
+	// introspect
+	cy.mockNext(
+		idxIntrospectDefaultResponse.code,
+		idxIntrospectDefaultResponse.response,
+	);
+	// enroll
+	cy.mockNext(idxEnrollResponse.code, idxEnrollResponse.response);
+};
+
+const verifyInPasscodeEmailSentPage = () => {
+	cy.contains('Enter your code');
 	cy.contains('send again');
 };
 
@@ -24,21 +47,24 @@ userStatuses.forEach((status) => {
 			switch (status) {
 				case false:
 					specify("Then I should be shown the 'Check your inbox' page", () => {
-						// Set the correct user status on the response
-						const response = { ...userResponse.response, status: 'STAGED' };
-						cy.mockNext(userResponse.code, response);
+						baseIdxPasscodeRegistrationMocks();
 						cy.mockNext(
-							successTokenResponse.code,
-							successTokenResponse.response,
+							idxEnrollNewResponse.code,
+							idxEnrollNewResponse.response,
 						);
 						cy.get('button[type=submit]').click();
-						verifyInRegularEmailSentPage();
+						verifyInPasscodeEmailSentPage();
 					});
 					break;
 				case 'ACTIVE':
 					specify(
 						"Then I should be shown the 'Check your inbox' page if I have a validated email",
 						() => {
+							baseIdxPasscodeRegistrationMocks();
+							cy.mockNext(
+								idxEnrollNewExistingUserResponse.code,
+								idxEnrollNewExistingUserResponse.response,
+							);
 							// Set the correct user status on the response
 							const response = { ...userResponse.response, status };
 							const responseWithPassword = {
@@ -58,6 +84,11 @@ userStatuses.forEach((status) => {
 					specify(
 						"Then I should be shown the 'Check your inbox' page if I have a validated email but no password",
 						() => {
+							baseIdxPasscodeRegistrationMocks();
+							cy.mockNext(
+								idxEnrollNewExistingUserResponse.code,
+								idxEnrollNewExistingUserResponse.response,
+							);
 							// Set the correct user status on the response
 							const response = { ...userResponse.response, status };
 							cy.mockNext(userExistsError.code, userExistsError.response);
@@ -86,6 +117,11 @@ userStatuses.forEach((status) => {
 					specify(
 						"Then I should be shown the 'Check your inbox' page for social user",
 						() => {
+							baseIdxPasscodeRegistrationMocks();
+							cy.mockNext(
+								idxEnrollNewExistingUserResponse.code,
+								idxEnrollNewExistingUserResponse.response,
+							);
 							cy.mockNext(userExistsError.code, userExistsError.response);
 							cy.mockNext(socialUserResponse.code, socialUserResponse.response);
 							cy.mockNext(userGroupsResponse.code, userGroupsResponse.response);
@@ -112,6 +148,11 @@ userStatuses.forEach((status) => {
 					specify(
 						"Then I should be shown the 'Check your inbox' page if I don't have a validated email and don't have a password set",
 						() => {
+							baseIdxPasscodeRegistrationMocks();
+							cy.mockNext(
+								idxEnrollNewExistingUserResponse.code,
+								idxEnrollNewExistingUserResponse.response,
+							);
 							// Set the correct user status on the response
 							const response = { ...userResponse.response, status };
 							cy.mockNext(userExistsError.code, userExistsError.response);
@@ -149,6 +190,11 @@ userStatuses.forEach((status) => {
 					specify(
 						"Then I should be shown the 'Check your inbox' page if I don't have a validated email and do have a password set",
 						() => {
+							baseIdxPasscodeRegistrationMocks();
+							cy.mockNext(
+								idxEnrollNewExistingUserResponse.code,
+								idxEnrollNewExistingUserResponse.response,
+							);
 							// Set the correct user status on the response
 							const response = { ...userResponse.response, status };
 							const responseWithPassword = {
@@ -172,6 +218,11 @@ userStatuses.forEach((status) => {
 				case 'STAGED':
 					// Then Gateway should generate an activation token
 					specify("Then I should be shown the 'Check your inbox' page", () => {
+						baseIdxPasscodeRegistrationMocks();
+						cy.mockNext(
+							idxEnrollNewExistingUserResponse.code,
+							idxEnrollNewExistingUserResponse.response,
+						);
 						// Set the correct user status on the response
 						const response = { ...userResponse.response, status };
 						cy.mockNext(userExistsError.code, userExistsError.response);
@@ -188,6 +239,11 @@ userStatuses.forEach((status) => {
 				case 'PASSWORD_EXPIRED':
 					// Then Gateway should generate a reset password token
 					specify("Then I should be shown the 'Check your inbox' page", () => {
+						baseIdxPasscodeRegistrationMocks();
+						cy.mockNext(
+							idxEnrollNewExistingUserResponse.code,
+							idxEnrollNewExistingUserResponse.response,
+						);
 						// Set the correct user status on the response
 						const response = { ...userResponse.response, status };
 						cy.mockNext(userExistsError.code, userExistsError.response);

--- a/src/server/controllers/changePassword.ts
+++ b/src/server/controllers/changePassword.ts
@@ -209,12 +209,12 @@ const changePasswordInOkta = async (
 ) => {
 	const { token: encryptedRecoveryToken } = req.params;
 	const { password, firstName, secondName } = req.body;
-	const { clientId, signInGateId } = res.locals.queryParams;
+	const { clientId, signInGateId, useOktaClassic } = res.locals.queryParams;
 
 	// OKTA IDX API FLOW
 	// If the user is using the passcode registration flow, we need to handle the password change/creation.
 	// If there are specific failures, we fall back to the legacy Okta change password flow.
-	if (registrationPasscodesEnabled) {
+	if (registrationPasscodesEnabled && !useOktaClassic) {
 		try {
 			// Read the encrypted state cookie to get the state handle and email
 			const encryptedState = readEncryptedStateCookie(req);

--- a/src/server/controllers/changePassword.ts
+++ b/src/server/controllers/changePassword.ts
@@ -214,10 +214,7 @@ const changePasswordInOkta = async (
 	// OKTA IDX API FLOW
 	// If the user is using the passcode registration flow, we need to handle the password change/creation.
 	// If there are specific failures, we fall back to the legacy Okta change password flow.
-	if (
-		registrationPasscodesEnabled &&
-		res.locals.queryParams.usePasscodeRegistration
-	) {
+	if (registrationPasscodesEnabled) {
 		try {
 			// Read the encrypted state cookie to get the state handle and email
 			const encryptedState = readEncryptedStateCookie(req);

--- a/src/server/controllers/checkPasswordToken.ts
+++ b/src/server/controllers/checkPasswordToken.ts
@@ -167,7 +167,6 @@ export const checkTokenInOkta = async (
 	// If there are specific failures, we fall back to the legacy Okta change password flow.
 	if (
 		registrationPasscodesEnabled &&
-		res.locals.queryParams.usePasscodeRegistration &&
 		path === '/welcome' // only check the state handle for registration passcode flow on the welcome page
 	) {
 		try {

--- a/src/server/controllers/checkPasswordToken.ts
+++ b/src/server/controllers/checkPasswordToken.ts
@@ -167,6 +167,7 @@ export const checkTokenInOkta = async (
 	// If there are specific failures, we fall back to the legacy Okta change password flow.
 	if (
 		registrationPasscodesEnabled &&
+		!res.locals.queryParams.useOktaClassic &&
 		path === '/welcome' // only check the state handle for registration passcode flow on the welcome page
 	) {
 		try {

--- a/src/server/lib/queryParams.ts
+++ b/src/server/lib/queryParams.ts
@@ -52,7 +52,6 @@ export const parseExpressQueryParams = (
 		appClientId,
 		maxAge,
 		signInGateId,
-		usePasscodeRegistration,
 	}: Record<keyof QueryParams, string | undefined>, // parameters from req.query
 	// some parameters may be manually passed in req.body too,
 	// generally for tracking purposes
@@ -77,7 +76,6 @@ export const parseExpressQueryParams = (
 		appClientId,
 		maxAge: stringToNumber(maxAge),
 		signInGateId: getMatchingSignInGateId(signInGateId),
-		usePasscodeRegistration: isStringBoolean(usePasscodeRegistration),
 	};
 };
 

--- a/src/server/lib/queryParams.ts
+++ b/src/server/lib/queryParams.ts
@@ -52,6 +52,7 @@ export const parseExpressQueryParams = (
 		appClientId,
 		maxAge,
 		signInGateId,
+		useOktaClassic,
 	}: Record<keyof QueryParams, string | undefined>, // parameters from req.query
 	// some parameters may be manually passed in req.body too,
 	// generally for tracking purposes
@@ -76,6 +77,7 @@ export const parseExpressQueryParams = (
 		appClientId,
 		maxAge: stringToNumber(maxAge),
 		signInGateId: getMatchingSignInGateId(signInGateId),
+		useOktaClassic: isStringBoolean(useOktaClassic),
 	};
 };
 

--- a/src/server/routes/register.ts
+++ b/src/server/routes/register.ts
@@ -434,10 +434,7 @@ export const OktaRegistration = async (
 	// Attempt to register the user with Okta using the IDX API
 	// and specifically using passcodes.
 	// If there are specific failures, we fall back to the legacy Okta registration flow
-	if (
-		registrationPasscodesEnabled &&
-		res.locals.queryParams.usePasscodeRegistration
-	) {
+	if (registrationPasscodesEnabled) {
 		try {
 			// start the interaction code flow, and get the interaction handle + authState
 			const [{ interaction_handle }, authState] = await interact(req, res, {

--- a/src/server/routes/register.ts
+++ b/src/server/routes/register.ts
@@ -408,7 +408,13 @@ export const OktaRegistration = async (
 	const { email = '' } = req.body;
 
 	const {
-		queryParams: { appClientId, ref, refViewId, componentEventParams },
+		queryParams: {
+			appClientId,
+			ref,
+			refViewId,
+			componentEventParams,
+			useOktaClassic,
+		},
 		requestId: request_id,
 	} = res.locals;
 
@@ -434,7 +440,7 @@ export const OktaRegistration = async (
 	// Attempt to register the user with Okta using the IDX API
 	// and specifically using passcodes.
 	// If there are specific failures, we fall back to the legacy Okta registration flow
-	if (registrationPasscodesEnabled) {
+	if (registrationPasscodesEnabled && !useOktaClassic) {
 		try {
 			// start the interaction code flow, and get the interaction handle + authState
 			const [{ interaction_handle }, authState] = await interact(req, res, {

--- a/src/server/routes/welcome.ts
+++ b/src/server/routes/welcome.ts
@@ -504,7 +504,7 @@ router.post(
 const OktaResendEmail = async (req: Request, res: ResponseWithRequestState) => {
 	// if registration passcodes are enabled, we need to handle this differently
 	// by using the passcode registration flow
-	if (registrationPasscodesEnabled) {
+	if (registrationPasscodesEnabled && !res.locals.queryParams.useOktaClassic) {
 		return OktaRegistration(req, res);
 	}
 

--- a/src/server/routes/welcome.ts
+++ b/src/server/routes/welcome.ts
@@ -504,10 +504,7 @@ router.post(
 const OktaResendEmail = async (req: Request, res: ResponseWithRequestState) => {
 	// if registration passcodes are enabled, we need to handle this differently
 	// by using the passcode registration flow
-	if (
-		registrationPasscodesEnabled &&
-		res.locals.queryParams.usePasscodeRegistration
-	) {
+	if (registrationPasscodesEnabled) {
 		return OktaRegistration(req, res);
 	}
 

--- a/src/shared/__tests__/queryParams.test.ts
+++ b/src/shared/__tests__/queryParams.test.ts
@@ -37,7 +37,6 @@ describe('getPersistableQueryParams', () => {
 			signInGateId: undefined,
 			fromURI: 'fromURI',
 			appClientId: 'appClientId',
-			usePasscodeRegistration: undefined,
 		};
 
 		expect(output).toStrictEqual(expected);

--- a/src/shared/__tests__/queryParams.test.ts
+++ b/src/shared/__tests__/queryParams.test.ts
@@ -37,6 +37,7 @@ describe('getPersistableQueryParams', () => {
 			signInGateId: undefined,
 			fromURI: 'fromURI',
 			appClientId: 'appClientId',
+			useOktaClassic: undefined,
 		};
 
 		expect(output).toStrictEqual(expected);

--- a/src/shared/lib/queryParams.ts
+++ b/src/shared/lib/queryParams.ts
@@ -42,7 +42,6 @@ export const getPersistableQueryParams = (
 	fromURI: params.fromURI,
 	appClientId: params.appClientId,
 	signInGateId: params.signInGateId,
-	usePasscodeRegistration: params.usePasscodeRegistration,
 });
 
 /**

--- a/src/shared/lib/queryParams.ts
+++ b/src/shared/lib/queryParams.ts
@@ -42,6 +42,7 @@ export const getPersistableQueryParams = (
 	fromURI: params.fromURI,
 	appClientId: params.appClientId,
 	signInGateId: params.signInGateId,
+	useOktaClassic: params.useOktaClassic,
 });
 
 /**

--- a/src/shared/model/QueryParams.ts
+++ b/src/shared/model/QueryParams.ts
@@ -49,8 +49,6 @@ export interface PersistableQueryParams
 	fromURI?: string;
 	// This is the client Id of a calling application in Okta (ie iOS app etc)
 	appClientId?: string;
-	// temporary flag to enable passcode registration
-	usePasscodeRegistration?: boolean;
 }
 
 /**

--- a/src/shared/model/QueryParams.ts
+++ b/src/shared/model/QueryParams.ts
@@ -49,6 +49,8 @@ export interface PersistableQueryParams
 	fromURI?: string;
 	// This is the client Id of a calling application in Okta (ie iOS app etc)
 	appClientId?: string;
+	// fallback to Okta Classic if needed
+	useOktaClassic?: boolean;
 }
 
 /**


### PR DESCRIPTION
## What does this change?

*~Note: This PR is currently pointing to #2639 (`mm/passcodes-ete`), once that PR is merged this PR should point to `main` instead~*

*~Note: This PR is currently pointing to #2773 (`mm/passcodes-fixes`), once that PR is merged this PR should point to `main` instead~*

*~Note: This PR is currently pointing to #2779 (`mm/passcode-bugs`), once that PR is merged this PR should point to `main` instead~*

While this PR may seem large at first glance, it's actually pretty straightforward, most of the changes relate to test files.

This PR simply removes the `usePasscodeRegistration` query parameter, which were introduced in #2639, thus making new account creation with passcodes the default.

It also updates the cypress tests that previously relied on the old flow to use passcodes instead, this is what is the largest change with this PR.

A `useOktaClassic` flag is also added in, so we can fallback and/or test the old Okta Classic flow behaviour continues to work, and cypress tests were kept for this.

# Tested

- [x] CODE