### PR TITLE
Passwordless | Passcodes for reset password - ACTIVE users with only "password" authenticator

### DIFF
--- a/src/server/controllers/sendChangePasswordEmail.ts
+++ b/src/server/controllers/sendChangePasswordEmail.ts
@@ -231,7 +231,7 @@ const changePasswordEmailIdx = async (
 						email: user.profile.email,
 						stateHandle: challengeEmailResponse.stateHandle,
 						stateHandleExpiresAt: challengeEmailResponse.expiresAt,
-						userState: 1,
+						userState: 'ACTIVE_EMAIL_PASSWORD',
 					});
 
 					// show the email sent page, with passcode instructions
@@ -353,7 +353,7 @@ const changePasswordEmailIdx = async (
 						email: user.profile.email,
 						stateHandle: challengeEmailResponse.stateHandle,
 						stateHandleExpiresAt: challengeEmailResponse.expiresAt,
-						userState: 2,
+						userState: 'ACTIVE_PASSWORD_ONLY',
 					});
 
 					// show the email sent page, with passcode instructions

--- a/src/server/lib/okta/idx/challenge.ts
+++ b/src/server/lib/okta/idx/challenge.ts
@@ -32,6 +32,7 @@ import { OAuthError } from '@/server/models/okta/Error';
 // list of all possible remediations for the challenge response
 export const challengeRemediations = z.union([
 	challengeAuthenticatorSchema,
+	selectAuthenticationEnrollSchema,
 	baseRemediationValueSchema,
 ]);
 

--- a/src/server/models/Metrics.ts
+++ b/src/server/models/Metrics.ts
@@ -75,6 +75,7 @@ type UnconditionalMetrics =
 	| 'OktaIDX::UnexpectedVersion'
 	| 'OktaIDXSocialSignIn::Redirect'
 	| 'OktaIDXSocialSignIn::Failure'
+	| 'OktaIDXEmailVerificationDisabled'
 	| 'VerifyEmailPage::Accessed'
 	| `${RateLimitMetrics}GatewayRateLimitHit`
 	| `User-${'EmailValidated' | 'EmailNotValidated'}-${

--- a/src/server/models/okta/User.ts
+++ b/src/server/models/okta/User.ts
@@ -130,3 +130,19 @@ const sessionResponseSchema = z.object({
 	status: z.string(),
 });
 export type SessionResponse = z.infer<typeof sessionResponseSchema>;
+
+/**
+ *	@name InternalOktaUserState
+ *	@description Okta IDX API - State of the user in the Okta determines if we can send passcodes to the user when resetting the password
+ *	@values NON_EXISTENT - user doesn't exist - not currently used in any code
+ *	@values ACTIVE_EMAIL_PASSWORD - ACTIVE - user has email + password authenticator (okta idx email verified)
+ *	@values ACTIVE_PASSWORD_ONLY - ACTIVE - user has only password authenticator (okta idx email not verified)
+ *	@values ACTIVE_EMAIL_ONLY - ACTIVE - user has only email authenticator (okta idx email verified) - not currently used in any code
+ *	@values NOT_ACTIVE - user not in ACTIVE state - not currently used in any code
+ */
+export type InternalOktaUserState =
+	| 'NON_EXISTENT'
+	| 'ACTIVE_EMAIL_PASSWORD'
+	| 'ACTIVE_PASSWORD_ONLY'
+	| 'ACTIVE_EMAIL_ONLY'
+	| 'NOT_ACTIVE';

--- a/src/server/routes/resetPassword.ts
+++ b/src/server/routes/resetPassword.ts
@@ -153,9 +153,9 @@ router.post(
 					passcode: code,
 					stateHandle,
 					introspectRemediation:
-						// if the user is in the `2` state, then they are trying enroll the email authenticator
+						// if the user is in the `ACTIVE_PASSWORD_ONLY` state, then they are trying enroll the email authenticator
 						// otherwise they are trying to recover their password, see the comment below for more info
-						encryptedState.userState === 2
+						encryptedState.userState === 'ACTIVE_PASSWORD_ONLY'
 							? 'select-authenticator-enroll'
 							: 'challenge-authenticator',
 					ip: req.ip,
@@ -166,7 +166,7 @@ router.post(
 				// "2. ACTIVE users - has only password authenticator (okta idx email not verified)" state at the
 				// start of the reset password flow, but verify using the `userState` from encrypted state
 				if (isChallengeAnswerCompleteLoginResponse(challengeAnswerResponse)) {
-					if (encryptedState.userState !== 2) {
+					if (encryptedState.userState !== 'ACTIVE_PASSWORD_ONLY') {
 						throw new OAuthError({
 							error: 'invalid_response',
 							error_description:
@@ -174,7 +174,7 @@ router.post(
 						});
 					}
 
-					// if the user was in the `2` state and they were trying to reset their password
+					// if the user was in the `ACTIVE_PASSWORD_ONLY` state and they were trying to reset their password
 					// since they've verified their email using the passcode, we can allow them to set a password
 					// rather than sending them down the reset password flow again to get another passcode
 					// we instead generate a recovery token for them and allow them to set a password right away

--- a/src/shared/model/EncryptedState.ts
+++ b/src/shared/model/EncryptedState.ts
@@ -13,4 +13,12 @@ export interface EncryptedState {
 	stateHandleExpiresAt?: string;
 	// Okta IDX API - Flag to determine if the user has used a passcode
 	passcodeUsed?: boolean;
+	// Okta IDX API - State of the user in the Okta determines if we can send passcodes to the user when resetting the password
+	// 0 - user doesn't exist - not currently used in any code
+	// 1 - ACTIVE - user has email + password authenticator (okta idx email verified)
+	// 2 - ACTIVE - user has only password authenticator (okta idx email not verified)
+	// 3 - ACTIVE - user has only email authenticator (okta idx email verified) - not currently used in any code
+	// 4 - user not in ACTIVE state - not currently used in any code
+	// Only including states that we actually currently set on the EncryptedState cookie
+	userState?: 1 | 2;
 }

--- a/src/shared/model/EncryptedState.ts
+++ b/src/shared/model/EncryptedState.ts
@@ -1,3 +1,4 @@
+import { InternalOktaUserState } from '@/server/models/okta/User';
 import { PersistableQueryParams } from './QueryParams';
 
 export interface EncryptedState {
@@ -14,11 +15,5 @@ export interface EncryptedState {
 	// Okta IDX API - Flag to determine if the user has used a passcode
 	passcodeUsed?: boolean;
 	// Okta IDX API - State of the user in the Okta determines if we can send passcodes to the user when resetting the password
-	// 0 - user doesn't exist - not currently used in any code
-	// 1 - ACTIVE - user has email + password authenticator (okta idx email verified)
-	// 2 - ACTIVE - user has only password authenticator (okta idx email not verified)
-	// 3 - ACTIVE - user has only email authenticator (okta idx email verified) - not currently used in any code
-	// 4 - user not in ACTIVE state - not currently used in any code
-	// Only including states that we actually currently set on the EncryptedState cookie
-	userState?: 1 | 2;
+	userState?: InternalOktaUserState;
 }


### PR DESCRIPTION
In https://github.com/guardian/gateway/pull/2852 we implemented passcodes for reset password for some "ACTIVE" users. Namely the ones with both the "password" and "email" authenticator, and users with just the "email" authenticator.

The next step was to implement this for users who only had the "password" authenticator, this is being completed in this PR.

Here's a reminder of the possible active user states:
1. ACTIVE users - has email + password authenticator (okta idx email verified)
    - Implemented in https://github.com/guardian/gateway/pull/2852 
2. ACTIVE users - has only password authenticator (okta idx email not verified)
    - Implemented in this PR
    - For a user to get into this state, they would have had to NOT verify the passcode, and then reset their password using the classic flow.
3. ACTIVE users - has only email authenticator (SOCIAL users - no password, or passcode only users (not implemented yet))
    - Implemented in https://github.com/guardian/gateway/pull/2852 

This PR adds the ability for users in state 2 to reset their password with an OTP

For these users the following steps would have to be taken when a user wants to reset their password:

1. Call the `dangerouslySetPlaceholderPassword` method in order to set a placeholder password, this will overwrite any password the user had, but should they complete the flow successfully then that should be fine
2. Call `/identify` and use the placeholder password to authenticate
3. Check that we need to set an `email` authenticator
4. If so call the `/credential/enroll` endpoint to send OTP
5. Have the user input the OTP
6. Verify the OTP, this will put the user into ACTIVE State 1
7. Generate a classic Okta Recovery Token, and redirect the user here to set a password, and sign in

## Tested
- [x] CODE