### PR TITLE
use the email address from the create test user response

### DIFF
--- a/cypress/support/commands/testUser.ts
+++ b/cypress/support/commands/testUser.ts
@@ -253,7 +253,7 @@ export const createTestUser = ({
 			})
 			.then((res) => {
 				return cy.wrap({
-					emailAddress: finalEmail,
+					emailAddress: res.body.emailAddress as string,
 					cookies: res.body.values as IDAPITestUserResponse,
 					finalPassword,
 				});


### PR DESCRIPTION
Traditionally test users have used the first name field to determine whether someone is a test user or not.

However this is less reliable than using email address as the email address field is passed around everywhere whereas there has to be special logic to get test users' first name around to the right places (as for a "real" user, first name would be extra PII)

In some other PRs, changes are proposed to embed the generated token into email addresses.  This means that the email address is generated on the fly, so anything using the create test user endpoint, needs to look in the response to find out what the generated email address is.

--

This PR updates gateway to get the email address out of the response, rather than relying on what was passed in to be correct.  See https://github.com/guardian/identity/pull/2528 for the PR that makes the changes that this PR depends on.