### PR TITLE
Passwordless | Refactor and fix some Okta IDX API endpoints

### DIFF
--- a/src/server/lib/okta/idx/challenge.ts
+++ b/src/server/lib/okta/idx/challenge.ts
@@ -20,10 +20,39 @@ import { trackMetric } from '@/server/lib/trackMetric';
 import { sendOphanComponentEventFromQueryParamsServer } from '@/server/lib/ophan';
 
 // schema for the challenge-authenticator object inside the challenge response remediation object
-const challengeResponseSchema = baseRemediationValueSchema.merge(
+const challengeAuthenticatorSchema = baseRemediationValueSchema.merge(
 	z.object({
 		name: z.literal('challenge-authenticator'),
 		value: authenticatorAnswerSchema,
+	}),
+);
+
+// Schema for the challenge response
+const challengeResponseSchema = idxBaseResponseSchema.merge(
+	z.object({
+		remediation: z.object({
+			type: z.string(),
+			value: z.array(
+				z.union([challengeAuthenticatorSchema, baseRemediationValueSchema]),
+			),
+		}),
+		currentAuthenticatorEnrollment: z.object({
+			type: z.literal('object'),
+			value: z.union([
+				z.object({
+					type: z.literal('email'),
+					resend: z.object({
+						name: z.literal('resend'),
+					}),
+				}),
+				z.object({
+					type: z.literal('password'),
+					recover: z.object({
+						name: z.literal('recover'),
+					}),
+				}),
+			]),
+		}),
 	}),
 );
 type ChallengeResponse = z.infer<typeof challengeResponseSchema>;

--- a/src/server/lib/okta/idx/introspect.ts
+++ b/src/server/lib/okta/idx/introspect.ts
@@ -48,7 +48,7 @@ const introspectResponseSchema = idxBaseResponseSchema.merge(
 		}),
 	}),
 );
-type IntrospectResponse = z.infer<typeof introspectResponseSchema>;
+export type IntrospectResponse = z.infer<typeof introspectResponseSchema>;
 
 // Introspect body type - can use either interactionHandle or stateHandle
 type IntrospectBody =

--- a/src/server/lib/okta/idx/recover.ts
+++ b/src/server/lib/okta/idx/recover.ts
@@ -1,17 +1,52 @@
 import { z } from 'zod';
 import {
+	baseRemediationValueSchema,
 	IdxBaseResponse,
 	idxBaseResponseSchema,
 	idxFetch,
 	IdxStateHandleBody,
-	selectAuthenticatorValueSchema,
 } from './shared';
+
+// schema for the authenticator-verification-data object inside the recover response remediation object
+export const authenticatorVerificationDataRemediationSchema =
+	baseRemediationValueSchema.merge(
+		z.object({
+			name: z.literal('authenticator-verification-data'),
+			value: z.array(
+				z.union([
+					z.object({
+						name: z.literal('authenticator'),
+						label: z.string(),
+						form: z.object({
+							value: z.array(
+								z.object({
+									name: z.enum(['id', 'methodType']),
+									value: z.string().optional(),
+								}),
+							),
+						}),
+					}),
+					z.object({
+						name: z.literal('stateHandle'),
+						value: z.string(),
+					}),
+				]),
+			),
+		}),
+	);
 
 // schema for the recover response
 const recoverResponseSchema = idxBaseResponseSchema.merge(
 	z.object({
-		name: z.literal('authenticator-verification-data'),
-		value: selectAuthenticatorValueSchema,
+		remediation: z.object({
+			type: z.string(),
+			value: z.array(
+				z.union([
+					authenticatorVerificationDataRemediationSchema,
+					baseRemediationValueSchema,
+				]),
+			),
+		}),
 	}),
 );
 type RecoverResponse = z.infer<typeof recoverResponseSchema>;

--- a/src/server/lib/okta/idx/startIdxFlow.ts
+++ b/src/server/lib/okta/idx/startIdxFlow.ts
@@ -1,0 +1,86 @@
+import { encryptRegistrationConsents } from '@/server/lib/registrationConsents';
+import {
+	updateAuthorizationStateData,
+	setAuthorizationStateCookie,
+} from '@/server/lib/okta/openid-connect';
+import { interact } from '@/server/lib/okta/idx/interact';
+import {
+	introspect,
+	IntrospectResponse,
+} from '@/server/lib/okta/idx/introspect';
+import { Request } from 'express';
+import { ResponseWithRequestState } from '@/server/models/Express';
+import { PerformAuthorizationCodeFlowOptions } from '@/server/lib/okta/oauth';
+import { RegistrationConsents } from '@/shared/model/RegistrationConsents';
+
+type StartIdxFlowParams = {
+	req: Request;
+	res: ResponseWithRequestState;
+	authorizationCodeFlowOptions: Pick<
+		PerformAuthorizationCodeFlowOptions,
+		| 'confirmationPagePath'
+		| 'closeExistingSession'
+		| 'doNotSetLastAccessCookie'
+		| 'extraData'
+	>;
+	consents?: RegistrationConsents;
+	request_id?: string;
+};
+
+/**
+ * @name startIdxFlow
+ * @description Starts the Okta Interaction Code/IDX flow, and returns the introspect response
+ *
+ * This is a wrapper around the `interact` and `introspect` functions, which are the first two
+ * steps in the Okta IDX flow, and are used in every flow using the Okta IDX API.
+ *
+ * @param req - Express request
+ * @param res - Express response
+ * @param authorizationCodeFlowOptions - Subset of the `PerformAuthorizationCodeFlowOptions` used by our standard authorization code flow, namely the parameters needed for authentication
+ * @param consents - The registration consents to encrypt and store in the authorization state if they exist
+ * @param request_id - The request id
+ * @returns Promise<IntrospectResponse>
+ */
+export const startIdxFlow = async ({
+	req,
+	res,
+	authorizationCodeFlowOptions: {
+		confirmationPagePath,
+		closeExistingSession = true,
+		doNotSetLastAccessCookie = false,
+		extraData,
+	},
+	consents,
+	request_id,
+}: StartIdxFlowParams): Promise<IntrospectResponse> => {
+	// start the interaction code flow, and get the interaction handle + authState
+	const [{ interaction_handle }, authState] = await interact(req, res, {
+		confirmationPagePath,
+		closeExistingSession,
+		doNotSetLastAccessCookie,
+		extraData,
+	});
+
+	// introspect the interaction handle to get state handle
+	const introspectResponse = await introspect(
+		{
+			interactionHandle: interaction_handle,
+		},
+		request_id,
+	);
+
+	// Encrypt any consents we need to preserve, if consents exist, i.e through the create account flow
+	const encryptedRegistrationConsents =
+		consents && encryptRegistrationConsents(consents);
+
+	// update the authState with the stateToken and encrypted consents
+	const updatedAuthState = updateAuthorizationStateData(authState, {
+		stateToken: introspectResponse.stateHandle.split('~')[0],
+		encryptedRegistrationConsents,
+	});
+	setAuthorizationStateCookie(updatedAuthState, res);
+
+	// return the introspect response, so that any implementations can use the state handle
+	// and continue the flow
+	return introspectResponse;
+};


### PR DESCRIPTION
## What does this change?

Fixes and refactors a few things with the IDX API, thank you `zod` for helping identify these! Split into 3 individual commits to make it easier to review.

- Creates a `sartIdxFlow` helper method to implement the `interact` and `introspect` calls which will be needed at the start of every possible passwordless/passcode flow.
  - [`4b7b8b8` (#2853)](https://github.com/guardian/gateway/pull/2853/commits/4b7b8b83a6acbd304a95acd2070a9ada5de4f283) 
  - Updates the create account (register) flow to use this new method
- Fixes the `challenge` endpoint
  - Initially implemented in https://github.com/guardian/gateway/pull/2833 but wasn't correct 
  - `challengeResponseSchema` should inherit the `idxBaseResponseSchema` and not the `baseRemediationValueSchema` as it was previously doing (this should be used under the `remediation` property)
  - [`7991a7b` (#2853)](https://github.com/guardian/gateway/pull/2853/commits/7991a7b2f6ee903e741c538a0b1ef3c2af4629fb)
- Fixes the `recover` endpoint
  - Initially implemented in https://github.com/guardian/gateway/pull/2833 but wasn't correct 
  - Correctly type the response object
  - No longer inherit from `selectAuthenticatorValueSchema` for the `authenticator-verification-data` remediation, as the type is different (although very similar)
  - [`9a01457` (#2853)](https://github.com/guardian/gateway/pull/2853/commits/9a01457bdca52df54dca4bf1620f56e4f0161651)
 