### PR TITLE
Passwordless | Passcodes for reset password - ACTIVE users

### DIFF
--- a/.github/workflows/cypress-ete.yml
+++ b/.github/workflows/cypress-ete.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        group: [1, 2, 3, 4, 5, 6]
+        group: [1, 2, 3, 4, 5, 6, 7]
     timeout-minutes: 15
     services:
       redis:

--- a/cypress/integration/ete/reset_password_passcode.7.cy.ts
+++ b/cypress/integration/ete/reset_password_passcode.7.cy.ts
@@ -1,0 +1,345 @@
+import { randomPassword } from '../../support/commands/testUser';
+
+describe('Password reset recovery flows - with Passcodes', () => {
+	context('ACTIVE user with password', () => {
+		it('allows the user to change their password', () => {
+			const encodedReturnUrl = encodeURIComponent(
+				'https://www.theguardian.com/technology/2017/may/04/nier-automata-sci-fi-game-sleeper-hit-designer-yoko-taro',
+			);
+			const encodedRef = 'https%3A%2F%2Fm.theguardian.com';
+			const refViewId = 'testRefViewId';
+			const clientId = 'jobs';
+
+			cy.createTestUser({
+				isUserEmailValidated: true,
+			}).then(({ emailAddress }) => {
+				cy.visit(
+					`/reset-password?returnUrl=${encodedReturnUrl}&ref=${encodedRef}&refViewId=${refViewId}&clientId=${clientId}&usePasscodesResetPassword=true`,
+				);
+				const timeRequestWasMade = new Date();
+
+				cy.contains('Reset password');
+				cy.get('input[name=email]').type(emailAddress);
+				cy.get('[data-cy="main-form-submit-button"]').click();
+
+				cy.checkForEmailAndGetDetails(emailAddress, timeRequestWasMade).then(
+					({ body, codes }) => {
+						// email
+						expect(body).to.have.string('Your one-time passcode');
+						expect(codes?.length).to.eq(1);
+						const code = codes?.[0].value;
+						expect(code).to.match(/^\d{6}$/);
+
+						// passcode page
+						cy.url().should('include', '/reset-password/email-sent');
+						cy.contains('Enter your one-time code');
+						cy.get('input[name=code]').type(code!);
+
+						cy.get('form')
+							.should('have.attr', 'action')
+							.and('match', new RegExp(encodedReturnUrl))
+							.and('match', new RegExp(refViewId))
+							.and('match', new RegExp(encodedRef))
+							.and('match', new RegExp(clientId));
+
+						cy.contains('Submit one-time code').click();
+
+						// password page
+						cy.url().should('include', '/reset-password/password');
+						cy.get('form')
+							.should('have.attr', 'action')
+							.and('match', new RegExp(encodedReturnUrl))
+							.and('match', new RegExp(refViewId))
+							.and('match', new RegExp(encodedRef))
+							.and('match', new RegExp(clientId));
+
+						cy.get('input[name="password"]').type(randomPassword());
+						cy.get('button[type="submit"]').click();
+
+						// password complete page
+						cy.url()
+							.should('include', '/reset-password/complete')
+							.should('contain', encodedReturnUrl)
+							.should('contain', refViewId)
+							.should('contain', encodedRef)
+							.should('contain', clientId);
+
+						cy.contains('Password updated');
+						cy.contains('Continue to the Guardian').should(
+							'have.attr',
+							'href',
+							decodeURIComponent(encodedReturnUrl),
+						);
+					},
+				);
+			});
+		});
+
+		it('allows the user to change their password - with fromUri', () => {
+			const encodedReturnUrl = encodeURIComponent(
+				'https://www.theguardian.com/technology/2017/may/04/nier-automata-sci-fi-game-sleeper-hit-designer-yoko-taro',
+			);
+			const encodedRef = 'https%3A%2F%2Fm.theguardian.com';
+			const refViewId = 'testRefViewId';
+			const clientId = 'jobs';
+
+			const appClientId = 'appClientId1';
+			const fromURI = '/oauth2/v1/authorize';
+
+			// Intercept the external redirect page.
+			// We just want to check that the redirect happens, not that the page loads.
+			cy.intercept(
+				'GET',
+				`https://${Cypress.env('BASE_URI')}${decodeURIComponent(fromURI)}`,
+				(req) => {
+					req.reply(200);
+				},
+			);
+
+			cy.createTestUser({
+				isUserEmailValidated: true,
+			}).then(({ emailAddress }) => {
+				cy.visit(
+					`/reset-password?returnUrl=${encodedReturnUrl}&ref=${encodedRef}&refViewId=${refViewId}&clientId=${clientId}&appClientId=${appClientId}&fromURI=${fromURI}&usePasscodesResetPassword=true`,
+				);
+				const timeRequestWasMade = new Date();
+
+				cy.contains('Reset password');
+				cy.get('input[name=email]').type(emailAddress);
+				cy.get('[data-cy="main-form-submit-button"]').click();
+
+				cy.checkForEmailAndGetDetails(emailAddress, timeRequestWasMade).then(
+					({ body, codes }) => {
+						// email
+						expect(body).to.have.string('Your one-time passcode');
+						expect(codes?.length).to.eq(1);
+						const code = codes?.[0].value;
+						expect(code).to.match(/^\d{6}$/);
+
+						// passcode page
+						cy.url().should('include', '/reset-password/email-sent');
+						cy.contains('Enter your one-time code');
+						cy.get('input[name=code]').type(code!);
+
+						cy.get('form')
+							.should('have.attr', 'action')
+							.and('match', new RegExp(encodedReturnUrl))
+							.and('match', new RegExp(refViewId))
+							.and('match', new RegExp(encodedRef))
+							.and('match', new RegExp(clientId))
+							.and('match', new RegExp(appClientId))
+							.and('match', new RegExp(encodeURIComponent(fromURI)));
+
+						cy.contains('Submit one-time code').click();
+
+						// password page
+						cy.url().should('include', '/reset-password/password');
+						cy.get('form')
+							.should('have.attr', 'action')
+							.and('match', new RegExp(encodedReturnUrl))
+							.and('match', new RegExp(refViewId))
+							.and('match', new RegExp(encodedRef))
+							.and('match', new RegExp(clientId))
+							.and('match', new RegExp(appClientId))
+							.and('match', new RegExp(encodeURIComponent(fromURI)));
+
+						cy.get('input[name="password"]').type(randomPassword());
+						cy.get('button[type="submit"]').click();
+
+						// fromURI redirect
+						cy.url().should('contain', decodeURIComponent(fromURI));
+					},
+				);
+			});
+		});
+
+		it('passcode incorrect functionality', () => {
+			cy.createTestUser({
+				isUserEmailValidated: true,
+			}).then(({ emailAddress }) => {
+				cy.visit(`/reset-password?usePasscodesResetPassword=true`);
+
+				const timeRequestWasMade = new Date();
+				cy.get('input[name=email]').type(emailAddress);
+				cy.get('[data-cy="main-form-submit-button"]').click();
+
+				cy.contains('Enter your one-time code');
+				cy.contains(emailAddress);
+				cy.contains('send again');
+				cy.contains('try another address');
+
+				cy.checkForEmailAndGetDetails(emailAddress, timeRequestWasMade).then(
+					({ body, codes }) => {
+						// email
+						expect(body).to.have.string('Your one-time passcode');
+						expect(codes?.length).to.eq(1);
+						const code = codes?.[0].value;
+						expect(code).to.match(/^\d{6}$/);
+
+						// passcode page
+						cy.url().should('include', '/reset-password/email-sent');
+						cy.contains('Enter your one-time code');
+						cy.get('input[name=code]').type(`${+code! + 1}`);
+
+						cy.contains('Submit one-time code').click();
+
+						cy.url().should('include', '/reset-password/code');
+
+						cy.contains('Incorrect code');
+
+						cy.get('input[name=code]').clear().type(code!);
+						cy.contains('Submit one-time code').click();
+
+						cy.url().should('contain', '/reset-password/password');
+
+						cy.get('input[name="password"]').type(randomPassword());
+						cy.get('button[type="submit"]').click();
+
+						cy.url().should('contain', '/reset-password/complete');
+					},
+				);
+			});
+		});
+
+		it('passcode used functionality', () => {
+			cy.createTestUser({
+				isUserEmailValidated: true,
+			}).then(({ emailAddress }) => {
+				cy.visit(`/reset-password?usePasscodesResetPassword=true`);
+
+				const timeRequestWasMade = new Date();
+				cy.get('input[name=email]').type(emailAddress);
+				cy.get('[data-cy="main-form-submit-button"]').click();
+
+				cy.contains('Enter your one-time code');
+				cy.contains(emailAddress);
+				cy.contains('send again');
+				cy.contains('try another address');
+
+				cy.checkForEmailAndGetDetails(emailAddress, timeRequestWasMade).then(
+					({ body, codes }) => {
+						// email
+						expect(body).to.have.string('Your one-time passcode');
+						expect(codes?.length).to.eq(1);
+						const code = codes?.[0].value;
+						expect(code).to.match(/^\d{6}$/);
+
+						// passcode page
+						cy.url().should('include', '/reset-password/email-sent');
+						cy.contains('Enter your one-time code');
+
+						cy.get('input[name=code]').clear().type(code!);
+						cy.contains('Submit one-time code').click();
+
+						cy.url().should('contain', '/reset-password/password');
+
+						cy.go('back');
+						cy.url().should('contain', '/reset-password/email-sent');
+						cy.contains('Passcode verified');
+						cy.contains('Complete setting password').click();
+
+						cy.url().should('contain', '/reset-password/password');
+
+						cy.get('input[name="password"]').type(randomPassword());
+						cy.get('button[type="submit"]').click();
+
+						cy.url().should('contain', '/reset-password/complete');
+					},
+				);
+			});
+		});
+
+		it('resend email functionality', () => {
+			cy.createTestUser({
+				isUserEmailValidated: true,
+			}).then(({ emailAddress }) => {
+				cy.visit(`/reset-password?usePasscodesResetPassword=true`);
+
+				const timeRequestWasMade = new Date();
+				cy.get('input[name=email]').type(emailAddress);
+				cy.get('[data-cy="main-form-submit-button"]').click();
+
+				cy.contains('Enter your one-time code');
+				cy.contains(emailAddress);
+				cy.contains('send again');
+				cy.contains('try another address');
+
+				cy.checkForEmailAndGetDetails(emailAddress, timeRequestWasMade).then(
+					({ body, codes }) => {
+						// email
+						expect(body).to.have.string('Your one-time passcode');
+						expect(codes?.length).to.eq(1);
+						const code = codes?.[0].value;
+						expect(code).to.match(/^\d{6}$/);
+
+						// passcode page
+						cy.url().should('include', '/reset-password/email-sent');
+						cy.contains('Enter your one-time code');
+
+						// resend email
+						const timeRequestWasMade2 = new Date();
+						cy.contains('send again').click();
+
+						cy.checkForEmailAndGetDetails(
+							emailAddress,
+							timeRequestWasMade2,
+						).then(({ body, codes }) => {
+							// email
+							expect(body).to.have.string('Your one-time passcode');
+							expect(codes?.length).to.eq(1);
+							const code = codes?.[0].value;
+							expect(code).to.match(/^\d{6}$/);
+
+							// passcode page
+							cy.url().should('include', '/reset-password/email-sent');
+							cy.contains('Enter your one-time code');
+
+							cy.get('input[name=code]').clear().type(code!);
+							cy.contains('Submit one-time code').click();
+
+							cy.url().should('contain', '/reset-password/password');
+
+							cy.get('input[name="password"]').type(randomPassword());
+							cy.get('button[type="submit"]').click();
+
+							cy.url().should('contain', '/reset-password/complete');
+						});
+					},
+				);
+			});
+		});
+
+		it('change email functionality', () => {
+			cy.createTestUser({
+				isUserEmailValidated: true,
+			}).then(({ emailAddress }) => {
+				cy.visit(`/reset-password?usePasscodesResetPassword=true`);
+
+				const timeRequestWasMade = new Date();
+				cy.get('input[name=email]').type(emailAddress);
+				cy.get('[data-cy="main-form-submit-button"]').click();
+
+				cy.contains('Enter your one-time code');
+				cy.contains(emailAddress);
+				cy.contains('send again');
+				cy.contains('try another address');
+
+				cy.checkForEmailAndGetDetails(emailAddress, timeRequestWasMade).then(
+					({ body, codes }) => {
+						// email
+						expect(body).to.have.string('Your one-time passcode');
+						expect(codes?.length).to.eq(1);
+						const code = codes?.[0].value;
+						expect(code).to.match(/^\d{6}$/);
+
+						// passcode page
+						cy.url().should('include', '/reset-password/email-sent');
+						cy.contains('try another address').click();
+
+						cy.url().should('include', '/reset-password');
+					},
+				);
+			});
+		});
+	});
+});

--- a/src/server/controllers/changePassword.ts
+++ b/src/server/controllers/changePassword.ts
@@ -95,6 +95,12 @@ const oktaIdxApiPasswordHandler = async ({
 					introspectResponse,
 					'enroll-authenticator',
 				);
+			} else {
+				// if we're setting a password, we should be in the reset-authenticator remediation
+				validateIntrospectRemediation(
+					introspectResponse,
+					'reset-authenticator',
+				);
 			}
 
 			// validate the password field
@@ -166,9 +172,14 @@ export const setPasswordController = (
 		const { clientId, useOktaClassic } = res.locals.queryParams;
 
 		// OKTA IDX API FLOW
-		// If the user is using the passcode registration flow, we need to handle the password change/creation.
+		// If the user is using the passcode flow for registration/reset password,
+		// we need to handle the password change/creation.
 		// If there are specific failures, we fall back to the legacy Okta change password flow.
-		if (passcodesEnabled && !useOktaClassic && path === '/welcome') {
+		if (
+			passcodesEnabled &&
+			!useOktaClassic &&
+			(path === '/welcome' || res.locals.queryParams.usePasscodesResetPassword)
+		) {
 			await oktaIdxApiPasswordHandler({
 				req,
 				res,

--- a/src/server/controllers/changePassword.ts
+++ b/src/server/controllers/changePassword.ts
@@ -115,6 +115,9 @@ const oktaIdxApiPasswordHandler = async ({
 				});
 			}
 
+			// track the password change metric
+			trackMetric(changePasswordMetric(path, 'Success', true));
+
 			// Set the password in Okta, redirect the user to set a global session, and then complete
 			// the interaction code flow, eventually redirecting the user back to where they need to go.
 			return await setPasswordAndRedirect({
@@ -133,6 +136,8 @@ const oktaIdxApiPasswordHandler = async ({
 		logger.error('Okta IDX setPassword failure', error, {
 			request_id: state.requestId,
 		});
+
+		trackMetric(changePasswordMetric(path, 'Failure', true));
 
 		if (error instanceof OAuthError) {
 			// case for session expired
@@ -276,7 +281,7 @@ export const setPasswordController = (
 					);
 				}
 
-				changePasswordMetric(path, 'Success');
+				trackMetric(changePasswordMetric(path, 'Success'));
 
 				return await performAuthorizationCodeFlow(req, res, {
 					sessionToken,
@@ -300,7 +305,7 @@ export const setPasswordController = (
 				request_id: res.locals.requestId,
 			});
 
-			changePasswordMetric(path, 'Failure');
+			trackMetric(changePasswordMetric(path, 'Failure'));
 
 			// see the comment above around the success metrics
 			if (clientId === 'jobs' && path === '/welcome') {

--- a/src/server/controllers/sendChangePasswordEmail.ts
+++ b/src/server/controllers/sendChangePasswordEmail.ts
@@ -23,8 +23,8 @@ import {
 	forgotPassword,
 	deactivateUser,
 } from '@/server/lib/okta/api/users';
-import { Status } from '@/server/models/okta/User';
-import { OktaError } from '@/server/models/okta/Error';
+import { Status, UserResponse } from '@/server/models/okta/User';
+import { OAuthError, OktaError } from '@/server/models/okta/Error';
 import { sendCreatePasswordEmail } from '@/email/templates/CreatePassword/sendCreatePasswordEmail';
 import { sendResetPasswordEmail } from '@/email/templates/ResetPassword/sendResetPasswordEmail';
 import { PasswordRoutePath } from '@/shared/model/Routes';
@@ -32,6 +32,14 @@ import { mergeRequestState } from '@/server/lib/requestState';
 import dangerouslySetPlaceholderPassword from '@/server/lib/okta/dangerouslySetPlaceholderPassword';
 import { encryptOktaRecoveryToken } from '@/server/lib/deeplink/oktaRecoveryToken';
 import { getConfiguration } from '@/server/lib/getConfiguration';
+import { startIdxFlow } from '@/server/lib/okta/idx/startIdxFlow';
+import {
+	identify,
+	validateIdentifyRemediation,
+} from '@/server/lib/okta/idx/identify';
+import { challenge } from '@/server/lib/okta/idx/challenge';
+import { recover } from '@/server/lib/okta/idx/recover';
+import { findAuthenticatorId } from '@/server/lib/okta/idx/shared/findAuthenticatorId';
 
 const { passcodesEnabled } = getConfiguration();
 
@@ -68,6 +76,221 @@ const setEncryptedCookieOkta = (
 	});
 };
 
+/**
+ * @name changePasswordEmailIdx
+ * @description Start the Okta IDX flow to change the user's password
+ *
+ * NB: This is a WIP and is not fully implemented yet, it should be used behind the `usePasscodesResetPassword` query param flag
+ * Current status:
+ *   - [x] ACTIVE users with a password
+ * 	   - [x] With email + password authenticator
+ *     - [ ] With only password authenticator
+ *   - [ ] ACTIVE users - SOCIAL only
+ *     - [ ] With only email authenticator
+ *   - [ ] ACTIVE users without a password
+ *   - [ ] Non-ACTIVE user states
+ *
+ * @param {Request} req - Express request object
+ * @param {ResponseWithRequestState} res - Express response object
+ * @param {UserResponse} user - Okta user object
+ * @param {string} request_id - Request ID
+ * @returns {Promise<void | ResponseWithRequestState>}
+ */
+const changePasswordEmailIdx = async (
+	req: Request,
+	res: ResponseWithRequestState,
+	user: UserResponse,
+	request_id?: string,
+): Promise<void | ResponseWithRequestState> => {
+	// placeholder warning message
+	logger.warn('Passcode reset password flow is not fully implemented yet', {
+		request_id,
+	});
+
+	try {
+		// start the IDX flow by calling interact and introspect
+		const introspectResponse = await startIdxFlow({
+			req,
+			res,
+			authorizationCodeFlowOptions: {
+				// if the user has a password, then we show the reset password page
+				// otherwise we show the set password page
+				confirmationPagePath: user.credentials.password
+					? '/reset-password/complete'
+					: '/set-password/complete',
+			},
+			request_id,
+		});
+
+		// check the user's status to determine the correct remediation flow
+		switch (user.status) {
+			case Status.ACTIVE: {
+				/**
+				 *
+				 * If the user is ACTIVE, then they'll be in one of 3 states:
+				 * 1. ACTIVE users - has email + password authenticator (okta idx email verified)
+				 * 2. ACTIVE users - has only password authenticator (okta idx email not verified)
+				 * 3. ACTIVE users - has only email authenticator (SOCIAL users - no password, or passcode only users (not implemented yet))
+				 *
+				 * We can identify the users state by calling the IDX API /identify endpoint
+				 * and checking the authenticators available
+				 *
+				 * Depending on their state, we have to perform different steps to reset their password
+				 *
+				 * This only happens when the "Username enumeration protection" setting is disabled in Okta
+				 * under Security > General > User enumeration prevention
+				 *
+				 * When this is enabled, the IDX API will behave the same for every user,
+				 * regardless of their status
+				 *
+				 * When disabled, the IDX API will return different remediations based on the
+				 * user's status, which is helpful for us to determine the correct flow
+				 *
+				 */
+
+				// call "identify", essentially to start an authentication process
+				const identifyResponse = await identify(
+					introspectResponse.stateHandle,
+					user.profile.email,
+					request_id,
+					req.ip,
+				);
+
+				validateIdentifyRemediation(
+					identifyResponse,
+					'select-authenticator-authenticate',
+				);
+
+				const emailAuthenticatorId = findAuthenticatorId({
+					authenticator: 'email',
+					response: identifyResponse,
+					remediationName: 'select-authenticator-authenticate',
+				});
+
+				const passwordAuthenticatorId = findAuthenticatorId({
+					authenticator: 'password',
+					response: identifyResponse,
+					remediationName: 'select-authenticator-authenticate',
+				});
+
+				// check the user's authenticators to determine the correct flow
+				if (emailAuthenticatorId && passwordAuthenticatorId) {
+					// user has both email and password authenticators so:
+					// 1. ACTIVE users - has email + password authenticator (okta idx email verified)
+
+					// ACTIVE users with a password *should* be able to user the `recover` flow
+					// even if we're not logging the user in, we have to perform these steps
+					// in order to ensure we replicate the behaviour the idx flow expects
+
+					// Call the "challenge" endpoint to start the password authentication process
+					const challengePasswordResponse = await challenge(
+						identifyResponse.stateHandle,
+						{
+							id: passwordAuthenticatorId,
+							methodType: 'password',
+						},
+						request_id,
+						req.ip,
+					);
+
+					// validate that the response from the challenge endpoint is a password authenticator
+					// and has the "recover" remediation
+					if (
+						challengePasswordResponse.currentAuthenticatorEnrollment.value
+							.type !== 'password'
+					) {
+						throw new OAuthError(
+							{
+								error: 'idx_error',
+								error_description:
+									'challengePasswordResponse - recover not found',
+							},
+							400,
+						);
+					}
+
+					// call the "recover" endpoint to start the password recovery process
+					const recoverResponse = await recover(
+						challengePasswordResponse.stateHandle,
+						request_id,
+						req.ip,
+					);
+
+					// call the "challenge" endpoint to start the email challenge process
+					// and send the user a passcode
+					const challengeEmailResponse = await challenge(
+						recoverResponse.stateHandle,
+						{
+							id: emailAuthenticatorId,
+							methodType: 'email',
+						},
+						request_id,
+						req.ip,
+					);
+
+					// track the success metrics
+					trackMetric('OktaIDXResetPasswordSend::Success');
+					trackMetric(`OktaIDXResetPasswordSend::${user.status}::Success`);
+
+					// at this point the user will have been sent an email with a passcode
+
+					// set the encrypted state cookie to persist the email and stateHandle
+					// which we need to persist during the passcode reset flow
+					setEncryptedStateCookie(res, {
+						email: user.profile.email,
+						stateHandle: challengeEmailResponse.stateHandle,
+						stateHandleExpiresAt: challengeEmailResponse.expiresAt,
+					});
+
+					// show the email sent page, with passcode instructions
+					return res.redirect(
+						303,
+						addQueryParamsToPath(
+							'/reset-password/email-sent',
+							res.locals.queryParams,
+						),
+					);
+				} else if (passwordAuthenticatorId) {
+					// user has only password authenticator so:
+					// 2. ACTIVE users - has only password authenticator (okta idx email not verified)
+					// If the user only has a password authenticator, then they failed to use a passcode
+					// to verify their account when they created it, and instead set a password using
+					// the okta classic reset password flow. In this case, we have to have to enroll
+					// the user in the email authenticator to allow them to reset their password.
+					// We do this by first setting a placeholder password for the user, then using the
+					// identify flow to authenticate the user with the placeholder password. After
+					// authenticating the user, the IDX API will tell us that the user needs to enroll
+					// in the email authenticator, which we can then use to send them a passcode to verify
+					// their account.
+					// Once they've verified their account, we use the okta classic api to generate a
+					// recover token, and instantly show the set password page to the user for them to
+					// set their password.
+				} else if (emailAuthenticatorId) {
+					// user has only email authenticator so:
+					// 3. ACTIVE users - has only email authenticator (SOCIAL users - no password, or passcode only users (not implemented yet))
+					// If the user only has an email authenticator, that means that they don't have a
+					// password set, and most likely are user created via a social provider. In this case,
+					// we have to set a placeholder password for this user, then use the standard idx recovery
+					// flow to send them a passcode to verify their account and reset their password.
+				}
+			}
+			// eslint-disable-next-line no-fallthrough -- allow fallthrough for time being for cases we haven't implemented yet
+			default:
+				throw new OktaError({
+					message: `Okta changePasswordEmailIdx failed with unaccepted Okta user status: ${user.status}`,
+				});
+		}
+	} catch (error) {
+		trackMetric('OktaIDXResetPasswordSend::Failure');
+
+		logger.error('Okta changePasswordEmailIdx failed', error, {
+			request_id,
+		});
+
+		// don't throw the error, so we can fall back to okta classic flow
+	}
+};
+
 export const sendEmailInOkta = async (
 	req: Request,
 	res: ResponseWithRequestState,
@@ -86,11 +309,13 @@ export const sendEmailInOkta = async (
 		const user = await getUser(email, req.ip);
 
 		if (passcodesEnabled && usePasscodesResetPassword) {
-			// TODO: implement passcode reset password flow
-			// this is a placeholder for now
-			logger.warn('Passcode reset password flow is not implemented yet', {
-				request_id,
-			});
+			// try to start the IDX flow to send the user a passcode for reset password
+			await changePasswordEmailIdx(req, res, user, request_id);
+			// if successful, the user will be redirected to the email sent page
+			// so we need to check if the headers have been sent to prevent further processing
+			if (res.headersSent) {
+				return;
+			}
 		}
 
 		switch (user.status) {

--- a/src/server/models/Metrics.ts
+++ b/src/server/models/Metrics.ts
@@ -42,13 +42,16 @@ type ConditionalMetrics =
 	| `OktaIDX::${IDXPath}`
 	| 'OktaRegistration'
 	| 'OktaRegistrationResendEmail'
+	| 'OktaIdxResetPassword'
 	| 'OktaResetPassword'
+	| 'OktaIdxSetPassword'
 	| 'OktaSetPassword'
 	| 'OktaSignIn'
 	| 'OktaSignOut'
 	| 'OktaSignOutGlobal'
 	| 'OktaUpdatePassword'
 	| 'OktaValidatePasswordToken'
+	| 'OktaIdxWelcome'
 	| 'OktaWelcome'
 	| 'OktaWelcomeResendEmail'
 	| 'RecaptchaMiddleware'
@@ -96,13 +99,18 @@ export const rateLimitHitMetric = (bucketType: RateLimitMetrics): Metrics =>
 export const changePasswordMetric = (
 	path: PasswordRoutePath,
 	type: 'Success' | 'Failure',
+	isPasscode = false,
 ): Metrics => {
 	switch (path) {
 		case '/set-password':
-			return `OktaSetPassword::${type}`;
+			return isPasscode
+				? `OktaIdxSetPassword::${type}`
+				: `OktaSetPassword::${type}`;
 		case '/reset-password':
-			return `OktaResetPassword::${type}`;
+			return isPasscode
+				? `OktaIdxResetPassword::${type}`
+				: `OktaResetPassword::${type}`;
 		case '/welcome':
-			return `OktaWelcome::${type}`;
+			return isPasscode ? `OktaIdxWelcome::${type}` : `OktaWelcome::${type}`;
 	}
 };

--- a/src/server/models/Metrics.ts
+++ b/src/server/models/Metrics.ts
@@ -3,6 +3,7 @@
 import { BucketType } from '@/server/lib/rate-limit';
 import { PasswordRoutePath } from '@/shared/model/Routes';
 import { IDXPath } from '@/server/lib/okta/idx/shared/paths';
+import { Status } from './okta/User';
 
 // Specific emails to track
 type EmailMetrics =
@@ -36,6 +37,8 @@ type ConditionalMetrics =
 	| 'OktaDeactivateUser'
 	| 'OktaIDXInteract'
 	| 'OktaIDXRegister'
+	| 'OktaIDXResetPasswordSend'
+	| `OktaIDXResetPasswordSend::${Status}`
 	| `OktaIDX::${IDXPath}`
 	| 'OktaRegistration'
 	| 'OktaRegistrationResendEmail'

--- a/src/server/routes/register.ts
+++ b/src/server/routes/register.ts
@@ -226,6 +226,7 @@ router.post(
 // Route to resend the email for passcode registration
 router.post(
 	'/register/code/resend',
+	handleRecaptcha,
 	redirectIfLoggedIn,
 	handleAsyncErrors(async (req: Request, res: ResponseWithRequestState) => {
 		const { requestId } = res.locals;

--- a/src/server/routes/resetPassword.ts
+++ b/src/server/routes/resetPassword.ts
@@ -8,7 +8,17 @@ import { rateLimitedTypedRouter as router } from '@/server/lib/typedRoutes';
 import handleRecaptcha from '@/server/lib/recaptcha';
 import { sendEmailInOkta } from '@/server/controllers/sendChangePasswordEmail';
 import { mergeRequestState } from '@/server/lib/requestState';
-import { handleAsyncErrors } from '../lib/expressWrappers';
+import { handleAsyncErrors } from '@/server/lib/expressWrappers';
+import { addQueryParamsToPath } from '@/shared/lib/queryParams';
+import {
+	readEncryptedStateCookie,
+	updateEncryptedStateCookie,
+} from '@/server/lib/encryptedStateCookie';
+import { redirectIfLoggedIn } from '@/server/lib/middleware/redirectIfLoggedIn';
+import { convertExpiresAtToExpiryTimeInMs } from '@/server/lib/okta/idx/shared/convertExpiresAtToExpiryTimeInMs';
+import { submitPasscode } from '@/server/lib/okta/idx/shared/submitPasscode';
+import { handlePasscodeError } from '@/server/lib/okta/idx/shared/errorHandling';
+import { getAuthorizationStateCookie } from '@/server/lib/okta/openid-connect';
 
 // reset password email form
 router.get('/reset-password', (req: Request, res: ResponseWithRequestState) => {
@@ -88,6 +98,107 @@ router.get(
 		});
 		res.type('html').send(html);
 	},
+);
+
+// Essentially the email-sent page, but for passcode reset password
+router.get(
+	'/reset-password/code',
+	(req: Request, res: ResponseWithRequestState) => {
+		const state = res.locals;
+
+		const encryptedState = readEncryptedStateCookie(req);
+
+		if (encryptedState?.email && encryptedState.stateHandle) {
+			const html = renderer('/reset-password/email-sent', {
+				requestState: mergeRequestState(state, {
+					pageData: {
+						email: encryptedState?.email,
+						timeUntilTokenExpiry: convertExpiresAtToExpiryTimeInMs(
+							encryptedState.stateHandleExpiresAt,
+						),
+					},
+				}),
+				pageTitle: 'Check Your Inbox',
+			});
+			return res.type('html').send(html);
+		}
+		return res.redirect(
+			303,
+			addQueryParamsToPath('/reset-password', state.queryParams),
+		);
+	},
+);
+
+// handler for the passcode reset password form
+router.post(
+	'/reset-password/code',
+	handleAsyncErrors(async (req: Request, res: ResponseWithRequestState) => {
+		const { requestId } = res.locals;
+		const { code } = req.body;
+
+		const encryptedState = readEncryptedStateCookie(req);
+
+		// make sure we have the encrypted state cookie and the code otherwise redirect to the reset page
+		if (encryptedState?.stateHandle && code) {
+			const { stateHandle } = encryptedState;
+
+			try {
+				// submit the passcode to Okta
+				await submitPasscode({
+					passcode: code,
+					stateHandle,
+					introspectRemediation: 'challenge-authenticator',
+					challengeAnswerRemediation: 'reset-authenticator',
+					requestId,
+					ip: req.ip,
+				});
+
+				// update the encrypted state cookie to show the passcode was used
+				// so that if the user clicks back to the email sent page, they will be shown a message
+				updateEncryptedStateCookie(req, res, {
+					passcodeUsed: true,
+				});
+
+				// redirect to the password page to set a password depending on if the are setting
+				// or resetting a password
+				const authState = getAuthorizationStateCookie(req);
+				const passwordPage = (() => {
+					switch (authState?.confirmationPage) {
+						case '/set-password/complete':
+							return '/set-password/password';
+						default:
+							return '/reset-password/password';
+					}
+				})();
+
+				// redirect to the password page
+				return res.redirect(
+					303,
+					addQueryParamsToPath(passwordPage, res.locals.queryParams),
+				);
+			} catch (error) {
+				// handle passcode specific error
+				handlePasscodeError({
+					error,
+					req,
+					res,
+					emailSentPage: '/reset-password/email-sent',
+					expiredPage: '/reset-password/expired',
+				});
+
+				// if we redirected away during the handlePasscodeError function, we can't redirect again
+				if (res.headersSent) {
+					return;
+				}
+			}
+		}
+
+		// if we reach this point, redirect back to the reset password page, as something has gone wrong
+		return res.redirect(
+			303,
+			addQueryParamsToPath('/reset-password', res.locals.queryParams),
+		);
+	}),
 );
 
 // IMPORTANT: The /reset-password/:token routes must be defined below the other routes.

--- a/src/server/routes/resetPassword.ts
+++ b/src/server/routes/resetPassword.ts
@@ -14,7 +14,6 @@ import {
 	readEncryptedStateCookie,
 	updateEncryptedStateCookie,
 } from '@/server/lib/encryptedStateCookie';
-import { redirectIfLoggedIn } from '@/server/lib/middleware/redirectIfLoggedIn';
 import { convertExpiresAtToExpiryTimeInMs } from '@/server/lib/okta/idx/shared/convertExpiresAtToExpiryTimeInMs';
 import { submitPasscode } from '@/server/lib/okta/idx/shared/submitPasscode';
 import { handlePasscodeError } from '@/server/lib/okta/idx/shared/errorHandling';
@@ -198,6 +197,16 @@ router.post(
 			303,
 			addQueryParamsToPath('/reset-password', res.locals.queryParams),
 		);
+	}),
+);
+
+// Route to resend the email for passcode reset password
+// Essentially the same as POST /reset-password, just start the process again
+router.post(
+	'/reset-password/code/resend',
+	handleRecaptcha,
+	handleAsyncErrors(async (req: Request, res: ResponseWithRequestState) => {
+		await sendEmailInOkta(req, res);
 	}),
 );
 

--- a/src/shared/model/Routes.ts
+++ b/src/shared/model/Routes.ts
@@ -38,6 +38,7 @@ export const ValidRoutePathsArray = [
 	'/reset-password',
 	'/reset-password/:token',
 	'/reset-password/code',
+	'/reset-password/code/resend',
 	'/reset-password/complete',
 	'/reset-password/email-sent',
 	'/reset-password/expired',


### PR DESCRIPTION
## What does this change?

This PR sets up the first bit of functionality to allow some readers in the ACTIVE state, to reset their password using a passcode sent to their email instead of a link.

If the user is ACTIVE, then they'll be in one of 3 states:
1. ACTIVE users - has email + password authenticator (okta idx email verified)
2. ACTIVE users - has only password authenticator (okta idx email not verified)
3. ACTIVE users - has only email authenticator (SOCIAL users - no password, or passcode only users (not implemented yet))

This PR adds in the ability for users in states 1 and 3 to reset their passwords using a passcode.

This functionality has been added behind the `usePasscodesResetPassword` feature flag.

This allows us to merge this into production and iron out any bugs we find while developing this feature for the other user states. The flag will eventually be removed when all user states for reset password have been migrated to passcodes.

The general IDX API flow for users in these state is:

1. Call the `POST /oauth2/<custom_auth_server>/v1/interact` endpoint  
	- Same parameters auth an authorization code flow call (`/authorize` endpoint)   
		- We only want to allow the `profile` application to do this (this is the gateway one)  
		- And maybe the sample application for testing  
	- This returns a single key in the response body \- `interaction_handle`  
2. Call the `POST /idp/idx/introspect` endpoint with the `interaction_handle` in the post body  
	- This returns a number of things in the response body, effectively all the information needed to generate a login form  
	- The only thing we need from this is the `stateHandle` key, which identifies the current authentication request 
		- There is an `expiresAt` key here, which initially is set to 2 hours in the future  
		- The other things here include information on how to generate a login form, and the social options (and links) available to do this  
	- You can also call this endpoint at any other time with the `stateHandle` in the body to get the current transaction state to see if it’s valid
3. Call the `POST /idp/idx/identify` endpoint with the `email`, `rememberMe=true`, and `stateHandle` in the body  
	- This returns an object very similar to the `/introspect` endpoint but with different things 
		- The `expiresAt` key has now changed to 5 mins 
	- The `remediation` key has everything in it relating to how to resolve the current request 
	- This also lists which authenticators the user has available, and lets us identify the users in each given state
		- If there is both the `password` and `email` authenticator, then the user is in state 1
			- Continue to the next step 
		- If there is only a `password` authenticator, then the user is in state 2
			- This will be implemented in a future PR 
		- If there is only an `email` authenticator then the user is in state 3
			- Set a placeholder password for the user, this will give them the `password` authenticator, and start again from step 1
	- In `remediation.value[1].value` array, there should be 2 authenticators listed, `Email` and `Password`
		- To reset password be need to first select `Password` option  
4. Call `POST /idp/idx/challenge` with `stateHandle` `authenticator:methodType=password,id=password_authenticator_id`  
	- Normally a form to submit a password, however we want to call the recover option  
5. Call `POST /idp/idx/recover` with `stateHandle`  
	- Remediation should have `authenticator-verification-data` with authenticator type `Email`  
6. Call `POST /idp/idx/challenge` with `stateHandle` `authenticator:methodType=email,id=email_authenticator_id`  
	- User should be sent a passcode, recover email  
7. Call the `POST /idp/idx/challenge/answer` with the following shape  
	  - `{“credentials”: { “passcode”: “<passcode>” }, “stateHandle”: “<state_handle>” }` as request body  
	  - Remediation with `reset-authenticator` with how to set a new password, and optionally revoke sessions  
8. Call the `POST /idp/idx/challenge/answer` with the following shape  
	  - `{“credentials”: { “passcode”: “<password>” }, “stateHandle”: “<state_handle>” }` as request body  
	  - This authenticates the code, if valid returns a 200 with the following  
	      - A basic `user` object  
	      - `Set-cookie` with `idx` cookie and value, set this  
9. Redirect the user to `/login/token/redirect?stateToken=${stateHandle.split('~')[0]}`  
	  - The `idx` cookie returned in the previous call doesn’t set a global session, you have to redirect the user to this endpoint for it to be enforced  
	  - The `stateToken` is the `stateHandle` everything before the first `~` character  
	  - This will redirect the user to the callback defined in the `interact` call at the start and completes the interaction code flow

Steps 1 and 2 are provided by the `startIdxFlow` method.

Steps 3 - 6 are provided by the new `changePasswordEmailIdx` method.

Step 7 is `submitPasscode` inside the new `POST /reset-password/code` method 

Steps 8-9 is already provided for us the registration passcode flow, with the exception we add a check for the `reset-authenticator` inside the introspect response to make sure the user is in the correct state.

Here's more information about each individual commit in detail:

---

**Update `changePassword.ts`/`checkPasswordToken.ts` for password (re)set with passcodes**

We update the IDX API handlers in both files to handle the case for password (re)set, which is to add a check for the query parameter (`usePasscodesResetPassword`) and `validateIntrospectRemediation` for the `reset-authenticator` name.

---

**Add `/reset-password/code` `GET` and `POST` methods to handle passcodes**

`GET /reset-password/code` - Essentially the email sent page, but for when using passcodes. Users can end up at this URL after calling `POST /reset-password/code` and the code was incorrect/there was an error.

`POST /reset-password/code` - Endpoint to handle passcode submitted from the email sent page. It tries to submit the passcode and redirect the user to the correct page to set or reset their password.

---

**Add `POST /reset-password/code/resend` to handle resend functionality**

Simple endpoint that just reruns the `sendEmailInOkta` function when the user clicks resend, no need for anything fancy here.

---

**Add `changePasswordEmailIdx` to `sendChangePasswordEmail.ts`**

This set's up the functionality to send an email with a passcode inside the `sendChangePasswordEmail` which is used for all things password reset related.

The `changePasswordEmailIdx` starts the Okta IDX flow and goes through all the steps necessary to send the user an email with a passcode. Currently it only checks for the user with `Status.ACTIVE` and `user.credentials.password` (user has a password). If a user is not in this state it will revert to the legacy password reset flow.

The steps and api calls this function makes are described above.

It will redirect the user to the email sent page with a passcode input if successful, or give an error and revert to the legacy flow.

---

**Add idx/passcode usage metrics for `changePasswordMetric`**

`changePasswordMetric` was only used for the legacy flow, this commit updates this functionality so that we can use this for passcodes also and provide a slightly different metric

---

**Add cypress tests**

As it says on the tin, adds cypress tests to test reset password with passcodes for ACTIVE users with password.

---

**Add passcode reset for users with only email authenticator (i.e SOCIAL users)**

If a user has only the email authenticator, and no password, we set a placeholder password for these users, and then rerun the `changePasswordEmailIdx` method to send a passcode to these users.

---

## How to test

- Deploy this PR to CODE.
- Go to `https://profile.code.dev-theguardian.com/reset-password?usePasscodesResetPassword=true`
- Go through the reset password process, depending on the user type you'll get a different journey
  - In this PR if you want to use passcodes you need to do reset password for an already ACTIVE user with password
  - The easiest way to get a user into this state is to create a new user and go through the whole flow, once you've signed in, sign out, and then do the reset password process

## Tested?

- [x] CODE - ACTIVE user with password, email factors - with flag - passcodes
- [x] CODE - ACTIVE user with password, email factors - without flag - no passcodes
- [x] CODE - ACTIVE user only email factor - with flag - passcodes
- [x] CODE - ACTIVE user only email factor - without flag - no passcodes
- [x] CODE - ACTIVE user only password factor - with flag - no passcodes
- [x] CODE - ACTIVE user only password factor - without flag - no passcodes
- [x] CODE - Other states - with flag - no passcodes
- [x] CODE - Other states - without flag - no passcodes