### PR TITLE
Update language on Self Service account deletion screen.

### DIFF
--- a/src/client/pages/DeleteAccount.tsx
+++ b/src/client/pages/DeleteAccount.tsx
@@ -64,8 +64,12 @@ export const DeleteAccount = ({
 				</ExternalLink>
 			</MainBodyText>
 			<MainBodyText>
-				Deleting your account removes your personal information from our
-				database.
+				Deleting your account will remove your account. If you wish to delete
+				your personal data, please contact{' '}
+				<ExternalLink href="dataprotection@guardian.co.uk">
+					dataprotection@guardian.co.uk
+				</ExternalLink>
+				.
 			</MainBodyText>
 
 			{/* Comments */}


### PR DESCRIPTION

## What does this change?

Update the language on the self service "Delete Account" form to state that users must contact dataprivacy in order to delete their personal data.

| Before | After |
|--------|--------|
| <img width="454" alt="image" src="https://github.com/user-attachments/assets/bb9f7971-b9e7-4747-afd9-deb1ea4f8c7a"> | <img width="453" alt="image" src="https://github.com/user-attachments/assets/9e982fed-0dd7-4797-9091-432f52c5270b"> | 

