### PR TITLE
Passwordless | Query parameter setup for Reset Password with passcodes

### DIFF
--- a/src/server/controllers/changePassword.ts
+++ b/src/server/controllers/changePassword.ts
@@ -41,7 +41,7 @@ import { setPasswordAndRedirect } from '@/server/lib/okta/idx/challenge';
 import { PasswordFieldErrors } from '@/shared/model/Errors';
 import { isBreachedPassword } from '@/server/lib/breachedPasswordCheck';
 
-const { registrationPasscodesEnabled } = getConfiguration();
+const { passcodesEnabled } = getConfiguration();
 
 export const setPasswordController = (
 	path: PasswordRoutePath,
@@ -56,7 +56,7 @@ export const setPasswordController = (
 		// OKTA IDX API FLOW
 		// If the user is using the passcode registration flow, we need to handle the password change/creation.
 		// If there are specific failures, we fall back to the legacy Okta change password flow.
-		if (registrationPasscodesEnabled && !useOktaClassic) {
+		if (passcodesEnabled && !useOktaClassic) {
 			try {
 				// Read the encrypted state cookie to get the state handle and email
 				const encryptedState = readEncryptedStateCookie(req);

--- a/src/server/controllers/checkPasswordToken.ts
+++ b/src/server/controllers/checkPasswordToken.ts
@@ -30,7 +30,7 @@ import {
 } from '@/server/lib/okta/idx/introspect';
 import { convertExpiresAtToExpiryTimeInMs } from '@/server/lib/okta/idx/shared';
 
-const { defaultReturnUri, registrationPasscodesEnabled } = getConfiguration();
+const { defaultReturnUri, passcodesEnabled } = getConfiguration();
 
 const handleBackButtonEventOnWelcomePage = (
 	path: PasswordRoutePath,
@@ -106,7 +106,7 @@ export const checkTokenInOkta = async (
 	// in the correct state to be able to change their password.
 	// If there are specific failures, we fall back to the legacy Okta change password flow.
 	if (
-		registrationPasscodesEnabled &&
+		passcodesEnabled &&
 		!res.locals.queryParams.useOktaClassic &&
 		path === '/welcome' // only check the state handle for registration passcode flow on the welcome page
 	) {

--- a/src/server/controllers/sendChangePasswordEmail.ts
+++ b/src/server/controllers/sendChangePasswordEmail.ts
@@ -31,6 +31,9 @@ import { PasswordRoutePath } from '@/shared/model/Routes';
 import { mergeRequestState } from '@/server/lib/requestState';
 import dangerouslySetPlaceholderPassword from '@/server/lib/okta/dangerouslySetPlaceholderPassword';
 import { encryptOktaRecoveryToken } from '@/server/lib/deeplink/oktaRecoveryToken';
+import { getConfiguration } from '@/server/lib/getConfiguration';
+
+const { passcodesEnabled } = getConfiguration();
 
 const getPath = (req: Request): PasswordRoutePath => {
 	const path = req.path;
@@ -74,13 +77,21 @@ export const sendEmailInOkta = async (
 	const { email = '' } = req.body;
 	const path = getPath(req);
 	const {
-		queryParams: { appClientId, ref, refViewId },
+		queryParams: { appClientId, ref, refViewId, usePasscodesResetPassword },
 		requestId: request_id,
 	} = state;
 
 	try {
 		// get the user object to check user status
 		const user = await getUser(email);
+
+		if (passcodesEnabled && usePasscodesResetPassword) {
+			// TODO: implement passcode reset password flow
+			// this is a placeholder for now
+			logger.warn('Passcode reset password flow is not implemented yet', {
+				request_id,
+			});
+		}
 
 		switch (user.status) {
 			case Status.ACTIVE:

--- a/src/server/lib/__tests__/getConfiguration.test.ts
+++ b/src/server/lib/__tests__/getConfiguration.test.ts
@@ -135,7 +135,7 @@ describe('getConfiguration', () => {
 				},
 			},
 			membersDataApiUrl: 'members-data-api-url',
-			registrationPasscodesEnabled: true,
+			passcodesEnabled: true,
 			deleteAccountStepFunction: {
 				url: 'delete-account-step-function-url',
 				apiKey: 'delete-account-api-key',

--- a/src/server/lib/getConfiguration.ts
+++ b/src/server/lib/getConfiguration.ts
@@ -47,7 +47,7 @@ const getStage = (value: string | undefined): Stage => {
 interface StageVariables {
 	guardianDotcomDomain: string;
 	apiDomain: string;
-	registrationPasscodesEnabled: boolean;
+	passcodesEnabled: boolean;
 	accountManagementUrl: string;
 }
 
@@ -57,24 +57,21 @@ const getStageVariables = (stage: Stage): StageVariables => {
 			return {
 				guardianDotcomDomain: GU_DOMAIN.PROD,
 				apiDomain: GU_API_DOMAIN.PROD,
-				registrationPasscodesEnabled:
-					featureSwitches.registrationPasscodesEnabled.PROD,
+				passcodesEnabled: featureSwitches.passcodesEnabled.PROD,
 				accountManagementUrl: GU_MANAGE_URL.PROD,
 			};
 		case 'CODE':
 			return {
 				guardianDotcomDomain: GU_DOMAIN.CODE,
 				apiDomain: GU_API_DOMAIN.CODE,
-				registrationPasscodesEnabled:
-					featureSwitches.registrationPasscodesEnabled.CODE,
+				passcodesEnabled: featureSwitches.passcodesEnabled.CODE,
 				accountManagementUrl: GU_MANAGE_URL.CODE,
 			};
 		default:
 			return {
 				guardianDotcomDomain: GU_DOMAIN.DEV,
 				apiDomain: GU_API_DOMAIN.DEV,
-				registrationPasscodesEnabled:
-					featureSwitches.registrationPasscodesEnabled.DEV,
+				passcodesEnabled: featureSwitches.passcodesEnabled.DEV,
 				accountManagementUrl: GU_MANAGE_URL.DEV,
 			};
 	}
@@ -129,7 +126,7 @@ export const getConfiguration = (): Configuration => {
 		guardianDotcomDomain,
 		apiDomain,
 		accountManagementUrl,
-		registrationPasscodesEnabled,
+		passcodesEnabled,
 	} = getStageVariables(stage);
 
 	const isHttps: boolean = JSON.parse(
@@ -243,7 +240,7 @@ export const getConfiguration = (): Configuration => {
 		accountManagementUrl,
 		rateLimiter,
 		membersDataApiUrl,
-		registrationPasscodesEnabled,
+		passcodesEnabled: passcodesEnabled,
 		deleteAccountStepFunction,
 	};
 };

--- a/src/server/lib/queryParams.ts
+++ b/src/server/lib/queryParams.ts
@@ -51,6 +51,7 @@ export const parseExpressQueryParams = (
 		appClientId,
 		maxAge,
 		useOktaClassic,
+		usePasscodesResetPassword,
 	}: Record<keyof QueryParams, string | undefined>, // parameters from req.query
 	// some parameters may be manually passed in req.body too,
 	// generally for tracking purposes
@@ -74,6 +75,7 @@ export const parseExpressQueryParams = (
 		appClientId,
 		maxAge: stringToNumber(maxAge),
 		useOktaClassic: isStringBoolean(useOktaClassic),
+		usePasscodesResetPassword: isStringBoolean(usePasscodesResetPassword),
 	};
 };
 

--- a/src/server/models/Configuration.ts
+++ b/src/server/models/Configuration.ts
@@ -27,7 +27,7 @@ export interface Configuration {
 	accountManagementUrl: string;
 	rateLimiter: RateLimiterConfiguration;
 	membersDataApiUrl: string;
-	registrationPasscodesEnabled: boolean;
+	passcodesEnabled: boolean;
 	deleteAccountStepFunction: {
 		url: string;
 		apiKey: string;

--- a/src/server/routes/register.ts
+++ b/src/server/routes/register.ts
@@ -52,7 +52,7 @@ import {
 	selectAuthenticationEnrollSchema,
 } from '@/server/lib/okta/idx/shared';
 
-const { registrationPasscodesEnabled } = getConfiguration();
+const { passcodesEnabled: passcodesEnabled } = getConfiguration();
 
 router.get(
 	'/register',
@@ -409,7 +409,7 @@ export const OktaRegistration = async (
 	// Attempt to register the user with Okta using the IDX API
 	// and specifically using passcodes.
 	// If there are specific failures, we fall back to the legacy Okta registration flow
-	if (registrationPasscodesEnabled && !useOktaClassic) {
+	if (passcodesEnabled && !useOktaClassic) {
 		try {
 			// start the interaction code flow, and get the interaction handle + authState
 			const [{ interaction_handle }, authState] = await interact(req, res, {

--- a/src/server/routes/welcome.ts
+++ b/src/server/routes/welcome.ts
@@ -50,7 +50,8 @@ import { getNextWelcomeFlowPage } from '@/server/lib/welcome';
 import { newslettersSubscriptionsFromFormBody } from '@/shared/lib/newsletter';
 import { requestStateHasOAuthTokens } from '../lib/middleware/requestState';
 
-const { registrationPasscodesEnabled, signInPageUrl } = getConfiguration();
+const { passcodesEnabled: passcodesEnabled, signInPageUrl } =
+	getConfiguration();
 
 // temp return to app page for app users who get stuck in browser
 router.get(
@@ -487,7 +488,7 @@ const OktaResendEmail = async (req: Request, res: ResponseWithRequestState) => {
 	const state = res.locals;
 	// if registration passcodes are enabled, we need to handle this differently
 	// by using the passcode registration flow
-	if (registrationPasscodesEnabled && !state.queryParams.useOktaClassic) {
+	if (passcodesEnabled && !state.queryParams.useOktaClassic) {
 		return OktaRegistration(req, res);
 	}
 

--- a/src/shared/__tests__/queryParams.test.ts
+++ b/src/shared/__tests__/queryParams.test.ts
@@ -36,6 +36,7 @@ describe('getPersistableQueryParams', () => {
 			fromURI: 'fromURI',
 			appClientId: 'appClientId',
 			useOktaClassic: undefined,
+			usePasscodesResetPassword: undefined,
 		};
 
 		expect(output).toStrictEqual(expected);

--- a/src/shared/lib/featureSwitches.ts
+++ b/src/shared/lib/featureSwitches.ts
@@ -8,7 +8,7 @@
  */
 interface FeatureSwitches {
 	demoSwitch: boolean;
-	registrationPasscodesEnabled: {
+	passcodesEnabled: {
 		DEV: boolean;
 		CODE: boolean;
 		PROD: boolean;
@@ -17,7 +17,7 @@ interface FeatureSwitches {
 
 export const featureSwitches: FeatureSwitches = {
 	demoSwitch: false,
-	registrationPasscodesEnabled: {
+	passcodesEnabled: {
 		DEV: true,
 		CODE: true,
 		PROD: true,

--- a/src/shared/lib/queryParams.ts
+++ b/src/shared/lib/queryParams.ts
@@ -41,6 +41,7 @@ export const getPersistableQueryParams = (
 	fromURI: params.fromURI,
 	appClientId: params.appClientId,
 	useOktaClassic: params.useOktaClassic,
+	usePasscodesResetPassword: params.usePasscodesResetPassword,
 });
 
 /**

--- a/src/shared/model/QueryParams.ts
+++ b/src/shared/model/QueryParams.ts
@@ -46,6 +46,8 @@ export interface PersistableQueryParams
 	appClientId?: string;
 	// fallback to Okta Classic if needed
 	useOktaClassic?: boolean;
+	// temporary flag to enable the use of passcodes for reset password flow
+	usePasscodesResetPassword?: boolean;
 }
 
 /**


### PR DESCRIPTION
## What does this change?

In preparation for developing full passwordless, we'd like to be able to test new features before we roll them out to users, we can do this using a query parameter flag.

This PR adds a query parameter flag for Reset Password using passcodes functionality - `usePasscodesResetPassword`.

For now this simply logs saying this route has been accessed, but as more functionality is developed it will use this query parameter flag.

I've also renamed the switch `registrationPasscodesEnabled` to `passcodesEnabled` as it will better reflect the scope of the switch going forward.
