### PR TITLE
Passwordless | Add `EmailChallengePasscode` email and rendered route

### DIFF
--- a/src/email/templates/EmailChallengePasscode/EmailChallengePasscode.stories.tsx
+++ b/src/email/templates/EmailChallengePasscode/EmailChallengePasscode.stories.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { Meta } from '@storybook/react';
+
+import { EmailChallengePasscode } from './EmailChallengePasscode';
+import { renderMJML } from '../../testUtils';
+
+export default {
+	title: 'Email/Templates/EmailChallengePasscode',
+	component: EmailChallengePasscode,
+	parameters: {
+		chromatic: {
+			modes: {
+				'dark desktop': { disable: true },
+				'dark mobile': { disable: true },
+			},
+		},
+	},
+} as Meta;
+
+export const Default = () => {
+	return renderMJML(<EmailChallengePasscode />);
+};
+Default.storyName = 'with defaults';
+
+export const Passcode = () => {
+	return renderMJML(<EmailChallengePasscode storybookPasscode="123456" />);
+};
+Passcode.storyName = 'with passcode';

--- a/src/email/templates/EmailChallengePasscode/EmailChallengePasscode.tsx
+++ b/src/email/templates/EmailChallengePasscode/EmailChallengePasscode.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+
+import { Mjml, MjmlBody, MjmlHead, MjmlTitle } from '@faire/mjml-react';
+import { Header } from '@/email/components/Header';
+import { SubHeader } from '@/email/components/SubHeader';
+import { Text } from '@/email/components/Text';
+import { Footer } from '@/email/components/Footer';
+import { space } from '@guardian/source/foundations';
+
+type Props = {
+	storybookPasscode?: string;
+};
+
+export const EmailChallengePasscode = ({ storybookPasscode }: Props) => {
+	return (
+		<Mjml>
+			<MjmlHead>
+				<MjmlTitle>Your one-time passcode | The Guardian</MjmlTitle>
+			</MjmlHead>
+			<MjmlBody width={600}>
+				<Header />
+				<SubHeader>Your one-time passcode</SubHeader>
+				<Text>
+					This passcode can only be used once. Do not share this code with
+					anyone. This code will expire in 30 minutes.
+				</Text>
+				<Text largeText letterSpacing={`${space[0]}px`}>
+					<strong>{`${storybookPasscode ? storybookPasscode : '{{CTA}}'}`}</strong>
+				</Text>
+				<Text>If your code has expired, please request a new code.</Text>
+				<Footer
+					mistakeParagraphComponent={
+						'If you did not request this code, you can safely disregard this email.'
+					}
+				/>
+			</MjmlBody>
+		</Mjml>
+	);
+};

--- a/src/email/templates/EmailChallengePasscode/EmailChallengePasscodeText.ts
+++ b/src/email/templates/EmailChallengePasscode/EmailChallengePasscodeText.ts
@@ -1,0 +1,17 @@
+import { SUPPORT_EMAIL } from '@/shared/model/Configuration';
+
+export const EmailChallengePasscodeText = () => `
+Your one-time passcode
+
+This passcode can only be used once. Do not share this code with anyone. This code will expire in 30 minutes.
+
+\${oneTimePassword}
+
+If your code has expired, please request a new code.
+
+If you did not request this code, you can safely disregard this email.
+
+If you have any queries about why you are receiving this email, please contact our customer service team at ${SUPPORT_EMAIL}
+
+Guardian News and Media Limited, Kings Place, 90 York Way, London, N1 9GU, United Kingdom
+`;

--- a/src/email/templates/EmailChallengePasscode/sendEmailChallengePasscode.ts
+++ b/src/email/templates/EmailChallengePasscode/sendEmailChallengePasscode.ts
@@ -1,0 +1,25 @@
+import { render } from '@faire/mjml-react/utils/render';
+import { send } from '@/email/lib/send';
+
+import { EmailChallengePasscode } from './EmailChallengePasscode';
+import { EmailChallengePasscodeText } from './EmailChallengePasscodeText';
+
+type Props = {
+	to: string;
+	subject?: string;
+};
+
+const plainText = EmailChallengePasscodeText();
+const { html } = render(EmailChallengePasscode({}));
+
+export const sendEmailChallengePasscodeEmail = ({
+	to,
+	subject = 'Your one-time passcode',
+}: Props) => {
+	return send({
+		html,
+		plainText,
+		subject,
+		to,
+	});
+};

--- a/src/email/templates/RegistrationPasscode/RegistrationPasscodeText.ts
+++ b/src/email/templates/RegistrationPasscode/RegistrationPasscodeText.ts
@@ -1,3 +1,5 @@
+import { SUPPORT_EMAIL } from '@/shared/model/Configuration';
+
 export const RegistrationPasscodeText = () => `
 Thank you for creating an account with the Guardian. Use the following code to verify your email.
 
@@ -8,6 +10,8 @@ Do not share this code with anyone. This code will expire in 30 minutes.
 If your code has expired, create your Guardian account again.
 
 If you received this email by mistake, please delete it. You won't be registered if you don't do anything.
+
+If you have any queries about why you are receiving this email, please contact our customer service team at ${SUPPORT_EMAIL}
 
 Guardian News and Media Limited, Kings Place, 90 York Way, London, N1 9GU, United Kingdom
 `;

--- a/src/email/templates/RegistrationPasscode/sendRegistrationPasscode.ts
+++ b/src/email/templates/RegistrationPasscode/sendRegistrationPasscode.ts
@@ -14,7 +14,7 @@ const { html } = render(RegistrationPasscode({}));
 
 export const sendRegistrationPasscodeEmail = ({
 	to,
-	subject = 'Your Guardian account and discount code',
+	subject = 'One-time verification code',
 }: Props) => {
 	return send({
 		html,

--- a/src/email/templates/renderedTemplates.ts
+++ b/src/email/templates/renderedTemplates.ts
@@ -18,6 +18,8 @@ import { CompleteRegistrationText } from './CompleteRegistration/CompleteRegistr
 import { render } from '@faire/mjml-react/utils/render';
 import { RegistrationPasscode } from './RegistrationPasscode/RegistrationPasscode';
 import { RegistrationPasscodeText } from './RegistrationPasscode/RegistrationPasscodeText';
+import { EmailChallengePasscodeText } from './EmailChallengePasscode/EmailChallengePasscodeText';
+import { EmailChallengePasscode } from './EmailChallengePasscode/EmailChallengePasscode';
 
 type EmailRenderResult = {
 	plain: string;
@@ -68,3 +70,8 @@ export const renderedRegistrationPasscode = {
 	plain: RegistrationPasscodeText(),
 	html: render(RegistrationPasscode({})).html,
 } as EmailRenderResult;
+
+export const renderedEmailChallengePasscode = {
+	plain: EmailChallengePasscodeText(),
+	html: render(EmailChallengePasscode({})).html,
+};

--- a/src/server/routes/emailTemplates.ts
+++ b/src/server/routes/emailTemplates.ts
@@ -4,11 +4,13 @@ import { rateLimitedTypedRouter as router } from '@/server/lib/typedRoutes';
 
 import {
 	renderedAccidentalEmail,
+	renderedEmailChallengePasscode,
 	renderedRegistrationPasscode,
 } from '@/email/templates/renderedTemplates';
 
 const emailTemplateTypes = [
 	'accidental-email',
+	'email-challenge-passcode',
 	'registration-passcode',
 ] as const;
 type EmailTemplateType = (typeof emailTemplateTypes)[number];
@@ -24,6 +26,8 @@ const renderEmailTemplate = (
 	switch (template) {
 		case 'accidental-email':
 			return renderedAccidentalEmail;
+		case 'email-challenge-passcode':
+			return renderedEmailChallengePasscode;
 		case 'registration-passcode':
 			return renderedRegistrationPasscode;
 		default:


### PR DESCRIPTION
## What does this change?

Authentication (sign in) or account recovery (password reset) with an OTP sends an email through Okta to do this. This is different from the email that is sent when creating an account.

This is the `EmailChallenge` email under the brand customisations in Okta email templates. The same email is sent to users attempting to authenticate or reset their password, so this email has to be relatively generic for both use cases.

This PR adds the email template in to Gateway. A separate PR, https://github.com/guardian/identity-platform/pull/751, pulls the template from Gateway to Okta through Terraform. This PR should be merged in before that one.

![localhost_6006_iframe html_args= globals=viewport_mobile id=email-templates-emailchallengepasscode--passcode viewMode=story(Pixel 7)](https://github.com/user-attachments/assets/c293cab6-6968-4c6d-8209-372b90b5dd71)
