### PR TITLE
Alarm blindness | Improve metrics and alarms

### DIFF
--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -598,38 +598,9 @@ Resources:
         - '${Priority} - ${App} ${Stage} has had no new sign-ins in the last 20 minutes'
         - Priority: !FindInMap [StageVariables, AlarmPriorities, P1]
       AlarmDescription: No one has successfully signed ins in the last 20 minutes.
-      Metrics:
-        - Id: totalSignInCount
-          Expression: idapiSignInCount + oktaSignInCount
-          Label: 'Total sign-ins between IDAPI and Okta'
-        - Id: idapiSignInCount
-          MetricStat:
-            Metric:
-              Namespace: Gateway
-              MetricName: 'SignIn::Success'
-              Dimensions:
-                - Name: Stage
-                  Value: !Ref 'Stage'
-                - Name: ApiMode
-                  Value: identity-gateway
-            Period: 1200
-            Stat: Sum
-            Unit: Count
-          ReturnData: false
-        - Id: oktaSignInCount
-          MetricStat:
-            Metric:
-              Namespace: Gateway
-              MetricName: 'OktaSignIn::Success'
-              Dimensions:
-                - Name: Stage
-                  Value: !Ref 'Stage'
-                - Name: ApiMode
-                  Value: identity-gateway
-            Period: 1200
-            Stat: Sum
-            Unit: Count
-          ReturnData: false
+      Namespace: Gateway
+      MetricName: 'OktaSignIn::Success'
+      Statistic: Sum
       ComparisonOperator: LessThanThreshold
       Threshold: 1
       EvaluationPeriods: 1
@@ -645,38 +616,9 @@ Resources:
         - '${Priority} - ${App} ${Stage} has had no new registrations in the last hour'
         - Priority: !FindInMap [StageVariables, AlarmPriorities, P1]
       AlarmDescription: No one has successfully registered in the last hour.
-      Metrics:
-        - Id: totalRegistrationCount
-          Expression: idapiRegistrationCount + oktaRegistrationCount
-          Label: 'Total registrations between IDAPI and Okta'
-        - Id: idapiRegistrationCount
-          MetricStat:
-            Metric:
-              Namespace: Gateway
-              MetricName: 'Register::Success'
-              Dimensions:
-                - Name: Stage
-                  Value: !Ref 'Stage'
-                - Name: ApiMode
-                  Value: identity-gateway
-            Period: 3600
-            Stat: Sum
-            Unit: Count
-          ReturnData: false
-        - Id: oktaRegistrationCount
-          MetricStat:
-            Metric:
-              Namespace: Gateway
-              MetricName: 'OktaRegistration::Success'
-              Dimensions:
-                - Name: Stage
-                  Value: !Ref 'Stage'
-                - Name: ApiMode
-                  Value: identity-gateway
-            Period: 3600
-            Stat: Sum
-            Unit: Count
-          ReturnData: false
+      Namespace: Gateway
+      MetricName: 'OktaRegistration::Success'
+      Statistic: Sum
       ComparisonOperator: LessThanThreshold
       Threshold: 1
       EvaluationPeriods: 1

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -455,7 +455,9 @@ Resources:
     Type: AWS::CloudWatch::Alarm
     Condition: IsProd
     Properties:
-      AlarmName: !Sub '${App}-${Stage} high load balancer latency scaling'
+      AlarmName: !Sub
+        - '${Priority} - ${App}-${Stage} high load balancer latency scaling'
+        - Priority: !FindInMap [StageVariables, AlarmPriorities, P3]
       AlarmDescription: !Sub
         - 'Scale-Up if latency is greater than ${Threshold} seconds over last ${Period} seconds'
         - Period: !FindInMap [StageVariables, !Ref 'Stage', LatencyAlarmPeriod]
@@ -494,7 +496,9 @@ Resources:
     Type: AWS::CloudWatch::Alarm
     Condition: IsProd
     Properties:
-      AlarmName: !Sub '${App}-${Stage} high load balancer latency'
+      AlarmName: !Sub
+        - '${Priority} - ${App}-${Stage} high load balancer latency'
+        - Priority: !FindInMap [StageVariables, AlarmPriorities, P3]
       AlarmDescription: !Sub
         - 'Latency is greater than ${Threshold} seconds over ${Period} seconds for last 5 periods'
         - Period: !FindInMap [StageVariables, !Ref 'Stage', LatencyAlarmPeriod]
@@ -520,7 +524,9 @@ Resources:
     Condition: IsProd
     Properties:
       ActionsEnabled: 'true'
-      AlarmName: !Sub '${App}-${Stage} insufficient healthy hosts'
+      AlarmName: !Sub
+        - '${Priority} - ${App}-${Stage} insufficient healthy hosts'
+        - Priority: !FindInMap [StageVariables, AlarmPriorities, P3]
       AlarmDescription: There are insufficient healthy hosts
       ComparisonOperator: LessThanThreshold
       EvaluationPeriods: 1
@@ -548,7 +554,9 @@ Resources:
     Condition: IsProd
     Properties:
       ActionsEnabled: 'true'
-      AlarmName: !Sub '${App}-${Stage} sustained 5xx errors'
+      AlarmName: !Sub
+        - '${Priority} - ${App}-${Stage} sustained 5xx errors'
+        - Priority: !FindInMap [StageVariables, AlarmPriorities, P2]
       AlarmDescription: 'Sustained server errors detected'
       AlarmActions:
         - !Ref 'TopicSendEmail'

--- a/src/server/lib/middleware/login.ts
+++ b/src/server/lib/middleware/login.ts
@@ -130,6 +130,8 @@ export const loginMiddlewareOAuth = async (
 		} else {
 			trackMetric('LoginMiddlewareOAuth::OAuthTokensInvalid');
 		}
+	} else {
+		trackMetric('LoginMiddlewareOAuth::NoOAuthTokens');
 	}
 
 	// no: attempt to do auth code flow to get new tokens

--- a/src/server/models/Metrics.ts
+++ b/src/server/models/Metrics.ts
@@ -6,19 +6,12 @@ import { IDXPath } from '@/server/lib/okta/idx/shared';
 
 // Specific emails to track
 type EmailMetrics =
-	| 'AccountExists'
-	| 'AccountExistsWithoutPassword'
-	| 'AccountVerification'
-	| 'CreatePassword'
-	| 'ResetPassword'
 	| 'OktaAccountExists'
 	| 'OktaAccountExistsWithoutPassword'
 	| 'OktaCompleteRegistration'
 	| 'OktaCreatePassword'
 	| 'OktaResetPassword'
-	| 'OktaUnvalidatedEmailResetPassword'
-	| 'GuardianLiveOffer'
-	| 'MyGuardianOffer';
+	| 'OktaUnvalidatedEmailResetPassword';
 
 // Rate limit buckets to track
 type RateLimitMetrics = BucketType;
@@ -26,18 +19,15 @@ type RateLimitMetrics = BucketType;
 // Any metrics with conditions to append to the end
 // i.e ::Success or ::Failure
 type ConditionalMetrics =
-	| 'AccountVerification'
 	| 'BreachedPasswordCheck'
 	| 'ChangeEmail'
 	| 'ConsentToken'
 	| 'ConsentTokenResend'
 	| `${EmailMetrics}EmailSend`
-	| 'EmailValidated'
+	| 'JobsGRSGroupAgree'
 	| 'NewAccountReview'
 	| 'NewAccountReviewSubmit'
 	| 'NewAccountNewslettersSubmit'
-	| 'JobsGRSGroupAgree'
-	| 'LoginMiddleware'
 	| 'OAuthAuthorization'
 	| 'OAuthApplicationCallback'
 	| 'OAuthAuthenticationCallback'
@@ -57,25 +47,17 @@ type ConditionalMetrics =
 	| 'OktaValidatePasswordToken'
 	| 'OktaWelcome'
 	| 'OktaWelcomeResendEmail'
-	| 'Register'
-	| 'SendValidationEmail'
-	| 'SignIn'
+	| 'RecaptchaMiddleware'
 	| 'SignOut'
 	| 'SignOutGlobal'
-	| 'Unsubscribe'
-	| 'UnsubscribeAll'
 	| 'Subscribe'
-	| 'UpdatePassword'
-	| 'RecaptchaMiddleware'
-	| 'ValidatePasswordToken';
+	| 'Unsubscribe'
+	| 'UnsubscribeAll';
 
 // Unconditional metrics that we want to track directly
 type UnconditionalMetrics =
 	| 'PasswordCheck::Breached'
 	| 'PasswordCheck::NotBreached'
-	| 'LoginMiddlewareNotRecent'
-	| 'LoginMiddlewareNotSignedIn'
-	| 'LoginMiddlewareUnverified'
 	| 'LoginMiddlewareOAuth::HasOAuthTokens'
 	| 'LoginMiddlewareOAuth::NoOAuthTokens'
 	| 'LoginMiddlewareOAuth::NoOktaSession'


### PR DESCRIPTION
## What does this change?

In the Identity & Trust team find it hard to discern certain alarms on how relevant they are to investigate. This PR is a step to improving that.

We've already made a change to IDAPI to remove the spammiest alarms: https://github.com/guardian/identity/pull/2552

This PR improves the alarms within Gateway.

Firstly we remove unused `Metrics`, which cleans up the type definition for metrics. We also add the `LoginMiddlewareOAuth::NoOAuthTokens` to the `loginMiddlewareOAuth` as it was missing from there.

Then we update the alarms. The `SigninInactivityAlarm` and `RegisterInactivityAlarm` now only take into account Okta, after IDAPI authentication was removed in https://github.com/guardian/gateway/pull/2794

Finally we update the remaining alarms to include a priority; `P1` - CRITICAL Respond Immediately, `P2` -  URGENT Investigate during working hours (9-5), `P3` - MODERATE Keep an eye on if sustained or investigate if issues arise.

`HighLatencyScalingAlarm` - `P3`
`AlarmHighLatency` - `P3`
`AlarmNoHealthyHosts` - `P3`
`Alarm5XXSustained` - `P2`
`SigninInactivityAlarm` - `P1`
`RegisterInactivityAlarm` - `P1`

The next steps following this PR would be to add additional alarms for other crucial metrics/flows.