### PR TITLE
Account Review Flow | Remove SC_GU_U cookie use

### DIFF
--- a/src/server/routes/welcome.ts
+++ b/src/server/routes/welcome.ts
@@ -351,7 +351,6 @@ router.get(
 		const newsletters = await getUserNewsletterSubscriptions({
 			newslettersOnPage: NewsletterMap.get(geolocation) as string[],
 			ip: req.ip,
-			sc_gu_u: req.cookies.SC_GU_U,
 			request_id: state.requestId,
 			accessToken: state.oauthState.accessToken?.toString(),
 		});
@@ -427,6 +426,7 @@ router.post(
 
 router.post(
 	'/welcome/newsletters',
+	loginMiddlewareOAuth,
 	async (req: Request, res: ResponseWithRequestState) => {
 		const state = res.locals;
 		const { returnUrl } = state.queryParams;
@@ -435,7 +435,6 @@ router.post(
 			const userNewsletterSubscriptions = await getUserNewsletterSubscriptions({
 				newslettersOnPage: ALL_NEWSLETTER_IDS,
 				ip: req.ip,
-				sc_gu_u: req.cookies.SC_GU_U,
 				request_id: state.requestId,
 				accessToken: state.oauthState.accessToken?.toString(),
 			});
@@ -472,7 +471,6 @@ router.post(
 
 			await updateNewsletters({
 				ip: req.ip,
-				sc_gu_u: req.cookies.SC_GU_U,
 				request_id: state.requestId,
 				accessToken: state.oauthState.accessToken?.toString(),
 				payload: newsletterSubscriptionsToUpdate,


### PR DESCRIPTION
## What does this change?

@pvighi noticed that Gateway was still making a few calls to IDAPI with the SC_GU_U cookie when it shouldn't be doing so. These were isolated to the `PATCH /users/me/newsletters` and `GET /users/me/newsletters` endpoints in IDAPI.

In Gateway the only place using these endpoints was the account review flow's newsletter page (`/welcome/newsletters`).

The issue occurred because the `loginMiddlewareOAuth` was left out from the `POST /welcome/newsletters` endpoint, meaning that the access token would be undefined on the request state. However since the SC_GU_U cookie was available on the request headers, it would use that to call IDAPI instead, thus causing this issue.

This PR adds the `loginMiddlewareOAuth` back in, and removes any usage of the `SC_GU_U` cookie.