### PR TITLE
Passwordless | Passcode email sent page changes

### DIFF
--- a/src/client/pages/PasscodeEmailSent.stories.tsx
+++ b/src/client/pages/PasscodeEmailSent.stories.tsx
@@ -8,13 +8,15 @@ export default {
 	component: PasscodeEmailSent,
 } as Meta;
 
-export const Defaults = () => <PasscodeEmailSent passcodeAction="#" />;
+export const Defaults = () => (
+	<PasscodeEmailSent passcodeAction="#" expiredPage="#" />
+);
 Defaults.story = {
 	name: 'with defaults',
 };
 
 export const ChangeEmail = () => (
-	<PasscodeEmailSent passcodeAction="#" changeEmailPage="#" />
+	<PasscodeEmailSent passcodeAction="#" expiredPage="#" changeEmailPage="#" />
 );
 ChangeEmail.story = {
 	name: 'with changeEmailPage',
@@ -23,6 +25,7 @@ ChangeEmail.story = {
 export const WithEmail = () => (
 	<PasscodeEmailSent
 		passcodeAction="#"
+		expiredPage="#"
 		changeEmailPage="#"
 		email="example@theguardian.com"
 	/>
@@ -34,6 +37,7 @@ WithEmail.story = {
 export const WithPasscode = () => (
 	<PasscodeEmailSent
 		passcodeAction="#"
+		expiredPage="#"
 		changeEmailPage="#"
 		email="example@theguardian.com"
 		passcode="123456"
@@ -46,6 +50,7 @@ WithPasscode.story = {
 export const WithPasscodeError = () => (
 	<PasscodeEmailSent
 		passcodeAction="#"
+		expiredPage="#"
 		changeEmailPage="#"
 		email="example@theguardian.com"
 		passcode="123456"
@@ -64,6 +69,7 @@ WithPasscodeError.story = {
 export const WithRecaptchaError = () => (
 	<PasscodeEmailSent
 		passcodeAction="#"
+		expiredPage="#"
 		changeEmailPage="#"
 		email="example@theguardian.com"
 		recaptchaSiteKey="invalid-key"
@@ -74,12 +80,116 @@ WithRecaptchaError.story = {
 };
 
 export const WithSuccessMessage = () => (
-	<PasscodeEmailSent passcodeAction="#" showSuccess={true} />
+	<PasscodeEmailSent passcodeAction="#" expiredPage="#" showSuccess={true} />
 );
 WithSuccessMessage.story = {
 	name: 'with success message',
 };
 
 export const WithErrorMessage = () => (
-	<PasscodeEmailSent passcodeAction="#" errorMessage="•⩊• UwU" />
+	<PasscodeEmailSent
+		passcodeAction="#"
+		expiredPage="#"
+		errorMessage="•⩊• UwU"
+	/>
 );
+WithErrorMessage.story = {
+	name: 'with error message',
+};
+
+export const DefaultsRegistration = () => (
+	<PasscodeEmailSent passcodeAction="#/register" expiredPage="#" />
+);
+DefaultsRegistration.story = {
+	name: 'with defaults - create account',
+};
+
+export const ChangeEmailRegistration = () => (
+	<PasscodeEmailSent
+		passcodeAction="#/register"
+		expiredPage="#"
+		changeEmailPage="#"
+	/>
+);
+ChangeEmailRegistration.story = {
+	name: 'with changeEmailPage - create account',
+};
+
+export const WithEmailRegistration = () => (
+	<PasscodeEmailSent
+		passcodeAction="#register"
+		expiredPage="#"
+		changeEmailPage="#"
+		email="example@theguardian.com"
+	/>
+);
+WithEmailRegistration.story = {
+	name: 'with email - create account',
+};
+
+export const WithPasscodeRegistration = () => (
+	<PasscodeEmailSent
+		passcodeAction="#/register"
+		expiredPage="#"
+		changeEmailPage="#"
+		email="example@theguardian.com"
+		passcode="123456"
+	/>
+);
+WithPasscodeRegistration.story = {
+	name: 'with passcode - create account',
+};
+
+export const WithPasscodeErrorRegistration = () => (
+	<PasscodeEmailSent
+		passcodeAction="#/register"
+		expiredPage="#"
+		changeEmailPage="#"
+		email="example@theguardian.com"
+		passcode="123456"
+		fieldErrors={[
+			{
+				field: 'code',
+				message: 'Invalid code',
+			},
+		]}
+	/>
+);
+WithPasscodeErrorRegistration.story = {
+	name: 'with passcode error - create account',
+};
+
+export const WithRecaptchaErrorRegistration = () => (
+	<PasscodeEmailSent
+		passcodeAction="#/register"
+		expiredPage="#"
+		changeEmailPage="#"
+		email="example@theguardian.com"
+		recaptchaSiteKey="invalid-key"
+	/>
+);
+WithRecaptchaErrorRegistration.story = {
+	name: 'with reCAPTCHA error - create account',
+};
+
+export const WithSuccessMessageRegistration = () => (
+	<PasscodeEmailSent
+		passcodeAction="#/register"
+		expiredPage="#"
+		showSuccess={true}
+	/>
+);
+WithSuccessMessageRegistration.story = {
+	name: 'with success message - create account',
+};
+
+export const WithErrorMessageRegistration = () => (
+	<PasscodeEmailSent
+		passcodeAction="#/register"
+		expiredPage="#"
+		errorMessage="•⩊• UwU"
+	/>
+);
+WithErrorMessageRegistration.story = {
+	name: 'with error message - create account',
+};

--- a/src/client/pages/RegistrationEmailSentPage.tsx
+++ b/src/client/pages/RegistrationEmailSentPage.tsx
@@ -45,6 +45,11 @@ export const RegistrationEmailSentPage = () => {
 				formTrackingName="register-resend"
 				fieldErrors={fieldErrors}
 				passcode={token}
+				expiredPage={buildUrlWithQueryParams(
+					'/welcome/expired',
+					{},
+					queryParams,
+				)}
 			/>
 		);
 	}


### PR DESCRIPTION
## What does this change?

Make the `PasscodeEmailSent` page able to change copy based on the given route.

Previously the copy on this page was specifically for the create account flow (registration), however this copy isn't ideal for the new passcode flows that are being implemented, specifically sign in and reset password.

This PR updates the component so that depending on the route being passed into the component it will show different copy.

| Sign In / Reset Password | Create Account |
|--------|--------|
| ![localhost_6006_iframe html_args= globals=viewport_mobile id=pages-passcodeemailsent--with-passcode viewMode=story(Samsung Galaxy S8+) (1)](https://github.com/user-attachments/assets/7af44ca0-ceba-4898-806f-867464c7419b) | ![localhost_6006_iframe html_args= globals=viewport_mobile id=pages-passcodeemailsent--with-passcode-registration viewMode=story(Samsung Galaxy S8+)](https://github.com/user-attachments/assets/83d01394-b9c8-463a-9040-b3e638cc2bc3) | 
