### PR TITLE
Passcodes | Improve passcode styling/functionality 

### DIFF
--- a/src/client/components/PasscodeInput.tsx
+++ b/src/client/components/PasscodeInput.tsx
@@ -3,6 +3,7 @@ import { FieldError } from '@/shared/model/ClientState';
 import { TextInputProps } from '@guardian/source/react-components';
 import { css } from '@emotion/react';
 import ThemedTextInput from '@/client/components/ThemedTextInput';
+import { remSpace } from '@guardian/source/foundations';
 
 interface PasscodeInputProps extends Omit<TextInputProps, 'label'> {
 	passcode?: string;
@@ -11,6 +12,7 @@ interface PasscodeInputProps extends Omit<TextInputProps, 'label'> {
 
 const passcodeInputStyles = css`
 	text-align: center;
+	letter-spacing: ${remSpace[0]};
 `;
 
 export const PasscodeInput = ({

--- a/src/client/components/PasscodeInput.tsx
+++ b/src/client/components/PasscodeInput.tsx
@@ -1,6 +1,6 @@
+import React, { useState } from 'react';
 import { FieldError } from '@/shared/model/ClientState';
 import { TextInputProps } from '@guardian/source/react-components';
-import React from 'react';
 import { css } from '@emotion/react';
 import ThemedTextInput from '@/client/components/ThemedTextInput';
 
@@ -14,9 +14,44 @@ const passcodeInputStyles = css`
 `;
 
 export const PasscodeInput = ({
-	passcode,
+	passcode = '',
 	fieldErrors,
 }: PasscodeInputProps) => {
+	/**
+	 * In gateway we normally avoid using client side javascript, but in this case
+	 * we allow it as it an enhancement to the user experience and not required for
+	 * the form to work.
+	 */
+
+	// This function removes all non-numeric characters from the input
+	const sanitiseCode = (code: string) => {
+		return code.replace(/\D*/g, '');
+	};
+
+	// Using an object to store the input value so that we re-render the component
+	// whenever there is an user input, rather than only when the state changes
+	const [input, setInput] = useState({ value: sanitiseCode(passcode) });
+
+	// Update the input value on user input
+	const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+		setInput({
+			value: sanitiseCode(e.target.value),
+		});
+	};
+
+	// Update the input value on paste
+	const onPaste = (e: React.ClipboardEvent<HTMLInputElement>) => {
+		const paste = e.clipboardData.getData('text/plain');
+
+		if (!paste) {
+			return;
+		}
+
+		setInput({
+			value: sanitiseCode(paste),
+		});
+	};
+
 	return (
 		<div>
 			<ThemedTextInput
@@ -30,6 +65,9 @@ export const PasscodeInput = ({
 				error={fieldErrors?.find((error) => error.field === 'code')?.message}
 				defaultValue={passcode}
 				cssOverrides={passcodeInputStyles}
+				value={input.value}
+				onChange={onChange}
+				onPaste={onPaste}
 			/>
 		</div>
 	);

--- a/src/email/components/Text.tsx
+++ b/src/email/components/Text.tsx
@@ -8,6 +8,7 @@ type Props = {
 	noPaddingBottom?: boolean;
 	cssClass?: string;
 	largeText?: boolean;
+	letterSpacing?: string;
 };
 
 export const Text = ({
@@ -15,6 +16,7 @@ export const Text = ({
 	noPaddingBottom = false,
 	cssClass,
 	largeText = false,
+	letterSpacing,
 }: Props) => (
 	<MjmlSection
 		background-color={background.primary}
@@ -26,7 +28,7 @@ export const Text = ({
 				padding="0"
 				fontSize={largeText ? '20px' : '17px'}
 				lineHeight="1.35"
-				letterSpacing="-0.02px"
+				letterSpacing={letterSpacing ? letterSpacing : '-0.02px'}
 				fontFamily="Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif"
 				color={text.primary}
 			>

--- a/src/email/templates/RegistrationPasscode/RegistrationPasscode.stories.tsx
+++ b/src/email/templates/RegistrationPasscode/RegistrationPasscode.stories.tsx
@@ -21,3 +21,8 @@ export const Default = () => {
 	return renderMJML(<RegistrationPasscode />);
 };
 Default.storyName = 'with defaults';
+
+export const Passcode = () => {
+	return renderMJML(<RegistrationPasscode storybookPasscode="123456" />);
+};
+Passcode.storyName = 'with passcode';

--- a/src/email/templates/RegistrationPasscode/RegistrationPasscode.tsx
+++ b/src/email/templates/RegistrationPasscode/RegistrationPasscode.tsx
@@ -5,8 +5,13 @@ import { Header } from '@/email/components/Header';
 import { SubHeader } from '@/email/components/SubHeader';
 import { Text } from '@/email/components/Text';
 import { Footer } from '@/email/components/Footer';
+import { space } from '@guardian/source/foundations';
 
-export const RegistrationPasscode = () => {
+type Props = {
+	storybookPasscode?: string;
+};
+
+export const RegistrationPasscode = ({ storybookPasscode }: Props) => {
 	return (
 		<Mjml>
 			<MjmlHead>
@@ -19,19 +24,15 @@ export const RegistrationPasscode = () => {
 					Thank you for creating an account with the Guardian. Use the following
 					code to verify your email.
 				</Text>
-				<Text largeText>
-					<strong>{`{{CTA}}`}</strong>
+				<Text largeText letterSpacing={`${space[0]}px`}>
+					<strong>{`${storybookPasscode ? storybookPasscode : '{{CTA}}'}`}</strong>
 				</Text>
 				<Text>
-					<strong>
-						Do not share this code with anyone. This code will expire in 30
-						minutes.
-					</strong>
+					Do not share this code with anyone. This code will expire in 30
+					minutes.
 				</Text>
 				<Text>
-					<strong>
-						If your code has expired, create your Guardian account again.
-					</strong>
+					If your code has expired, create your Guardian account again.
 				</Text>
 				<Footer
 					mistakeParagraphComponent={

--- a/src/email/templates/RegistrationPasscode/sendRegistrationPasscode.ts
+++ b/src/email/templates/RegistrationPasscode/sendRegistrationPasscode.ts
@@ -10,7 +10,7 @@ type Props = {
 };
 
 const plainText = RegistrationPasscodeText();
-const { html } = render(RegistrationPasscode());
+const { html } = render(RegistrationPasscode({}));
 
 export const sendRegistrationPasscodeEmail = ({
 	to,

--- a/src/email/templates/renderedTemplates.ts
+++ b/src/email/templates/renderedTemplates.ts
@@ -66,5 +66,5 @@ export const renderedCompleteRegistration = {
 
 export const renderedRegistrationPasscode = {
 	plain: RegistrationPasscodeText(),
-	html: render(RegistrationPasscode()).html,
+	html: render(RegistrationPasscode({})).html,
 } as EmailRenderResult;

--- a/src/server/routes/register.ts
+++ b/src/server/routes/register.ts
@@ -176,6 +176,18 @@ router.post(
 			const { stateHandle } = encryptedState;
 
 			try {
+				// validate the code contains only numbers and is 6 characters long
+				// The okta api will validate the input fully, but validating here will prevent unnecessary requests
+				if (!/^\d{6}$/.test(code)) {
+					throw new OAuthError(
+						{
+							error: 'api.authn.error.PASSCODE_INVALID',
+							error_description: 'Passcode invalid', // this is ignored, and a error based on the `error` key is shown
+						},
+						400,
+					);
+				}
+
 				// check the state handle is valid and we can proceed with the registration
 				const introspectResponse = await introspect(
 					{


### PR DESCRIPTION
## What does this change?

### Passcode Email

- Update the email template to include 4px letter spacing to make it easier to read (based on [Guardian Source `space[1]`](https://guardian.github.io/storybooks/?path=/docs/source_foundations-space--docs))
- Remove bold text under the passcode to make the code the main CTA

## Passcode Input

- Add letter spacing to the passcode input field, for the same reason as above, this time using `remSpace[1]`
- Add client side code to validate the input field, e.g. sanitising the text on input and on paste
- Add server side code to validate the code sent to the server before we send it to Okta as we shouldn't rely on client side only validation
  - Even though Okta validates the input for us, we can avoid making requests to Okta if we check the input format ourselves

## Screenshots

| Email | Page |
|--------|--------|
| ![60929d168594f80039336501-rhqwmpyrqw chromatic com_iframe html_args= globals=viewport_mobile id=email-templates-registrationpasscode--passcode viewMode=story(iPhone 12 Pro)](https://github.com/guardian/gateway/assets/13315440/5630432d-d4d0-44ca-a005-068158992151) | ![60929d168594f80039336501-rhqwmpyrqw chromatic com_iframe html_args= globals=viewport_mobile id=pages-passcodeemailsent--with-passcode viewMode=story(iPhone 12 Pro)](https://github.com/guardian/gateway/assets/13315440/a84ed3db-4a31-4dca-9f0b-dab15967058e) |
