### PR TITLE
Passwordless | Refactoring multiple Okta IDX API related things

### DIFF
--- a/src/server/controllers/checkPasswordToken.ts
+++ b/src/server/controllers/checkPasswordToken.ts
@@ -28,7 +28,7 @@ import {
 	introspect,
 	validateIntrospectRemediation,
 } from '@/server/lib/okta/idx/introspect';
-import { convertExpiresAtToExpiryTimeInMs } from '@/server/lib/okta/idx/shared';
+import { convertExpiresAtToExpiryTimeInMs } from '@/server/lib/okta/idx/shared/convertExpiresAtToExpiryTimeInMs';
 
 const { defaultReturnUri, passcodesEnabled } = getConfiguration();
 

--- a/src/server/lib/okta/idx/challenge.ts
+++ b/src/server/lib/okta/idx/challenge.ts
@@ -1,16 +1,4 @@
 import { z } from 'zod';
-import {
-	AuthenticatorBody,
-	ExtractLiteralRemediationNames,
-	IdxBaseResponse,
-	IdxStateHandleBody,
-	authenticatorAnswerSchema,
-	baseRemediationValueSchema,
-	idxBaseResponseSchema,
-	idxFetch,
-	idxFetchCompletion,
-	selectAuthenticationEnrollSchema,
-} from './shared';
 import { ResponseWithRequestState } from '@/server/models/Express';
 import { validateEmailAndPasswordSetSecurely } from '@/server/lib/okta/validateEmail';
 import { logger } from '@/server/lib/serverSideLogger';
@@ -20,6 +8,20 @@ import { setupJobsUserInOkta } from '@/server/lib/jobs';
 import { trackMetric } from '@/server/lib/trackMetric';
 import { sendOphanComponentEventFromQueryParamsServer } from '@/server/lib/ophan';
 import { OAuthError } from '@/server/models/okta/Error';
+import {
+	idxFetch,
+	idxFetchCompletion,
+} from '@/server/lib/okta/idx/shared/idxFetch';
+import {
+	baseRemediationValueSchema,
+	authenticatorAnswerSchema,
+	idxBaseResponseSchema,
+	IdxBaseResponse,
+	AuthenticatorBody,
+	selectAuthenticationEnrollSchema,
+	IdxStateHandleBody,
+	ExtractLiteralRemediationNames,
+} from '@/server/lib/okta/idx/shared/schemas';
 
 // schema for the challenge-authenticator object inside the challenge response remediation object
 const challengeAuthenticatorSchema = baseRemediationValueSchema.merge(

--- a/src/server/lib/okta/idx/challenge.ts
+++ b/src/server/lib/okta/idx/challenge.ts
@@ -27,14 +27,18 @@ const challengeAuthenticatorSchema = baseRemediationValueSchema.merge(
 	}),
 );
 
+// list of all possible remediations for the challenge response
+export const challengeRemediations = z.union([
+	challengeAuthenticatorSchema,
+	baseRemediationValueSchema,
+]);
+
 // Schema for the challenge response
 const challengeResponseSchema = idxBaseResponseSchema.merge(
 	z.object({
 		remediation: z.object({
 			type: z.string(),
-			value: z.array(
-				z.union([challengeAuthenticatorSchema, baseRemediationValueSchema]),
-			),
+			value: z.array(challengeRemediations),
 		}),
 		currentAuthenticatorEnrollment: z.object({
 			type: z.literal('object'),
@@ -89,18 +93,19 @@ export const skipSchema = baseRemediationValueSchema.merge(
 	}),
 );
 
+// list of all possible remediations for the challenge/answer response
+export const challengeAnswerRemediations = z.union([
+	selectAuthenticationEnrollSchema,
+	skipSchema,
+	baseRemediationValueSchema,
+]);
+
 // Schema for the challenge/answer response
 const challengeAnswerResponseSchema = idxBaseResponseSchema.merge(
 	z.object({
 		remediation: z.object({
 			type: z.string(),
-			value: z.array(
-				z.union([
-					selectAuthenticationEnrollSchema,
-					skipSchema,
-					baseRemediationValueSchema,
-				]),
-			),
+			value: z.array(challengeAnswerRemediations),
 		}),
 	}),
 );

--- a/src/server/lib/okta/idx/challenge.ts
+++ b/src/server/lib/okta/idx/challenge.ts
@@ -98,7 +98,7 @@ export const skipSchema = baseRemediationValueSchema.merge(
 );
 
 // Schema for the 'reset-authenticator' object inside the challenge response remediation object
-export const resetAuthenticatorSchema = baseRemediationValueSchema.merge(
+const resetAuthenticatorSchema = baseRemediationValueSchema.merge(
 	z.object({
 		name: z.literal('reset-authenticator'),
 		href: z.string().url(),

--- a/src/server/lib/okta/idx/challenge.ts
+++ b/src/server/lib/okta/idx/challenge.ts
@@ -141,7 +141,9 @@ const challengeAnswerResponseSchema = idxBaseResponseSchema.merge(
 		}),
 	}),
 );
-type ChallengeAnswerResponse = z.infer<typeof challengeAnswerResponseSchema>;
+export type ChallengeAnswerResponse = z.infer<
+	typeof challengeAnswerResponseSchema
+>;
 
 // Body type for the challenge/answer request - passcode can refer to a OTP code or a password
 type ChallengeAnswerPasswordBody = IdxStateHandleBody<{
@@ -288,6 +290,11 @@ export const setPasswordAndRedirect = async ({
 	return expressRes.redirect(303, redirectUrl);
 };
 
+// Type to extract all the remediation names from the challenge/answer response
+export type ChallengeAnswerRemediationNames = ExtractLiteralRemediationNames<
+	ChallengeAnswerResponse['remediation']['value'][number]
+>;
+
 /**
  * @name validateChallengeAnswerRemediation
  * @description Validates that the challenge/answer response contains a remediation with the given name, throwing an error if it does not. This is useful for ensuring that the remediation we want to perform is available in the challenge/answer response, and the state is correct.
@@ -298,9 +305,7 @@ export const setPasswordAndRedirect = async ({
  */
 export const validateChallengeAnswerRemediation = (
 	challengeAnswerResponse: ChallengeAnswerResponse,
-	remediationName: ExtractLiteralRemediationNames<
-		ChallengeAnswerResponse['remediation']['value'][number]
-	>,
+	remediationName: ChallengeAnswerRemediationNames,
 ) => {
 	const hasRemediation = challengeAnswerResponse.remediation.value.some(
 		({ name }) => name === remediationName,

--- a/src/server/lib/okta/idx/challenge.ts
+++ b/src/server/lib/okta/idx/challenge.ts
@@ -93,10 +93,38 @@ export const skipSchema = baseRemediationValueSchema.merge(
 	}),
 );
 
+// Schema for the 'reset-authenticator' object inside the challenge response remediation object
+export const resetAuthenticatorSchema = baseRemediationValueSchema.merge(
+	z.object({
+		name: z.literal('reset-authenticator'),
+		href: z.string().url(),
+		value: z.array(
+			z.union([
+				z.object({
+					name: z.literal('credentials'),
+					type: z.literal('object'),
+					form: z.object({
+						value: z.array(
+							z.object({
+								name: z.string(),
+							}),
+						),
+					}),
+				}),
+				z.object({
+					name: z.literal('stateHandle'),
+					value: z.string(),
+				}),
+			]),
+		),
+	}),
+);
+
 // list of all possible remediations for the challenge/answer response
 export const challengeAnswerRemediations = z.union([
 	selectAuthenticationEnrollSchema,
 	skipSchema,
+	resetAuthenticatorSchema,
 	baseRemediationValueSchema,
 ]);
 

--- a/src/server/lib/okta/idx/credential.ts
+++ b/src/server/lib/okta/idx/credential.ts
@@ -10,19 +10,20 @@ import {
 import { enrollAuthenticatorSchema } from './enroll';
 import { skipSchema } from './challenge';
 
+// list of all possible remediations for the credential/enroll response
+export const credentialEnrollRemediations = z.union([
+	enrollAuthenticatorSchema,
+	selectAuthenticationEnrollSchema,
+	skipSchema,
+	baseRemediationValueSchema,
+]);
+
 // Schema for the credential/enroll response - very similar to the enroll response
 const credentialEnrollResponse = idxBaseResponseSchema.merge(
 	z.object({
 		remediation: z.object({
 			type: z.string(),
-			value: z.array(
-				z.union([
-					enrollAuthenticatorSchema,
-					selectAuthenticationEnrollSchema,
-					skipSchema,
-					baseRemediationValueSchema,
-				]),
-			),
+			value: z.array(credentialEnrollRemediations),
 		}),
 	}),
 );

--- a/src/server/lib/okta/idx/credential.ts
+++ b/src/server/lib/okta/idx/credential.ts
@@ -1,14 +1,14 @@
 import { z } from 'zod';
+import { enrollAuthenticatorSchema } from '@/server/lib/okta/idx/enroll';
+import { skipSchema } from '@/server/lib/okta/idx/challenge';
+import { idxFetch } from '@/server/lib/okta/idx/shared/idxFetch';
 import {
-	AuthenticatorBody,
-	IdxBaseResponse,
+	selectAuthenticationEnrollSchema,
 	baseRemediationValueSchema,
 	idxBaseResponseSchema,
-	idxFetch,
-	selectAuthenticationEnrollSchema,
-} from './shared';
-import { enrollAuthenticatorSchema } from './enroll';
-import { skipSchema } from './challenge';
+	IdxBaseResponse,
+	AuthenticatorBody,
+} from '@/server/lib/okta/idx/shared/schemas';
 
 // list of all possible remediations for the credential/enroll response
 export const credentialEnrollRemediations = z.union([

--- a/src/server/lib/okta/idx/enroll.ts
+++ b/src/server/lib/okta/idx/enroll.ts
@@ -16,14 +16,18 @@ const enrollProfileSchema = baseRemediationValueSchema.merge(
 	}),
 );
 
+// list of all possible remediations for the enroll response
+export const enrollRemediations = z.union([
+	enrollProfileSchema,
+	baseRemediationValueSchema,
+]);
+
 // schema for the enroll response
 const enrollResponseSchema = idxBaseResponseSchema.merge(
 	z.object({
 		remediation: z.object({
 			type: z.string(),
-			value: z.array(
-				z.union([enrollProfileSchema, baseRemediationValueSchema]),
-			),
+			value: z.array(enrollRemediations),
 		}),
 	}),
 );

--- a/src/server/lib/okta/idx/enroll.ts
+++ b/src/server/lib/okta/idx/enroll.ts
@@ -1,13 +1,13 @@
 import { z } from 'zod';
+import { idxFetch } from '@/server/lib/okta/idx/shared/idxFetch';
 import {
+	baseRemediationValueSchema,
+	idxBaseResponseSchema,
 	IdxBaseResponse,
 	IdxStateHandleBody,
 	authenticatorAnswerSchema,
-	baseRemediationValueSchema,
-	idxBaseResponseSchema,
-	idxFetch,
 	selectAuthenticationEnrollSchema,
-} from './shared';
+} from '@/server/lib/okta/idx/shared/schemas';
 
 // schema for the enroll-profile object inside the enroll response remediation object
 const enrollProfileSchema = baseRemediationValueSchema.merge(

--- a/src/server/lib/okta/idx/identify.ts
+++ b/src/server/lib/okta/idx/identify.ts
@@ -1,11 +1,11 @@
 import { z } from 'zod';
+import { idxFetch } from '@/server/lib/okta/idx/shared/idxFetch';
 import {
 	baseRemediationValueSchema,
-	IdxBaseResponse,
-	idxBaseResponseSchema,
-	idxFetch,
 	selectAuthenticatorValueSchema,
-} from './shared';
+	idxBaseResponseSchema,
+	IdxBaseResponse,
+} from '@/server/lib/okta/idx/shared/schemas';
 
 // schema for the select-authenticator-authenticate object inside the identify response remediation object
 export const selectAuthenticationAuthenticateSchema =

--- a/src/server/lib/okta/idx/identify.ts
+++ b/src/server/lib/okta/idx/identify.ts
@@ -8,24 +8,26 @@ import {
 } from './shared';
 
 // schema for the select-authenticator-authenticate object inside the identify response remediation object
-const selectAuthenticationAuthenticateSchema = baseRemediationValueSchema.merge(
-	z.object({
-		name: z.literal('select-authenticator-authenticate'),
-		value: selectAuthenticatorValueSchema,
-	}),
-);
+export const selectAuthenticationAuthenticateSchema =
+	baseRemediationValueSchema.merge(
+		z.object({
+			name: z.literal('select-authenticator-authenticate'),
+			value: selectAuthenticatorValueSchema,
+		}),
+	);
+
+// list of all possible remediations for the identify response
+export const identifyRemediations = z.union([
+	selectAuthenticationAuthenticateSchema,
+	baseRemediationValueSchema,
+]);
 
 // schema for the identify response
 const identifyResponseSchema = idxBaseResponseSchema.merge(
 	z.object({
 		remediation: z.object({
 			type: z.string(),
-			value: z.array(
-				z.union([
-					selectAuthenticationAuthenticateSchema,
-					baseRemediationValueSchema,
-				]),
-			),
+			value: z.array(identifyRemediations),
 		}),
 	}),
 );

--- a/src/server/lib/okta/idx/introspect.ts
+++ b/src/server/lib/okta/idx/introspect.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 import { InteractResponse } from './interact';
 import {
 	baseRemediationValueSchema,
+	ExtractLiteralRemediationNames,
 	idxBaseResponseSchema,
 	idxFetch,
 } from './shared';
@@ -84,6 +85,11 @@ export const introspect = (
 	});
 };
 
+// Type to extract all the remediation names from the introspect response
+type IntrospectRemediationNames = ExtractLiteralRemediationNames<
+	IntrospectResponse['remediation']['value'][number]
+>;
+
 /**
  * @name validateIntrospectRemediation
  * @description Validates that the introspect response contains a remediation with the given name, throwing an error if it does not. This is useful for ensuring that the remediation we want to perform is available in the introspect response, and the state is correct.
@@ -94,7 +100,7 @@ export const introspect = (
  */
 export const validateIntrospectRemediation = (
 	introspectResponse: IntrospectResponse,
-	remediationName: string,
+	remediationName: IntrospectRemediationNames,
 ) => {
 	const hasRemediation = introspectResponse.remediation.value.some(
 		({ name }) => name === remediationName,

--- a/src/server/lib/okta/idx/introspect.ts
+++ b/src/server/lib/okta/idx/introspect.ts
@@ -102,7 +102,7 @@ export const introspect = (
 };
 
 // Type to extract all the remediation names from the introspect response
-type IntrospectRemediationNames = ExtractLiteralRemediationNames<
+export type IntrospectRemediationNames = ExtractLiteralRemediationNames<
 	IntrospectResponse['remediation']['value'][number]
 >;
 

--- a/src/server/lib/okta/idx/introspect.ts
+++ b/src/server/lib/okta/idx/introspect.ts
@@ -1,20 +1,20 @@
 import { z } from 'zod';
-import { InteractResponse } from './interact';
-import {
-	baseRemediationValueSchema,
-	ExtractLiteralRemediationNames,
-	idxBaseResponseSchema,
-	idxFetch,
-} from './shared';
 import { OAuthError } from '@/server/models/okta/Error';
+import { InteractResponse } from '@/server/lib/okta/idx/interact';
 import {
 	challengeAnswerRemediations,
 	challengeRemediations,
-} from './challenge';
-import { credentialEnrollRemediations } from './credential';
-import { enrollRemediations } from './enroll';
-import { identifyRemediations } from './identify';
-import { recoverRemediations } from './recover';
+} from '@/server/lib/okta/idx/challenge';
+import { credentialEnrollRemediations } from '@/server/lib/okta/idx/credential';
+import { enrollRemediations } from '@/server/lib/okta/idx/enroll';
+import { identifyRemediations } from '@/server/lib/okta/idx/identify';
+import { recoverRemediations } from '@/server/lib/okta/idx/recover';
+import { idxFetch } from '@/server/lib/okta/idx/shared/idxFetch';
+import {
+	baseRemediationValueSchema,
+	idxBaseResponseSchema,
+	ExtractLiteralRemediationNames,
+} from '@/server/lib/okta/idx/shared/schemas';
 
 // Schema for the 'redirect-idp' object inside the introspect response remediation object
 export const redirectIdpSchema = baseRemediationValueSchema.merge(

--- a/src/server/lib/okta/idx/recover.ts
+++ b/src/server/lib/okta/idx/recover.ts
@@ -1,11 +1,11 @@
 import { z } from 'zod';
+import { idxFetch } from '@/server/lib/okta/idx/shared/idxFetch';
 import {
 	baseRemediationValueSchema,
-	IdxBaseResponse,
 	idxBaseResponseSchema,
-	idxFetch,
+	IdxBaseResponse,
 	IdxStateHandleBody,
-} from './shared';
+} from '@/server/lib/okta/idx/shared/schemas';
 
 // schema for the authenticator-verification-data object inside the recover response remediation object
 export const authenticatorVerificationDataRemediationSchema =

--- a/src/server/lib/okta/idx/recover.ts
+++ b/src/server/lib/okta/idx/recover.ts
@@ -35,17 +35,18 @@ export const authenticatorVerificationDataRemediationSchema =
 		}),
 	);
 
+// list of all possible remediations for the recover response
+export const recoverRemediations = z.union([
+	authenticatorVerificationDataRemediationSchema,
+	baseRemediationValueSchema,
+]);
+
 // schema for the recover response
 const recoverResponseSchema = idxBaseResponseSchema.merge(
 	z.object({
 		remediation: z.object({
 			type: z.string(),
-			value: z.array(
-				z.union([
-					authenticatorVerificationDataRemediationSchema,
-					baseRemediationValueSchema,
-				]),
-			),
+			value: z.array(recoverRemediations),
 		}),
 	}),
 );

--- a/src/server/lib/okta/idx/shared.ts
+++ b/src/server/lib/okta/idx/shared.ts
@@ -52,6 +52,15 @@ export const baseRemediationValueSchema = z.object({
 	value: z.unknown().optional(),
 });
 
+// Type to extract all the `name` properties from the remediation value array
+export type ExtractLiteralRemediationNames<T> = T extends { name: infer N }
+	? N extends string
+		? string extends N
+			? never
+			: N
+		: never
+	: never;
+
 // Base type for the body of a request to the IDX API
 // Which should include the stateHandle, and any other data needed using the generic type
 export type IdxStateHandleBody<T = object> = T & {

--- a/src/server/lib/okta/idx/shared/convertExpiresAtToExpiryTimeInMs.ts
+++ b/src/server/lib/okta/idx/shared/convertExpiresAtToExpiryTimeInMs.ts
@@ -1,0 +1,11 @@
+/**
+ * @name convertExpiresAtToExpiryTimeInMs
+ * @description Convert the expiresAt string from the IDX API response to a number representing the time until expiry in ms
+ * @param expiresAt - The expiresAt string from the IDX API response
+ * @returns	number | undefined - The time until expiry in ms, or undefined if expiresAt is not provided
+ */
+export const convertExpiresAtToExpiryTimeInMs = (
+	expiresAt?: string,
+): number | undefined => {
+	return expiresAt ? new Date(expiresAt).getTime() - Date.now() : undefined;
+};

--- a/src/server/lib/okta/idx/shared/errorHandling.ts
+++ b/src/server/lib/okta/idx/shared/errorHandling.ts
@@ -1,0 +1,89 @@
+import { Request } from 'express';
+import { readEncryptedStateCookie } from '@/server/lib/encryptedStateCookie';
+import { renderer } from '@/server/lib/renderer';
+import { mergeRequestState } from '@/server/lib/requestState';
+import { ResponseWithRequestState } from '@/server/models/Express';
+import { OAuthError } from '@/server/models/okta/Error';
+import { addQueryParamsToPath } from '@/shared/lib/queryParams';
+import { RegistrationErrors } from '@/shared/model/Errors';
+import { convertExpiresAtToExpiryTimeInMs } from './convertExpiresAtToExpiryTimeInMs';
+import { RoutePaths } from '@/shared/model/Routes';
+
+type HandlePasscodeErrorParams = {
+	error: unknown;
+	req: Request;
+	res: ResponseWithRequestState;
+	emailSentPage: RoutePaths;
+	expiredPage: RoutePaths;
+};
+
+/**
+ * @name handlePasscodeError
+ * @description Handles errors from the IDX API when the user is entering a passcode.
+ *
+ * Note: Use res.headersSent to check if headers have been sent after calling this function
+ * to avoid errors if we redirect within this function.
+ *
+ * @param error - The error object from the IDX API
+ * @param req - The Express request object
+ * @param res - The Express response object
+ * @param emailSentPage - The path to the email sent page
+ * @param expiredPage - The path to the expired page
+ * @returns void - The function does not return anything, or it redirects the user
+ */
+export const handlePasscodeError = ({
+	error,
+	req,
+	res,
+	emailSentPage,
+	expiredPage,
+}: HandlePasscodeErrorParams) => {
+	const state = res.locals;
+	const { code } = req.body;
+	const encryptedState = readEncryptedStateCookie(req);
+
+	if (error instanceof OAuthError) {
+		if (error.name === 'api.authn.error.PASSCODE_INVALID') {
+			// case for invalid passcode
+			const html = renderer(emailSentPage, {
+				requestState: mergeRequestState(state, {
+					queryParams: {
+						returnUrl: state.queryParams.returnUrl,
+						emailSentSuccess: false,
+					},
+					pageData: {
+						email: encryptedState?.email,
+						timeUntilTokenExpiry: convertExpiresAtToExpiryTimeInMs(
+							encryptedState?.stateHandleExpiresAt,
+						),
+						fieldErrors: [
+							{
+								field: 'code',
+								message: RegistrationErrors.PASSCODE_INVALID,
+							},
+						],
+						token: code,
+					},
+				}),
+				pageTitle: 'Check Your Inbox',
+			});
+			return res.type('html').send(html);
+		}
+
+		// case for too many passcode attempts
+		if (error.name === 'oie.tooManyRequests') {
+			return res.redirect(
+				303,
+				addQueryParamsToPath(expiredPage, state.queryParams),
+			);
+		}
+
+		// case for session expired
+		if (error.name === 'idx.session.expired') {
+			return res.redirect(
+				303,
+				addQueryParamsToPath(expiredPage, state.queryParams),
+			);
+		}
+	}
+};

--- a/src/server/lib/okta/idx/shared/findAuthenticatorId.ts
+++ b/src/server/lib/okta/idx/shared/findAuthenticatorId.ts
@@ -1,0 +1,102 @@
+import { selectAuthenticationAuthenticateSchema } from '../identify';
+import { IntrospectRemediationNames, IntrospectResponse } from '../introspect';
+import { authenticatorVerificationDataRemediationSchema } from '../recover';
+import { selectAuthenticationEnrollSchema } from './schemas';
+
+type Params = {
+	response: IntrospectResponse; // all responses regardless of api call will overlap with the introspect response
+	remediationName: Extract<
+		IntrospectRemediationNames,
+		| 'authenticator-verification-data'
+		| 'select-authenticator-authenticate'
+		| 'select-authenticator-enroll'
+	>;
+	authenticator: 'email' | 'password';
+};
+
+/**
+ * @name findAuthenticatorId
+ * @description Find the authenticator id from a given response, remediation name, and authenticator type
+ * @param response - The response object
+ * @param remediationName - The remediation name
+ * @param authenticator - The authenticator type - email or password
+ * @returns string | undefined - The authenticator id
+ */
+export const findAuthenticatorId = ({
+	response,
+	remediationName,
+	authenticator,
+}: Params): string | undefined =>
+	response.remediation.value
+		.flatMap((remediation) => {
+			// depending on the remediation name, the schema shape will be different
+			// so we can't do the same check to get the id
+			// instead we have to check which schema to use, and then attempt to get the authenticator id
+			// depending on the authenticator type and schema
+
+			// this is the schema where the remediation value is of selectAuthenticatorValueSchema type
+			const selectAuthenticatorValueRemediation = (() => {
+				switch (remediationName) {
+					case 'select-authenticator-authenticate':
+						return selectAuthenticationAuthenticateSchema.safeParse(
+							remediation,
+						);
+					case 'select-authenticator-enroll':
+						return selectAuthenticationEnrollSchema.safeParse(remediation);
+					default:
+						break;
+				}
+			})();
+
+			// this is the schema where the remediation value is of authenticatorVerificationDataRemediationSchema type
+			const authenticatorVerificationDataRemediation = (() => {
+				switch (remediationName) {
+					case 'authenticator-verification-data':
+						return authenticatorVerificationDataRemediationSchema.safeParse(
+							remediation,
+						);
+					default:
+						break;
+				}
+			})();
+
+			// if the remediation value is of selectAuthenticatorValueSchema type, we can get the authenticator id using this
+			if (selectAuthenticatorValueRemediation?.success) {
+				return selectAuthenticatorValueRemediation.data.value.flatMap(
+					(value) => {
+						if (value.name === 'authenticator') {
+							return value.options.flatMap((option) => {
+								if (option.label.toLowerCase() === authenticator) {
+									if (
+										option.value.form.value.some(
+											(v) => v.value === authenticator,
+										)
+									) {
+										return [
+											option.value.form.value.find((v) => v.name === 'id')
+												?.value,
+										];
+									}
+								}
+							});
+						}
+					},
+				);
+			}
+
+			// if the remediation value is of authenticatorVerificationDataRemediationSchema type, we can get the authenticator id using this
+			if (authenticatorVerificationDataRemediation?.success) {
+				return authenticatorVerificationDataRemediation.data.value.flatMap(
+					(value) => {
+						if (
+							value.name === 'authenticator' &&
+							value.label.toLowerCase() === authenticator
+						) {
+							return value.form.value.find((v) => v.name === 'id')?.value;
+						}
+					},
+				);
+			}
+		})
+		.filter((id): id is string => typeof id === 'string' && id.length > 0)
+		.at(0);

--- a/src/server/lib/okta/idx/shared/idxFetch.ts
+++ b/src/server/lib/okta/idx/shared/idxFetch.ts
@@ -1,131 +1,14 @@
 import { z } from 'zod';
-import { logger } from '@/server/lib/serverSideLogger';
+import { joinUrl } from '@guardian/libs';
+import { logger } from '@/client/lib/clientSideLogger';
 import { trackMetric } from '@/server/lib/trackMetric';
+import { ResponseWithRequestState } from '@/server/models/Express';
 import { OAuthError } from '@/server/models/okta/Error';
 import { getConfiguration } from '@/server/lib/getConfiguration';
-import { joinUrl } from '@guardian/libs';
-import { ResponseWithRequestState } from '@/server/models/Express';
+import { idxBaseResponseSchema } from '@/server/lib/okta/idx/shared/schemas';
+import { IDXPath } from '@/server/lib/okta/idx/shared/paths';
 
 const { okta } = getConfiguration();
-
-// Okta IDX API paths
-const idxPaths = [
-	'challenge',
-	'challenge/answer',
-	'challenge/resend',
-	'credential/enroll',
-	'enroll',
-	'enroll/new',
-	'identify',
-	'introspect',
-	'recover',
-] as const;
-export type IDXPath = (typeof idxPaths)[number];
-
-// Schema to check the version of the IDX API, and warn if it's not 1.0.0
-const idxVersionSchema = z.string().refine((val) => {
-	// warn if the version is not 1.0.0
-	if (val !== '1.0.0') {
-		logger.warn('Okta IDX - unexpected version:', val);
-		trackMetric('OktaIDX::UnexpectedVersion');
-	}
-
-	// but pass validation regardless
-	return true;
-});
-
-// Base schema for the IDX API response, everything should inherit from this (using .merge)
-export const idxBaseResponseSchema = z.object({
-	version: idxVersionSchema,
-	stateHandle: z.string(),
-	expiresAt: z.string(),
-});
-export type IdxBaseResponse = z.infer<typeof idxBaseResponseSchema>;
-
-// Base schema for the remediation object in the IDX API response
-// Used in cases where the Okta IDX API during the authentication process
-export const baseRemediationValueSchema = z.object({
-	name: z.string(),
-	type: z.string().optional(),
-	href: z.string().url().optional(),
-	method: z.string().optional(),
-	value: z.unknown().optional(),
-});
-
-// Type to extract all the `name` properties from the remediation value array
-export type ExtractLiteralRemediationNames<T> = T extends { name: infer N }
-	? N extends string
-		? string extends N
-			? never
-			: N
-		: never
-	: never;
-
-// Base type for the body of a request to the IDX API
-// Which should include the stateHandle, and any other data needed using the generic type
-export type IdxStateHandleBody<T = object> = T & {
-	stateHandle: IdxBaseResponse['stateHandle'];
-};
-
-// schema for the select-authenticator-{enroll|authenticate}
-export const selectAuthenticatorValueSchema = z.array(
-	z.union([
-		z.object({
-			name: z.literal('authenticator'),
-			type: z.string(),
-			options: z.array(
-				z.object({
-					label: z.string(),
-					value: z.object({
-						form: z.object({
-							value: z.array(
-								z.object({
-									name: z.enum(['id', 'methodType']),
-									value: z.string(),
-								}),
-							),
-						}),
-					}),
-				}),
-			),
-		}),
-		z.object({
-			name: z.literal('stateHandle'),
-		}),
-	]),
-);
-
-// schema for the select-authenticator-enroll object
-export const selectAuthenticationEnrollSchema =
-	baseRemediationValueSchema.merge(
-		z.object({
-			name: z.literal('select-authenticator-enroll'),
-			value: selectAuthenticatorValueSchema,
-		}),
-	);
-
-// schema for the (challenge|enroll)-authenticator remediation value object
-export const authenticatorAnswerSchema = z.array(
-	z.union([
-		z.object({
-			name: z.literal('credentials'),
-			form: z.object({
-				value: z.array(z.object({ name: z.literal('passcode') })),
-			}),
-		}),
-		z.object({
-			name: z.literal('stateHandle'),
-		}),
-	]),
-);
-
-// Body type for the credential/enroll and challenge requests to select a given authenticator
-export type AuthenticatorBody = IdxStateHandleBody<{
-	authenticator: {
-		id: string;
-		methodType: 'email' | 'password';
-	};
-}>;
 
 // Schema for when the authentication process is completed, and we return a base user object
 const completeLoginResponseSchema = idxBaseResponseSchema.merge(
@@ -447,16 +330,4 @@ const handleError = async (response: Response) => {
 		},
 		response.status,
 	);
-};
-
-/**
- * @name convertExpiresAtToExpiryTimeInMs
- * @description Convert the expiresAt string from the IDX API response to a number representing the time until expiry in ms
- * @param expiresAt - The expiresAt string from the IDX API response
- * @returns	number | undefined - The time until expiry in ms, or undefined if expiresAt is not provided
- */
-export const convertExpiresAtToExpiryTimeInMs = (
-	expiresAt?: string,
-): number | undefined => {
-	return expiresAt ? new Date(expiresAt).getTime() - Date.now() : undefined;
 };

--- a/src/server/lib/okta/idx/shared/paths.ts
+++ b/src/server/lib/okta/idx/shared/paths.ts
@@ -1,0 +1,13 @@
+// Okta IDX API paths
+const idxPaths = [
+	'challenge',
+	'challenge/answer',
+	'challenge/resend',
+	'credential/enroll',
+	'enroll',
+	'enroll/new',
+	'identify',
+	'introspect',
+	'recover',
+] as const;
+export type IDXPath = (typeof idxPaths)[number];

--- a/src/server/lib/okta/idx/shared/schemas.ts
+++ b/src/server/lib/okta/idx/shared/schemas.ts
@@ -1,0 +1,108 @@
+import { z } from 'zod';
+import { logger } from '@/client/lib/clientSideLogger';
+import { trackMetric } from '@/server/lib/trackMetric';
+
+// Schema to check the version of the IDX API, and warn if it's not 1.0.0
+const idxVersionSchema = z.string().refine((val) => {
+	// warn if the version is not 1.0.0
+	if (val !== '1.0.0') {
+		logger.warn('Okta IDX - unexpected version:', val);
+		trackMetric('OktaIDX::UnexpectedVersion');
+	}
+
+	// but pass validation regardless
+	return true;
+});
+
+// Base schema for the IDX API response, everything should inherit from this (using .merge)
+export const idxBaseResponseSchema = z.object({
+	version: idxVersionSchema,
+	stateHandle: z.string(),
+	expiresAt: z.string(),
+});
+export type IdxBaseResponse = z.infer<typeof idxBaseResponseSchema>;
+
+// Base schema for the remediation object in the IDX API response
+// Used in cases where the Okta IDX API during the authentication process
+export const baseRemediationValueSchema = z.object({
+	name: z.string(),
+	type: z.string().optional(),
+	href: z.string().url().optional(),
+	method: z.string().optional(),
+	value: z.unknown().optional(),
+});
+
+// Base type for the body of a request to the IDX API
+// Which should include the stateHandle, and any other data needed using the generic type
+export type IdxStateHandleBody<T = object> = T & {
+	stateHandle: IdxBaseResponse['stateHandle'];
+};
+
+// schema for the select-authenticator-{enroll|authenticate}
+export const selectAuthenticatorValueSchema = z.array(
+	z.union([
+		z.object({
+			name: z.literal('authenticator'),
+			type: z.string(),
+			options: z.array(
+				z.object({
+					label: z.string(),
+					value: z.object({
+						form: z.object({
+							value: z.array(
+								z.object({
+									name: z.enum(['id', 'methodType']),
+									value: z.string(),
+								}),
+							),
+						}),
+					}),
+				}),
+			),
+		}),
+		z.object({
+			name: z.literal('stateHandle'),
+		}),
+	]),
+);
+
+// schema for the select-authenticator-enroll object
+export const selectAuthenticationEnrollSchema =
+	baseRemediationValueSchema.merge(
+		z.object({
+			name: z.literal('select-authenticator-enroll'),
+			value: selectAuthenticatorValueSchema,
+		}),
+	);
+
+// schema for the (challenge|enroll)-authenticator remediation value object
+export const authenticatorAnswerSchema = z.array(
+	z.union([
+		z.object({
+			name: z.literal('credentials'),
+			form: z.object({
+				value: z.array(z.object({ name: z.literal('passcode') })),
+			}),
+		}),
+		z.object({
+			name: z.literal('stateHandle'),
+		}),
+	]),
+);
+
+// Body type for the credential/enroll and challenge requests to select a given authenticator
+export type AuthenticatorBody = IdxStateHandleBody<{
+	authenticator: {
+		id: string;
+		methodType: 'email' | 'password';
+	};
+}>;
+
+// Type to extract all the `name` properties from the remediation value array
+export type ExtractLiteralRemediationNames<T> = T extends { name: infer N }
+	? N extends string
+		? string extends N
+			? never
+			: N
+		: never
+	: never;

--- a/src/server/lib/okta/idx/shared/submitPasscode.ts
+++ b/src/server/lib/okta/idx/shared/submitPasscode.ts
@@ -1,0 +1,78 @@
+import { OAuthError } from '@/server/models/okta/Error';
+import {
+	introspect,
+	IntrospectRemediationNames,
+	validateIntrospectRemediation,
+} from '@/server/lib/okta/idx/introspect';
+import {
+	challengeAnswerPasscode,
+	ChallengeAnswerRemediationNames,
+	ChallengeAnswerResponse,
+	validateChallengeAnswerRemediation,
+} from '@/server/lib/okta/idx/challenge';
+
+/**
+ * @name submitPasscode
+ * @description Submit a passcode to Okta to answer the passcode challenge using the `challenge/answer` endpoint and return the response
+ *
+ * @param passcode The passcode to submit
+ * @param stateHandle The state handle from the `identify`/`introspect` step
+ * @param introspectRemediation The remediation object name to validate the introspect response against
+ * @param challengeAnswerRemediation The remediation object name to validate the challenge answer response against
+ * @param requestId The request id
+ * @returns Promise<ChallengeAnswerResponse> - The challenge answer response
+ */
+export const submitPasscode = async ({
+	passcode,
+	stateHandle,
+	introspectRemediation,
+	challengeAnswerRemediation,
+	requestId,
+}: {
+	passcode: string;
+	stateHandle: string;
+	introspectRemediation: IntrospectRemediationNames;
+	challengeAnswerRemediation: ChallengeAnswerRemediationNames;
+	requestId?: string;
+}): Promise<ChallengeAnswerResponse> => {
+	// validate the code contains only numbers and is 6 characters long
+	// The okta api will validate the input fully, but validating here will prevent unnecessary requests
+	if (!/^\d{6}$/.test(passcode)) {
+		throw new OAuthError(
+			{
+				error: 'api.authn.error.PASSCODE_INVALID',
+				error_description: 'Passcode invalid', // this is ignored, and a error based on the `error` key is shown
+			},
+			400,
+		);
+	}
+
+	// check the state handle is valid and we can proceed with the request
+	const introspectResponse = await introspect(
+		{
+			stateHandle,
+		},
+		requestId,
+	);
+
+	// check if the remediation array contains the correct remediation object supplied
+	// if it does, then we know the stateHandle is valid and we're in the correct state for
+	// the current flow
+	validateIntrospectRemediation(introspectResponse, introspectRemediation);
+
+	// attempt to answer the passcode challenge, if this fails, it falls through to the catch block where we handle the error
+	const challengeAnswerResponse = await challengeAnswerPasscode(
+		stateHandle,
+		{ passcode },
+		requestId,
+	);
+
+	// check if the remediation array contains the correct remediation object supplied
+	// if it does, then we know that we're in the correct state and the passcode was correct
+	validateChallengeAnswerRemediation(
+		challengeAnswerResponse,
+		challengeAnswerRemediation,
+	);
+
+	return challengeAnswerResponse;
+};

--- a/src/server/models/Metrics.ts
+++ b/src/server/models/Metrics.ts
@@ -2,7 +2,7 @@
 
 import { BucketType } from '@/server/lib/rate-limit';
 import { PasswordRoutePath } from '@/shared/model/Routes';
-import { IDXPath } from '@/server/lib/okta/idx/shared';
+import { IDXPath } from '@/server/lib/okta/idx/shared/paths';
 
 // Specific emails to track
 type EmailMetrics =

--- a/src/server/routes/register.ts
+++ b/src/server/routes/register.ts
@@ -39,11 +39,9 @@ import {
 import { getRegistrationPlatform } from '@/server/lib/registrationPlatform';
 import { credentialEnroll } from '@/server/lib/okta/idx/credential';
 import { bodyFormFieldsToRegistrationConsents } from '@/server/lib/registrationConsents';
-import {
-	convertExpiresAtToExpiryTimeInMs,
-	selectAuthenticationEnrollSchema,
-} from '@/server/lib/okta/idx/shared';
 import { startIdxFlow } from '@/server/lib/okta/idx/startIdxFlow';
+import { selectAuthenticationEnrollSchema } from '@/server/lib/okta/idx/shared/schemas';
+import { convertExpiresAtToExpiryTimeInMs } from '@/server/lib/okta/idx/shared/convertExpiresAtToExpiryTimeInMs';
 
 const { passcodesEnabled: passcodesEnabled } = getConfiguration();
 


### PR DESCRIPTION
## This PR

This PR refactors, fixes, and adds things related to the Okta IDX API, especially stuff that will be used when we implement passcodes for reset password and sign in.

It's best to review this PR commit by commit, as each one is a separate change.

This description describes each in order of commit.

This has been tested in CODE.

## Changes

---

#### Add helper `ExtractLiteralRemediationNames` type
**refactor**
*commit [0c9acd5](https://github.com/guardian/gateway/pull/2854/commits/0c9acd59bb8ebdac332947e04657501678845b26)*

This is used to extract all possible remediation `name` values into a template literal type containing all the possible values except `string`.

For example:

```ts
// Type to extract all the remediation names from the introspect response
type IntrospectRemediationNames = ExtractLiteralRemediationNames<
	IntrospectResponse['remediation']['value'][number]
>;
```

Will evaluate to:

```ts
type IntrospectRemediationNames = "redirect-idp" | "select-enroll-profile" | "identify"
```

Which is helpful as it means we can avoid using the `string` type when validating the remediation

---

#### Make `IntrospectResponse` remediation a union of all other remediations
**refactor**
*commit [40aa5cc](https://github.com/guardian/gateway/pull/2854/commits/40aa5ccfe17fd0d46b71fb45a5f9a242fd3e018a)*

Since the `introspect` call can be called at any point in the IDX flow to check the current state of the flow, the response returned by the introspect call could be the same as any other IDX API call.

This means that the remediation object could be any remediation object from the other IDX API calls.

This commit updates the remediation object inside the `IntrospectResponse` to be a union of all the other remediation objects from the other IDX API calls.

---

#### Add `reset-authenticator` remediation to `challengeAnswerRemediations`
**feature**
*commit [ed2bb97](https://github.com/guardian/gateway/pull/2854/commits/ed2bb97cc9dc096e4d7e90812963ff919b3a8676)*

This is used by password reset with passcodes. This remediation was missed out in the updated API setup in https://github.com/guardian/gateway/pull/2833

---

#### Add `validateChallengeAnswerRemediation` method
**feature**
*commit [7029c01](https://github.com/guardian/gateway/pull/2854/commits/7029c015f4f79947599d9631a3e155a5a55a773d)*

Validates that the `challenge/answer` response contains a remediation with the given name, throwing an error if it does not. This is useful for ensuring that the remediation we want to perform is available in the challenge/answer response, and the current state is correct.

---

#### Split idx `shared.ts` file into `shared` folder
**refactor**
*commit [5eacb0a](https://github.com/guardian/gateway/pull/2854/commits/5eacb0a61fe07029461887f784b2e26a59f2b3a8)*

The `shared.ts` file was getting very large and unmanageable with all the different things it was doing.

This commit splits the file up into files inside a `shared` folder, each with an individual task making it easier to reason about.

- `convertExpiresAtToExpiryTimeInMs.ts`
  - Just the `convertExpiresAtToExpiryTimeInMs` function
- `idxFetch.ts`
  - Handles all the calls to and responses/errors from the IDX API
- `paths.ts`
  - A list of all the IDX API paths/endpoints
- `schemas.ts`
  - Shared schemas for that all the different IDX API endpoints can inherit from 

---

#### Move `submitPasscode` functionality into shared method
**refactor**
*commit [d7504a0](https://github.com/guardian/gateway/pull/2854/commits/d7504a05cd89bcf8db6bef13818d9d169e949385)*

Create a `submitPasscode` method, and add it to shared folder. This repeating block of code will be repeatedly used to verify passcodes so having a helper method that manages it will prove helpful.

---

#### Create findAuthenticatorId helper method
**refactor**
*commit [d401d12](https://github.com/guardian/gateway/pull/2854/commits/d401d1281a152fd1cf71e6530f11144db2484110)*

To extract a given authenticators id from within the remediation object is a bit of a mess.

Since this functionality will be needed quite often, I've moved this to it's own method.

This method handles all the current possible scenarios where we'll need to find authenticator ids.

Currently in the create account flow it's using the `select-authenticator-enroll` remediation to find the authenticator id for the `password` authenticator.

When we start doing passwordless we'll need more options here. In this commit I've also added the two that are required for password reset using passcodes, specifically `select-authenticator-authenticate` and `authenticator-verification-data`.

Since the shape to find the id can sometimes be different, this also takes into account the possible schema shapes too, so we can hid the complexity from the usages.

---

#### Move passcode error handing into a `handlePasscodeError` function
**refactor**
*commit [57d4da6](https://github.com/guardian/gateway/pull/2854/commits/57d4da6b9557e019a94866349872011f843fee03)*

The passcode error handling will be similar among all routes that will need it. So move it into it's own method.

Any following errors would need to check for `res.headersSent` in case we redirected or rendered a page inside this method.

---