### PR TITLE
Alarm blindness | Add priority to alarms

### DIFF
--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -468,7 +468,9 @@ Resources:
     Type: AWS::CloudWatch::Alarm
     Condition: IsProd
     Properties:
-      AlarmName: !Sub '${App}-${Stage} high load balancer latency scaling'
+      AlarmName: !Sub
+        - '${Priority} - ${App}-${Stage} high load balancer latency scaling'
+        - Priority: !FindInMap [StageVariables, AlarmPriorities, P3]
       AlarmDescription: !Sub
         - 'Scale-Up if latency is greater than ${Threshold} seconds over last ${Period} seconds'
         - Period: !FindInMap [StageVariables, !Ref 'Stage', LatencyAlarmPeriod]
@@ -507,7 +509,9 @@ Resources:
     Type: AWS::CloudWatch::Alarm
     Condition: IsProd
     Properties:
-      AlarmName: !Sub '${App}-${Stage} high load balancer latency'
+      AlarmName: !Sub
+        - '${Priority} - ${App}-${Stage} high load balancer latency'
+        - Priority: !FindInMap [StageVariables, AlarmPriorities, P3]
       AlarmDescription: !Sub
         - 'Latency is greater than ${Threshold} seconds over ${Period} seconds for last 5 periods'
         - Period: !FindInMap [StageVariables, !Ref 'Stage', LatencyAlarmPeriod]
@@ -533,7 +537,9 @@ Resources:
     Condition: IsProd
     Properties:
       ActionsEnabled: 'true'
-      AlarmName: !Sub '${App}-${Stage} insufficient healthy hosts'
+      AlarmName: !Sub
+        - '${Priority} - ${App}-${Stage} insufficient healthy hosts'
+        - Priority: !FindInMap [StageVariables, AlarmPriorities, P3]
       AlarmDescription: There are insufficient healthy hosts
       ComparisonOperator: LessThanThreshold
       EvaluationPeriods: 1
@@ -561,7 +567,9 @@ Resources:
     Condition: IsProd
     Properties:
       ActionsEnabled: 'true'
-      AlarmName: !Sub '${App}-${Stage} sustained 5xx errors'
+      AlarmName: !Sub
+        - '${Priority} - ${App}-${Stage} sustained 5xx errors'
+        - Priority: !FindInMap [StageVariables, AlarmPriorities, P2]
       AlarmDescription: 'Sustained server errors detected'
       AlarmActions:
         - !Ref 'TopicSendEmail'
@@ -613,22 +621,8 @@ Resources:
       AlarmDescription: No one has successfully signed ins in the last 20 minutes.
       Metrics:
         - Id: totalSignInCount
-          Expression: idapiSignInCount + oktaSignInCount
-          Label: 'Total sign-ins between IDAPI and Okta'
-        - Id: idapiSignInCount
-          MetricStat:
-            Metric:
-              Namespace: Gateway
-              MetricName: 'SignIn::Success'
-              Dimensions:
-                - Name: Stage
-                  Value: !Ref 'Stage'
-                - Name: ApiMode
-                  Value: identity-gateway
-            Period: 1200
-            Stat: Sum
-            Unit: Count
-          ReturnData: false
+          Expression: oktaSignInCount
+          Label: 'Total sign-ins in Okta'
         - Id: oktaSignInCount
           MetricStat:
             Metric:
@@ -660,13 +654,13 @@ Resources:
       AlarmDescription: No one has successfully registered in the last hour.
       Metrics:
         - Id: totalRegistrationCount
-          Expression: idapiRegistrationCount + oktaRegistrationCount
-          Label: 'Total registrations between IDAPI and Okta'
-        - Id: idapiRegistrationCount
+          Expression: oktaIdxRegistrationCount + oktaRegistrationCount
+          Label: 'Total registrations in Okta Classic and Okta IDX'
+        - Id: oktaIdxRegistrationCount
           MetricStat:
             Metric:
               Namespace: Gateway
-              MetricName: 'Register::Success'
+              MetricName: 'OktaIDXRegister::Success'
               Dimensions:
                 - Name: Stage
                   Value: !Ref 'Stage'


### PR DESCRIPTION
## What does this change?

We tried updating priorities for certain alarms in https://github.com/guardian/gateway/pull/2804. However the cloudformation failed to apply, so we [reverted](https://github.com/guardian/gateway/pull/2805) it.

This PR updates the cloudformation again to fix the issues encountered.

Finally we update the alarms without a priority to include a priority; `P1` - CRITICAL Respond Immediately, `P2` -  URGENT Investigate during working hours (9-5), `P3` - MODERATE Keep an eye on if sustained or investigate if issues arise.

`HighLatencyScalingAlarm` - `P3`
`AlarmHighLatency` - `P3`
`AlarmNoHealthyHosts` - `P3`
`Alarm5XXSustained` - `P2`
`SigninInactivityAlarm` - `P1`
`RegisterInactivityAlarm` - `P1`

The `SigninInactivityAlarm` and `RegisterInactivityAlarm` now only take into account Okta, after IDAPI authentication was removed in https://github.com/guardian/gateway/pull/2794

This has been already applied on CODE and PROD to make sure the Cloudformation works correctly.