### PR TITLE
Add #2828 to `.git-blame-ignore-revs`

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -24,3 +24,6 @@ f9faff6e255ae523604b0d659d8870db29f85407
 
 # Rewrite files after dependecy updates 2024-05-28
 50162ed720060e9e9ceb60cc4100d51289f4aabb
+
+# Eslint Part 2: Enable and fix "easy" errors 
+c6c98b49bb86ae965b252e58068009eb8c0527b0


### PR DESCRIPTION
## What does this change?

Add #2828 to `.git-blame-ignore-revs` as the changes it makes arent particularly useful to see in the Git blame.