### PR TITLE
Passwordless | Add additional IDX API endpoints required

### DIFF
--- a/src/server/lib/okta/idx/challenge.ts
+++ b/src/server/lib/okta/idx/challenge.ts
@@ -6,8 +6,8 @@ import {
 	idxBaseResponseSchema,
 	idxFetch,
 	idxFetchCompletion,
+	selectAuthenticationEnrollSchema,
 } from './shared';
-import { selectAuthenticationEnrollSchema } from './enroll';
 import { ResponseWithRequestState } from '@/server/models/Express';
 import { validateEmailAndPasswordSetSecurely } from '@/server/lib/okta/validateEmail';
 import { logger } from '@/server/lib/serverSideLogger';

--- a/src/server/lib/okta/idx/credential.ts
+++ b/src/server/lib/okta/idx/credential.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import {
+	AuthenticatorBody,
 	IdxBaseResponse,
-	IdxStateHandleBody,
 	baseRemediationValueSchema,
 	idxBaseResponseSchema,
 	idxFetch,
@@ -28,28 +28,20 @@ const credentialEnrollResponse = idxBaseResponseSchema.merge(
 );
 type CredentialEnrollResponse = z.infer<typeof credentialEnrollResponse>;
 
-// Body type for the credential/enroll request
-type CredentialEnrollBody = IdxStateHandleBody<{
-	authenticator: {
-		id: string;
-		methodType: 'password';
-	};
-}>;
-
 /**
  * @name credentialEnroll
- * @description Okta IDX API/Interaction Code flow - Enroll a new credential (currently `password`) for the user.
+ * @description Okta IDX API/Interaction Code flow - Enroll a new credential (currently `email` or `password`) for the user.
  * @param stateHandle - The state handle from the `enroll` step
- * @param body - The credential object, containing the authenticator id and method type
+ * @param body - The authenticator object, containing the authenticator id and method type
  * @param request_id - The request id
  * @returns	Promise<CredentialEnrollResponse> - The credential enroll response
  */
 export const credentialEnroll = (
 	stateHandle: IdxBaseResponse['stateHandle'],
-	body: CredentialEnrollBody['authenticator'],
+	body: AuthenticatorBody['authenticator'],
 	request_id?: string,
 ): Promise<CredentialEnrollResponse> => {
-	return idxFetch<CredentialEnrollResponse, CredentialEnrollBody>({
+	return idxFetch<CredentialEnrollResponse, AuthenticatorBody>({
 		path: 'credential/enroll',
 		body: {
 			stateHandle,

--- a/src/server/lib/okta/idx/credential.ts
+++ b/src/server/lib/okta/idx/credential.ts
@@ -5,11 +5,9 @@ import {
 	baseRemediationValueSchema,
 	idxBaseResponseSchema,
 	idxFetch,
-} from './shared';
-import {
-	enrollAuthenticatorSchema,
 	selectAuthenticationEnrollSchema,
-} from './enroll';
+} from './shared';
+import { enrollAuthenticatorSchema } from './enroll';
 import { skipSchema } from './challenge';
 
 // Schema for the credential/enroll response - very similar to the enroll response

--- a/src/server/lib/okta/idx/enroll.ts
+++ b/src/server/lib/okta/idx/enroll.ts
@@ -5,6 +5,7 @@ import {
 	baseRemediationValueSchema,
 	idxBaseResponseSchema,
 	idxFetch,
+	selectAuthenticationEnrollSchema,
 } from './shared';
 
 // schema for the enroll-profile object inside the enroll response remediation object
@@ -78,43 +79,6 @@ export const enrollAuthenticatorSchema = baseRemediationValueSchema.merge(
 		),
 	}),
 );
-
-// schema for the select-authenticator-enroll value object inside selectAuthenticationEnrollSchema
-const selectAuthenticationEnrollValueSchema = z.array(
-	z.union([
-		z.object({
-			name: z.literal('authenticator'),
-			type: z.string(),
-			options: z.array(
-				z.object({
-					label: z.string(),
-					value: z.object({
-						form: z.object({
-							value: z.array(
-								z.object({
-									name: z.enum(['id', 'methodType']),
-									value: z.string(),
-								}),
-							),
-						}),
-					}),
-				}),
-			),
-		}),
-		z.object({
-			name: z.literal('stateHandle'),
-		}),
-	]),
-);
-
-// schema for the select-authenticator-enroll object inside the enroll new response remediation object
-export const selectAuthenticationEnrollSchema =
-	baseRemediationValueSchema.merge(
-		z.object({
-			name: z.literal('select-authenticator-enroll'),
-			value: selectAuthenticationEnrollValueSchema,
-		}),
-	);
 
 // schema for the enroll/new response
 const enrollNewResponseSchema = idxBaseResponseSchema.merge(

--- a/src/server/lib/okta/idx/enroll.ts
+++ b/src/server/lib/okta/idx/enroll.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 import {
 	IdxBaseResponse,
 	IdxStateHandleBody,
+	authenticatorAnswerSchema,
 	baseRemediationValueSchema,
 	idxBaseResponseSchema,
 	idxFetch,
@@ -64,19 +65,7 @@ type EnrollNewWithEmailBody = IdxStateHandleBody<{
 export const enrollAuthenticatorSchema = baseRemediationValueSchema.merge(
 	z.object({
 		name: z.literal('enroll-authenticator'),
-		value: z.array(
-			z.union([
-				z.object({
-					name: z.literal('credentials'),
-					form: z.object({
-						value: z.array(z.object({ name: z.literal('passcode') })),
-					}),
-				}),
-				z.object({
-					name: z.literal('stateHandle'),
-				}),
-			]),
-		),
+		value: authenticatorAnswerSchema,
 	}),
 );
 

--- a/src/server/lib/okta/idx/identify.ts
+++ b/src/server/lib/okta/idx/identify.ts
@@ -1,0 +1,65 @@
+import { z } from 'zod';
+import {
+	baseRemediationValueSchema,
+	IdxBaseResponse,
+	idxBaseResponseSchema,
+	idxFetch,
+	selectAuthenticatorValueSchema,
+} from './shared';
+
+// schema for the select-authenticator-authenticate object inside the identify response remediation object
+const selectAuthenticationAuthenticateSchema = baseRemediationValueSchema.merge(
+	z.object({
+		name: z.literal('select-authenticator-authenticate'),
+		value: selectAuthenticatorValueSchema,
+	}),
+);
+
+// schema for the identify response
+const identifyResponseSchema = idxBaseResponseSchema.merge(
+	z.object({
+		remediation: z.object({
+			type: z.string(),
+			value: z.array(
+				z.union([
+					selectAuthenticationAuthenticateSchema,
+					baseRemediationValueSchema,
+				]),
+			),
+		}),
+	}),
+);
+type IdentifyResponse = z.infer<typeof identifyResponseSchema>;
+
+// Body type for the identify request
+type IdentifyBody = {
+	stateHandle: IdxBaseResponse['stateHandle'];
+	identifier: string;
+	rememberMe: true;
+};
+
+/**
+ * @name identify
+ * @description Okta IDX API/Interaction Code flow - Use the stateHandle from the `introspect` step to start the identify process. This is used when authenticating an existing user.
+ *
+ * @param stateHandle - The state handle from the `introspect` step
+ * @param email - The email address of the user
+ * @param request_id - The request id
+ * @returns Promise<IdentifyResponse> - The identify response
+ */
+export const identify = (
+	stateHandle: IdxBaseResponse['stateHandle'],
+	email: string,
+	request_id?: string,
+): Promise<IdentifyResponse> => {
+	return idxFetch<IdentifyResponse, IdentifyBody>({
+		path: 'identify',
+		body: {
+			stateHandle,
+			identifier: email,
+			rememberMe: true,
+		},
+		schema: identifyResponseSchema,
+		request_id,
+	});
+};

--- a/src/server/lib/okta/idx/introspect.ts
+++ b/src/server/lib/okta/idx/introspect.ts
@@ -24,6 +24,13 @@ export const selectEnrollProfileSchema = baseRemediationValueSchema.merge(
 	}),
 );
 
+// Schema for the 'identify' object inside the introspect response remediation object
+export const identifySchema = baseRemediationValueSchema.merge(
+	z.object({
+		name: z.literal('identify'),
+	}),
+);
+
 // Schema for the introspect response
 const introspectResponseSchema = idxBaseResponseSchema.merge(
 	z.object({
@@ -34,6 +41,7 @@ const introspectResponseSchema = idxBaseResponseSchema.merge(
 				z.union([
 					redirectIdpSchema,
 					selectEnrollProfileSchema,
+					identifySchema,
 					baseRemediationValueSchema,
 				]),
 			),

--- a/src/server/lib/okta/idx/recover.ts
+++ b/src/server/lib/okta/idx/recover.ts
@@ -1,0 +1,38 @@
+import { z } from 'zod';
+import {
+	IdxBaseResponse,
+	idxBaseResponseSchema,
+	idxFetch,
+	IdxStateHandleBody,
+	selectAuthenticatorValueSchema,
+} from './shared';
+
+// schema for the recover response
+const recoverResponseSchema = idxBaseResponseSchema.merge(
+	z.object({
+		name: z.literal('authenticator-verification-data'),
+		value: selectAuthenticatorValueSchema,
+	}),
+);
+type RecoverResponse = z.infer<typeof recoverResponseSchema>;
+
+/**
+ * @name recover
+ * @description Okta IDX API/Interaction Code flow - Start password recovery process.
+ * @param stateHandle - The state handle from the `identify`/`introspect` step
+ * @param request_id - The request id
+ * @returns	Promise<RecoverResponse> - The recover response
+ */
+export const recover = (
+	stateHandle: IdxBaseResponse['stateHandle'],
+	request_id?: string,
+): Promise<RecoverResponse> => {
+	return idxFetch<RecoverResponse, IdxStateHandleBody>({
+		path: 'recover',
+		body: {
+			stateHandle,
+		},
+		schema: recoverResponseSchema,
+		request_id,
+	});
+};

--- a/src/server/lib/okta/idx/shared.ts
+++ b/src/server/lib/okta/idx/shared.ts
@@ -10,6 +10,7 @@ const { okta } = getConfiguration();
 
 // Okta IDX API paths
 const idxPaths = [
+	'challenge',
 	'challenge/answer',
 	'challenge/resend',
 	'credential/enroll',
@@ -92,6 +93,29 @@ export const selectAuthenticationEnrollSchema =
 			value: selectAuthenticatorValueSchema,
 		}),
 	);
+
+// schema for the (challenge|enroll)-authenticator remediation value object
+export const authenticatorAnswerSchema = z.array(
+	z.union([
+		z.object({
+			name: z.literal('credentials'),
+			form: z.object({
+				value: z.array(z.object({ name: z.literal('passcode') })),
+			}),
+		}),
+		z.object({
+			name: z.literal('stateHandle'),
+		}),
+	]),
+);
+
+// Body type for the credential/enroll and challenge requests to select a given authenticator
+export type AuthenticatorBody = IdxStateHandleBody<{
+	authenticator: {
+		id: string;
+		methodType: 'email' | 'password';
+	};
+}>;
 
 // Schema for when the authentication process is completed, and we return a base user object
 export const completeLoginResponseSchema = idxBaseResponseSchema.merge(

--- a/src/server/lib/okta/idx/shared.ts
+++ b/src/server/lib/okta/idx/shared.ts
@@ -15,6 +15,7 @@ const idxPaths = [
 	'credential/enroll',
 	'enroll',
 	'enroll/new',
+	'identify',
 	'introspect',
 ] as const;
 export type IDXPath = (typeof idxPaths)[number];
@@ -54,6 +55,43 @@ export const baseRemediationValueSchema = z.object({
 export type IdxStateHandleBody<T = object> = T & {
 	stateHandle: IdxBaseResponse['stateHandle'];
 };
+
+// schema for the select-authenticator-{enroll|authenticate}
+export const selectAuthenticatorValueSchema = z.array(
+	z.union([
+		z.object({
+			name: z.literal('authenticator'),
+			type: z.string(),
+			options: z.array(
+				z.object({
+					label: z.string(),
+					value: z.object({
+						form: z.object({
+							value: z.array(
+								z.object({
+									name: z.enum(['id', 'methodType']),
+									value: z.string(),
+								}),
+							),
+						}),
+					}),
+				}),
+			),
+		}),
+		z.object({
+			name: z.literal('stateHandle'),
+		}),
+	]),
+);
+
+// schema for the select-authenticator-enroll object
+export const selectAuthenticationEnrollSchema =
+	baseRemediationValueSchema.merge(
+		z.object({
+			name: z.literal('select-authenticator-enroll'),
+			value: selectAuthenticatorValueSchema,
+		}),
+	);
 
 // Schema for when the authentication process is completed, and we return a base user object
 export const completeLoginResponseSchema = idxBaseResponseSchema.merge(

--- a/src/server/lib/okta/idx/shared.ts
+++ b/src/server/lib/okta/idx/shared.ts
@@ -18,6 +18,7 @@ const idxPaths = [
 	'enroll/new',
 	'identify',
 	'introspect',
+	'recover',
 ] as const;
 export type IDXPath = (typeof idxPaths)[number];
 

--- a/src/server/routes/register.ts
+++ b/src/server/routes/register.ts
@@ -31,11 +31,7 @@ import {
 	challengeAnswerPasscode,
 	challengeResend,
 } from '@/server/lib/okta/idx/challenge';
-import {
-	enroll,
-	enrollNewWithEmail,
-	selectAuthenticationEnrollSchema,
-} from '@/server/lib/okta/idx/enroll';
+import { enroll, enrollNewWithEmail } from '@/server/lib/okta/idx/enroll';
 import { interact } from '@/server/lib/okta/idx/interact';
 import {
 	introspect,
@@ -51,7 +47,10 @@ import {
 	bodyFormFieldsToRegistrationConsents,
 	encryptRegistrationConsents,
 } from '@/server/lib/registrationConsents';
-import { convertExpiresAtToExpiryTimeInMs } from '@/server/lib/okta/idx/shared';
+import {
+	convertExpiresAtToExpiryTimeInMs,
+	selectAuthenticationEnrollSchema,
+} from '@/server/lib/okta/idx/shared';
 
 const { registrationPasscodesEnabled } = getConfiguration();
 


### PR DESCRIPTION
## What does this change?

In order to step towards passwordless authentication using OTPs (One Time Passcodes) being an option for sign in and account recovery at the Guardian, we need to add some addition Okta IDX API endpoints to facilitate this that weren't required when we implemented social authentication and create account with OTPs.

This PR simply sets up these API endpoints, but does not use them anywhere.

Some refactoring was also performed to share similar objects with different endpoints.

### `/identify`

Used to start the authentication process for an existing user. Available after the initial call to the `/introspect` endpoint.

This endpoint takes the `stateHandle` as with other endpoints, which identifies the current request state and context.
It also takes an `identifier` parameter, which is the user's email, and a `rememberMe` property, which is a boolean in our case will always be `true`.

The response object will include a remediation with the `select-authenticator-authenticate` name. This includes a list of authenticators that the user can authenticate with by calling the `/challenge` endpoint. This includes the `email` authenticator, which is required for OTP authentication, and the `password` authenticator, for authentication with a password.

### `/challenge`

Used to initiate a authentication request for a given authenticator.

Takes the `stateHandle`. Also takes an `authenticator` object, which is used to identify the authenticator to use. This has the `id` of the authenticator, and a `methodType` parameter, which is either `email` or `password`.

The response includes a remediation with the `challenge-authenticator` name, which has information on how to verify the given authenticator, which in our case would involve sending a `credentials` object which includes the `passcode` value (which is the value of the authenticator, whether thats a passcode or password), and the state handle, to the `/challenge/answer` endpoint, which has previously been implemented. 

### `/recover`

This endpoint becomes available if selecting the `password` authenticator after calling the `/identify` endpoint.

This is used in order to initiate a password reset flow.

It just takes the `stateHandle` in the body.

The response will include a `authenticator-verification-data` remediation name. Like `/identify` it is a list of authenticators which can be used to verify that the user is able to perform this request. In this case the only available authenticator will be `email`. As with `/identify` the `/challenge` endpoint must be called with the given authenticator.