### PR TITLE
Passcodes | Bug Fixes

### DIFF
--- a/cypress/integration/ete-okta/registration_2.6.cy.ts
+++ b/cypress/integration/ete-okta/registration_2.6.cy.ts
@@ -952,7 +952,7 @@ describe('Registration flow - Split 2/2', () => {
 
 					// passcode page
 					cy.url().should('include', '/register/email-sent');
-					cy.contains('Email sent');
+					cy.contains('Email with verification code sent');
 
 					cy.get('input[name=code]').type(code!);
 					cy.contains('Submit verification code').click();

--- a/src/client/components/EmailSentInformationBox.stories.tsx
+++ b/src/client/components/EmailSentInformationBox.stories.tsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import { Meta } from '@storybook/react';
+
+import { EmailSentInformationBox } from '@/client/components/EmailSentInformationBox';
+
+export default {
+	title: 'Components/EmailSentInformationBox',
+	component: EmailSentInformationBox,
+	parameters: {
+		layout: 'padded',
+	},
+} as Meta;
+
+export const Default = () => {
+	return (
+		<EmailSentInformationBox
+			setRecaptchaErrorContext={() => {}}
+			setRecaptchaErrorMessage={() => {}}
+		/>
+	);
+};
+Default.storyName = 'default';
+
+export const ChangeEmail = () => {
+	return (
+		<EmailSentInformationBox
+			setRecaptchaErrorContext={() => {}}
+			setRecaptchaErrorMessage={() => {}}
+			changeEmailPage="#"
+		/>
+	);
+};
+ChangeEmail.storyName = 'with changeEmailPage';
+
+export const WithEmail = () => {
+	return (
+		<EmailSentInformationBox
+			setRecaptchaErrorContext={() => {}}
+			setRecaptchaErrorMessage={() => {}}
+			changeEmailPage="#"
+			email="test@example.com"
+		/>
+	);
+};
+WithEmail.storyName = 'with email';
+
+export const WithResendEmailAction = () => {
+	return (
+		<EmailSentInformationBox
+			setRecaptchaErrorContext={() => {}}
+			setRecaptchaErrorMessage={() => {}}
+			changeEmailPage="#"
+			email="test@example.com"
+			resendEmailAction="#"
+		/>
+	);
+};
+WithResendEmailAction.storyName = 'with resendEmailAction';
+
+export const WithResendEmailActionNoChangeEmail = () => {
+	return (
+		<EmailSentInformationBox
+			setRecaptchaErrorContext={() => {}}
+			setRecaptchaErrorMessage={() => {}}
+			email="test@example.com"
+			resendEmailAction="#"
+		/>
+	);
+};
+WithResendEmailAction.storyName = 'with resendEmailActionNoChangeEmail';
+
+export const WithNoAccountInfo = () => {
+	return (
+		<EmailSentInformationBox
+			setRecaptchaErrorContext={() => {}}
+			setRecaptchaErrorMessage={() => {}}
+			changeEmailPage="#"
+			email="test@example.com"
+			resendEmailAction="#"
+			noAccountInfo
+		/>
+	);
+};
+WithNoAccountInfo.storyName = 'with noAccountInfo';

--- a/src/client/components/EmailSentInformationBox.tsx
+++ b/src/client/components/EmailSentInformationBox.tsx
@@ -1,0 +1,99 @@
+import React from 'react';
+import { MainForm } from '@/client/components/MainForm';
+import { EmailInput } from '@/client/components/EmailInput';
+import { ExternalLink } from '@/client/components/ExternalLink';
+import { buildUrl } from '@/shared/lib/routeUtils';
+import locations from '@/shared/lib/locations';
+import { SUPPORT_EMAIL } from '@/shared/model/Configuration';
+import {
+	InformationBox,
+	InformationBoxText,
+} from '@/client/components/InformationBox';
+import { css } from '@emotion/react';
+import ThemedLink from '@/client/components/ThemedLink';
+import { EmailSentProps } from '@/client/pages/EmailSent';
+
+type EmailSentInformationBoxProps = Pick<
+	EmailSentProps,
+	| 'email'
+	| 'resendEmailAction'
+	| 'queryString'
+	| 'noAccountInfo'
+	| 'changeEmailPage'
+	| 'recaptchaSiteKey'
+	| 'formTrackingName'
+	| 'formError'
+> & {
+	setRecaptchaErrorContext: React.Dispatch<
+		React.SetStateAction<React.ReactNode>
+	>;
+	setRecaptchaErrorMessage: React.Dispatch<React.SetStateAction<string>>;
+};
+
+const sendAgainFormWrapperStyles = css`
+	white-space: nowrap;
+`;
+
+export const EmailSentInformationBox = ({
+	email,
+	resendEmailAction,
+	noAccountInfo,
+	changeEmailPage,
+	recaptchaSiteKey,
+	formTrackingName,
+	formError,
+	setRecaptchaErrorContext,
+	setRecaptchaErrorMessage,
+	queryString,
+}: EmailSentInformationBoxProps) => (
+	<InformationBox>
+		<InformationBoxText>
+			Didn’t get the email? Check your spam&#8288;
+			{email && resendEmailAction && (
+				<span css={sendAgainFormWrapperStyles}>
+					,{!changeEmailPage ? <> or </> : <> </>}
+					<MainForm
+						formAction={`${resendEmailAction}${queryString}`}
+						submitButtonText={'send again'}
+						recaptchaSiteKey={recaptchaSiteKey}
+						setRecaptchaErrorContext={setRecaptchaErrorContext}
+						setRecaptchaErrorMessage={setRecaptchaErrorMessage}
+						formTrackingName={formTrackingName}
+						disableOnSubmit
+						formErrorMessageFromParent={formError}
+						displayInline
+						submitButtonLink
+						hideRecaptchaMessage
+					>
+						<EmailInput defaultValue={email} hidden hideLabel />
+					</MainForm>
+				</span>
+			)}
+			{changeEmailPage && (
+				<>
+					, or{' '}
+					<ThemedLink href={`${changeEmailPage}${queryString}`}>
+						try another address
+					</ThemedLink>
+				</>
+			)}
+			.
+		</InformationBoxText>
+		{noAccountInfo && (
+			<InformationBoxText>
+				If you don’t receive an email within 2 minutes you may not have an
+				account. Don’t have an account?{' '}
+				<ThemedLink href={`${buildUrl('/register')}${queryString}`}>
+					Create an account for free
+				</ThemedLink>
+				.
+			</InformationBoxText>
+		)}
+		<InformationBoxText>
+			For further assistance, email our customer service team at{' '}
+			<ExternalLink href={locations.SUPPORT_EMAIL_MAILTO}>
+				{SUPPORT_EMAIL}
+			</ExternalLink>
+		</InformationBoxText>
+	</InformationBox>
+);

--- a/src/client/pages/EmailSent.stories.tsx
+++ b/src/client/pages/EmailSent.stories.tsx
@@ -91,20 +91,6 @@ NoChangeEmailPage.story = {
 	name: 'with no change email',
 };
 
-export const WithStateHandle = () => (
-	<EmailSent
-		changeEmailPage="#"
-		email="example@theguardian.com"
-		resendEmailAction="#"
-		recaptchaSiteKey="6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI"
-		hasStateHandle
-		passcodeAction="#"
-	/>
-);
-WithStateHandle.story = {
-	name: 'with stateHandle',
-};
-
 export const RegistrationEmailSent = () => (
 	<EmailSent
 		pageHeader="Check your inbox to verify your email"

--- a/src/client/pages/EmailSent.stories.tsx
+++ b/src/client/pages/EmailSent.stories.tsx
@@ -93,7 +93,6 @@ NoChangeEmailPage.story = {
 
 export const RegistrationEmailSent = () => (
 	<EmailSent
-		pageHeader="Check your inbox to verify your email"
 		email="example@theguardian.com"
 		changeEmailPage="/register"
 		resendEmailAction="/register/email-sent/resend"

--- a/src/client/pages/EmailSent.tsx
+++ b/src/client/pages/EmailSent.tsx
@@ -20,7 +20,6 @@ import { MinimalLayout } from '@/client/layouts/MinimalLayout';
 import ThemedLink from '@/client/components/ThemedLink';
 
 type Props = {
-	pageHeader?: string;
 	email?: string;
 	changeEmailPage?: string;
 	resendEmailAction?: string;

--- a/src/client/pages/EmailSent.tsx
+++ b/src/client/pages/EmailSent.tsx
@@ -86,7 +86,7 @@ export const EmailSent = ({
 					undefined,
 					{ timeUntilTokenExpiry },
 				);
-				window.location.replace(buildUrl('/register/code/expired'));
+				window.location.replace(buildUrl('/welcome/expired'));
 			}, timeUntilTokenExpiry);
 		}
 	}, [timeUntilTokenExpiry]);

--- a/src/client/pages/EmailSent.tsx
+++ b/src/client/pages/EmailSent.tsx
@@ -5,21 +5,10 @@ import React, {
 	useEffect,
 } from 'react';
 import { MainBodyText } from '@/client/components/MainBodyText';
-import { MainForm } from '@/client/components/MainForm';
-import { EmailInput } from '@/client/components/EmailInput';
-import { ExternalLink } from '@/client/components/ExternalLink';
-import { buildUrl } from '@/shared/lib/routeUtils';
-import locations from '@/shared/lib/locations';
-import { SUPPORT_EMAIL } from '@/shared/model/Configuration';
-import {
-	InformationBox,
-	InformationBoxText,
-} from '@/client/components/InformationBox';
-import { css } from '@emotion/react';
 import { MinimalLayout } from '@/client/layouts/MinimalLayout';
-import ThemedLink from '@/client/components/ThemedLink';
+import { EmailSentInformationBox } from '@/client/components/EmailSentInformationBox';
 
-type Props = {
+export type EmailSentProps = {
 	email?: string;
 	changeEmailPage?: string;
 	resendEmailAction?: string;
@@ -32,10 +21,6 @@ type Props = {
 	formError?: string;
 	instructionContext?: string;
 };
-
-const sendAgainFormWrapperStyles = css`
-	white-space: nowrap;
-`;
 
 export const EmailSent = ({
 	email,
@@ -50,7 +35,7 @@ export const EmailSent = ({
 	children,
 	formError,
 	instructionContext,
-}: PropsWithChildren<Props>) => {
+}: PropsWithChildren<EmailSentProps>) => {
 	const [recaptchaErrorMessage, setRecaptchaErrorMessage] = useState('');
 	const [recaptchaErrorContext, setRecaptchaErrorContext] =
 		useState<ReactNode>(null);
@@ -99,56 +84,18 @@ export const EmailSent = ({
 			<MainBodyText>
 				For your security, the link in the email will expire in 60 minutes.
 			</MainBodyText>
-			<InformationBox>
-				<InformationBoxText>
-					Didn’t get the email? Check your spam&#8288;
-					{email && resendEmailAction && (
-						<span css={sendAgainFormWrapperStyles}>
-							,{!changeEmailPage ? <> or </> : <> </>}
-							<MainForm
-								formAction={`${resendEmailAction}${queryString}`}
-								submitButtonText={'send again'}
-								recaptchaSiteKey={recaptchaSiteKey}
-								setRecaptchaErrorContext={setRecaptchaErrorContext}
-								setRecaptchaErrorMessage={setRecaptchaErrorMessage}
-								formTrackingName={formTrackingName}
-								disableOnSubmit
-								formErrorMessageFromParent={formError}
-								displayInline
-								submitButtonLink
-								hideRecaptchaMessage
-							>
-								<EmailInput defaultValue={email} hidden hideLabel />
-							</MainForm>
-						</span>
-					)}
-					{changeEmailPage && (
-						<>
-							, or{' '}
-							<ThemedLink href={`${changeEmailPage}${queryString}`}>
-								try another address
-							</ThemedLink>
-						</>
-					)}
-					.
-				</InformationBoxText>
-				{noAccountInfo && (
-					<InformationBoxText>
-						If you don’t receive an email within 2 minutes you may not have an
-						account. Don’t have an account?{' '}
-						<ThemedLink href={`${buildUrl('/register')}${queryString}`}>
-							Create an account for free
-						</ThemedLink>
-						.
-					</InformationBoxText>
-				)}
-				<InformationBoxText>
-					For further assistance, email our customer service team at{' '}
-					<ExternalLink href={locations.SUPPORT_EMAIL_MAILTO}>
-						{SUPPORT_EMAIL}
-					</ExternalLink>
-				</InformationBoxText>
-			</InformationBox>
+			<EmailSentInformationBox
+				setRecaptchaErrorContext={setRecaptchaErrorContext}
+				setRecaptchaErrorMessage={setRecaptchaErrorMessage}
+				email={email}
+				resendEmailAction={resendEmailAction}
+				noAccountInfo={noAccountInfo}
+				changeEmailPage={changeEmailPage}
+				recaptchaSiteKey={recaptchaSiteKey}
+				formTrackingName={formTrackingName}
+				formError={formError}
+				queryString={queryString}
+			/>
 		</MinimalLayout>
 	);
 };

--- a/src/client/pages/EmailSentPage.tsx
+++ b/src/client/pages/EmailSentPage.tsx
@@ -9,11 +9,7 @@ interface Props {
 	formTrackingName?: string;
 }
 
-export const EmailSentPage = ({
-	noAccountInfo,
-	formTrackingName,
-	pageHeader,
-}: Props) => {
+export const EmailSentPage = ({ noAccountInfo, formTrackingName }: Props) => {
 	const clientState = useClientState();
 	const {
 		pageData = {},
@@ -32,7 +28,6 @@ export const EmailSentPage = ({
 
 	return (
 		<EmailSent
-			pageHeader={pageHeader}
 			formError={formError}
 			email={email}
 			changeEmailPage={changeEmailPage}

--- a/src/client/pages/PasscodeEmailSent.stories.tsx
+++ b/src/client/pages/PasscodeEmailSent.stories.tsx
@@ -1,0 +1,86 @@
+/* eslint-disable functional/immutable-data */
+import React from 'react';
+import { Meta } from '@storybook/react';
+
+import { PasscodeEmailSent } from '@/client/pages/PasscodeEmailSent';
+
+export default {
+	title: 'Pages/PasscodeEmailSent',
+	component: PasscodeEmailSent,
+} as Meta;
+
+export const Defaults = () => <PasscodeEmailSent passcodeAction="#" />;
+Defaults.story = {
+	name: 'with defaults',
+};
+
+export const ChangeEmail = () => (
+	<PasscodeEmailSent passcodeAction="#" changeEmailPage="#" />
+);
+ChangeEmail.story = {
+	name: 'with changeEmailPage',
+};
+
+export const WithEmail = () => (
+	<PasscodeEmailSent
+		passcodeAction="#"
+		changeEmailPage="#"
+		email="example@theguardian.com"
+	/>
+);
+WithEmail.story = {
+	name: 'with email',
+};
+
+export const WithPasscode = () => (
+	<PasscodeEmailSent
+		passcodeAction="#"
+		changeEmailPage="#"
+		email="example@theguardian.com"
+		passcode="123456"
+	/>
+);
+WithPasscode.story = {
+	name: 'with passcode',
+};
+
+export const WithPasscodeError = () => (
+	<PasscodeEmailSent
+		passcodeAction="#"
+		changeEmailPage="#"
+		email="example@theguardian.com"
+		passcode="123456"
+		fieldErrors={[
+			{
+				field: 'code',
+				message: 'Invalid code',
+			},
+		]}
+	/>
+);
+WithPasscodeError.story = {
+	name: 'with passcode error',
+};
+
+export const WithRecaptchaError = () => (
+	<PasscodeEmailSent
+		passcodeAction="#"
+		changeEmailPage="#"
+		email="example@theguardian.com"
+		recaptchaSiteKey="invalid-key"
+	/>
+);
+WithRecaptchaError.story = {
+	name: 'with reCAPTCHA error',
+};
+
+export const WithSuccessMessage = () => (
+	<PasscodeEmailSent passcodeAction="#" showSuccess={true} />
+);
+WithSuccessMessage.story = {
+	name: 'with success message',
+};
+
+export const WithErrorMessage = () => (
+	<PasscodeEmailSent passcodeAction="#" errorMessage="•⩊• UwU" />
+);

--- a/src/client/pages/PasscodeEmailSent.tsx
+++ b/src/client/pages/PasscodeEmailSent.tsx
@@ -1,49 +1,26 @@
-import React, {
-	PropsWithChildren,
-	ReactNode,
-	useState,
-	useEffect,
-} from 'react';
+import React, { ReactNode, useState, useEffect } from 'react';
 import { MainBodyText } from '@/client/components/MainBodyText';
 import { MainForm } from '@/client/components/MainForm';
-import { EmailInput } from '@/client/components/EmailInput';
-import { ExternalLink } from '@/client/components/ExternalLink';
 import { buildUrl } from '@/shared/lib/routeUtils';
-import locations from '@/shared/lib/locations';
-import { SUPPORT_EMAIL } from '@/shared/model/Configuration';
-import {
-	InformationBox,
-	InformationBoxText,
-} from '@/client/components/InformationBox';
-import { css } from '@emotion/react';
 import { FieldError } from '@/shared/model/ClientState';
 import { logger } from '@/client/lib/clientSideLogger';
 import { MinimalLayout } from '@/client/layouts/MinimalLayout';
-import ThemedLink from '@/client/components/ThemedLink';
 import { PasscodeInput } from '@/client/components/PasscodeInput';
+import { EmailSentInformationBox } from '@/client/components/EmailSentInformationBox';
+import { EmailSentProps } from '@/client/pages/EmailSent';
 
 type Props = {
 	passcodeAction: string;
-	changeEmailPage?: string;
-	email?: string;
-	errorMessage?: string;
 	fieldErrors?: FieldError[];
-	formError?: string;
-	formTrackingName?: string;
 	passcode?: string;
-	queryString?: string;
 	recaptchaSiteKey?: string;
-	showSuccess?: boolean;
 	timeUntilTokenExpiry?: number;
 };
 
-const sendAgainFormWrapperStyles = css`
-	white-space: nowrap;
-`;
+type PasscodeEmailSentProps = EmailSentProps & Props;
 
 export const PasscodeEmailSent = ({
 	changeEmailPage,
-	children,
 	email,
 	errorMessage,
 	fieldErrors,
@@ -55,7 +32,7 @@ export const PasscodeEmailSent = ({
 	recaptchaSiteKey,
 	showSuccess,
 	timeUntilTokenExpiry,
-}: PropsWithChildren<Props>) => {
+}: PasscodeEmailSentProps) => {
 	const [recaptchaErrorMessage, setRecaptchaErrorMessage] = useState('');
 	const [recaptchaErrorContext, setRecaptchaErrorContext] =
 		useState<ReactNode>(null);
@@ -96,15 +73,15 @@ export const PasscodeEmailSent = ({
 	return (
 		<MinimalLayout
 			pageHeader="Enter your code"
-			successOverride={showSuccess ? 'Email sent' : undefined}
+			successOverride={
+				showSuccess ? 'Email with verification code sent' : undefined
+			}
 			errorOverride={
 				recaptchaErrorMessage ? recaptchaErrorMessage : errorMessage
 			}
 			errorContext={recaptchaErrorContext}
 			imageId="email"
 		>
-			{children}
-
 			{email ? (
 				<MainBodyText>
 					We’ve sent a temporary verification code to <strong>{email}</strong>.
@@ -125,46 +102,17 @@ export const PasscodeEmailSent = ({
 			>
 				<PasscodeInput passcode={passcode} fieldErrors={fieldErrors} />
 			</MainForm>
-			<InformationBox>
-				<InformationBoxText>
-					Didn’t get the email? Check your spam&#8288;
-					{email && (
-						<span css={sendAgainFormWrapperStyles}>
-							,{!changeEmailPage ? <> or </> : <> </>}
-							<MainForm
-								formAction={`${passcodeAction}/resend${queryString}`}
-								submitButtonText={'send again'}
-								recaptchaSiteKey={recaptchaSiteKey}
-								setRecaptchaErrorContext={setRecaptchaErrorContext}
-								setRecaptchaErrorMessage={setRecaptchaErrorMessage}
-								formTrackingName={formTrackingName}
-								disableOnSubmit
-								formErrorMessageFromParent={formError}
-								displayInline
-								submitButtonLink
-								hideRecaptchaMessage
-							>
-								<EmailInput defaultValue={email} hidden hideLabel />
-							</MainForm>
-						</span>
-					)}
-					{changeEmailPage && (
-						<>
-							, or{' '}
-							<ThemedLink href={`${changeEmailPage}${queryString}`}>
-								try another address
-							</ThemedLink>
-						</>
-					)}
-					.
-				</InformationBoxText>
-				<InformationBoxText>
-					For further assistance, email our customer service team at{' '}
-					<ExternalLink href={locations.SUPPORT_EMAIL_MAILTO}>
-						{SUPPORT_EMAIL}
-					</ExternalLink>
-				</InformationBoxText>
-			</InformationBox>
+			<EmailSentInformationBox
+				setRecaptchaErrorContext={setRecaptchaErrorContext}
+				setRecaptchaErrorMessage={setRecaptchaErrorMessage}
+				email={email}
+				resendEmailAction={`${passcodeAction}/resend`}
+				changeEmailPage={changeEmailPage}
+				recaptchaSiteKey={recaptchaSiteKey}
+				formTrackingName={formTrackingName}
+				formError={formError}
+				queryString={queryString}
+			/>
 		</MinimalLayout>
 	);
 };

--- a/src/client/pages/PasscodeUsed.stories.tsx
+++ b/src/client/pages/PasscodeUsed.stories.tsx
@@ -1,0 +1,15 @@
+/* eslint-disable functional/immutable-data */
+import React from 'react';
+import { Meta } from '@storybook/react';
+
+import { PasscodeUsed } from '@/client/pages/PasscodeUsed';
+
+export default {
+	title: 'Pages/PasscodeUsed',
+	component: PasscodeUsed,
+} as Meta;
+
+export const Defaults = () => <PasscodeUsed queryParams={{ returnUrl: '#' }} />;
+Defaults.story = {
+	name: 'with defaults',
+};

--- a/src/client/pages/PasscodeUsed.tsx
+++ b/src/client/pages/PasscodeUsed.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { MinimalLayout } from '@/client/layouts/MinimalLayout';
+import { LinkButton } from '@guardian/source/react-components';
+import { primaryButtonStyles } from '@/client/styles/Shared';
+import { buildUrlWithQueryParams } from '@/shared/lib/routeUtils';
+import { QueryParams } from '@/shared/model/QueryParams';
+
+type Props = {
+	queryParams: QueryParams;
+};
+
+export const PasscodeUsed = ({ queryParams }: Props) => {
+	return (
+		<MinimalLayout
+			pageHeader="Email verified"
+			imageId="email"
+			leadText="Your email has already been verified. Continue to finish creating your account."
+		>
+			<LinkButton
+				css={primaryButtonStyles()}
+				href={buildUrlWithQueryParams('/welcome/password', {}, queryParams)}
+				priority="primary"
+			>
+				Complete creating account
+			</LinkButton>
+		</MinimalLayout>
+	);
+};

--- a/src/client/pages/RegistrationEmailSentPage.tsx
+++ b/src/client/pages/RegistrationEmailSentPage.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import useClientState from '@/client/lib/hooks/useClientState';
 import { EmailSent } from '@/client/pages/EmailSent';
+import { PasscodeEmailSent } from '@/client/pages/PasscodeEmailSent';
 import { buildQueryParamsString } from '@/shared/lib/queryParams';
 
 import { buildUrl, buildUrlWithQueryParams } from '@/shared/lib/routeUtils';
@@ -22,6 +23,29 @@ export const RegistrationEmailSentPage = () => {
 		emailSentSuccess: true,
 	});
 
+	// show passcode email sent page if we have a state handle
+	if (hasStateHandle) {
+		return (
+			<PasscodeEmailSent
+				email={email}
+				queryString={queryString}
+				changeEmailPage={buildUrlWithQueryParams(
+					'/register/email',
+					{},
+					queryParams,
+				)}
+				passcodeAction={buildUrl('/register/code')}
+				showSuccess={emailSentSuccess}
+				errorMessage={error}
+				recaptchaSiteKey={recaptchaSiteKey}
+				formTrackingName="register-resend"
+				fieldErrors={fieldErrors}
+				passcode={token}
+			/>
+		);
+	}
+
+	// otherwise show original email sent page
 	return (
 		<EmailSent
 			pageHeader="Check your inbox to verify your email"
@@ -33,15 +57,11 @@ export const RegistrationEmailSentPage = () => {
 				queryParams,
 			)}
 			resendEmailAction={buildUrl('/register/email-sent/resend')}
-			passcodeAction={buildUrl('/register/code')}
 			instructionContext="verify and complete creating your account"
 			showSuccess={emailSentSuccess}
 			errorMessage={error}
 			recaptchaSiteKey={recaptchaSiteKey}
 			formTrackingName="register-resend"
-			hasStateHandle={hasStateHandle}
-			fieldErrors={fieldErrors}
-			passcode={token}
 		/>
 	);
 };

--- a/src/client/pages/RegistrationEmailSentPage.tsx
+++ b/src/client/pages/RegistrationEmailSentPage.tsx
@@ -5,6 +5,7 @@ import { PasscodeEmailSent } from '@/client/pages/PasscodeEmailSent';
 import { buildQueryParamsString } from '@/shared/lib/queryParams';
 
 import { buildUrl, buildUrlWithQueryParams } from '@/shared/lib/routeUtils';
+import { PasscodeUsed } from './PasscodeUsed';
 
 export const RegistrationEmailSentPage = () => {
 	const clientState = useClientState();
@@ -14,7 +15,7 @@ export const RegistrationEmailSentPage = () => {
 		globalMessage = {},
 		recaptchaConfig,
 	} = clientState;
-	const { email, hasStateHandle, fieldErrors, token } = pageData;
+	const { email, hasStateHandle, fieldErrors, token, passcodeUsed } = pageData;
 	const { emailSentSuccess } = queryParams;
 	const { error } = globalMessage;
 	const { recaptchaSiteKey } = recaptchaConfig;
@@ -25,6 +26,10 @@ export const RegistrationEmailSentPage = () => {
 
 	// show passcode email sent page if we have a state handle
 	if (hasStateHandle) {
+		if (passcodeUsed) {
+			return <PasscodeUsed queryParams={queryParams} />;
+		}
+
 		return (
 			<PasscodeEmailSent
 				email={email}

--- a/src/client/pages/RegistrationEmailSentPage.tsx
+++ b/src/client/pages/RegistrationEmailSentPage.tsx
@@ -3,9 +3,8 @@ import useClientState from '@/client/lib/hooks/useClientState';
 import { EmailSent } from '@/client/pages/EmailSent';
 import { PasscodeEmailSent } from '@/client/pages/PasscodeEmailSent';
 import { buildQueryParamsString } from '@/shared/lib/queryParams';
-
 import { buildUrl, buildUrlWithQueryParams } from '@/shared/lib/routeUtils';
-import { PasscodeUsed } from './PasscodeUsed';
+import { PasscodeUsed } from '@/client/pages/PasscodeUsed';
 
 export const RegistrationEmailSentPage = () => {
 	const clientState = useClientState();

--- a/src/client/pages/RegistrationEmailSentPage.tsx
+++ b/src/client/pages/RegistrationEmailSentPage.tsx
@@ -48,7 +48,6 @@ export const RegistrationEmailSentPage = () => {
 	// otherwise show original email sent page
 	return (
 		<EmailSent
-			pageHeader="Check your inbox to verify your email"
 			email={email}
 			queryString={queryString}
 			changeEmailPage={buildUrlWithQueryParams(

--- a/src/server/controllers/changePassword.ts
+++ b/src/server/controllers/changePassword.ts
@@ -277,10 +277,7 @@ const changePasswordInOkta = async (
 				if (error.name === 'idx.session.expired') {
 					return res.redirect(
 						303,
-						addQueryParamsToPath(
-							'/register/code/expired',
-							res.locals.queryParams,
-						),
+						addQueryParamsToPath('/welcome/expired', res.locals.queryParams),
 					);
 				}
 			}

--- a/src/server/controllers/checkPasswordToken.ts
+++ b/src/server/controllers/checkPasswordToken.ts
@@ -30,6 +30,7 @@ import {
 	introspect,
 	validateIntrospectRemediation,
 } from '@/server/lib/okta/idx/introspect';
+import { convertExpiresAtToExpiryTimeInMs } from '@/server/lib/okta/idx/shared';
 
 const { okta, defaultReturnUri, registrationPasscodesEnabled } =
 	getConfiguration();
@@ -208,6 +209,9 @@ export const checkTokenInOkta = async (
 								token,
 								isNativeApp: state.pageData.isNativeApp,
 								appName: state.pageData.appName,
+								timeUntilTokenExpiry: convertExpiresAtToExpiryTimeInMs(
+									introspectResponse.expiresAt,
+								),
 							},
 						}),
 					},

--- a/src/server/lib/middleware/requestState.ts
+++ b/src/server/lib/middleware/requestState.ts
@@ -87,6 +87,7 @@ const getRequestState = async (
 			isNativeApp,
 			appName,
 			hasStateHandle: !!encryptedState?.stateHandle,
+			passcodeUsed: !!encryptedState?.passcodeUsed,
 		},
 		globalMessage: {},
 		csrf: {

--- a/src/server/routes/index.ts
+++ b/src/server/routes/index.ts
@@ -76,7 +76,7 @@ uncachedRoutes.use(consentToken);
 uncachedRoutes.use(deleteAccount);
 
 // email template routes
-router.use(emailTemplates);
+uncachedRoutes.use(emailTemplates);
 
 router.use(uncachedRoutes);
 

--- a/src/server/routes/register.ts
+++ b/src/server/routes/register.ts
@@ -289,10 +289,7 @@ router.post(
 					if (error.name === 'oie.tooManyRequests') {
 						return res.redirect(
 							303,
-							addQueryParamsToPath(
-								'/register/code/expired',
-								res.locals.queryParams,
-							),
+							addQueryParamsToPath('/welcome/expired', res.locals.queryParams),
 						);
 					}
 
@@ -300,10 +297,7 @@ router.post(
 					if (error.name === 'idx.session.expired') {
 						return res.redirect(
 							303,
-							addQueryParamsToPath(
-								'/register/code/expired',
-								res.locals.queryParams,
-							),
+							addQueryParamsToPath('/welcome/expired', res.locals.queryParams),
 						);
 					}
 				}
@@ -372,10 +366,7 @@ router.post(
 					if (error.name === 'idx.session.expired') {
 						return res.redirect(
 							303,
-							addQueryParamsToPath(
-								'/register/code/expired',
-								res.locals.queryParams,
-							),
+							addQueryParamsToPath('/welcome/expired', res.locals.queryParams),
 						);
 					}
 				}

--- a/src/server/routes/register.ts
+++ b/src/server/routes/register.ts
@@ -3,6 +3,7 @@ import handleRecaptcha from '@/server/lib/recaptcha';
 import {
 	readEncryptedStateCookie,
 	setEncryptedStateCookie,
+	updateEncryptedStateCookie,
 } from '@/server/lib/encryptedStateCookie';
 import { handleAsyncErrors } from '@/server/lib/expressWrappers';
 import { guest } from '@/server/lib/idapi/guest';
@@ -250,6 +251,10 @@ router.post(
 					{ id: passwordAuthenticatorId[0], methodType: 'password' },
 					requestId,
 				);
+
+				updateEncryptedStateCookie(req, res, {
+					passcodeUsed: true,
+				});
 
 				// redirect to the password page to set a password
 				return res.redirect(

--- a/src/shared/model/ClientState.ts
+++ b/src/shared/model/ClientState.ts
@@ -72,6 +72,7 @@ export interface PageData {
 	contentAccess?: UserAttributesResponse['contentAccess'];
 	// okta idx api specific
 	hasStateHandle?: boolean; // determines if the state handle is present in the encrypted state, so we know if we're in an Okta IDX flow
+	passcodeUsed?: boolean; // determines if the passcode has been used in the Okta IDX flow, so don't show the passcode page again
 }
 
 export interface RecaptchaConfig {

--- a/src/shared/model/EncryptedState.ts
+++ b/src/shared/model/EncryptedState.ts
@@ -10,4 +10,5 @@ export interface EncryptedState {
 	queryParams?: PersistableQueryParams;
 	stateHandle?: string; // part of the Okta IDX flow
 	stateHandleExpiresAt?: string; // part of the Okta IDX flow
+	passcodeUsed?: boolean; // part of the Okta IDX flow, determines if the passcode has been used
 }

--- a/src/shared/model/Routes.ts
+++ b/src/shared/model/Routes.ts
@@ -31,7 +31,6 @@ export const ValidRoutePathsArray = [
 	'/reauthenticate',
 	'/register',
 	'/register/code',
-	'/register/code/expired',
 	'/register/code/resend',
 	'/register/email',
 	'/register/email-sent',


### PR DESCRIPTION
## What does this change?

Fixes a few bugs found after testing behind the feature flag. Each one is commit, so can step through in commit order when reviewing.

### `/register/code/expired` not found

If a user takes too long to type a passcode, they should be redirected to an expired page.

The idea initially was to make a new `/register/code/expired` page. This was never implemented in the original PR, so if a user ended up in this scenario they would see a 404 page.

At first we thought we should create a new page under this url, but since this has the exact same functionality as `/welcome/expired` we should just use that one, which is what this commit does.

### Refactor `EmailSent` page into new `PasscodeEmailSent` page and existing `EmailSent` page

The display logic in the `EmailSent` page component was getting super messy and difficult to reason about, more so when passcodes were added in.

It is a sensible decision to make a new EmailSent page component for when we're using passcodes. So we create a `PasscodeEmailSent` component to handle this behaviour.

We also remove the `pageHeader` prop from `EmailSent` component as it was no longer being used.

### Cache headers not being sent

*tl;dr: express ghosts*

We noticed that the `Cache-Control` and `Pragma` headers weren't been sent in the response headers, which is vitally important as we don't want to cache most pages in Gateway, and so we need these headers set to specific values to tell browsers (and Fastly) not to cache.

This meant that browsers fell back on a default caching policy, where new pages would be retrieved from the server, but using forwards/backwards in the browser would use the local cached page instead.

We assumed that the no caching behaviour would be working, as the `noCache` middleware is set on our uncached routes. However investigating further we found that this middleware was not being called!

After much investigation, the culprit turned out to be the `emailTemplate` routes. Why? We don't know. Express ghosts probably. Temporarily removing `emailTemplates` would fix the problem, or adding `emailTemplates` to the uncached routes.

So the solution was the latter, we made `emailTemplates` an `uncachedRoute` too, and the correct headers were being sent on all other routes now! `emailTemplates` don't need to be cached anyway, as it's only used by terraform for getting email templates to use in Okta.

### Passcode Used Message

Users who click back in their browser on the next page after submitting their passcode will see the page again to enter the passcode. Entering the passcode again here will cause errors to be returned, and a user left confused, as the passcode has already been used.

So we want to block users from doing this again, and continue in the journey.

We set a parameter `passcodeUsed` when the passcode is used, and if the user navigates back to the enter passcode page, this parameter is checked. If the `passcodeUsed` is set, we show a new page saying that the code has already been verified and a CTA asking the user to continue.

![60929d168594f80039336501-mgoczjxxiv chromatic com__path=_story_pages-passcodeused--defaults globals=viewport_iphone6](https://github.com/guardian/gateway/assets/13315440/b95b6b5a-7ae2-4404-9d46-221ef188f562)

### Use expiry on set password page when using passcodes

If a user takes too long to set a password on the password set page, they will get shown an error saying something went wrong.

This happens because the Okta IDX state expired while the user was on the page.

We need to set the `timeUntilTokenExpiry` based on the `expiresAt` from the `stateHandle` on the set password page, so if the token expires while on the set password page, they will be shown the expired page instead.

## Tested

### CODE
- [x] `/register/code/expired` not found
- [x] Cache headers not being sent
- [x] Passcode Used Message
- [x] Use expiry on set password page when using passcodes