### PR TITLE
Passcodes | Enable `registrationPasscodesEnabled` switch on PROD

### DIFF
--- a/src/shared/lib/featureSwitches.ts
+++ b/src/shared/lib/featureSwitches.ts
@@ -40,6 +40,6 @@ export const featureSwitches: FeatureSwitches = {
 	registrationPasscodesEnabled: {
 		DEV: true,
 		CODE: true,
-		PROD: false,
+		PROD: true,
 	},
 };


### PR DESCRIPTION
## What does this change?

Flick the `registrationPasscodesEnabled` to enabled on `PROD`.

This means that passcodes will be enabled on `PROD`, but will still be behind the `usePasscodeRegistration` query parameter flag until https://github.com/guardian/gateway/pull/2752 is merged in.

This will allow us to do testing in PROD, but not release to users who don't know about the flag.