### PR TITLE
Delete |  Block feast users from deleting their account if active subscription

### DIFF
--- a/cypress/integration/ete-okta/delete.4.cy.ts
+++ b/cypress/integration/ete-okta/delete.4.cy.ts
@@ -101,6 +101,22 @@ describe('Delete my account flow in Okta', () => {
 		);
 	});
 
+	it('should block user from deleting account if they have a feast subscription', () => {
+		cy.createTestUser({ isUserEmailValidated: true }).then(
+			({ emailAddress, finalPassword }) => {
+				// set the mock state cookie
+				cy.setCookie('cypress-mock-state', 'feast');
+
+				signInAndVisitDeletePage(emailAddress, finalPassword);
+
+				// Then, try to delete the account, but blocked
+				cy.contains(
+					'You have an active subscription to the Guardian Feast app',
+				);
+			},
+		);
+	});
+
 	it('should block user from deleting account if they are a recurring contributor', () => {
 		cy.createTestUser({ isUserEmailValidated: true }).then(
 			({ emailAddress, finalPassword }) => {

--- a/src/client/pages/DeleteAccountBlocked.tsx
+++ b/src/client/pages/DeleteAccountBlocked.tsx
@@ -15,7 +15,8 @@ export const DeleteAccountBlocked = ({ contentAccess = {} }: Props) => {
 	const hasSubscription =
 		contentAccess.digitalPack ||
 		contentAccess.paperSubscriber ||
-		contentAccess.guardianWeeklySubscriber;
+		contentAccess.guardianWeeklySubscriber ||
+		contentAccess.feast;
 
 	return (
 		<MinimalLayout
@@ -90,6 +91,15 @@ export const DeleteAccountBlocked = ({ contentAccess = {} }: Props) => {
 							<MainBodyText>
 								<strong>
 									You have an active print subscription to the Guardian Weekly
+								</strong>
+							</MainBodyText>
+						</>
+					)}
+					{contentAccess.feast && (
+						<>
+							<MainBodyText>
+								<strong>
+									You have an active subscription to the Guardian Feast app
 								</strong>
 							</MainBodyText>
 						</>

--- a/src/server/routes/delete.ts
+++ b/src/server/routes/delete.ts
@@ -132,6 +132,9 @@ router.get(
 								// eslint-disable-next-line functional/immutable-data
 								cypressContentAccess.recurringContributor = true;
 								break;
+							case 'feast':
+								// eslint-disable-next-line functional/immutable-data
+								cypressContentAccess.feast = true;
 							default:
 								break;
 						}
@@ -152,7 +155,8 @@ router.get(
 					contentAccess.member ||
 					contentAccess.paidMember ||
 					contentAccess.paperSubscriber ||
-					contentAccess.recurringContributor;
+					contentAccess.recurringContributor ||
+					contentAccess.feast;
 
 				if (hasPaidProduct) {
 					// if so, show the delete blocked page


### PR DESCRIPTION
## What does this change?

We noticed that users who had only feast subscriptions could delete their account, this was because we weren't checking if they had a feast subscription when checking if a user is eligible for self deletion.

This PR adds that in.

This does not fix a separate issue where it's possible for a user to delete their account and then purchase a product. That will involve more investigation.