### PR TITLE
Move link-expired instructions to footer

### DIFF
--- a/src/email/templates/ResetPassword/ResetPassword.tsx
+++ b/src/email/templates/ResetPassword/ResetPassword.tsx
@@ -17,18 +17,16 @@ export const ResetPassword = () => {
 			<Text>
 				You&apos;ve asked us to send you a link to reset your password.
 			</Text>
-			<Text noPaddingBottom>
-				This link is valid for 60 minutes. If your link has expired, please try{' '}
-				<Link href="https://profile.theguardian.com/reset-password">
-					resetting your password again
-				</Link>
-				.
-			</Text>
+			<Text noPaddingBottom>This link is valid for 60 minutes.</Text>
 			<Button href={'$passwordResetLink'}>Reset password</Button>
 			<Footer
 				mistakeParagraphComponent={
 					<>
-						If you didn&apos;t request to reset your password, please ignore
+						If your link has expired, please try{' '}
+						<Link href="https://profile.theguardian.com/reset-password">
+							resetting your password again
+						</Link>
+						. If you didn&apos;t request to reset your password, please ignore
 						this email. Your details won&apos;t be changed and no one has
 						accessed your account.
 					</>


### PR DESCRIPTION
We recently added instructions to the password-reset email explaining to users what to do if the reset link has expired: https://github.com/guardian/gateway/pull/2799

We now believe there is a risk that users might confuse the two links in the body of the password reset email:

**Screenshot illustrating the problem**
<img width="579" alt="Screenshot of the password-reset email with instructions for link-expired scenario" src="https://github.com/user-attachments/assets/0e605831-d52d-4d66-8339-5b25bbb8e25b">
_The call-to-action and new instructions both feature the words 'reset' and 'password'_

This PR aims to remedy any user confusion by moving the instructions to the footer.