### PR TITLE
Passwordless | `ResetPasswordEmailSentPage` and API refactors

### DIFF
--- a/src/client/pages/ResetPasswordEmailSentPage.tsx
+++ b/src/client/pages/ResetPasswordEmailSentPage.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import useClientState from '@/client/lib/hooks/useClientState';
+import { EmailSent } from '@/client/pages/EmailSent';
+import { PasscodeEmailSent } from '@/client/pages/PasscodeEmailSent';
+import { buildQueryParamsString } from '@/shared/lib/queryParams';
+import { buildUrl } from '@/shared/lib/routeUtils';
+import { PasscodeUsed } from '@/client/pages/PasscodeUsed';
+
+export const ResetPasswordEmailSentPage = () => {
+	const clientState = useClientState();
+	const {
+		pageData = {},
+		queryParams,
+		globalMessage = {},
+		recaptchaConfig,
+	} = clientState;
+	const { email, hasStateHandle, fieldErrors, token, passcodeUsed } = pageData;
+	const { emailSentSuccess } = queryParams;
+	const { error } = globalMessage;
+	const { recaptchaSiteKey } = recaptchaConfig;
+
+	const queryString = buildQueryParamsString(queryParams, {
+		emailSentSuccess: true,
+	});
+
+	// show passcode email sent page if we have a state handle
+	if (hasStateHandle) {
+		if (passcodeUsed) {
+			return <PasscodeUsed path="/reset-password" queryParams={queryParams} />;
+		}
+
+		return (
+			<PasscodeEmailSent
+				email={email}
+				queryString={queryString}
+				changeEmailPage={buildUrl('/reset-password')}
+				passcodeAction={buildUrl('/reset-password/code')}
+				showSuccess={emailSentSuccess}
+				errorMessage={error}
+				recaptchaSiteKey={recaptchaSiteKey}
+				formTrackingName="forgot-password-resend"
+				fieldErrors={fieldErrors}
+				passcode={token}
+				expiredPage={buildUrl('/reset-password/expired')}
+			/>
+		);
+	}
+
+	// otherwise show original email sent page
+	return (
+		<EmailSent
+			email={email}
+			queryString={queryString}
+			changeEmailPage={buildUrl('/reset-password')}
+			resendEmailAction={buildUrl('/register/email-sent/resend')}
+			instructionContext="verify and complete creating your account"
+			showSuccess={emailSentSuccess}
+			errorMessage={error}
+			recaptchaSiteKey={recaptchaSiteKey}
+			formTrackingName="forgot-password-resend"
+			noAccountInfo
+		/>
+	);
+};

--- a/src/client/routes.tsx
+++ b/src/client/routes.tsx
@@ -39,7 +39,8 @@ import { WelcomeSocialPage } from '@/client/pages/WelcomeSocialPage';
 import { ReturnToAppPage } from '@/client/pages/ReturnToAppPage';
 import { NewAccountReviewPage } from '@/client/pages/NewAccountReviewPage';
 import { NewAccountNewslettersPage } from '@/client/pages/NewAccountNewslettersPage';
-import { VerifyEmailResetPasswordPage } from './pages/VerifyEmailResetPasswordPage';
+import { VerifyEmailResetPasswordPage } from '@/client/pages/VerifyEmailResetPasswordPage';
+import { ResetPasswordEmailSentPage } from '@/client/pages/ResetPasswordEmailSentPage';
 
 export type RoutingConfig = {
 	clientState: ClientState;
@@ -86,9 +87,7 @@ const routes: Array<{
 	},
 	{
 		path: '/reset-password/email-sent',
-		element: (
-			<EmailSentPage formTrackingName="forgot-password-resend" noAccountInfo />
-		),
+		element: <ResetPasswordEmailSentPage />,
 	},
 	{
 		path: '/reset-password/complete',

--- a/src/server/lib/__tests__/okta/idx/validateRemediation.test.ts
+++ b/src/server/lib/__tests__/okta/idx/validateRemediation.test.ts
@@ -1,0 +1,121 @@
+import {
+	ExtractLiteralRemediationNames,
+	validateRemediation,
+} from '@/server/lib/okta/idx/shared/schemas';
+
+// mocked configuration
+jest.mock('@/server/lib/getConfiguration', () => ({
+	getConfiguration: () => ({}),
+}));
+
+// mocked logger
+jest.mock('@/server/lib/serverSideLogger');
+
+// mocked response type
+type ResponseType = {
+	remediation: { value: Array<{ name: string }> };
+};
+
+// test response type
+interface TestResponseType extends ResponseType {
+	remediation: {
+		value: Array<
+			| {
+					name: 'select-authenticator-enroll';
+			  }
+			| {
+					name: 'challenge-authenticator';
+			  }
+		>;
+	};
+}
+
+// test remediation names
+type TestRemediationNames = ExtractLiteralRemediationNames<
+	TestResponseType['remediation']['value'][number]
+>;
+
+describe('okta#idx#validateRemediation', () => {
+	test('should validate the remediation object of a given response', () => {
+		const response: TestResponseType = {
+			remediation: {
+				value: [
+					{
+						name: 'select-authenticator-enroll',
+					},
+					{
+						name: 'challenge-authenticator',
+					},
+				],
+			},
+		};
+
+		expect(
+			validateRemediation<TestResponseType, TestRemediationNames>(
+				response,
+				'select-authenticator-enroll',
+			),
+		).toBe(true);
+	});
+
+	test('should throw an error if the remediation object is not found in the response', () => {
+		const response: TestResponseType = {
+			remediation: {
+				value: [
+					{
+						name: 'select-authenticator-enroll',
+					},
+				],
+			},
+		};
+
+		expect(() =>
+			validateRemediation<TestResponseType, TestRemediationNames>(
+				response,
+				'challenge-authenticator',
+			),
+		).toThrow(
+			'IDX response does not contain the expected remediation: challenge-authenticator',
+		);
+	});
+
+	test('should return true if the remediation object is found in the response and useThrow is false', () => {
+		const response: TestResponseType = {
+			remediation: {
+				value: [
+					{
+						name: 'select-authenticator-enroll',
+					},
+				],
+			},
+		};
+
+		expect(
+			validateRemediation<TestResponseType, TestRemediationNames>(
+				response,
+				'select-authenticator-enroll',
+				false,
+			),
+		).toBe(true);
+	});
+
+	test('should return false if the remediation object is not found in the response and useThrow is false', () => {
+		const response: TestResponseType = {
+			remediation: {
+				value: [
+					{
+						name: 'select-authenticator-enroll',
+					},
+				],
+			},
+		};
+
+		expect(
+			validateRemediation<TestResponseType, TestRemediationNames>(
+				response,
+				'challenge-authenticator',
+				false,
+			),
+		).toBe(false);
+	});
+});

--- a/src/server/lib/okta/idx/challenge.ts
+++ b/src/server/lib/okta/idx/challenge.ts
@@ -7,7 +7,6 @@ import { Request } from 'express';
 import { setupJobsUserInOkta } from '@/server/lib/jobs';
 import { trackMetric } from '@/server/lib/trackMetric';
 import { sendOphanComponentEventFromQueryParamsServer } from '@/server/lib/ophan';
-import { OAuthError } from '@/server/models/okta/Error';
 import {
 	idxFetch,
 	idxFetchCompletion,
@@ -21,6 +20,7 @@ import {
 	IdxStateHandleBody,
 	ExtractLiteralRemediationNames,
 	challengeAuthenticatorSchema,
+	validateRemediation,
 } from '@/server/lib/okta/idx/shared/schemas';
 
 // list of all possible remediations for the challenge response
@@ -292,24 +292,11 @@ export type ChallengeAnswerRemediationNames = ExtractLiteralRemediationNames<
  * @description Validates that the challenge/answer response contains a remediation with the given name, throwing an error if it does not. This is useful for ensuring that the remediation we want to perform is available in the challenge/answer response, and the state is correct.
  * @param challengeAnswerResponse - The challenge/answer response
  * @param remediationName - The name of the remediation to validate
+ * @param useThrow - Whether to throw an error if the remediation is not found (default: true)
  * @throws OAuthError - If the remediation is not found in the challenge/answer response
- * @returns void
+ * @returns boolean | void - Whether the remediation was found in the response
  */
-export const validateChallengeAnswerRemediation = (
-	challengeAnswerResponse: ChallengeAnswerResponse,
-	remediationName: ChallengeAnswerRemediationNames,
-) => {
-	const hasRemediation = challengeAnswerResponse.remediation.value.some(
-		({ name }) => name === remediationName,
-	);
-
-	if (!hasRemediation) {
-		throw new OAuthError(
-			{
-				error: 'invalid_request',
-				error_description: `Remediation ${remediationName} not found in challenge/answer response`,
-			},
-			400,
-		);
-	}
-};
+export const validateChallengeAnswerRemediation = validateRemediation<
+	ChallengeAnswerResponse,
+	ChallengeAnswerRemediationNames
+>;

--- a/src/server/lib/okta/idx/challenge.ts
+++ b/src/server/lib/okta/idx/challenge.ts
@@ -14,22 +14,14 @@ import {
 } from '@/server/lib/okta/idx/shared/idxFetch';
 import {
 	baseRemediationValueSchema,
-	authenticatorAnswerSchema,
 	idxBaseResponseSchema,
 	IdxBaseResponse,
 	AuthenticatorBody,
 	selectAuthenticationEnrollSchema,
 	IdxStateHandleBody,
 	ExtractLiteralRemediationNames,
+	challengeAuthenticatorSchema,
 } from '@/server/lib/okta/idx/shared/schemas';
-
-// schema for the challenge-authenticator object inside the challenge response remediation object
-const challengeAuthenticatorSchema = baseRemediationValueSchema.merge(
-	z.object({
-		name: z.literal('challenge-authenticator'),
-		value: authenticatorAnswerSchema,
-	}),
-);
 
 // list of all possible remediations for the challenge response
 export const challengeRemediations = z.union([

--- a/src/server/lib/okta/idx/enroll.ts
+++ b/src/server/lib/okta/idx/enroll.ts
@@ -8,8 +8,8 @@ import {
 	authenticatorAnswerSchema,
 	selectAuthenticationEnrollSchema,
 	ExtractLiteralRemediationNames,
+	validateRemediation,
 } from '@/server/lib/okta/idx/shared/schemas';
-import { OAuthError } from '@/server/models/okta/Error';
 
 // schema for the enroll-profile object inside the enroll response remediation object
 const enrollProfileSchema = baseRemediationValueSchema.merge(
@@ -140,26 +140,9 @@ export type EnrollNewRemediationNames = ExtractLiteralRemediationNames<
  * @param remediationName - The name of the remediation to validate
  * @param useThrow - Whether to throw an error if the remediation is not found
  * @throws OAuthError - If the remediation is not found in the enroll/new response
- * @returns void
+ * @returns boolean | void - Whether the remediation was found in the response
  */
-export const validateEnrollNewRemediation = (
-	enrollNewResponse: EnrollNewResponse,
-	remediationName: EnrollNewRemediationNames,
-	useThrow = true,
-) => {
-	const hasRemediation = enrollNewResponse.remediation.value.some(
-		({ name }) => name === remediationName,
-	);
-
-	if (!hasRemediation && useThrow) {
-		throw new OAuthError(
-			{
-				error: 'invalid_request',
-				error_description: `Remediation ${remediationName} not found in enroll/new response`,
-			},
-			400,
-		);
-	}
-
-	return hasRemediation;
-};
+export const validateEnrollNewRemediation = validateRemediation<
+	EnrollNewResponse,
+	EnrollNewRemediationNames
+>;

--- a/src/server/lib/okta/idx/identify.ts
+++ b/src/server/lib/okta/idx/identify.ts
@@ -5,6 +5,7 @@ import {
 	selectAuthenticatorValueSchema,
 	idxBaseResponseSchema,
 	IdxBaseResponse,
+	challengeAuthenticatorSchema,
 } from '@/server/lib/okta/idx/shared/schemas';
 
 // schema for the select-authenticator-authenticate object inside the identify response remediation object
@@ -19,6 +20,7 @@ export const selectAuthenticationAuthenticateSchema =
 // list of all possible remediations for the identify response
 export const identifyRemediations = z.union([
 	selectAuthenticationAuthenticateSchema,
+	challengeAuthenticatorSchema,
 	baseRemediationValueSchema,
 ]);
 

--- a/src/server/lib/okta/idx/identify.ts
+++ b/src/server/lib/okta/idx/identify.ts
@@ -6,6 +6,8 @@ import {
 	idxBaseResponseSchema,
 	IdxBaseResponse,
 	challengeAuthenticatorSchema,
+	ExtractLiteralRemediationNames,
+	validateRemediation,
 } from '@/server/lib/okta/idx/shared/schemas';
 
 // schema for the select-authenticator-authenticate object inside the identify response remediation object
@@ -67,3 +69,22 @@ export const identify = (
 		request_id,
 	});
 };
+
+// Type to extract all the remediation names from the challenge/answer response
+type IdentifyRemediationNames = ExtractLiteralRemediationNames<
+	IdentifyResponse['remediation']['value'][number]
+>;
+
+/**
+ * @name validateIdentifyRemediation
+ * @description Validates that the identify response contains a remediation with the given name, throwing an error if it does not. This is useful for ensuring that the remediation we want to perform is available in the identify response, and the state is correct.
+ * @param identifyResponse - The identify response
+ * @param remediationName - The name of the remediation to validate
+ * @param useThrow - Whether to throw an error if the remediation is not found (default: true)
+ * @throws OAuthError - If the remediation is not found in the identify response
+ * @returns boolean | void - Whether the remediation was found in the response
+ */
+export const validateIdentifyRemediation = validateRemediation<
+	IdentifyResponse,
+	IdentifyRemediationNames
+>;

--- a/src/server/lib/okta/idx/introspect.ts
+++ b/src/server/lib/okta/idx/introspect.ts
@@ -1,5 +1,4 @@
 import { z } from 'zod';
-import { OAuthError } from '@/server/models/okta/Error';
 import { InteractResponse } from '@/server/lib/okta/idx/interact';
 import {
 	challengeAnswerRemediations,
@@ -14,6 +13,7 @@ import {
 	baseRemediationValueSchema,
 	idxBaseResponseSchema,
 	ExtractLiteralRemediationNames,
+	validateRemediation,
 } from '@/server/lib/okta/idx/shared/schemas';
 
 // Schema for the 'redirect-idp' object inside the introspect response remediation object
@@ -111,24 +111,11 @@ export type IntrospectRemediationNames = ExtractLiteralRemediationNames<
  * @description Validates that the introspect response contains a remediation with the given name, throwing an error if it does not. This is useful for ensuring that the remediation we want to perform is available in the introspect response, and the state is correct.
  * @param introspectResponse - The introspect response
  * @param remediationName - The name of the remediation to validate
+ * @param useThrow - Whether to throw an error if the remediation is not found (default: true)
  * @throws OAuthError - If the remediation is not found in the introspect response
- * @returns void
+ * @returns boolean | void - Whether the remediation was found in the response
  */
-export const validateIntrospectRemediation = (
-	introspectResponse: IntrospectResponse,
-	remediationName: IntrospectRemediationNames,
-) => {
-	const hasRemediation = introspectResponse.remediation.value.some(
-		({ name }) => name === remediationName,
-	);
-
-	if (!hasRemediation) {
-		throw new OAuthError(
-			{
-				error: 'invalid_request',
-				error_description: `Remediation ${remediationName} not found in introspect response`,
-			},
-			400,
-		);
-	}
-};
+export const validateIntrospectRemediation = validateRemediation<
+	IntrospectResponse,
+	IntrospectRemediationNames
+>;

--- a/src/server/lib/okta/idx/shared/schemas.ts
+++ b/src/server/lib/okta/idx/shared/schemas.ts
@@ -90,6 +90,14 @@ export const authenticatorAnswerSchema = z.array(
 	]),
 );
 
+// schema for the challenge-authenticator object inside the challenge/identify response remediation object
+export const challengeAuthenticatorSchema = baseRemediationValueSchema.merge(
+	z.object({
+		name: z.literal('challenge-authenticator'),
+		value: authenticatorAnswerSchema,
+	}),
+);
+
 // Body type for the credential/enroll and challenge requests to select a given authenticator
 export type AuthenticatorBody = IdxStateHandleBody<{
 	authenticator: {

--- a/src/server/lib/okta/idx/shared/schemas.ts
+++ b/src/server/lib/okta/idx/shared/schemas.ts
@@ -114,3 +114,40 @@ export type ExtractLiteralRemediationNames<T> = T extends { name: infer N }
 			: N
 		: never
 	: never;
+
+/**
+ * @name validateRemediation
+ * @description Validate that the IDX response contains the expected remediation based on the response type and the remediation name.
+ *
+ * Either throws an error or returns a boolean based on the `useThrow` parameter.
+ *
+ * This should not be used directly, but rather through the specific remediation validation functions which are exported from the Okta IDX API function files.
+ *
+ * @param response - The IDX response object (ResponseType)
+ * @param remediationName - The name of the remediation to validate (RemediationNamesType), extracted from the response object and ExtractLiteralRemediationNames
+ * @param useThrow - Whether to throw an error if the remediation is not found (default: true)
+ * @returns boolean | void - Whether the remediation was found in the response
+ */
+export const validateRemediation = <
+	ResponseType extends { remediation: { value: Array<{ name: string }> } },
+	RemediationNamesType extends ExtractLiteralRemediationNames<
+		ResponseType['remediation']['value'][number]
+	>,
+>(
+	response: ResponseType,
+	remediationName: RemediationNamesType,
+	useThrow = true,
+) => {
+	const hasRemediation = response.remediation.value.some(
+		({ name }) => name === remediationName,
+	);
+
+	if (!hasRemediation && useThrow) {
+		throw new Error(
+			// eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+			`IDX response does not contain the expected remediation: ${remediationName}`,
+		);
+	}
+
+	return hasRemediation;
+};

--- a/src/shared/model/Routes.ts
+++ b/src/shared/model/Routes.ts
@@ -37,6 +37,7 @@ export const ValidRoutePathsArray = [
 	'/register/email-sent/resend',
 	'/reset-password',
 	'/reset-password/:token',
+	'/reset-password/code',
 	'/reset-password/complete',
 	'/reset-password/email-sent',
 	'/reset-password/expired',


### PR DESCRIPTION
## What does this change?

- Sets up an `ResetPasswordEmailSentPage` component that displays the correct page based on whether we're using passcodes or the legacy link method
  - If we're using passcodes, as defined by `hasStateHandle` variable, then we show the `PasscodeEmailSent` component
    - If the passcode has already been used, then we show the `PasscodeUsed` component
  - If we're not using passcodes, then we show the `EmailSent` component as previously done
- We also move `challengeAuthenticatorSchema` to `shared/schemas.ts` as it's also needed by the `identifyRemediations` type too
- Finally we refactor the `validate<ENDPOINT>Remediation` methods into a single method called `validateRemediation` which takes type generics
  -  Anything that was previously using the full method definition can just use the types instead, e.g. for `validateChallengeAnswerRemediation` it becomes

```ts
export const validateChallengeAnswerRemediation = validateRemediation<
	ChallengeAnswerResponse,
	ChallengeAnswerRemediationNames
>;
```

instead of

```ts
export const validateChallengeAnswerRemediation = (
	challengeAnswerResponse: ChallengeAnswerResponse,
	remediationName: ChallengeAnswerRemediationNames,
) => {
	const hasRemediation = challengeAnswerResponse.remediation.value.some(
		({ name }) => name === remediationName,
	);

	if (!hasRemediation) {
		throw new OAuthError(
			{
				error: 'invalid_request',
				error_description: `Remediation ${remediationName} not found in challenge/answer response`,
			},
			400,
		);
	}
};
```