### PR TITLE
Use devx-logging instead of custom Kinesis appender

### DIFF
--- a/.github/workflows/cypress-ete.yml
+++ b/.github/workflows/cypress-ete.yml
@@ -117,7 +117,6 @@ jobs:
           OKTA_IDP_APPLE: ${{ secrets.OKTA_IDP_APPLE }}
           OKTA_IDP_GOOGLE: ${{ secrets.OKTA_IDP_GOOGLE }}
           OKTA_GUARDIAN_USERS_ALL_GROUP_ID: ${{ secrets.OKTA_GUARDIAN_USERS_ALL_GROUP_ID }}
-          LOGGING_KINESIS_STREAM: ''
           EC2_INSTANCE_ID: ''
           # This is a public URL+key sent to Sentry on the client side
           # We disable Sentry for our tests

--- a/.github/workflows/cypress-ete.yml
+++ b/.github/workflows/cypress-ete.yml
@@ -117,7 +117,6 @@ jobs:
           OKTA_IDP_APPLE: ${{ secrets.OKTA_IDP_APPLE }}
           OKTA_IDP_GOOGLE: ${{ secrets.OKTA_IDP_GOOGLE }}
           OKTA_GUARDIAN_USERS_ALL_GROUP_ID: ${{ secrets.OKTA_GUARDIAN_USERS_ALL_GROUP_ID }}
-          EC2_INSTANCE_ID: ''
           # This is a public URL+key sent to Sentry on the client side
           # We disable Sentry for our tests
           SENTRY_DSN: ''

--- a/.github/workflows/cypress-mocked.yml
+++ b/.github/workflows/cypress-mocked.yml
@@ -107,7 +107,6 @@ jobs:
           OKTA_IDP_APPLE: oktaappleidp
           OKTA_IDP_GOOGLE: oktagoogleidp
           OKTA_GUARDIAN_USERS_ALL_GROUP_ID: oktaGuardianUserGroupId
-          LOGGING_KINESIS_STREAM: ''
           EC2_INSTANCE_ID: ''
           # This is a public URL+key sent to Sentry on the client side
           # We disable Sentry for our tests

--- a/.github/workflows/cypress-mocked.yml
+++ b/.github/workflows/cypress-mocked.yml
@@ -107,7 +107,6 @@ jobs:
           OKTA_IDP_APPLE: oktaappleidp
           OKTA_IDP_GOOGLE: oktagoogleidp
           OKTA_GUARDIAN_USERS_ALL_GROUP_ID: oktaGuardianUserGroupId
-          EC2_INSTANCE_ID: ''
           # This is a public URL+key sent to Sentry on the client side
           # We disable Sentry for our tests
           SENTRY_DSN: ''

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -344,7 +344,6 @@ Resources:
               Environment=OKTA_IDP_APPLE=$OKTA_IDP_APPLE
               Environment=OKTA_IDP_GOOGLE=$OKTA_IDP_GOOGLE
               Environment=OKTA_GUARDIAN_USERS_ALL_GROUP_ID=$OKTA_GUARDIAN_USERS_ALL_GROUP_ID            
-              Environment=EC2_INSTANCE_ID=$(curl -s http://169.254.169.254/latest/meta-data/instance-id)
               Environment=SENTRY_DSN=${SentryDsn}
               Environment=REDIS_PASSWORD=$REDIS_PASSWORD
               Environment=REDIS_HOST=${RedisHost}

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -124,10 +124,19 @@ Resources:
                 Action: s3:GetObject
                 Resource:
                   - !Sub arn:aws:s3:::${IdentityConfigBucket}/${Stage}/${App}/*
+        - PolicyName: DevxLogs
+          PolicyDocument:
+            Statement:
               - Effect: Allow
                 Action:
-                  - kinesis:Describe*
-                  - kinesis:Put*
+                  - ec2:DescribeTags
+                  - ec2:DescribeInstances
+                Resource: '*'
+              - Effect: Allow
+                Action:
+                  - kinesis:DescribeStream
+                  - kinesis:PutRecord
+                  - kinesis:PutRecords
                 Resource:
                   - !Sub arn:aws:kinesis:${AWS::Region}:${AWS::AccountId}:stream/${KinesisStream}
         - PolicyName: GetParameters
@@ -231,6 +240,12 @@ Resources:
         - Key: Stage
           Value: !Ref Stage
           PropagateAtLaunch: true
+        - Key: LogKinesisStreamName
+          Value: !Ref KinesisStream
+          PropagateAtLaunch: true
+        - Key: SystemdUnit
+          Value: identity-gateway.service
+          PropagateAtLaunch: true
   LaunchTemplate:
     Type: AWS::EC2::LaunchTemplate
     Properties:
@@ -300,10 +315,10 @@ Resources:
               # systemd setup
               cat > /etc/systemd/system/identity-gateway.service <<EOL
               [Service]
-              ExecStart=/bin/sh -ec '/usr/bin/node /etc/gu/server.js > /var/log/identity-gateway.log 2>&1'
+              ExecStart=/bin/sh -ec '/usr/bin/node /etc/gu/server.js 2>&1'
               Restart=always
-              StandardOutput=syslog
-              StandardError=syslog
+              StandardOutput=journal
+              StandardError=journal
               SyslogIdentifier=identity-gateway
               User=identity-gateway
               Group=identity-gateway
@@ -329,7 +344,6 @@ Resources:
               Environment=OKTA_IDP_APPLE=$OKTA_IDP_APPLE
               Environment=OKTA_IDP_GOOGLE=$OKTA_IDP_GOOGLE
               Environment=OKTA_GUARDIAN_USERS_ALL_GROUP_ID=$OKTA_GUARDIAN_USERS_ALL_GROUP_ID            
-              Environment=LOGGING_KINESIS_STREAM=${KinesisStream}
               Environment=EC2_INSTANCE_ID=$(curl -s http://169.254.169.254/latest/meta-data/instance-id)
               Environment=SENTRY_DSN=${SentryDsn}
               Environment=REDIS_PASSWORD=$REDIS_PASSWORD

--- a/package.json
+++ b/package.json
@@ -123,7 +123,6 @@
 	},
 	"dependencies": {
 		"@aws-sdk/client-cloudwatch": "^3.616.0",
-		"@aws-sdk/client-kinesis": "^3.616.0",
 		"@aws-sdk/client-sesv2": "^3.616.0",
 		"@aws-sdk/credential-providers": "^3.616.0",
 		"@emotion/react": "^11.13.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,9 +11,6 @@ importers:
       '@aws-sdk/client-cloudwatch':
         specifier: ^3.616.0
         version: 3.616.0
-      '@aws-sdk/client-kinesis':
-        specifier: ^3.616.0
-        version: 3.616.0
       '@aws-sdk/client-sesv2':
         specifier: ^3.616.0
         version: 3.616.0
@@ -385,10 +382,6 @@ packages:
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
 
-  '@aws-crypto/crc32@5.2.0':
-    resolution: {integrity: sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==}
-    engines: {node: '>=16.0.0'}
-
   '@aws-crypto/sha256-browser@5.2.0':
     resolution: {integrity: sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==}
 
@@ -408,10 +401,6 @@ packages:
 
   '@aws-sdk/client-cognito-identity@3.616.0':
     resolution: {integrity: sha512-3yli0rchw7FuI8CmxUKW5z6TzrAJzBm9x+Se20Gqm0idXc2X2RT4Z8axtni5umBu8+4QWgNDZAr/WG6bR/JUGA==}
-    engines: {node: '>=16.0.0'}
-
-  '@aws-sdk/client-kinesis@3.616.0':
-    resolution: {integrity: sha512-/NK1jupgQzOqq4IoHKNiYnN1UyQbn5/riydoXylGClP/yVCV0GW2KiNnhfWIK1szFj1FwxUWtHPzfwhHIJciJQ==}
     engines: {node: '>=16.0.0'}
 
   '@aws-sdk/client-sesv2@3.616.0':
@@ -1912,25 +1901,6 @@ packages:
 
   '@smithy/credential-provider-imds@3.1.4':
     resolution: {integrity: sha512-NKyH01m97Xa5xf3pB2QOF3lnuE8RIK0hTVNU5zvZAwZU8uspYO4DHQVlK+Y5gwSrujTfHvbfd1D9UFJAc0iYKQ==}
-    engines: {node: '>=16.0.0'}
-
-  '@smithy/eventstream-codec@3.1.2':
-    resolution: {integrity: sha512-0mBcu49JWt4MXhrhRAlxASNy0IjDRFU+aWNDRal9OtUJvJNiwDuyKMUONSOjLjSCeGwZaE0wOErdqULer8r7yw==}
-
-  '@smithy/eventstream-serde-browser@3.0.5':
-    resolution: {integrity: sha512-dEyiUYL/ekDfk+2Ra4GxV+xNnFoCmk1nuIXg+fMChFTrM2uI/1r9AdiTYzPqgb72yIv/NtAj6C3dG//1wwgakQ==}
-    engines: {node: '>=16.0.0'}
-
-  '@smithy/eventstream-serde-config-resolver@3.0.3':
-    resolution: {integrity: sha512-NVTYjOuYpGfrN/VbRQgn31x73KDLfCXCsFdad8DiIc3IcdxL+dYA9zEQPyOP7Fy2QL8CPy2WE4WCUD+ZsLNfaQ==}
-    engines: {node: '>=16.0.0'}
-
-  '@smithy/eventstream-serde-node@3.0.4':
-    resolution: {integrity: sha512-mjlG0OzGAYuUpdUpflfb9zyLrBGgmQmrobNT8b42ZTsGv/J03+t24uhhtVEKG/b2jFtPIHF74Bq+VUtbzEKOKg==}
-    engines: {node: '>=16.0.0'}
-
-  '@smithy/eventstream-serde-universal@3.0.4':
-    resolution: {integrity: sha512-Od9dv8zh3PgOD7Vj4T3HSuox16n0VG8jJIM2gvKASL6aCtcS8CfHZDWe1Ik3ZXW6xBouU+45Q5wgoliWDZiJ0A==}
     engines: {node: '>=16.0.0'}
 
   '@smithy/fetch-http-handler@3.2.2':
@@ -7355,12 +7325,6 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.5
       '@jridgewell/trace-mapping': 0.3.25
 
-  '@aws-crypto/crc32@5.2.0':
-    dependencies:
-      '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.609.0
-      tslib: 2.6.3
-
   '@aws-crypto/sha256-browser@5.2.0':
     dependencies:
       '@aws-crypto/sha256-js': 5.2.0
@@ -7477,56 +7441,6 @@ snapshots:
       '@smithy/util-middleware': 3.0.3
       '@smithy/util-retry': 3.0.3
       '@smithy/util-utf8': 3.0.0
-      tslib: 2.6.3
-    transitivePeerDependencies:
-      - aws-crt
-
-  '@aws-sdk/client-kinesis@3.616.0':
-    dependencies:
-      '@aws-crypto/sha256-browser': 5.2.0
-      '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/client-sso-oidc': 3.616.0(@aws-sdk/client-sts@3.616.0)
-      '@aws-sdk/client-sts': 3.616.0
-      '@aws-sdk/core': 3.616.0
-      '@aws-sdk/credential-provider-node': 3.616.0(@aws-sdk/client-sso-oidc@3.616.0(@aws-sdk/client-sts@3.616.0))(@aws-sdk/client-sts@3.616.0)
-      '@aws-sdk/middleware-host-header': 3.616.0
-      '@aws-sdk/middleware-logger': 3.609.0
-      '@aws-sdk/middleware-recursion-detection': 3.616.0
-      '@aws-sdk/middleware-user-agent': 3.616.0
-      '@aws-sdk/region-config-resolver': 3.614.0
-      '@aws-sdk/types': 3.609.0
-      '@aws-sdk/util-endpoints': 3.614.0
-      '@aws-sdk/util-user-agent-browser': 3.609.0
-      '@aws-sdk/util-user-agent-node': 3.614.0
-      '@smithy/config-resolver': 3.0.5
-      '@smithy/core': 2.2.8
-      '@smithy/eventstream-serde-browser': 3.0.5
-      '@smithy/eventstream-serde-config-resolver': 3.0.3
-      '@smithy/eventstream-serde-node': 3.0.4
-      '@smithy/fetch-http-handler': 3.2.2
-      '@smithy/hash-node': 3.0.3
-      '@smithy/invalid-dependency': 3.0.3
-      '@smithy/middleware-content-length': 3.0.4
-      '@smithy/middleware-endpoint': 3.0.5
-      '@smithy/middleware-retry': 3.0.11
-      '@smithy/middleware-serde': 3.0.3
-      '@smithy/middleware-stack': 3.0.3
-      '@smithy/node-config-provider': 3.1.4
-      '@smithy/node-http-handler': 3.1.3
-      '@smithy/protocol-http': 4.0.4
-      '@smithy/smithy-client': 3.1.9
-      '@smithy/types': 3.3.0
-      '@smithy/url-parser': 3.0.3
-      '@smithy/util-base64': 3.0.0
-      '@smithy/util-body-length-browser': 3.0.0
-      '@smithy/util-body-length-node': 3.0.0
-      '@smithy/util-defaults-mode-browser': 3.0.11
-      '@smithy/util-defaults-mode-node': 3.0.11
-      '@smithy/util-endpoints': 2.0.5
-      '@smithy/util-middleware': 3.0.3
-      '@smithy/util-retry': 3.0.3
-      '@smithy/util-utf8': 3.0.0
-      '@smithy/util-waiter': 3.1.2
       tslib: 2.6.3
     transitivePeerDependencies:
       - aws-crt
@@ -9598,36 +9512,6 @@ snapshots:
       '@smithy/property-provider': 3.1.3
       '@smithy/types': 3.3.0
       '@smithy/url-parser': 3.0.3
-      tslib: 2.6.3
-
-  '@smithy/eventstream-codec@3.1.2':
-    dependencies:
-      '@aws-crypto/crc32': 5.2.0
-      '@smithy/types': 3.3.0
-      '@smithy/util-hex-encoding': 3.0.0
-      tslib: 2.6.3
-
-  '@smithy/eventstream-serde-browser@3.0.5':
-    dependencies:
-      '@smithy/eventstream-serde-universal': 3.0.4
-      '@smithy/types': 3.3.0
-      tslib: 2.6.3
-
-  '@smithy/eventstream-serde-config-resolver@3.0.3':
-    dependencies:
-      '@smithy/types': 3.3.0
-      tslib: 2.6.3
-
-  '@smithy/eventstream-serde-node@3.0.4':
-    dependencies:
-      '@smithy/eventstream-serde-universal': 3.0.4
-      '@smithy/types': 3.3.0
-      tslib: 2.6.3
-
-  '@smithy/eventstream-serde-universal@3.0.4':
-    dependencies:
-      '@smithy/eventstream-codec': 3.1.2
-      '@smithy/types': 3.3.0
       tslib: 2.6.3
 
   '@smithy/fetch-http-handler@3.2.2':

--- a/src/server/lib/__tests__/deeplink/oktaRecoveryToken.test.ts
+++ b/src/server/lib/__tests__/deeplink/oktaRecoveryToken.test.ts
@@ -22,10 +22,6 @@ jest.mock('@/server/lib/getConfiguration', () => ({
 				GuardianUserAll: 'okta-guardian-users-group-id',
 			},
 		},
-		aws: {
-			instanceId: 'instanceId',
-			kinesisStreamName: 'kinesisStreamName',
-		},
 		// valid encryption key, only used for testing, hence safe to hardcode
 		encryptionSecretKey:
 			'f3d87b231ddd6f50d99e227c5bc9b7cbb649387b321008df412fd73805ac2e32',

--- a/src/server/lib/__tests__/getConfiguration.test.ts
+++ b/src/server/lib/__tests__/getConfiguration.test.ts
@@ -107,10 +107,6 @@ describe('getConfiguration', () => {
 					GuardianUserAll: 'okta-guardian-users-group-id',
 				},
 			},
-			aws: {
-				kinesisStreamName: '',
-				instanceId: '',
-			},
 			githubRunNumber: '5',
 			sentryDsn: 'sentry-dsn',
 			redis: {

--- a/src/server/lib/__tests__/headers.test.ts
+++ b/src/server/lib/__tests__/headers.test.ts
@@ -29,7 +29,6 @@ jest.mock('@/server/lib/serverSideLogger', () => ({
 }));
 jest.mock('@aws-sdk/credential-providers');
 jest.mock('@smithy/node-http-handler');
-jest.mock('@aws-sdk/client-kinesis');
 jest.mock('@aws-sdk/client-sesv2');
 jest.mock('@aws-sdk/client-cloudwatch');
 jest.mock('@/server/lib/getAssets', () => ({

--- a/src/server/lib/__tests__/okta/register.test.ts
+++ b/src/server/lib/__tests__/okta/register.test.ts
@@ -42,10 +42,6 @@ jest.mock('@/server/lib/getConfiguration', () => ({
 				GuardianUserAll: 'okta-guardian-users-group-id',
 			},
 		},
-		aws: {
-			instanceId: 'instanceId',
-			kinesisStreamName: 'kinesisStreamName',
-		},
 	}),
 }));
 

--- a/src/server/lib/__tests__/rate-limit/rateLimitMiddleware.test.ts
+++ b/src/server/lib/__tests__/rate-limit/rateLimitMiddleware.test.ts
@@ -26,7 +26,6 @@ describe('rate limiter middleware', () => {
 
 		jest.mock('@aws-sdk/credential-providers');
 		jest.mock('@smithy/node-http-handler');
-		jest.mock('@aws-sdk/client-kinesis');
 		jest.mock('@aws-sdk/client-sesv2');
 		jest.mock('@aws-sdk/client-cloudwatch');
 		jest.mock('@/server/lib/idapi/user');

--- a/src/server/lib/awsConfig.ts
+++ b/src/server/lib/awsConfig.ts
@@ -1,6 +1,6 @@
 import { fromNodeProviderChain } from '@aws-sdk/credential-providers';
 import { NodeHttpHandler } from '@smithy/node-http-handler';
-import { KinesisClientConfig } from '@aws-sdk/client-kinesis';
+import { CloudWatchClientConfig } from '@aws-sdk/client-cloudwatch';
 
 const AWS_REGION = 'eu-west-1';
 
@@ -12,10 +12,10 @@ const CREDENTIAL_PROVIDER = fromNodeProviderChain({
 	profile: PROFILE,
 });
 
-// shared config for all aws clients, using the KinesisClientConfig type as
+// shared config for all aws clients, using the CloudwatchClientConfig type as
 // the base type for the shared config
 type SharedAwsConfig = Pick<
-	KinesisClientConfig,
+	CloudWatchClientConfig,
 	'region' | 'credentials' | 'maxAttempts' | 'requestHandler'
 >;
 

--- a/src/server/lib/getConfiguration.ts
+++ b/src/server/lib/getConfiguration.ts
@@ -1,5 +1,4 @@
 import {
-	AWSConfiguration,
 	Configuration,
 	GU_API_DOMAIN,
 	GU_DOMAIN,
@@ -201,25 +200,6 @@ export const getConfiguration = (): Configuration => {
 	const sentryDsn = getOrDefault(process.env.SENTRY_DSN, '');
 	const githubRunNumber = getOrDefault(process.env.GITHUB_RUN_NUMBER, '0');
 
-	const aws: AWSConfiguration = {
-		kinesisStreamName:
-			stage === 'DEV'
-				? process.env.LOGGING_KINESIS_STREAM || ''
-				: getOrThrow(
-						process.env.LOGGING_KINESIS_STREAM,
-						'LOGGING_KINESIS_STREAM missing',
-						false,
-					),
-		instanceId:
-			stage === 'DEV'
-				? ''
-				: getOrThrow(
-						process.env.EC2_INSTANCE_ID,
-						'EC2_INSTANCE_ID missing',
-						false,
-					),
-	};
-
 	const redis: RedisConfiguration = {
 		password: getOrThrow(process.env.REDIS_PASSWORD, 'Redis Password Missing'),
 		host: getOrThrow(process.env.REDIS_HOST, 'Redis Host missing'),
@@ -257,7 +237,6 @@ export const getConfiguration = (): Configuration => {
 		encryptionSecretKey,
 		oauthBaseUrl,
 		okta,
-		aws,
 		githubRunNumber,
 		sentryDsn,
 		redis,

--- a/src/server/lib/serverSideLogger.ts
+++ b/src/server/lib/serverSideLogger.ts
@@ -1,105 +1,12 @@
 /* eslint-disable no-console */
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { Kinesis } from '@aws-sdk/client-kinesis';
 import { LogLevel } from '@/shared/model/Logger';
 import { createLogger, transports } from 'winston';
-import Transport, { TransportStreamOptions } from 'winston-transport';
 import { formatWithOptions, InspectOptions } from 'util';
-import { awsConfig } from './awsConfig';
-import { getConfiguration } from './getConfiguration';
 import { BaseLogger, ExtraLogFields } from '@/shared/lib/baseLogger';
 
-const {
-	stage,
-	aws: { instanceId, kinesisStreamName },
-} = getConfiguration();
-
-const encoder = new TextEncoder();
-
-// custom "Winston Transport" to send logs to the AWS kinesis stream
-// see https://github.com/winstonjs/winston-transport#usage
-class KinesisTransport extends Transport {
-	private kinesis: Kinesis;
-
-	constructor(opts?: TransportStreamOptions) {
-		super(opts);
-
-		this.kinesis = new Kinesis(awsConfig);
-	}
-
-	public log(info: any, callback: () => void) {
-		const { level, message, ...extraFields } = info;
-
-		setImmediate(() => {
-			this.emit('logger', level);
-
-			if (process.env.RUNNING_IN_CYPRESS === 'true') {
-				// return void in cypress
-				return;
-			}
-
-			if (kinesisStreamName) {
-				const data = JSON.stringify({
-					type: 'app',
-					app: 'identity-gateway',
-					stack: 'identity',
-					path: '/var/log/identity-gateway.log',
-					instance_id: instanceId,
-					stage,
-					level,
-					message,
-					...extraFields,
-				});
-
-				this.kinesis
-					.putRecord({
-						StreamName: kinesisStreamName,
-						PartitionKey: stage,
-						Data: encoder.encode(data),
-					})
-					.catch((error: unknown) => {
-						if (error instanceof Error) {
-							if (
-								error.name === 'CredentialsProviderError' &&
-								stage === 'DEV'
-							) {
-								console.log(error.message);
-								console.warn(
-									'AWS Credentials Expired. Have you added `Identity` Janus credentials?',
-								);
-							}
-
-							if (error.name === 'TimeoutError') {
-								console.warn(error.message);
-								console.warn(
-									'Timeout when attempting to log to kinesis stream.',
-								);
-							}
-
-							if (
-								error.name !== 'TimeoutError' &&
-								error.name !== 'ExpiredTokenException'
-							) {
-								console.warn('Error when attempting to log to kinesis stream.');
-								console.warn(error.name);
-								console.warn(error.message);
-							}
-						} else {
-							console.warn(
-								'Unknown error when attempting to log to kinesis stream.',
-							);
-							console.warn(error);
-						}
-					});
-			}
-		});
-
-		callback();
-	}
-}
-
 const winstonLogger = createLogger({
-	transports: [new transports.Console(), new KinesisTransport()],
+	transports: [new transports.Console()],
 });
 
 const loggingOptions: InspectOptions = {

--- a/src/server/lib/trackMetric.ts
+++ b/src/server/lib/trackMetric.ts
@@ -68,19 +68,19 @@ export const trackMetric = (
 
 				if (error.name === 'TimeoutError') {
 					logger.warn(error.message);
-					logger.warn('Timeout when attempting to log to kinesis stream.');
+					logger.warn('Timeout when attempting to record to cloudwatch.');
 				}
 
 				if (
 					error.name !== 'TimeoutError' &&
 					error.name !== 'ExpiredTokenException'
 				) {
-					logger.warn('Error when attempting to log to kinesis stream.');
+					logger.warn('Error when attempting to record to cloudwatch.');
 					logger.warn(error.name);
 					logger.warn(error.message);
 				}
 			} else {
-				logger.warn('Unknown error when attempting to log to kinesis stream.');
+				logger.warn('Unknown error when attempting to record to cloudwatch.');
 				// eslint-disable-next-line no-console
 				console.warn(error);
 			}

--- a/src/server/models/Configuration.ts
+++ b/src/server/models/Configuration.ts
@@ -21,7 +21,6 @@ export interface Configuration {
 	encryptionSecretKey: string;
 	oauthBaseUrl: string;
 	okta: Okta;
-	aws: AWSConfiguration;
 	githubRunNumber: string;
 	sentryDsn: string;
 	redis: RedisConfiguration;
@@ -33,11 +32,6 @@ export interface Configuration {
 		url: string;
 		apiKey: string;
 	};
-}
-
-export interface AWSConfiguration {
-	kinesisStreamName: string;
-	instanceId: string;
 }
 
 export interface Okta {


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Removes the custom kinesis appender for logging and rely on the [devx-logs](https://github.com/guardian/devx-logs) service provided by the cdk-base role.

This relies on adding some custom cloudformation tags to our EC2 instances which devx-logs uses to discover which service to read logs from and what kinesis stream to send them to.

The downside to this approach is that logs from DEV/local machine aren't sent to Kinesis anymore, however you could use something like [lnav](https://lnav.org/) if you want local log analysis.

## How to test

Deployed to CODE.

Based on the logs we can see the `ShippedBy` tag is now showing that Gateway is using devx-logs:

<img width="416" alt="image" src="https://github.com/user-attachments/assets/56712fad-044a-4b0a-8ff0-acad44ffd814">

We can also see that custom fields also still work (I tested by adding an extra `port` field to the server start message)

<img width="584" alt="image" src="https://github.com/user-attachments/assets/b07e72b4-7633-4d17-afae-4283ac94080a">

