### PR TITLE
Password reset email update

### DIFF
--- a/cypress/integration/ete/registration_2.6.cy.ts
+++ b/cypress/integration/ete/registration_2.6.cy.ts
@@ -206,7 +206,7 @@ describe('Registration flow - Split 2/2', () => {
 									).then(({ links, body }) => {
 										expect(body).to.have.string('Password reset');
 										expect(body).to.have.string('Reset password');
-										expect(links.length).to.eq(2);
+										expect(links.length).to.eq(3);
 										const resetPasswordLink = links.find((s) =>
 											s.text?.includes('Reset password'),
 										);
@@ -259,7 +259,7 @@ describe('Registration flow - Split 2/2', () => {
 									).then(({ links, body }) => {
 										expect(body).to.have.string('Password reset');
 										expect(body).to.have.string('Reset password');
-										expect(links.length).to.eq(2);
+										expect(links.length).to.eq(3);
 										const resetPasswordLink = links.find((s) =>
 											s.text?.includes('Reset password'),
 										);
@@ -522,7 +522,7 @@ describe('Registration flow - Split 2/2', () => {
 								).then(({ links, body }) => {
 									expect(body).to.have.string('Password reset');
 									expect(body).to.have.string('Reset password');
-									expect(links.length).to.eq(2);
+									expect(links.length).to.eq(3);
 									const resetPasswordLink = links.find((s) =>
 										s.text?.includes('Reset password'),
 									);
@@ -575,7 +575,7 @@ describe('Registration flow - Split 2/2', () => {
 								).then(({ links, body }) => {
 									expect(body).to.have.string('Password reset');
 									expect(body).to.have.string('Reset password');
-									expect(links.length).to.eq(2);
+									expect(links.length).to.eq(3);
 									const resetPasswordLink = links.find((s) =>
 										s.text?.includes('Reset password'),
 									);

--- a/cypress/integration/ete/reset_password.3.cy.ts
+++ b/cypress/integration/ete/reset_password.3.cy.ts
@@ -447,7 +447,7 @@ describe('Password reset flow in Okta', () => {
 						).then(({ links, body }) => {
 							expect(body).to.have.string('Password reset');
 							expect(body).to.have.string('Reset password');
-							expect(links.length).to.eq(2);
+							expect(links.length).to.eq(3);
 							const resetPasswordLink = links.find((s) =>
 								s.text?.includes('Reset password'),
 							);
@@ -499,7 +499,7 @@ describe('Password reset flow in Okta', () => {
 						).then(({ links, body }) => {
 							expect(body).to.have.string('Password reset');
 							expect(body).to.have.string('Reset password');
-							expect(links.length).to.eq(2);
+							expect(links.length).to.eq(3);
 							const resetPasswordLink = links.find((s) =>
 								s.text?.includes('Reset password'),
 							);

--- a/src/email/templates/ResetPassword/ResetPassword.tsx
+++ b/src/email/templates/ResetPassword/ResetPassword.tsx
@@ -6,6 +6,7 @@ import { Header } from '@/email/components/Header';
 import { SubHeader } from '@/email/components/SubHeader';
 import { Text } from '@/email/components/Text';
 import { Footer } from '@/email/components/Footer';
+import { Link } from '@/email/components/Link';
 
 export const ResetPassword = () => {
 	return (
@@ -16,7 +17,13 @@ export const ResetPassword = () => {
 			<Text>
 				You&apos;ve asked us to send you a link to reset your password.
 			</Text>
-			<Text noPaddingBottom>This link is valid for 60 minutes.</Text>
+			<Text noPaddingBottom>
+				This link is valid for 60 minutes. If your link has expired, please try{' '}
+				<Link href="https://profile.theguardian.com/reset-password">
+					resetting your password again
+				</Link>
+				.
+			</Text>
 			<Button href={'$passwordResetLink'}>Reset password</Button>
 			<Footer
 				mistakeParagraphComponent={


### PR DESCRIPTION
## What does this change?

We need to make it clear to readers that they can retry resetting their password if the link has expired. Many readers contact User Help to say their link has expired, but they don’t realise they can trigger a new one themselves. This change hopes to solve that problem.