### PR TITLE
Dependabot | Group dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,10 +4,39 @@ updates:
     directory: '/'
     schedule:
       interval: 'weekly'
-    open-pull-requests-limit: 10
+      day: monday
+      time: '08:00'
     labels:
       - 'dependencies'
+    groups:
+      dependencies:
+        dependency-type: 'production'
+        update-types: ['minor', 'patch']
+      devDependencies:
+        dependency-type: 'development'
+        update-types: ['minor', 'patch']
+  - package-ecosystem: 'npm'
+    directory: '/cdk'
+    schedule:
+      interval: 'weekly'
+      day: monday
+      time: '08:00'
+    labels:
+      - 'dependencies'
+    groups:
+      cdk:
+        update-types:
+          - 'minor'
+          - 'patch'
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:
       interval: 'weekly'
+      day: monday
+      time: '08:00'
+    labels:
+      - 'dependencies'
+    groups:
+      actions:
+        patterns:
+          - '*'


### PR DESCRIPTION
## What does this change?

- Group dependency updates so that it groups together minor and patch updates.
	- Hopefully means less dependency PR spam

- Adds cdk dependency updates

- Run all dependency updates every Monday at 8AM, so they should be ready to review by the time we start work.

- Major dependency updates will have to be manually updated, so this should still be kept and eye on.
