### PR TITLE
Alarm Blindness | Add some alarms!

### DIFF
--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -757,3 +757,36 @@ Resources:
         - !Ref 'TopicSendEmail'
       InsufficientDataActions:
         - !Ref 'TopicSendEmail'
+  DeletionInactivityAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Condition: IsProd
+    Properties:
+      AlarmName: !Sub
+        - '${Priority} - ${App} ${Stage} has had no success self service user deletion in the last 6 hours'
+        - Priority: !FindInMap [StageVariables, AlarmPriorities, P2]
+      AlarmDescription: No one has successfully deleted their account in the last 6 hours.
+      Metrics:
+        - Id: totalDeletionCount
+          Expression: deleteAccountCount
+          Label: 'Total self service user deletions'
+        - Id: deleteAccountCount
+          MetricStat:
+            Metric:
+              Namespace: Gateway
+              MetricName: 'OAuthDeleteCallback::Success'
+              Dimensions:
+                - Name: Stage
+                  Value: !Ref 'Stage'
+                - Name: ApiMode
+                  Value: identity-gateway
+            Period: 21600
+            Stat: Sum
+            Unit: Count
+          ReturnData: false
+      ComparisonOperator: LessThanThreshold
+      Threshold: 1
+      EvaluationPeriods: 1
+      AlarmActions:
+        - !Ref 'TopicSendEmail'
+      InsufficientDataActions:
+        - !Ref 'TopicSendEmail'

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -790,3 +790,36 @@ Resources:
         - !Ref 'TopicSendEmail'
       InsufficientDataActions:
         - !Ref 'TopicSendEmail'
+  UnsubscribeAllInactivityAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Condition: IsProd
+    Properties:
+      AlarmName: !Sub
+        - '${Priority} - ${App} ${Stage} has had successful no unsubscribe all from email clients in the last hour'
+        - Priority: !FindInMap [StageVariables, AlarmPriorities, P2]
+      AlarmDescription: 'No one has successfully unsubscribed all from email clients in the last hour.'
+      Metrics:
+        - Id: totalUnsubscribeAllCount
+          Expression: unsubscribeAllCount
+          Label: 'Total unsubscribe all'
+        - Id: unsubscribeAllCount
+          MetricStat:
+            Metric:
+              Namespace: Gateway
+              MetricName: 'UnsubscribeAll::Success'
+              Dimensions:
+                - Name: Stage
+                  Value: !Ref 'Stage'
+                - Name: ApiMode
+                  Value: identity-gateway
+            Period: 3600
+            Stat: Sum
+            Unit: Count
+          ReturnData: false
+      ComparisonOperator: LessThanThreshold
+      Threshold: 1
+      EvaluationPeriods: 1
+      AlarmActions:
+        - !Ref 'TopicSendEmail'
+      InsufficientDataActions:
+        - !Ref 'TopicSendEmail'

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -691,3 +691,69 @@ Resources:
         - !Ref 'TopicSendEmail'
       InsufficientDataActions:
         - !Ref 'TopicSendEmail'
+  OAuthAuthenticationCallbackInactivityAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Condition: IsProd
+    Properties:
+      AlarmName: !Sub
+        - '${Priority} - ${App} ${Stage} has had no success OAuth Authorization code flow callbacks for Authentication in the last 20 minutes'
+        - Priority: !FindInMap [StageVariables, AlarmPriorities, P1]
+      AlarmDescription: No one has successfully completed OAuth Authorization code flow callbacks for Authentication in the last 20 minutes.
+      Metrics:
+        - Id: totalOAuthAuthenticationCallbackCount
+          Expression: oktaOAuthAuthenticationCallbackCount
+          Label: 'Total OAuth Authorization Callbacks for Authentication in Okta'
+        - Id: oktaOAuthAuthenticationCallbackCount
+          MetricStat:
+            Metric:
+              Namespace: Gateway
+              MetricName: 'OAuthAuthenticationCallback::Success'
+              Dimensions:
+                - Name: Stage
+                  Value: !Ref 'Stage'
+                - Name: ApiMode
+                  Value: identity-gateway
+            Period: 1200
+            Stat: Sum
+            Unit: Count
+          ReturnData: false
+      ComparisonOperator: LessThanThreshold
+      Threshold: 1
+      EvaluationPeriods: 1
+      AlarmActions:
+        - !Ref 'TopicSendEmail'
+      InsufficientDataActions:
+        - !Ref 'TopicSendEmail'
+  OAuthApplicationCallbackInactivityAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Condition: IsProd
+    Properties:
+      AlarmName: !Sub
+        - '${Priority} - ${App} ${Stage} has had no success OAuth Authorization code flow callbacks for internal Gateway routes in the last 1 hour'
+        - Priority: !FindInMap [StageVariables, AlarmPriorities, P1]
+      AlarmDescription: No one has successfully completed OAuth Authorization code flow callbacks for internal Gateway routes in the last 1 hour.
+      Metrics:
+        - Id: totalOAuthApplicationCallbackCount
+          Expression: oktaOAuthApplicationCallbackCount
+          Label: 'Total OAuth Authorization Callbacks for internal Gateway routes in Okta'
+        - Id: oktaOAuthApplicationCallbackCount
+          MetricStat:
+            Metric:
+              Namespace: Gateway
+              MetricName: 'OAuthApplicationCallback::Success'
+              Dimensions:
+                - Name: Stage
+                  Value: !Ref 'Stage'
+                - Name: ApiMode
+                  Value: identity-gateway
+            Period: 3600
+            Stat: Sum
+            Unit: Count
+          ReturnData: false
+      ComparisonOperator: LessThanThreshold
+      Threshold: 1
+      EvaluationPeriods: 1
+      AlarmActions:
+        - !Ref 'TopicSendEmail'
+      InsufficientDataActions:
+        - !Ref 'TopicSendEmail'


### PR DESCRIPTION
## What does this change?

We weren't reporting on some possibly important alarms, so add them in!

#### `OAuthAuthenticationCallbackInactivityAlarm`
- Checks the successful OAuth Authorization Code flow callback for Authentication metric `OAuthAuthenticationCallback::Success`
- This metric is fired on every successful authentication in Gateway that is used to give the user a session
- This is crucial during all forms of authentication through Gateway, if this alarm is fired something is very wrong with authentication and should be investigated immediately.
- Alarm fires after 20 mins of no metric

#### `OAuthApplicationCallbackInactivityAlarm`
- Checks the successful OAuth Authorization Code flow callback for internal Gateway routes that require the user to be logged in `OAuthApplicationCallback::Success`
- This metric is fired when tokens are successfully received for specific gateway routes that require the user to be logged in, this is mainly the New Account Review flow and corresponding newsletter page.
- This is crucial as if this is failing, users are probably unable to finish setting up their account and logging in after creating an account
- Alarm fires after 1 hour of no metric

#### `DeletionInactivityAlarm`
- Checks if the user has been successfully deleted `OAuthDeleteCallback::Success`
- This metric is fired when the step function for the self service account deletion is successful
- This is a P2 as it's still important to investigate if this process is not working correctly 
- Alarm fires after 6 hours of no metric

#### `UnsubscribeAllInactivityAlarm`
- Checks if the user is able to unsubscribe from all communications using the `UnsubscribeAll::Success` metric
- This is based `List-Unsubscribe` header in an email which signals to email clients to allow a user to one click unsubscribe from emails: https://github.com/guardian/gateway/pull/2731
- This is a P2 as it's important to investigate as it could mean we're not compliant with some email provider services
- Alarm fires after 1 hour of no metric