### PR TITLE
Validate Return URL | Allowlist certain subdomains to preserve query parameters

### DIFF
--- a/src/server/lib/__tests__/validateUrl.test.ts
+++ b/src/server/lib/__tests__/validateUrl.test.ts
@@ -46,6 +46,22 @@ describe('validateReturnUrl', () => {
 
 		expect(output).toEqual(input);
 	});
+
+	test('it should return returnUrl with query parameters if on support subdomain', () => {
+		const input = 'https://support.theguardian.com/signin?foo=bar';
+
+		const output = validateReturnUrl(input);
+
+		expect(output).toEqual(input);
+	});
+
+	test('it should not return url with query parameters if on main domain', () => {
+		const input = 'https://www.theguardian.com?foo=bar';
+
+		const output = validateReturnUrl(input);
+
+		expect(output).toEqual('https://www.theguardian.com/');
+	});
 });
 
 describe('validateRefUrl', () => {

--- a/src/server/lib/validateUrl.ts
+++ b/src/server/lib/validateUrl.ts
@@ -7,6 +7,10 @@ const validHostnames = [
 	'.thegulocal.com',
 ];
 
+// valid subdomains
+const validSubdomains = ['profile.', 'support.'];
+
+// invalid paths for profile subdomain
 const invalidPaths = ['/signout'];
 
 const { defaultReturnUri } = getConfiguration();
@@ -27,15 +31,18 @@ export const validateReturnUrl = (returnUrl = ''): string => {
 			throw 'Invalid hostname';
 		}
 
-		// if the hostname is on the profile subdomain, we also want to check the pathname is valid
-		// and keep any query params
-		if (url.hostname.startsWith('profile.')) {
-			// then check the pathname is valid
-			if (invalidPaths.some((path) => url.pathname.startsWith(path))) {
-				throw 'Invalid pathname';
+		// if valid subdomains are present, we can return the url with the query params
+		if (
+			validSubdomains.some((subdomain) => url.hostname.startsWith(subdomain))
+		) {
+			// check the pathname is valid, only if on profile subdomain
+			if (
+				url.hostname.startsWith('profile.') &&
+				invalidPaths.some((path) => url.pathname.startsWith(path))
+			) {
+				throw 'Invalid path';
 			}
 
-			// and return the url if so, which will have the query params
 			return url.href;
 		}
 


### PR DESCRIPTION
## What does this change?

We currently don't preserve query parameter for non `profile` Guardian subdomains when they provide us with a `returnUrl`.

However some domains, such as `support` need access to query parameters for functionality.

This PR adds an allowlist of domains which will preserve query parameter.