### PR TITLE
Replace native <form> elements with <MainForm>

### DIFF
--- a/src/client/pages/NewAccountReview.tsx
+++ b/src/client/pages/NewAccountReview.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { MainLayout, buttonStyles } from '@/client/layouts/Main';
+import { MainLayout } from '@/client/layouts/Main';
 import { MainBodyText } from '@/client/components/MainBodyText';
 import { Consent } from '@/shared/model/Consent';
 import { ToggleSwitchInput } from '@/client/components/ToggleSwitchInput';
@@ -11,13 +11,12 @@ import { ExternalLink } from '@/client/components/ExternalLink';
 import locations from '@/shared/lib/locations';
 import { palette, space, textSans } from '@guardian/source/foundations';
 import { css } from '@emotion/react';
-import { Button } from '@guardian/source/react-components';
 import { buildUrlWithQueryParams } from '@/shared/lib/routeUtils';
-import { CsrfFormField } from '@/client/components/CsrfFormField';
 import { QueryParams } from '@/shared/model/QueryParams';
 import { consentsFormSubmitOphanTracking } from '@/client/lib/consentsTracking';
 import { usePageLoadOphanInteraction } from '@/client/lib/hooks/usePageLoadOphanInteraction';
 import { trackFormSubmit } from '@/client/lib/ophan';
+import { MainForm } from '../components/MainForm';
 
 const consentToggleCss = css`
 	display: flex;
@@ -78,15 +77,14 @@ export const NewAccountReview = ({
 	if (!profiling && !advertising) {
 		return (
 			<MainLayout pageHeader="You're signed in! Welcome to the Guardian.">
-				<form
-					action={buildUrlWithQueryParams('/welcome/review', {}, queryParams)}
-					method="post"
-				>
-					<CsrfFormField />
-					<Button css={buttonStyles({})} type="submit" priority="primary">
-						Continue to the Guardian
-					</Button>
-				</form>
+				<MainForm
+					formAction={buildUrlWithQueryParams(
+						'/welcome/review',
+						{},
+						queryParams,
+					)}
+					submitButtonText="Continue to the Guardian"
+				></MainForm>
 			</MainLayout>
 		);
 	}
@@ -96,18 +94,18 @@ export const NewAccountReview = ({
 				Before you start, confirm how you’d like the Guardian to use your
 				signed-in data.
 			</MainBodyText>
-			<form
-				action={buildUrlWithQueryParams('/welcome/review', {}, queryParams)}
-				method="post"
+			<MainForm
+				formAction={buildUrlWithQueryParams('/welcome/review', {}, queryParams)}
 				onSubmit={({ target: form }) => {
 					trackFormSubmit(formTrackingName);
 					consentsFormSubmitOphanTracking(
 						form as HTMLFormElement,
 						[profiling, advertising].filter(Boolean) as Consent[],
 					);
+					return undefined;
 				}}
+				submitButtonText="Save and continue"
 			>
-				<CsrfFormField />
 				<div css={consentToggleCss}>
 					{!!advertising && (
 						<fieldset css={switchRow}>
@@ -165,10 +163,7 @@ export const NewAccountReview = ({
 						on your Guardian account at any time.
 					</InformationBoxText>
 				</InformationBox>
-				<Button css={buttonStyles({})} type="submit" priority="primary">
-					Save and continue
-				</Button>
-			</form>
+			</MainForm>
 		</MainLayout>
 	);
 };

--- a/src/client/pages/ResendConsentEmail.tsx
+++ b/src/client/pages/ResendConsentEmail.tsx
@@ -1,13 +1,9 @@
 import React from 'react';
 import { MainBodyText } from '@/client/components/MainBodyText';
 import { MainLayout } from '@/client/layouts/Main';
-import { CsrfFormField } from '@/client/components/CsrfFormField';
 import { buildUrlWithQueryParams } from '@/shared/lib/routeUtils';
-import {
-	Button,
-	SvgArrowRightStraight,
-} from '@guardian/source/react-components';
 import { QueryParams } from '@/shared/model/QueryParams';
+import { MainForm } from '@/client/components/MainForm';
 
 interface Props {
 	token: string;
@@ -19,20 +15,16 @@ export const ResendConsentEmail = ({ token, queryParams }: Props) => {
 		<MainLayout pageHeader="Link expired">
 			<MainBodyText>This link has expired.</MainBodyText>
 			<MainBodyText>To receive a new link, please click below.</MainBodyText>
-			<form
-				method="post"
-				action={buildUrlWithQueryParams(
+			<MainForm
+				formAction={buildUrlWithQueryParams(
 					'/consent-token/resend',
 					{},
 					queryParams,
 				)}
+				submitButtonText="Resend link"
 			>
-				<CsrfFormField />
 				<input type="hidden" name="token" value={token} />
-				<Button type="submit" icon={<SvgArrowRightStraight />} iconSide="right">
-					Resend link
-				</Button>
-			</form>
+			</MainForm>
 		</MainLayout>
 	);
 };


### PR DESCRIPTION
## What does this change?

Our custom `<MainForm>` component automatically adds a CSRF field and has other niceties - we always prefer to use it instead of the native `<form>` element. For this reason, we're changing some stragglers to use `<MainForm>`.

## Testing

- [ ] Tested on CODE