### PR TITLE
Build | Make sure `pnpm-lock.yaml` is included in the `build` directory

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -142,6 +142,12 @@ const server = () => ({
 					from: 'package.json',
 					to: 'package.json',
 				},
+				// pnpm-lock.yaml is required pinning dependencies when
+				// installing prod dependencies inside the build folder
+				{
+					from: 'pnpm-lock.yaml',
+					to: 'pnpm-lock.yaml',
+				},
 			],
 		}),
 	],


### PR DESCRIPTION
## What does this change?

*tl;dr: verify your dependencies and use lock files when building production versions of your application*

We noticed an interesting issue where a production version of the gateway bundle was breaking in a live environment, while the development version was not.

The error was causing the instance/application to crash, and the error seen was:

```
{"level":"info","message":"GET, /welcome/review","request_id":"c26bf137-cfad-4156-8eef-3748586061e6"}
/Users/mahesh_makani/code/guardian/gateway/build/node_modules/@okta/jwt-verifier/lib.js:241
            jwt[methodName] = method.bind({ body: jwtBodyProxy });
                            ^

TypeError: Cannot assign to read only property 'setClaim' of object '[object Object]'
    at /Users/mahesh_makani/code/guardian/gateway/build/node_modules/@okta/jwt-verifier/lib.js:241:29
    at Array.forEach (<anonymous>)
    at /Users/mahesh_makani/code/guardian/gateway/build/node_modules/@okta/jwt-verifier/lib.js:238:30
    at /Users/mahesh_makani/code/guardian/gateway/build/node_modules/njwt/index.js:63:7
    at process.processTicksAndRejections (node:internal/process/task_queues:77:11)
```

At first we thought this was because Gateway was being built incorrectly using swc, but this turned out not to be the case.

We eventually decided to look at the `@okta/jwt-verifier` library closely, we noticed that a dependency it pulls in, [`njwt`](https://github.com/jwtk/njwt), was recently updated to fix a vulnerability. This was only pushed as a patch version to the `njwt` libary, updating it to `2.0.1`. However the `@okta/jwt-verifier` library was looking for `^2.0.0`, so on a fresh install of the package, it would pull in the latest patch version of `njwt`.

We verified that in our build directory, we were getting `2.0.1` of the library, and this caused the `@okta/jwt-verifier` library to break when we tried to use it.

However in our pnpm lock file, it was showing as `2.0.0`, so we were unsure as to why when building the production version we were getting the latest version

This essentially turned out to be a misunderstanding in how pnpm worked.

In our `package.json` script, we have a `build` command which does

```
"build": "ENVIRONMENT=production webpack --mode production && pnpm install --prod --node-linker=hoisted --dir=build --ignore-scripts",
```

The `pnpm install ...` command and the arguments are used to install only the production dependencies in the build folder along with a production build of gateway.

We had thought that the `pnpm install` command would respect the `pnpm-lock.yaml` in the project root directory. However what it was actually doing was running a fresh install inside the `build` directory, and essentally making a new `pnpm-lock.yaml` inside the build directory with the new dependencies!

This misunderstanding arised due to the way that it was previously done when we were using `yarn 1.x` where you could specify a modules directory, but it would respect the project root lock file.

To fix this, when building our project, we have to make sure we also copy the `pnpm-lock.yaml` file from the project root to the build directory, so that when running `pnpm install` during the `make build`/`yarn build` command, it would respect the lockfile in the `build` directory.

This did indeed fix the issue by making sure only the dependency versions listed in the lock file were installed in the build.

This also has the added benefit of speeding up production builds slightly, as it only pulls dependencies we already have in the `pnpm cache` and not new ones!

It was surprising that this hadn't caught us earlier, as any patch dependency could have been updated in any past build causing production to break if something went wrong!
