### PR TITLE
Fix | `RegistrationEmailSentPage` `try another address` link

### DIFF
--- a/src/client/pages/PasscodeEmailSent.tsx
+++ b/src/client/pages/PasscodeEmailSent.tsx
@@ -90,10 +90,10 @@ export const PasscodeEmailSent = ({
 					undefined,
 					{ timeUntilTokenExpiry },
 				);
-				window.location.replace(expiredPage);
+				window.location.replace(`${expiredPage}${queryString}`);
 			}, timeUntilTokenExpiry);
 		}
-	}, [timeUntilTokenExpiry, expiredPage]);
+	}, [timeUntilTokenExpiry, expiredPage, queryString]);
 
 	// autofocus the code input field when the page loads
 	useEffect(() => {

--- a/src/client/pages/RegistrationEmailSentPage.tsx
+++ b/src/client/pages/RegistrationEmailSentPage.tsx
@@ -3,7 +3,7 @@ import useClientState from '@/client/lib/hooks/useClientState';
 import { EmailSent } from '@/client/pages/EmailSent';
 import { PasscodeEmailSent } from '@/client/pages/PasscodeEmailSent';
 import { buildQueryParamsString } from '@/shared/lib/queryParams';
-import { buildUrl, buildUrlWithQueryParams } from '@/shared/lib/routeUtils';
+import { buildUrl } from '@/shared/lib/routeUtils';
 import { PasscodeUsed } from '@/client/pages/PasscodeUsed';
 
 export const RegistrationEmailSentPage = () => {
@@ -33,11 +33,7 @@ export const RegistrationEmailSentPage = () => {
 			<PasscodeEmailSent
 				email={email}
 				queryString={queryString}
-				changeEmailPage={buildUrlWithQueryParams(
-					'/register/email',
-					{},
-					queryParams,
-				)}
+				changeEmailPage={buildUrl('/register/email')}
 				passcodeAction={buildUrl('/register/code')}
 				showSuccess={emailSentSuccess}
 				errorMessage={error}
@@ -45,11 +41,7 @@ export const RegistrationEmailSentPage = () => {
 				formTrackingName="register-resend"
 				fieldErrors={fieldErrors}
 				passcode={token}
-				expiredPage={buildUrlWithQueryParams(
-					'/welcome/expired',
-					{},
-					queryParams,
-				)}
+				expiredPage={buildUrl('/welcome/expired')}
 			/>
 		);
 	}
@@ -59,11 +51,7 @@ export const RegistrationEmailSentPage = () => {
 		<EmailSent
 			email={email}
 			queryString={queryString}
-			changeEmailPage={buildUrlWithQueryParams(
-				'/register/email',
-				{},
-				queryParams,
-			)}
+			changeEmailPage={buildUrl('/register/email')}
 			resendEmailAction={buildUrl('/register/email-sent/resend')}
 			instructionContext="verify and complete creating your account"
 			showSuccess={emailSentSuccess}


### PR DESCRIPTION
## What does this change?

When pressing the `try another address` link on the `RegistrationEmailSentPage` component, either with or without passcodes version, would break when coming from an OAuth application.

This was because the query parameters were getting duplicated on this link for some reason.

![Screenshot 2024-08-28 at 08 42 59](https://github.com/user-attachments/assets/68569abd-3e54-4eac-9109-1087227b4f3f)

It turns out we were generating and appending the query parameters twice to a given link. Which meant that express would parse the query parameter as an array!

This would cause our validation to fail, and us to return an error page!

It turns out that we don't need to generate the query params using the `buildUrlWithQueryParams` on the `RegistrationEmailSentPage` component, as the `PasscodeEmailSent` and the `EmailSent` page already take care of adding the query parameters!

So we replace `buildUrlWithQueryParams` with `buildUrl`, and make sure every link is using the generated `queryString` parameter instead!

A follow up health task should be to validate the query params don't have any duplicates/arrays in the `src/server/lib/queryParams.ts` file, or where we validate specific parameters.