### PR TITLE
Okta | Add additional check to create account using IDX API

### DIFF
--- a/cypress/fixtures/okta-responses/success/idx-enroll-new-response-select-authenticator.json
+++ b/cypress/fixtures/okta-responses/success/idx-enroll-new-response-select-authenticator.json
@@ -1,0 +1,80 @@
+{
+	"code": 200,
+	"response": {
+		"version": "1.0.0",
+		"stateHandle": "02.id.state~c.handle",
+		"expiresAt": "2099-12-31T23:59:59.000Z",
+		"remediation": {
+			"type": "array",
+			"value": [
+				{
+					"rel": ["create-form"],
+					"name": "select-authenticator-enroll",
+					"href": "https://profile.code.dev-theguardian.com/idp/idx/credential/enroll",
+					"method": "POST",
+					"produces": "application/ion+json; okta-version=1.0.0",
+					"value": [
+						{
+							"name": "authenticator",
+							"type": "object",
+							"options": [
+								{
+									"label": "Email",
+									"value": {
+										"form": {
+											"value": [
+												{
+													"name": "id",
+													"required": true,
+													"value": "id",
+													"mutable": false
+												},
+												{
+													"name": "methodType",
+													"required": false,
+													"value": "email",
+													"mutable": false
+												}
+											]
+										}
+									},
+									"relatesTo": "$.authenticators.value[0]"
+								},
+								{
+									"label": "Password",
+									"value": {
+										"form": {
+											"value": [
+												{
+													"name": "id",
+													"required": true,
+													"value": "id",
+													"mutable": false
+												},
+												{
+													"name": "methodType",
+													"required": false,
+													"value": "password",
+													"mutable": false
+												}
+											]
+										}
+									},
+									"relatesTo": "$.authenticators.value[1]"
+								}
+							]
+						},
+						{
+							"name": "stateHandle",
+							"required": true,
+							"value": "02.id.state~c.handle",
+							"visible": false,
+							"mutable": false
+						}
+					],
+					"accepts": "application/json; okta-version=1.0.0"
+				}
+			]
+		}
+	}
+}

--- a/cypress/integration/mocked/registerController.1.cy.ts
+++ b/cypress/integration/mocked/registerController.1.cy.ts
@@ -9,6 +9,7 @@ import idxInteractResponse from '../../fixtures/okta-responses/success/idx-inter
 import idxIntrospectDefaultResponse from '../../fixtures/okta-responses/success/idx-introspect-default-response.json';
 import idxEnrollResponse from '../../fixtures/okta-responses/success/idx-enroll-response.json';
 import idxEnrollNewResponse from '../../fixtures/okta-responses/success/idx-enroll-new-response.json';
+import idxEnrollNewSelectAuthenticatorResponse from '../../fixtures/okta-responses/success/idx-enroll-new-response-select-authenticator.json';
 import idxEnrollNewExistingUserResponse from '../../fixtures/okta-responses/error/idx-enroll-new-existing-user-response.json';
 
 beforeEach(() => {
@@ -48,6 +49,10 @@ userStatuses.forEach((status) => {
 				case false:
 					specify("Then I should be shown the 'Check your inbox' page", () => {
 						baseIdxPasscodeRegistrationMocks();
+						cy.mockNext(
+							idxEnrollNewSelectAuthenticatorResponse.code,
+							idxEnrollNewSelectAuthenticatorResponse.response,
+						);
 						cy.mockNext(
 							idxEnrollNewResponse.code,
 							idxEnrollNewResponse.response,

--- a/cypress/integration/mocked/resendEmailController.3.cy.ts
+++ b/cypress/integration/mocked/resendEmailController.3.cy.ts
@@ -9,6 +9,7 @@ import idxInteractResponse from '../../fixtures/okta-responses/success/idx-inter
 import idxIntrospectDefaultResponse from '../../fixtures/okta-responses/success/idx-introspect-default-response.json';
 import idxEnrollResponse from '../../fixtures/okta-responses/success/idx-enroll-response.json';
 import idxEnrollNewResponse from '../../fixtures/okta-responses/success/idx-enroll-new-response.json';
+import idxEnrollNewSelectAuthenticatorResponse from '../../fixtures/okta-responses/success/idx-enroll-new-response-select-authenticator.json';
 import idxEnrollNewExistingUserResponse from '../../fixtures/okta-responses/error/idx-enroll-new-existing-user-response.json';
 
 beforeEach(() => {
@@ -182,6 +183,10 @@ userStatuses.forEach((status) => {
 					specify("Then I should be shown the 'Check your inbox' page", () => {
 						baseIdxPasscodeRegistrationMocks();
 						cy.mockNext(
+							idxEnrollNewSelectAuthenticatorResponse.code,
+							idxEnrollNewSelectAuthenticatorResponse.response,
+						);
+						cy.mockNext(
 							idxEnrollNewResponse.code,
 							idxEnrollNewResponse.response,
 						);
@@ -299,6 +304,10 @@ userStatuses.forEach((status) => {
 					specify("Then I should be shown the 'Check your inbox' page", () => {
 						baseIdxPasscodeRegistrationMocks();
 						cy.mockNext(
+							idxEnrollNewSelectAuthenticatorResponse.code,
+							idxEnrollNewSelectAuthenticatorResponse.response,
+						);
+						cy.mockNext(
 							idxEnrollNewResponse.code,
 							idxEnrollNewResponse.response,
 						);
@@ -413,6 +422,10 @@ userStatuses.forEach((status) => {
 				case false:
 					specify("Then I should be shown the 'Check your inbox' page", () => {
 						baseIdxPasscodeRegistrationMocks();
+						cy.mockNext(
+							idxEnrollNewSelectAuthenticatorResponse.code,
+							idxEnrollNewSelectAuthenticatorResponse.response,
+						);
 						cy.mockNext(
 							idxEnrollNewResponse.code,
 							idxEnrollNewResponse.response,

--- a/src/server/lib/okta/idx/challenge.ts
+++ b/src/server/lib/okta/idx/challenge.ts
@@ -315,7 +315,7 @@ export const validateChallengeAnswerRemediation = (
 		throw new OAuthError(
 			{
 				error: 'invalid_request',
-				error_description: `Remediation ${remediationName} not found in introspect response`,
+				error_description: `Remediation ${remediationName} not found in challenge/answer response`,
 			},
 			400,
 		);


### PR DESCRIPTION
## What does this change?

See https://github.com/guardian/identity-platform/pull/755 for more context, but we're currently investigating an issue where if a user doesn't verify their passcode after creating an account, they're left in a state where they're unable to recover themselves or sign in, even if they go through the password reset flow and set a password.

As part of that PR we changed the way that create account works for a user. Now, when using the Okta IDX API, instead of automatically sending the user a passcode, it gives the user an option to select which factor they want to set up when creating an account.

This PR updates our create account flow, so that we take into account this additional step, and perform a check for it (using the new `validateEnrollNewRemediation` method). If we're in this state we make sure to send the user an OTP first to verify their account, before setting a password as before

It also updates the Cypress tests to take this change into account.

## Tested

- New user
  - Validate Passcode
    - [x] Validate Password
      - [x] Sign in
    - No validate password
      - [x] Reset password flow
        - [x] Sign in 
      - [x] Register flow
        - [x] Sign in 
  - No validate passcode
    - [x] Reset password flow
      - [x] Sign in  
    - [x] Register flow
      - [x] Sign in 
  - [x] SOCIAL
- Existing user
  - [x] Valid email + password
  - [x] SOCIAL     