### PR TITLE
Use AsyncLocalStorage to enrich logs with Request information

### DIFF
--- a/src/server/controllers/changePassword.ts
+++ b/src/server/controllers/changePassword.ts
@@ -90,14 +90,11 @@ const oktaIdxApiPasswordHandler = async ({
 				expressRes: res,
 				introspectRemediation,
 				path,
-				request_id: state.requestId,
 				ip: req.ip,
 			});
 		}
 	} catch (error) {
-		logger.error('Okta IDX setPassword failure', error, {
-			request_id: state.requestId,
-		});
+		logger.error('Okta IDX setPassword failure', error);
 
 		trackMetric(changePasswordMetric(path, 'Failure', true));
 
@@ -174,7 +171,6 @@ export const setPasswordController = (
 			// decrypt the recovery token
 			const decryptedRecoveryToken = decryptOktaRecoveryToken({
 				encryptedToken: encryptedRecoveryToken,
-				request_id: res.locals.requestId,
 			});
 			const [recoveryToken, encryptedRegistrationConsents] =
 				decryptedRecoveryToken;
@@ -203,9 +199,6 @@ export const setPasswordController = (
 					logger.error(
 						'Failed to set validation flags in Okta as there was no id',
 						undefined,
-						{
-							request_id: res.locals.requestId,
-						},
 					);
 				}
 
@@ -218,9 +211,6 @@ export const setPasswordController = (
 						logger.error(
 							'Failed to set jobs user name and field in Okta as there was no id',
 							undefined,
-							{
-								request_id: res.locals.requestId,
-							},
 						);
 					}
 				}
@@ -239,7 +229,6 @@ export const setPasswordController = (
 						'SIGN_IN',
 						'web',
 						res.locals.ophanConfig.consentUUID,
-						res.locals.requestId,
 					);
 				}
 
@@ -263,9 +252,7 @@ export const setPasswordController = (
 				throw new OktaError({ message: 'Okta state token missing' });
 			}
 		} catch (error) {
-			logger.error('Okta change password failure', error, {
-				request_id: res.locals.requestId,
-			});
+			logger.error('Okta change password failure', error);
 
 			trackMetric(changePasswordMetric(path, 'Failure'));
 

--- a/src/server/controllers/checkPasswordToken.ts
+++ b/src/server/controllers/checkPasswordToken.ts
@@ -152,7 +152,6 @@ const oktaIdxApiCheckHandler = async ({
 				{
 					stateHandle: encryptedState.stateHandle,
 				},
-				state.requestId,
 				req.ip,
 			);
 
@@ -191,9 +190,6 @@ const oktaIdxApiCheckHandler = async ({
 		logger.error(
 			'IDX API - check state handle token - checkPasswordToken',
 			error,
-			{
-				request_id: state.requestId,
-			},
 		);
 	}
 };
@@ -242,7 +238,6 @@ export const checkTokenInOkta = async (
 		// decrypt the recovery token
 		const decryptedRecoveryToken = decryptOktaRecoveryToken({
 			encryptedToken: token,
-			request_id: state.requestId,
 		});
 		const [recoveryToken] = decryptedRecoveryToken;
 
@@ -333,9 +328,7 @@ export const checkTokenInOkta = async (
 
 		return res.type('html').send(html);
 	} catch (error) {
-		logger.error('Okta validate password token failure', error, {
-			request_id: res.locals.requestId,
-		});
+		logger.error('Okta validate password token failure', error);
 
 		trackMetric('OktaValidatePasswordToken::Failure');
 

--- a/src/server/lib/__tests__/members-data-api/user-attributes.test.ts
+++ b/src/server/lib/__tests__/members-data-api/user-attributes.test.ts
@@ -26,7 +26,6 @@ describe('mdapi#getUserAttributes - OAuth Access Token', () => {
 
 	test('should return user attributes', async () => {
 		const accessToken = '123';
-		const request_id = '456';
 
 		const userAttributesResponse: UserAttributesResponse = {
 			contentAccess: {
@@ -47,14 +46,13 @@ describe('mdapi#getUserAttributes - OAuth Access Token', () => {
 		const response = { ok: true, status: 200, json } as Response;
 		mockedFetch.mockReturnValueOnce(Promise.resolve(response));
 
-		const result = await getUserAttributes({ accessToken, request_id });
+		const result = await getUserAttributes({ accessToken });
 
 		expect(result).toEqual(userAttributesResponse);
 	});
 
 	test('should return undefined if response is not ok', async () => {
 		const accessToken = '123';
-		const request_id = '456';
 
 		const response = {
 			ok: false,
@@ -63,14 +61,13 @@ describe('mdapi#getUserAttributes - OAuth Access Token', () => {
 
 		mockedFetch.mockReturnValueOnce(Promise.resolve(response));
 
-		const result = await getUserAttributes({ accessToken, request_id });
+		const result = await getUserAttributes({ accessToken });
 
 		expect(result).toBeUndefined();
 	});
 
 	test('should return undefined if response is invalid', async () => {
 		const accessToken = '123';
-		const request_id = '456';
 
 		const userAttributesResponse = {
 			contentAccess: {
@@ -88,7 +85,7 @@ describe('mdapi#getUserAttributes - OAuth Access Token', () => {
 		const response = { ok: true, status: 200, json } as Response;
 		mockedFetch.mockReturnValueOnce(Promise.resolve(response));
 
-		const result = await getUserAttributes({ accessToken, request_id });
+		const result = await getUserAttributes({ accessToken });
 
 		expect(result).toBeUndefined();
 	});

--- a/src/server/lib/__tests__/okta/register.test.ts
+++ b/src/server/lib/__tests__/okta/register.test.ts
@@ -108,7 +108,7 @@ const mockedSendResetPasswordEmail = mocked<
 	(params: { to: string; resetPasswordToken: string }) => Promise<boolean>
 >(sendResetPasswordEmail);
 const mockedSendEmailToUnvalidatedUser = mocked<
-	(params: { id: string; email: string }) => Promise<void>
+	(params: { id: string; email: string; appClientId: string }) => Promise<void>
 >(sendEmailToUnvalidatedUser);
 const mockedSendCompleteRegistration = mocked<
 	(params: { to: string; activationToken: string }) => Promise<boolean>

--- a/src/server/lib/__tests__/okta/register.test.ts
+++ b/src/server/lib/__tests__/okta/register.test.ts
@@ -108,12 +108,7 @@ const mockedSendResetPasswordEmail = mocked<
 	(params: { to: string; resetPasswordToken: string }) => Promise<boolean>
 >(sendResetPasswordEmail);
 const mockedSendEmailToUnvalidatedUser = mocked<
-	(params: {
-		id: string;
-		email: string;
-		appClientId: string;
-		request_id: string;
-	}) => Promise<void>
+	(params: { id: string; email: string }) => Promise<void>
 >(sendEmailToUnvalidatedUser);
 const mockedSendCompleteRegistration = mocked<
 	(params: { to: string; activationToken: string }) => Promise<boolean>

--- a/src/server/lib/__tests__/rate-limit/rateLimitMiddleware.test.ts
+++ b/src/server/lib/__tests__/rate-limit/rateLimitMiddleware.test.ts
@@ -134,10 +134,6 @@ describe('rate limiter middleware', () => {
 
 		expect(loggerInfoMock).toHaveBeenLastCalledWith(
 			`RateLimit-Gateway ipBucket email=undefined ip=192.168.2.1 accessToken= identity-gateway GET /register`,
-			undefined,
-			{
-				request_id: expect.any(String),
-			},
 		);
 
 		// 192.168.2.7 should be allowed to make a request.
@@ -188,10 +184,6 @@ describe('rate limiter middleware', () => {
 		// Expect the access token to be truncated so we don't exceed the maximum message size for message.keywords in Kibana.
 		expect(loggerInfoMock).toHaveBeenLastCalledWith(
 			`RateLimit-Gateway accessTokenBucket email=undefined ip=::ffff:127.0.0.1 accessToken=verylo identity-gateway GET /register`,
-			undefined,
-			{
-				request_id: expect.any(String),
-			},
 		);
 
 		// GU_ACCESS_TOKEN=other should be allowed to make a request
@@ -300,10 +292,6 @@ describe('rate limiter middleware', () => {
 
 		expect(loggerInfoMock).toHaveBeenLastCalledWith(
 			`RateLimit-Gateway globalBucket email=undefined ip=::ffff:127.0.0.1 accessToken= identity-gateway GET /reset-password`,
-			undefined,
-			{
-				request_id: expect.any(String),
-			},
 		);
 
 		// Confirm that enabled overridden route: /register is rate limited.
@@ -360,10 +348,6 @@ describe('rate limiter middleware', () => {
 
 		expect(loggerInfoMock).toHaveBeenLastCalledWith(
 			`RateLimit-Gateway emailBucket email=test@test.com ip=::ffff:127.0.0.1 accessToken= identity-gateway POST /reset-password`,
-			undefined,
-			{
-				request_id: expect.any(String),
-			},
 		);
 
 		await request(server).get('/signin').expect(200);

--- a/src/server/lib/__tests__/serverSideLogger.test.ts
+++ b/src/server/lib/__tests__/serverSideLogger.test.ts
@@ -1,0 +1,61 @@
+import { requestContext } from '../middleware/requestContext';
+import { logger } from '../serverSideLogger';
+
+const log = jest.fn();
+jest.mock('winston', () => ({
+	...jest.requireActual('winston'),
+	createLogger: () => ({
+		log: (level: string, message: string, extraFields: object) => {
+			log(level, message, extraFields);
+		},
+	}),
+}));
+
+afterEach(() => {
+	jest.clearAllMocks();
+});
+
+describe('serverSideLogger context', () => {
+	it('returns the correct IP and request ID if context is available', () => {
+		requestContext.run(
+			{
+				requestId: 'request-id',
+				ip: '666.666.666.666',
+			},
+			() => {
+				logger.info('Test message');
+
+				expect(log).toHaveBeenCalledWith('info', 'Test message', {
+					ip: '666.666.666.666',
+					requestId: 'request-id',
+				});
+			},
+		);
+	});
+
+	it('supports extra fields in addition to request ID and IP', () => {
+		requestContext.run(
+			{
+				requestId: 'request-id',
+				ip: '666.666.666.666',
+			},
+			() => {
+				logger.info('Test message', undefined, {
+					extraField: 'extra-field',
+				});
+
+				expect(log).toHaveBeenCalledWith('info', 'Test message', {
+					ip: '666.666.666.666',
+					requestId: 'request-id',
+					extraField: 'extra-field',
+				});
+			},
+		);
+	});
+
+	it('logs sucessfully if context is not available', () => {
+		logger.info('Test message');
+
+		expect(log).toHaveBeenCalledWith('info', 'Test message', {});
+	});
+});

--- a/src/server/lib/deeplink/oktaRecoveryToken.ts
+++ b/src/server/lib/deeplink/oktaRecoveryToken.ts
@@ -44,7 +44,6 @@ export const extractOktaRecoveryToken = (token: string): string => {
 export const addAppPrefixToOktaRecoveryToken = async (
 	token: string,
 	appClientId?: string,
-	request_id?: string,
 ): Promise<string> => {
 	if (!appClientId) {
 		return token;
@@ -62,9 +61,6 @@ export const addAppPrefixToOktaRecoveryToken = async (
 		logger.error(
 			'Error getting app info in addAppPrefixToOktaRecoveryToken',
 			error,
-			{
-				request_id,
-			},
 		);
 		return token;
 	}
@@ -76,19 +72,16 @@ export const addAppPrefixToOktaRecoveryToken = async (
  * @param token string representing the recovery token
  * @param encryptedRegistrationConsents string representing the encrypted registration consents
  * @param appClientId string representing the app client id
- * @param request_id string representing the request id
  * @returns string representing the encrypted recovery token
  */
 export const encryptOktaRecoveryToken = ({
 	token,
 	encryptedRegistrationConsents,
 	appClientId,
-	request_id,
 }: {
 	token: string;
 	encryptedRegistrationConsents?: string;
 	appClientId?: string;
-	request_id?: string;
 }): Promise<string> => {
 	try {
 		const encrypted = encrypt(
@@ -101,16 +94,11 @@ export const encryptOktaRecoveryToken = ({
 		return addAppPrefixToOktaRecoveryToken(
 			base64ToUrlSafeString(encrypted),
 			appClientId,
-			request_id,
 		);
 	} catch (error) {
-		logger.error('Error encrypting token in encryptOktaRecoveryToken', error, {
-			request_id,
-		});
+		logger.error('Error encrypting token in encryptOktaRecoveryToken', error);
 		// if the token cannot be encrypted use token as is
-		return Promise.resolve(
-			addAppPrefixToOktaRecoveryToken(token, appClientId, request_id),
-		);
+		return Promise.resolve(addAppPrefixToOktaRecoveryToken(token, appClientId));
 	}
 };
 
@@ -118,15 +106,12 @@ export const encryptOktaRecoveryToken = ({
  * @name decryptOktaRecoveryToken
  * @description Decrypts an okta recovery token, and optionally also get the encrypted registration consents that are part of a link we send to the user. It can also call extractOktaRecoveryToken to remove a prefix representing an native application from the recovery token. See extractOktaRecoveryToken for more details.
  * @param encryptedToken string representing the encrypted recovery token
- * @param request_id string representing the request id
  * @returns [string] representing the decrypted recovery token
  */
 export const decryptOktaRecoveryToken = ({
 	encryptedToken,
-	request_id,
 }: {
 	encryptedToken: string;
-	request_id?: string;
 }): [recoveryToken: string, encryptedRegistrationConsents?: string] => {
 	try {
 		const token = extractOktaRecoveryToken(encryptedToken);
@@ -140,9 +125,7 @@ export const decryptOktaRecoveryToken = ({
 
 		return [recoveryToken, encryptedRegistrationConsents];
 	} catch (error) {
-		logger.error('Error decrypting token in decryptOktaRecoveryToken', error, {
-			request_id,
-		});
+		logger.error('Error decrypting token in decryptOktaRecoveryToken', error);
 		// if the token cannot be decrypted, it is likely that it is not encrypted
 		return [extractOktaRecoveryToken(encryptedToken)];
 	}

--- a/src/server/lib/encryptedStateCookie.ts
+++ b/src/server/lib/encryptedStateCookie.ts
@@ -69,9 +69,6 @@ export const readEncryptedStateCookie = (
 			`Error parsing cookie with length ${
 				encryptedCookie ? encryptedCookie.length : 'undefined'
 			}`,
-			{
-				request_id: req.get('x-request-id'),
-			},
 		);
 	}
 };

--- a/src/server/lib/idapi/auth.ts
+++ b/src/server/lib/idapi/auth.ts
@@ -31,7 +31,6 @@ const handleError = ({ error, status = 500 }: IDAPIError) => {
 export const exchangeAccessTokenForCookies = async (
 	token: string,
 	ip: string | undefined,
-	request_id?: string,
 ) => {
 	const options = APIPostOptions({
 		token,
@@ -48,9 +47,6 @@ export const exchangeAccessTokenForCookies = async (
 		logger.error(
 			`IDAPI Error auth exchangeAccessTokenForCookies '/auth/oauth-token'`,
 			error,
-			{
-				request_id,
-			},
 		);
 		handleError(error as IDAPIError);
 	}

--- a/src/server/lib/idapi/consentToken.ts
+++ b/src/server/lib/idapi/consentToken.ts
@@ -17,7 +17,6 @@ const handleError = (): never => {
 export const validateConsentToken = async (
 	ip: string | undefined,
 	token: string,
-	request_id?: string,
 ) => {
 	const options = APIAddClientAccessToken(APIPostOptions(), ip);
 	try {
@@ -30,9 +29,6 @@ export const validateConsentToken = async (
 		logger.error(
 			`IDAPI Error validating consent token with route '/consent-email/:token'`,
 			error,
-			{
-				request_id,
-			},
 		);
 		return handleError();
 	}
@@ -41,7 +37,6 @@ export const validateConsentToken = async (
 export const resendConsentEmail = async (
 	ip: string | undefined,
 	token: string,
-	request_id?: string,
 ) => {
 	const options = APIAddClientAccessToken(APIPostOptions(), ip);
 	try {
@@ -54,9 +49,6 @@ export const resendConsentEmail = async (
 		logger.error(
 			`IDAPI Error resending consent email with route '/consent-email/resend/:token'`,
 			error,
-			{
-				request_id,
-			},
 		);
 		return handleError();
 	}

--- a/src/server/lib/idapi/consents.ts
+++ b/src/server/lib/idapi/consents.ts
@@ -38,10 +38,8 @@ const responseToEntity = (consent: ConsentAPIResponse): Consent => {
 
 const read = async ({
 	filter,
-	request_id,
 }: {
 	filter: IdApiQueryParams['filter'];
-	request_id?: string;
 }): Promise<Consent[]> => {
 	const options = APIGetOptions();
 	try {
@@ -55,19 +53,15 @@ const read = async ({
 			})) as ConsentAPIResponse[]
 		).map(responseToEntity);
 	} catch (error) {
-		logger.error(`IDAPI Error consents read '/consents'`, error, {
-			request_id,
-		});
+		logger.error(`IDAPI Error consents read '/consents'`, error);
 		return handleError();
 	}
 };
 
 const readUserConsents = async ({
 	accessToken,
-	request_id,
 }: {
 	accessToken: string;
-	request_id?: string;
 }): Promise<UserConsent[]> => {
 	const options = APIAddOAuthAuthorization(APIGetOptions(), accessToken);
 	try {
@@ -76,9 +70,7 @@ const readUserConsents = async ({
 			options,
 		})) as UserConsent[];
 	} catch (error) {
-		logger.error(`IDAPI Error consents read '/users/me/consents'`, error, {
-			request_id,
-		});
+		logger.error(`IDAPI Error consents read '/users/me/consents'`, error);
 		return handleError();
 	}
 };
@@ -86,11 +78,9 @@ const readUserConsents = async ({
 export const update = async ({
 	payload,
 	accessToken,
-	request_id,
 }: {
 	payload: UserConsent[];
 	accessToken: string;
-	request_id?: string;
 }) => {
 	// Inversion required of four legitimate interest consents that are modelled as opt OUTS in the backend data model
 	// but which are presented as opt INs on the client UI/UX
@@ -107,9 +97,7 @@ export const update = async ({
 		});
 		return;
 	} catch (error) {
-		logger.error(`IDAPI Error consents update  '/users/me/consents'`, error, {
-			request_id,
-		});
+		logger.error(`IDAPI Error consents update  '/users/me/consents'`, error);
 		return handleError();
 	}
 };
@@ -117,19 +105,15 @@ export const update = async ({
 export const getUserConsentsForPage = async ({
 	pageConsents,
 	accessToken,
-	request_id,
 }: {
 	pageConsents: string[];
-	request_id?: string;
 	accessToken: string;
 }): Promise<Consent[]> => {
 	// Inversion required of four legitimate interest consents that are modelled as opt OUTS in the backend data model
 	// but which are presented as opt INs on the client UI/UX
-	const allConsents = invertOptOutConsents(
-		await read({ filter: 'all', request_id }),
-	);
+	const allConsents = invertOptOutConsents(await read({ filter: 'all' }));
 	const userConsents = invertOptOutConsents(
-		await readUserConsents({ accessToken, request_id }),
+		await readUserConsents({ accessToken }),
 	);
 
 	return pageConsents

--- a/src/server/lib/idapi/decryptToken.ts
+++ b/src/server/lib/idapi/decryptToken.ts
@@ -8,7 +8,6 @@ import { logger } from '@/server/lib/serverSideLogger';
 export const decrypt = async (
 	token: string,
 	ip: string | undefined,
-	request_id?: string,
 ): Promise<string | undefined> => {
 	const options = APIGetOptions();
 	try {
@@ -22,9 +21,6 @@ export const decrypt = async (
 		logger.error(
 			`IDAPI Error decryptEmail decrypt '/signin-token/token/:token'`,
 			error,
-			{
-				request_id,
-			},
 		);
 	}
 };

--- a/src/server/lib/idapi/newsletters.ts
+++ b/src/server/lib/idapi/newsletters.ts
@@ -36,7 +36,7 @@ const responseToEntity = (newsletter: NewsletterAPIResponse): NewsLetter => {
 	};
 };
 
-export const read = async (request_id?: string): Promise<NewsLetter[]> => {
+export const read = async (): Promise<NewsLetter[]> => {
 	const options = APIGetOptions();
 	try {
 		return (
@@ -46,9 +46,7 @@ export const read = async (request_id?: string): Promise<NewsLetter[]> => {
 			})) as NewsletterAPIResponse[]
 		).map(responseToEntity);
 	} catch (error) {
-		logger.error(`IDAPI Error newsletters read '/newsletters'`, error, {
-			request_id,
-		});
+		logger.error(`IDAPI Error newsletters read '/newsletters'`, error);
 		return handleError();
 	}
 };
@@ -56,11 +54,9 @@ export const read = async (request_id?: string): Promise<NewsLetter[]> => {
 export const update = async ({
 	accessToken,
 	payload,
-	request_id,
 }: {
 	accessToken: string;
 	payload: NewsletterPatch[];
-	request_id?: string;
 }) => {
 	const options = APIAddOAuthAuthorization(
 		APIPatchOptions(payload),
@@ -77,9 +73,6 @@ export const update = async ({
 		logger.error(
 			`IDAPI Error newsletters update '/users/me/newsletters'`,
 			error,
-			{
-				request_id,
-			},
 		);
 		return handleError();
 	}
@@ -91,11 +84,9 @@ interface Subscription {
 
 export const readUserNewsletters = async ({
 	accessToken,
-	request_id,
 }: {
 	ip?: string;
 	accessToken: string;
-	request_id?: string;
 }) => {
 	const options = APIAddOAuthAuthorization(APIGetOptions(), accessToken);
 
@@ -110,21 +101,12 @@ export const readUserNewsletters = async ({
 		logger.error(
 			`IDAPI Error readUserNewsletters '/users/me/newsletters'`,
 			error,
-			{
-				request_id,
-			},
 		);
 		return handleError();
 	}
 };
 
-export const touchBraze = async ({
-	accessToken,
-	request_id,
-}: {
-	accessToken: string;
-	request_id?: string;
-}) => {
+export const touchBraze = async ({ accessToken }: { accessToken: string }) => {
 	const options = APIAddOAuthAuthorization(APIPostOptions(), accessToken);
 
 	try {
@@ -134,9 +116,7 @@ export const touchBraze = async ({
 		});
 		return;
 	} catch (error) {
-		logger.error(`IDAPI Error touchBraze '/users/me/touch-braze'`, error, {
-			request_id,
-		});
+		logger.error(`IDAPI Error touchBraze '/users/me/touch-braze'`, error);
 		return handleError();
 	}
 };

--- a/src/server/lib/idapi/subscriptions.ts
+++ b/src/server/lib/idapi/subscriptions.ts
@@ -72,7 +72,6 @@ export const makeSubscriptionRequest = async (
 	unsubscribeData: SubscriptionData,
 	token: string,
 	ip: string | undefined,
-	request_id?: string,
 ): Promise<unknown> => {
 	const body = {
 		emailType,
@@ -91,9 +90,6 @@ export const makeSubscriptionRequest = async (
 		logger.error(
 			`IDAPI Error ${subscriptionAction} '/${subscriptionAction}'`,
 			error,
-			{
-				request_id,
-			},
 		);
 		return handleError(subscriptionAction, error as IDAPIError);
 	}
@@ -104,7 +100,6 @@ export const makeUnsubscribeAllRequest = async (
 	unsubscribeData: UnsubscribeAllData,
 	token: string,
 	ip: string | undefined,
-	request_id?: string,
 ) => {
 	const body = {
 		...unsubscribeData,
@@ -119,9 +114,7 @@ export const makeUnsubscribeAllRequest = async (
 			options,
 		});
 	} catch (error) {
-		logger.error(`IDAPI Error '${unsubscribeAllPath}'`, error, {
-			request_id,
-		});
+		logger.error(`IDAPI Error '${unsubscribeAllPath}'`, error);
 
 		throw new IdapiError({ message: 'Unsubscribe all failed', status: 500 });
 	}

--- a/src/server/lib/idapi/unauth.ts
+++ b/src/server/lib/idapi/unauth.ts
@@ -16,7 +16,6 @@ const handleError = ({ status = 500 }: IDAPIError) => {
 export const logoutFromIDAPI = async (
 	sc_gu_u: string,
 	ip: string | undefined,
-	request_id?: string,
 ): Promise<IdapiCookies | undefined> => {
 	const options = APIAddClientAccessToken(APIPostOptions(), ip);
 	// eslint-disable-next-line functional/immutable-data
@@ -32,9 +31,7 @@ export const logoutFromIDAPI = async (
 
 		return response.cookies;
 	} catch (error) {
-		logger.error(`IDAPI Error auth logout '/unauth'`, error, {
-			request_id,
-		});
+		logger.error(`IDAPI Error auth logout '/unauth'`, error);
 		return handleError(error as IDAPIError);
 	}
 };

--- a/src/server/lib/idapi/user.ts
+++ b/src/server/lib/idapi/user.ts
@@ -65,11 +65,7 @@ const responseToEntity = (response: APIResponse): User => {
 	};
 };
 
-export const changeEmail = async (
-	token: string,
-	ip: string | undefined,
-	request_id?: string,
-) => {
+export const changeEmail = async (token: string, ip: string | undefined) => {
 	const options = APIPostOptions({
 		token,
 	});
@@ -79,9 +75,7 @@ export const changeEmail = async (
 			options: APIAddClientAccessToken(options, ip),
 		});
 	} catch (error) {
-		logger.error(`IDAPI Error change email '/user/change-email'`, error, {
-			request_id,
-		});
+		logger.error(`IDAPI Error change email '/user/change-email'`, error);
 		return handleError(error as IDAPIError);
 	}
 };
@@ -89,7 +83,6 @@ export const changeEmail = async (
 export const getUserByEmailAddress = async (
 	email: string,
 	ip: string | undefined,
-	request_id?: string,
 ): Promise<User> => {
 	const options = APIAddClientAccessToken(APIGetOptions(), ip);
 	try {
@@ -101,9 +94,7 @@ export const getUserByEmailAddress = async (
 		})) as APIResponse;
 		return responseToEntity(response);
 	} catch (error) {
-		logger.warn(`IDAPI Error user get '/user?emailAddress'`, error, {
-			request_id,
-		});
+		logger.warn(`IDAPI Error user get '/user?emailAddress'`, error);
 		return handleError(error as IDAPIError);
 	}
 };

--- a/src/server/lib/members-data-api/user-attributes.ts
+++ b/src/server/lib/members-data-api/user-attributes.ts
@@ -20,15 +20,12 @@ const { membersDataApiUrl } = getConfiguration();
  * @name getUserAttributes
  * @description Call members-data-api to get user product information
  *
- * @param request_id optional request id for logging
  * @returns UserAttributesResponse | undefined
  */
 export const getUserAttributes = async ({
 	accessToken,
-	request_id,
 }: {
 	accessToken: string;
-	request_id?: string;
 }): Promise<UserAttributesResponse | undefined> => {
 	try {
 		const path = buildUrl('/user-attributes/me');
@@ -49,8 +46,6 @@ export const getUserAttributes = async ({
 
 		return userAttributesResponseSchema.parse(await response.json());
 	} catch (error) {
-		logger.error(`MDAPI Error getUserAttributes '/user-attributes/me'`, error, {
-			request_id,
-		});
+		logger.error(`MDAPI Error getUserAttributes '/user-attributes/me'`, error);
 	}
 };

--- a/src/server/lib/middleware/errorHandler.ts
+++ b/src/server/lib/middleware/errorHandler.ts
@@ -50,9 +50,7 @@ export const routeErrorHandler = (
 		return next(err);
 	}
 
-	logger.error('unexpected error', err, {
-		request_id: req.get('x-request-id'),
-	});
+	logger.error('unexpected error', err);
 
 	const html = renderer('/error', {
 		requestState: res.locals,

--- a/src/server/lib/middleware/index.ts
+++ b/src/server/lib/middleware/index.ts
@@ -11,12 +11,14 @@ import { default as routes } from '@/server/routes';
 import { routeErrorHandler } from '@/server/lib/middleware/errorHandler';
 import { fourZeroFourMiddleware } from '@/server/lib/middleware/404';
 import { requestIdMiddleware } from './requestId';
+import { requestContextMiddleware } from './requestContext';
 
 const { appSecret, stage } = getConfiguration();
 
 export const applyMiddleware = (server: Express): void => {
 	// add request id middleware
 	server.use(requestIdMiddleware);
+	server.use(requestContextMiddleware);
 	// apply helmet before anything else
 	server.use(helmetMiddleware as RequestHandler);
 	server.use(urlencoded({ extended: true }) as RequestHandler);

--- a/src/server/lib/middleware/logger.ts
+++ b/src/server/lib/middleware/logger.ts
@@ -6,9 +6,6 @@ export const loggerMiddleware = (
 	_: Response,
 	next: NextFunction,
 ) => {
-	logger.info(`${req.method}, ${req.path}`, undefined, {
-		request_id: req.get('x-request-id'),
-		ip: req.ip,
-	});
+	logger.info(`${req.method}, ${req.path}`);
 	next();
 };

--- a/src/server/lib/middleware/rateLimit.ts
+++ b/src/server/lib/middleware/rateLimit.ts
@@ -44,10 +44,6 @@ export const rateLimiterMiddleware = async (
 	if (!ValidRoutePathsArray.includes(routePathDefinition)) {
 		logger.info(
 			`RateLimit falling back to default configuration for unregistered path: ${routePathDefinition}`,
-			undefined,
-			{
-				request_id: res.locals.requestId,
-			},
 		);
 	}
 
@@ -87,10 +83,6 @@ export const rateLimiterMiddleware = async (
 		// We append `-Gateway` so that we can differentiate between IDAPI rate limit log entries.
 		logger.info(
 			`RateLimit-Gateway ${ratelimitBucketTypeIfHit}Bucket email=${rateLimitData.email} ip=${rateLimitData.ip} accessToken=${truncatedAccessToken} identity-gateway ${req.method} ${routePathDefinition}`,
-			undefined,
-			{
-				request_id: res.locals.requestId,
-			},
 		);
 
 		trackMetric(rateLimitHitMetric(ratelimitBucketTypeIfHit));

--- a/src/server/lib/middleware/redirectIfLoggedIn.ts
+++ b/src/server/lib/middleware/redirectIfLoggedIn.ts
@@ -95,10 +95,6 @@ export const redirectIfLoggedIn = async (
 		clearIDAPICookies(res);
 		logger.info(
 			'User attempting to access signed-out-only route had an existing Okta session cookie, but it was invalid',
-			undefined,
-			{
-				request_id: res.locals.requestId,
-			},
 		);
 		//we redirect to /reauthenticate to make sure the cookies has been removed
 		return res.redirect(

--- a/src/server/lib/middleware/requestContext.ts
+++ b/src/server/lib/middleware/requestContext.ts
@@ -1,0 +1,36 @@
+import { NextFunction, Request, Response } from 'express';
+import { AsyncLocalStorage } from 'node:async_hooks';
+
+type LoggerContext = {
+	request: Request;
+	response: Response;
+};
+
+export const requestContext = new AsyncLocalStorage<LoggerContext>();
+
+/**
+ * This middleware handles creating a new context store for each request.
+ *
+ * I recommend only using this store for for logging and debugging,
+ * as relying on it can quickly spiral into hard to refactor and hard to test
+ * spaghetti code.
+ *
+ * @param request - The Request object to be stored in the Store
+ * @param response - The Response object to be stored in the Store
+ * @param next - The next middleware to be called and wrapped in the Stores scope
+ */
+export const requestContextMiddleware = (
+	request: Request,
+	response: Response,
+	next: NextFunction,
+) => {
+	// Express middlewares form a function call chain under the hood, so wrapping one middleware in a Store
+	// will make it available to all subsequent middlewares in the chain.
+	requestContext.run(
+		{
+			request,
+			response,
+		},
+		next,
+	);
+};

--- a/src/server/lib/middleware/requestContext.ts
+++ b/src/server/lib/middleware/requestContext.ts
@@ -1,12 +1,12 @@
 import { NextFunction, Request, Response } from 'express';
 import { AsyncLocalStorage } from 'node:async_hooks';
 
-type LoggerContext = {
-	request: Request;
-	response: Response;
+type RequestContext = {
+	requestId?: string;
+	ip?: string;
 };
 
-export const requestContext = new AsyncLocalStorage<LoggerContext>();
+export const requestContext = new AsyncLocalStorage<RequestContext>();
 
 /**
  * This middleware handles creating a new context store for each request.
@@ -21,15 +21,15 @@ export const requestContext = new AsyncLocalStorage<LoggerContext>();
  */
 export const requestContextMiddleware = (
 	request: Request,
-	response: Response,
+	_: Response,
 	next: NextFunction,
 ) => {
 	// Express middlewares form a function call chain under the hood, so wrapping one middleware in a Store
 	// will make it available to all subsequent middlewares in the chain.
 	requestContext.run(
 		{
-			request,
-			response,
+			requestId: request.get('x-request-id'),
+			ip: request.ip,
 		},
 		next,
 	);

--- a/src/server/lib/middleware/requestState.ts
+++ b/src/server/lib/middleware/requestState.ts
@@ -83,9 +83,7 @@ const getRequestState = async (
 			}
 		}
 	} catch (error) {
-		logger.error('Error getting app info in request state', error, {
-			request_id: req.get('x-request-id'),
-		});
+		logger.error('Error getting app info in request state', error);
 	}
 
 	const encryptedState = readEncryptedStateCookie(req);

--- a/src/server/lib/newsletters.ts
+++ b/src/server/lib/newsletters.ts
@@ -36,16 +36,13 @@ export const NewsletterMap = new Map<GeoLocation | undefined, Newsletters[]>([
 
 export const getUserNewsletterSubscriptions = async ({
 	newslettersOnPage,
-	request_id,
 	accessToken,
 }: {
 	newslettersOnPage: string[];
-	request_id?: string;
 	accessToken: string;
 }): Promise<NewsLetter[]> => {
-	const allNewsletters = await getNewsletters(request_id);
+	const allNewsletters = await getNewsletters();
 	const userNewsletterSubscriptions = await readUserNewsletters({
-		request_id,
 		accessToken,
 	});
 

--- a/src/server/lib/okta/fixProfile.ts
+++ b/src/server/lib/okta/fixProfile.ts
@@ -7,12 +7,10 @@ export const fixOktaProfile = async ({
 	oktaId,
 	email,
 	ip,
-	request_id,
 }: {
 	oktaId: string;
 	email?: string;
 	ip?: string;
-	request_id?: string;
 }): Promise<boolean> => {
 	try {
 		const oktaUser = await getUser(oktaId, ip);
@@ -24,7 +22,7 @@ export const fixOktaProfile = async ({
 		if (!email) {
 			throw new Error(`fixOktaProfile - Email is required to fix Okta profile`);
 		}
-		const idapiUser = await getUserByEmailAddress(email, ip, request_id);
+		const idapiUser = await getUserByEmailAddress(email, ip);
 		if (!idapiUser.id) {
 			throw new Error(`fixOktaProfile - IDAPI profile missing ID`);
 		}

--- a/src/server/lib/okta/idx/challenge.ts
+++ b/src/server/lib/okta/idx/challenge.ts
@@ -68,14 +68,12 @@ export type ChallengeResponse = z.infer<typeof challengeResponseSchema>;
  * @description Okta IDX API/Interaction Code flow - Authenticate with a given authenticator (currently `email` or `password`) for the user.
  * @param stateHandle - The state handle from the `identify`/`introspect` step
  * @param body - The authenticator object, containing the authenticator id and method type
- * @param request_id - The request id
  * @param ip - The ip address
  * @returns	Promise<ChallengeResponse> - The given authenticator challenge response
  */
 export const challenge = (
 	stateHandle: IdxBaseResponse['stateHandle'],
 	body: AuthenticatorBody['authenticator'],
-	request_id?: string,
 	ip?: string,
 ): Promise<ChallengeResponse> => {
 	return idxFetch<ChallengeResponse, AuthenticatorBody>({
@@ -85,7 +83,6 @@ export const challenge = (
 			authenticator: body,
 		},
 		schema: challengeResponseSchema,
-		request_id,
 		ip,
 	});
 };
@@ -245,14 +242,12 @@ type ChallengeAnswerBody = IdxStateHandleBody<{
  *
  * @param stateHandle - The state handle from the previous step
  * @param body - The passcode object, containing the passcode
- * @param request_id - The request id
  * @param ip - The ip address
  * @returns Promise<ChallengeAnswerResponse> - The challenge answer response
  */
 export const challengeAnswer = (
 	stateHandle: IdxBaseResponse['stateHandle'],
 	body: ChallengeAnswerBody['credentials'],
-	request_id?: string,
 	ip?: string,
 ): Promise<ChallengeAnswerResponse | CompleteLoginResponse> => {
 	return idxFetch<
@@ -265,7 +260,6 @@ export const challengeAnswer = (
 			credentials: body,
 		},
 		schema: challengeAnswerResponseSchema.or(completeLoginResponseSchema),
-		request_id,
 		ip,
 	});
 };
@@ -275,13 +269,11 @@ export const challengeAnswer = (
  * @description Okta IDX API/Interaction Code flow - Resend a challenge.
  *
  * @param stateHandle - The state handle from the previous step
- * @param request_id - The request id
  * @param ip - The ip address
  * @returns Promise<ChallengeAnswerResponse> - The challenge answer response
  */
 export const challengeResend = (
 	stateHandle: IdxBaseResponse['stateHandle'],
-	request_id?: string,
 	ip?: string,
 ): Promise<ChallengeAnswerResponse> => {
 	return idxFetch<ChallengeAnswerResponse, IdxStateHandleBody>({
@@ -290,7 +282,6 @@ export const challengeResend = (
 			stateHandle,
 		},
 		schema: challengeAnswerResponseSchema,
-		request_id,
 		ip,
 	});
 };
@@ -304,7 +295,6 @@ export const challengeResend = (
  * @param expressRes - The express response object
  * @param introspectRemediation - The remediation object name to validate the introspect response against
  * @param path - The path of the page
- * @param request_id - The request id
  * @param ip - The ip address
  * @returns Promise<void> - Performs a express redirect
  */
@@ -315,7 +305,6 @@ export const setPasswordAndRedirect = async ({
 	expressRes,
 	introspectRemediation,
 	path,
-	request_id,
 	ip,
 }: {
 	stateHandle: IdxBaseResponse['stateHandle'];
@@ -324,14 +313,12 @@ export const setPasswordAndRedirect = async ({
 	expressRes: ResponseWithRequestState;
 	introspectRemediation: IntrospectRemediationNames;
 	path?: string;
-	request_id?: string;
 	ip?: string;
 }): Promise<void> => {
 	const challengeAnswerResponse = await submitPassword({
 		stateHandle,
 		password,
 		introspectRemediation,
-		requestId: request_id,
 		ip,
 		validateBreachedPassword: true,
 		validatePasswordLength: true,
@@ -354,9 +341,6 @@ export const setPasswordAndRedirect = async ({
 		logger.error(
 			'Failed to set validation flags in Okta as there was no id',
 			undefined,
-			{
-				request_id,
-			},
 		);
 	}
 
@@ -372,10 +356,6 @@ export const setPasswordAndRedirect = async ({
 		} else {
 			logger.error(
 				'Failed to set jobs user name and field in Okta as there was no id',
-				undefined,
-				{
-					request_id,
-				},
 			);
 		}
 	}
@@ -394,7 +374,6 @@ export const setPasswordAndRedirect = async ({
 			'SIGN_IN',
 			'web',
 			expressRes.locals.ophanConfig.consentUUID,
-			expressRes.locals.requestId,
 		);
 	}
 

--- a/src/server/lib/okta/idx/credential.ts
+++ b/src/server/lib/okta/idx/credential.ts
@@ -34,14 +34,12 @@ type CredentialEnrollResponse = z.infer<typeof credentialEnrollResponse>;
  * @description Okta IDX API/Interaction Code flow - Enroll a new credential (currently `email` or `password`) for the user.
  * @param stateHandle - The state handle from the `enroll` step
  * @param body - The authenticator object, containing the authenticator id and method type
- * @param request_id - The request id
  * @param ip - The IP address of the user
  * @returns	Promise<CredentialEnrollResponse> - The credential enroll response
  */
 export const credentialEnroll = (
 	stateHandle: IdxBaseResponse['stateHandle'],
 	body: AuthenticatorBody['authenticator'],
-	request_id?: string,
 	ip?: string,
 ): Promise<CredentialEnrollResponse> => {
 	return idxFetch<CredentialEnrollResponse, AuthenticatorBody>({
@@ -51,7 +49,6 @@ export const credentialEnroll = (
 			authenticator: body,
 		},
 		schema: credentialEnrollResponse,
-		request_id,
 		ip,
 	});
 };

--- a/src/server/lib/okta/idx/enroll.ts
+++ b/src/server/lib/okta/idx/enroll.ts
@@ -40,13 +40,11 @@ type EnrollResponse = z.infer<typeof enrollResponseSchema>;
  * @description Okta IDX API/Interaction Code flow - Use the stateHandle from the `introspect` step to start the enrollment process. This is used when registration a new user. Has to be called before `enrollNewWithEmail`.
  *
  * @param stateHandle - The state handle from the `introspect` step
- * @param request_id - The request id
  * @param ip - The IP address of the user
  * @returns Promise<EnrollResponse> - The enroll response
  */
 export const enroll = (
 	stateHandle: IdxBaseResponse['stateHandle'],
-	request_id?: string,
 	ip?: string,
 ): Promise<EnrollResponse> => {
 	return idxFetch<EnrollResponse, IdxStateHandleBody>({
@@ -55,7 +53,6 @@ export const enroll = (
 			stateHandle,
 		},
 		schema: enrollResponseSchema,
-		request_id,
 		ip,
 	});
 };
@@ -131,14 +128,12 @@ type EnrollNewResponse = z.infer<typeof enrollNewResponseSchema>;
  *
  * @param stateHandle - The state handle from the `enroll`/`introspect` step
  * @param body - The user profile object, containing the email address
- * @param request_id - The request id
  * @param ip - The IP address of the user
  * @returns Promise<EnrollNewResponse> - The enroll new response
  */
 export const enrollNewWithEmail = (
 	stateHandle: IdxBaseResponse['stateHandle'],
 	body: EnrollNewWithEmailBody['userProfile'],
-	request_id?: string,
 	ip?: string,
 ): Promise<EnrollNewResponse> => {
 	return idxFetch<EnrollNewResponse, EnrollNewWithEmailBody>({
@@ -148,7 +143,6 @@ export const enrollNewWithEmail = (
 			userProfile: body,
 		},
 		schema: enrollNewResponseSchema,
-		request_id,
 		ip,
 	});
 };

--- a/src/server/lib/okta/idx/identify.ts
+++ b/src/server/lib/okta/idx/identify.ts
@@ -50,14 +50,12 @@ type IdentifyBody = {
  *
  * @param stateHandle - The state handle from the `introspect` step
  * @param email - The email address of the user
- * @param request_id - The request id
  * @param ip - The IP address of the user
  * @returns Promise<IdentifyResponse> - The identify response
  */
 export const identify = (
 	stateHandle: IdxBaseResponse['stateHandle'],
 	email: string,
-	request_id?: string,
 	ip?: string,
 ): Promise<IdentifyResponse> => {
 	return idxFetch<IdentifyResponse, IdentifyBody>({
@@ -68,7 +66,6 @@ export const identify = (
 			rememberMe: true,
 		},
 		schema: identifyResponseSchema,
-		request_id,
 		ip,
 	});
 };

--- a/src/server/lib/okta/idx/interact.ts
+++ b/src/server/lib/okta/idx/interact.ts
@@ -168,9 +168,7 @@ export const interact = async (
 		return [interactResponse, authState];
 	} catch (error) {
 		trackMetric('OktaIDXInteract::Failure');
-		logger.error('Error - Okta IDX interact:', error, {
-			request_id: res.locals.requestId,
-		});
+		logger.error('Error - Okta IDX interact:', error);
 
 		throw error;
 	}

--- a/src/server/lib/okta/idx/introspect.ts
+++ b/src/server/lib/okta/idx/introspect.ts
@@ -86,20 +86,17 @@ type IntrospectBody =
  * in the flow.
  *
  * @param interactionHandle - The interaction handle returned from the `interact` step
- * @param request_id - The request id
  * @param ip - The IP address of the user
  * @returns Promise<IntrospectResponse> - The introspect response
  */
 export const introspect = (
 	body: IntrospectBody,
-	request_id?: string,
 	ip?: string,
 ): Promise<IntrospectResponse> => {
 	return idxFetch<IntrospectResponse, IntrospectBody>({
 		path: 'introspect',
 		body,
 		schema: introspectResponseSchema,
-		request_id,
 		ip,
 	});
 };

--- a/src/server/lib/okta/idx/recover.ts
+++ b/src/server/lib/okta/idx/recover.ts
@@ -56,13 +56,11 @@ type RecoverResponse = z.infer<typeof recoverResponseSchema>;
  * @name recover
  * @description Okta IDX API/Interaction Code flow - Start password recovery process.
  * @param stateHandle - The state handle from the `identify`/`introspect` step
- * @param request_id - The request id
  * @param ip - The IP address of the user
  * @returns	Promise<RecoverResponse> - The recover response
  */
 export const recover = (
 	stateHandle: IdxBaseResponse['stateHandle'],
-	request_id?: string,
 	ip?: string,
 ): Promise<RecoverResponse> => {
 	return idxFetch<RecoverResponse, IdxStateHandleBody>({
@@ -71,7 +69,6 @@ export const recover = (
 			stateHandle,
 		},
 		schema: recoverResponseSchema,
-		request_id,
 		ip,
 	});
 };

--- a/src/server/lib/okta/idx/shared/idxFetch.ts
+++ b/src/server/lib/okta/idx/shared/idxFetch.ts
@@ -48,7 +48,6 @@ type IDXFetchParams<ResponseType, BodyType> = {
 	path: IDXPath;
 	body: BodyType;
 	schema: z.Schema<ResponseType>;
-	request_id?: string;
 	ip?: string;
 };
 
@@ -90,7 +89,6 @@ const idxFetchBase = async ({
  * @param path - The path to the IDX API endpoint
  * @param body - The body of the request
  * @param schema - The zod schema to validate the response
- * @param request_id - The request id
  * @param ip - The IP address of the user
  * @returns Promise<ResponseType> - The response from the IDX API
  */
@@ -98,7 +96,6 @@ export const idxFetch = async <ResponseType, BodyType>({
 	path,
 	body,
 	schema,
-	request_id,
 	ip,
 }: IDXFetchParams<ResponseType, BodyType>): Promise<ResponseType> => {
 	try {
@@ -115,9 +112,7 @@ export const idxFetch = async <ResponseType, BodyType>({
 		return parsed;
 	} catch (error) {
 		trackMetric(`OktaIDX::${path}::Failure`);
-		logger.error(`Okta IDX ${path}`, error, {
-			request_id,
-		});
+		logger.error(`Okta IDX ${path}`, error);
 		throw error;
 	}
 };

--- a/src/server/lib/okta/idx/shared/submitPasscode.ts
+++ b/src/server/lib/okta/idx/shared/submitPasscode.ts
@@ -16,7 +16,6 @@ import { PasswordFieldErrors } from '@/shared/model/Errors';
 type Params = {
 	stateHandle: string;
 	introspectRemediation: IntrospectRemediationNames;
-	requestId?: string;
 	ip?: string;
 };
 
@@ -27,7 +26,6 @@ type Params = {
  * @param passcode The passcode to submit
  * @param stateHandle The state handle from the `identify`/`introspect` step
  * @param introspectRemediation The remediation object name to validate the introspect response against
- * @param requestId The request id
  * @param ip The IP address of the user
  * @returns Promise<ChallengeAnswerResponse | CompleteLoginResponse> - The challenge answer response
  */
@@ -35,7 +33,6 @@ export const submitPasscode = async ({
 	passcode,
 	stateHandle,
 	introspectRemediation,
-	requestId,
 	ip,
 }: Params & { passcode: string }): Promise<
 	ChallengeAnswerResponse | CompleteLoginResponse
@@ -57,7 +54,6 @@ export const submitPasscode = async ({
 		{
 			stateHandle,
 		},
-		requestId,
 		ip,
 	);
 
@@ -67,7 +63,7 @@ export const submitPasscode = async ({
 	validateIntrospectRemediation(introspectResponse, introspectRemediation);
 
 	// attempt to answer the passcode challenge, if this fails, it falls through to the catch block where we handle the error
-	return challengeAnswer(stateHandle, { passcode }, requestId, ip);
+	return challengeAnswer(stateHandle, { passcode }, ip);
 };
 
 /**
@@ -77,7 +73,6 @@ export const submitPasscode = async ({
  * @param password The password to submit
  * @param stateHandle The state handle from the `identify`/`introspect` step
  * @param introspectRemediation The remediation object name to validate the introspect response against
- * @param requestId The request id
  * @param ip The IP address of the user
  * @returns {Promise<ChallengeAnswerResponse | CompleteLoginResponse>} challengeAnswerResponse - The challenge answer response
  */
@@ -87,7 +82,6 @@ export const submitPassword = async ({
 	introspectRemediation,
 	validateBreachedPassword = false,
 	validatePasswordLength = false,
-	requestId,
 	ip,
 }: Params & {
 	password: string;
@@ -98,7 +92,6 @@ export const submitPassword = async ({
 		{
 			stateHandle,
 		},
-		requestId,
 		ip,
 	);
 
@@ -115,5 +108,5 @@ export const submitPassword = async ({
 		});
 	}
 
-	return challengeAnswer(stateHandle, { passcode: password }, requestId, ip);
+	return challengeAnswer(stateHandle, { passcode: password }, ip);
 };

--- a/src/server/lib/okta/idx/startIdxFlow.ts
+++ b/src/server/lib/okta/idx/startIdxFlow.ts
@@ -24,7 +24,6 @@ type StartIdxFlowParams = {
 		| 'extraData'
 	>;
 	consents?: RegistrationConsents;
-	request_id?: string;
 };
 
 /**
@@ -38,7 +37,6 @@ type StartIdxFlowParams = {
  * @param res - Express response
  * @param authorizationCodeFlowOptions - Subset of the `PerformAuthorizationCodeFlowOptions` used by our standard authorization code flow, namely the parameters needed for authentication
  * @param consents - The registration consents to encrypt and store in the authorization state if they exist
- * @param request_id - The request id
  * @returns Promise<IntrospectResponse>
  */
 export const startIdxFlow = async ({
@@ -51,7 +49,6 @@ export const startIdxFlow = async ({
 		extraData,
 	},
 	consents,
-	request_id,
 }: StartIdxFlowParams): Promise<IntrospectResponse> => {
 	// start the interaction code flow, and get the interaction handle + authState
 	const [{ interaction_handle }, authState] = await interact(req, res, {
@@ -66,7 +63,6 @@ export const startIdxFlow = async ({
 		{
 			interactionHandle: interaction_handle,
 		},
-		request_id,
 		req.ip,
 	);
 

--- a/src/server/lib/okta/openid-connect.ts
+++ b/src/server/lib/okta/openid-connect.ts
@@ -335,9 +335,7 @@ export const setAuthorizationStateCookie = (
 			AuthorizationStateCookieOptions,
 		);
 	} catch (error) {
-		logger.error('setAuthorizationStateCookie Error', error, {
-			request_id: res.locals.requestId,
-		});
+		logger.error('setAuthorizationStateCookie Error', error);
 	}
 };
 
@@ -372,9 +370,7 @@ export const getAuthorizationStateCookie = (
 
 		return null;
 	} catch (error) {
-		logger.error('getAuthorizationStateCookie Error', error, {
-			request_id: req.get('x-request-id'),
-		});
+		logger.error('getAuthorizationStateCookie Error', error);
 		return null;
 	}
 };

--- a/src/server/lib/okta/register.ts
+++ b/src/server/lib/okta/register.ts
@@ -50,7 +50,6 @@ const { okta } = getConfiguration();
 const sendRegistrationEmailByUserState = async ({
 	email,
 	appClientId,
-	request_id,
 	ref,
 	refViewId,
 	loopDetectionFlag = false,
@@ -58,7 +57,6 @@ const sendRegistrationEmailByUserState = async ({
 }: {
 	email: string;
 	appClientId?: string;
-	request_id?: string;
 	loopDetectionFlag?: boolean;
 	ip?: string;
 } & TrackingQueryParams): Promise<UserResponse> => {
@@ -90,7 +88,6 @@ const sendRegistrationEmailByUserState = async ({
 					activationToken: await encryptOktaRecoveryToken({
 						token: tokenResponse.token,
 						appClientId,
-						request_id,
 					}),
 					ref,
 					refViewId,
@@ -131,9 +128,6 @@ const sendRegistrationEmailByUserState = async ({
 						logger.error(
 							'Okta user deactivation failed',
 							error instanceof OktaError ? error.message : error,
-							{
-								request_id,
-							},
 						);
 						throw error;
 					}
@@ -146,7 +140,6 @@ const sendRegistrationEmailByUserState = async ({
 					return sendRegistrationEmailByUserState({
 						email,
 						appClientId,
-						request_id,
 						ref,
 						refViewId,
 						loopDetectionFlag: true,
@@ -157,9 +150,6 @@ const sendRegistrationEmailByUserState = async ({
 				logger.error(
 					'Okta user activation failed',
 					error instanceof OktaError ? error.message : error,
-					{
-						request_id,
-					},
 				);
 
 				// otherwise throw the error to the outer catch block
@@ -194,7 +184,6 @@ const sendRegistrationEmailByUserState = async ({
 					activationToken: await encryptOktaRecoveryToken({
 						token: tokenResponse.token,
 						appClientId,
-						request_id,
 					}),
 					ref,
 					refViewId,
@@ -235,9 +224,6 @@ const sendRegistrationEmailByUserState = async ({
 						logger.error(
 							'Okta user deactivation failed',
 							error instanceof OktaError ? error.message : error,
-							{
-								request_id,
-							},
 						);
 						throw error;
 					}
@@ -250,7 +236,6 @@ const sendRegistrationEmailByUserState = async ({
 					return sendRegistrationEmailByUserState({
 						email,
 						appClientId,
-						request_id,
 						ref,
 						refViewId,
 						loopDetectionFlag: true,
@@ -261,9 +246,6 @@ const sendRegistrationEmailByUserState = async ({
 				logger.error(
 					'Okta user reactivation failed',
 					error instanceof OktaError ? error.message : error,
-					{
-						request_id,
-					},
 				);
 
 				// otherwise throw the error to the outer catch block
@@ -320,7 +302,6 @@ const sendRegistrationEmailByUserState = async ({
 					id,
 					email: user.profile.email,
 					appClientId,
-					request_id,
 					ref,
 					refViewId,
 					ip,
@@ -338,7 +319,6 @@ const sendRegistrationEmailByUserState = async ({
 						activationToken: await encryptOktaRecoveryToken({
 							token: activationToken,
 							appClientId,
-							request_id,
 						}),
 						ref,
 						refViewId,
@@ -385,7 +365,6 @@ const sendRegistrationEmailByUserState = async ({
 				resetPasswordToken: await encryptOktaRecoveryToken({
 					token,
 					appClientId,
-					request_id,
 				}),
 				ref,
 				refViewId,
@@ -422,7 +401,6 @@ export const register = async ({
 	email,
 	registrationLocation,
 	appClientId,
-	request_id,
 	consents,
 	ref,
 	refViewId,
@@ -431,7 +409,6 @@ export const register = async ({
 	email: string;
 	registrationLocation?: RegistrationLocation;
 	appClientId?: string;
-	request_id?: string;
 	consents?: RegistrationConsents;
 	ip?: string;
 } & TrackingQueryParams): Promise<UserResponse> => {
@@ -481,7 +458,6 @@ export const register = async ({
 				token: tokenResponse.token,
 				encryptedRegistrationConsents: encryptedConsents,
 				appClientId,
-				request_id,
 			}),
 			ref,
 			refViewId,
@@ -503,7 +479,6 @@ export const register = async ({
 			return sendRegistrationEmailByUserState({
 				email,
 				appClientId,
-				request_id,
 				ip,
 			});
 		} else {

--- a/src/server/lib/ophan.ts
+++ b/src/server/lib/ophan.ts
@@ -47,7 +47,6 @@ export interface OphanConfig {
  */
 export const parseComponentEventParams = async (
 	componentEventParams: string,
-	request_id?: string,
 ): Promise<ComponentEventParams | undefined> => {
 	try {
 		const parsedQuery = Object.fromEntries(
@@ -61,14 +60,10 @@ export const parseComponentEventParams = async (
 			return componentEventParamsParsed.data;
 		}
 	} catch (error) {
-		logger.warn(`Ophan: Error parsing componentEventParams`, error, {
-			request_id,
-		});
+		logger.warn(`Ophan: Error parsing componentEventParams`, error);
 	}
 
-	logger.warn(`Ophan: Failed to parse componentEventParams`, undefined, {
-		request_id,
-	});
+	logger.warn(`Ophan: Failed to parse componentEventParams`, undefined);
 };
 
 /**
@@ -135,11 +130,7 @@ export const generateOphanComponentEvent = (
  * @param config The ophan configuration for this event
  * @returns void - This is a fire and forget call so no need to wait for a response
  */
-const record = (
-	event: OphanEvent,
-	config: OphanConfig = {},
-	request_id?: string,
-) => {
+const record = (event: OphanEvent, config: OphanConfig = {}) => {
 	const { bwid, consentUUID, viewId } = config;
 
 	if (bwid && viewId) {
@@ -164,10 +155,10 @@ const record = (
 				Cookie: cookie.toString().replace('&', ';'),
 			},
 		}).catch((error) => {
-			logger.warn(`Ophan: Failed to record Ophan event`, error, { request_id });
+			logger.warn(`Ophan: Failed to record Ophan event`, error);
 		});
 	} else {
-		logger.warn(`Ophan: Missing bwid or viewId`, undefined, { request_id });
+		logger.warn(`Ophan: Missing bwid or viewId`, undefined);
 	}
 };
 
@@ -197,11 +188,9 @@ export const sendOphanComponentEventFromQueryParamsServer = async (
 	action: OphanAction,
 	value?: string,
 	consentUUID?: string,
-	request_id?: string,
 ) => {
 	const componentEventParams = await parseComponentEventParams(
 		componentEventParamsQuery,
-		request_id,
 	);
 
 	if (componentEventParams) {
@@ -222,7 +211,6 @@ export const sendOphanComponentEventFromQueryParamsServer = async (
 				config,
 			)} componentEvent ${serialize(componentEvent)} `,
 			undefined,
-			{ request_id },
 		);
 
 		record({ componentEvent }, config);

--- a/src/server/lib/recaptcha.ts
+++ b/src/server/lib/recaptcha.ts
@@ -71,9 +71,6 @@ const handleRecaptcha = async (
 			logger.error(
 				'Problem verifying reCAPTCHA, error response',
 				formattedErrorCodes,
-				{
-					request_id: req.get('x-request-id'),
-				},
 			);
 			return next(recaptchaError);
 		}
@@ -81,9 +78,7 @@ const handleRecaptcha = async (
 		trackMetric('RecaptchaMiddleware::Success');
 		next();
 	} catch (error) {
-		logger.error('Error verifying reCAPTCHA token', error, {
-			request_id: req.get('x-request-id'),
-		});
+		logger.error('Error verifying reCAPTCHA token', error);
 		return next(recaptchaError);
 	}
 };

--- a/src/server/lib/registrationPlatform.ts
+++ b/src/server/lib/registrationPlatform.ts
@@ -37,12 +37,10 @@ export const getRegistrationPlatform = async (
 export const updateRegistrationPlatform = async ({
 	accessToken,
 	appClientId,
-	request_id,
 	ip,
 }: {
 	accessToken: Jwt;
 	appClientId?: string;
-	request_id?: string;
 	ip?: string;
 }): Promise<void> => {
 	if (!accessToken) {
@@ -69,8 +67,6 @@ export const updateRegistrationPlatform = async ({
 			ip,
 		);
 	} catch (error) {
-		logger.error(`Error updating registrationLocation via Okta`, error, {
-			request_id,
-		});
+		logger.error(`Error updating registrationLocation via Okta`, error);
 	}
 };

--- a/src/server/lib/serverSideLogger.ts
+++ b/src/server/lib/serverSideLogger.ts
@@ -30,16 +30,7 @@ class ServerSideLogger extends BaseLogger {
 
 		const extraFieldsWithContext = {
 			...extraFields,
-			...(context
-				? {
-						in_request_context: true,
-						request_id:
-							context.request.headers?.['x-request-id'] ?? 'no-request-id',
-						ip: context.request.ip ?? 'no-ip',
-					}
-				: {
-						in_request_context: false,
-					}),
+			...(context ?? {}),
 		};
 
 		if (

--- a/src/server/lib/serverSideLogger.ts
+++ b/src/server/lib/serverSideLogger.ts
@@ -3,6 +3,7 @@ import { LogLevel } from '@/shared/model/Logger';
 import { createLogger, transports } from 'winston';
 import { formatWithOptions, InspectOptions } from 'util';
 import { BaseLogger, ExtraLogFields } from '@/shared/lib/baseLogger';
+import { requestContext } from './middleware/requestContext';
 
 const winstonLogger = createLogger({
 	transports: [new transports.Console()],
@@ -25,6 +26,22 @@ class ServerSideLogger extends BaseLogger {
 		error?: any,
 		extraFields?: ExtraLogFields,
 	) {
+		const context = requestContext.getStore();
+
+		const extraFieldsWithContext = {
+			...extraFields,
+			...(context
+				? {
+						in_request_context: true,
+						request_id:
+							context.request.headers?.['x-request-id'] ?? 'no-request-id',
+						ip: context.request.ip ?? 'no-ip',
+					}
+				: {
+						in_request_context: false,
+					}),
+		};
+
 		if (
 			error &&
 			typeof error === 'object' &&
@@ -36,18 +53,22 @@ class ServerSideLogger extends BaseLogger {
 				`${formatLogParam(message)} - ${formatLogParam(
 					error.message,
 				)} - ${formatLogParam(error.stack)}`,
-				extraFields,
+				extraFieldsWithContext,
 			);
 		}
 		if (error) {
 			return winstonLogger.log(
 				level,
 				`${formatLogParam(message)} - ${formatLogParam(error)}`,
-				extraFields,
+				extraFieldsWithContext,
 			);
 		}
 
-		return winstonLogger.log(level, `${formatLogParam(message)}`, extraFields);
+		return winstonLogger.log(
+			level,
+			`${formatLogParam(message)}`,
+			extraFieldsWithContext,
+		);
 	}
 }
 

--- a/src/server/lib/unvalidatedEmail.ts
+++ b/src/server/lib/unvalidatedEmail.ts
@@ -10,7 +10,6 @@ type Props = {
 	id: string;
 	email: string;
 	appClientId?: string;
-	request_id?: string;
 	ip?: string;
 } & TrackingQueryParams;
 
@@ -27,7 +26,6 @@ export const sendEmailToUnvalidatedUser = async ({
 	id,
 	email,
 	appClientId,
-	request_id,
 	ref,
 	refViewId,
 	ip,
@@ -43,7 +41,6 @@ export const sendEmailToUnvalidatedUser = async ({
 		resetPasswordToken: await encryptOktaRecoveryToken({
 			token,
 			appClientId,
-			request_id,
 		}),
 		ref,
 		refViewId,

--- a/src/server/lib/updateRegistrationLocation.ts
+++ b/src/server/lib/updateRegistrationLocation.ts
@@ -41,9 +41,6 @@ export const updateRegistrationLocationViaOkta = async (
 		logger.error(
 			`${req.method} ${req.originalUrl} Error updating registrationLocation via Okta`,
 			error,
-			{
-				request_id: req.get('x-request-id'),
-			},
 		);
 	}
 };

--- a/src/server/lib/user-features.ts
+++ b/src/server/lib/user-features.ts
@@ -16,21 +16,17 @@ const domain = `${baseUri.replace('profile.', '').split(':')[0]}`;
  *
  * @param accessToken - the value of the oauth access token if using Okta
  * @param res - the express response object
- * @param requestId - loggable identifier for the request
  */
 export const setUserFeatureCookies = async ({
 	accessToken,
 	res,
-	requestId,
 }: {
 	accessToken: string;
 	res: Response;
-	requestId?: string;
 }): Promise<void> => {
 	// call the members-data-api to get the user's attributes/products if any
 	const userAttributes = await getUserAttributes({
 		accessToken,
-		request_id: requestId,
 	});
 
 	// set the GU_AF1 cookie if the user has the ad-free product

--- a/src/server/routes/agree.ts
+++ b/src/server/routes/agree.ts
@@ -76,9 +76,6 @@ router.get(
 			logger.error(
 				`${req.method} ${req.originalUrl} Error fetching Jobs user in Okta`,
 				error,
-				{
-					request_id: state.requestId,
-				},
 			);
 			// Redirect to /signin if an error occurs when fetching the users' data.
 			return res.redirect(
@@ -121,9 +118,6 @@ router.post(
 			logger.error(
 				`${req.method} ${req.originalUrl} Error updating Jobs user information`,
 				error,
-				{
-					request_id: state.requestId,
-				},
 			);
 			trackMetric('JobsGRSGroupAgree::Failure');
 		} finally {

--- a/src/server/routes/changeEmail.ts
+++ b/src/server/routes/changeEmail.ts
@@ -32,15 +32,13 @@ router.get(
 		const { token } = req.params;
 
 		try {
-			await changeEmail(token, req.ip, res.locals.requestId);
+			await changeEmail(token, req.ip);
 
 			trackMetric('ChangeEmail::Success');
 
 			return res.redirect(303, '/change-email/complete');
 		} catch (error) {
-			logger.error(`${req.method} ${req.originalUrl}  Error`, error, {
-				request_id: res.locals.requestId,
-			});
+			logger.error(`${req.method} ${req.originalUrl}  Error`, error);
 
 			trackMetric('ChangeEmail::Failure');
 

--- a/src/server/routes/consentToken.ts
+++ b/src/server/routes/consentToken.ts
@@ -22,7 +22,7 @@ router.get(
 		const ip = req.ip;
 		const token = req.params.token;
 		try {
-			await validateConsentToken(ip, token, res.locals.requestId);
+			await validateConsentToken(ip, token);
 
 			trackMetric('ConsentToken::Success');
 
@@ -35,9 +35,7 @@ router.get(
 				),
 			);
 		} catch (error) {
-			logger.error(`${req.method} ${req.originalUrl} Error`, error, {
-				request_id: res.locals.requestId,
-			});
+			logger.error(`${req.method} ${req.originalUrl} Error`, error);
 
 			trackMetric('ConsentToken::Failure');
 
@@ -76,13 +74,11 @@ router.post(
 		const ip = req.ip;
 		const { token } = req.body;
 		try {
-			await resendConsentEmail(ip, token, res.locals.requestId);
+			await resendConsentEmail(ip, token);
 
 			trackMetric('ConsentTokenResend::Success');
 		} catch (error) {
-			logger.error(`${req.method} ${req.originalUrl} Error`, error, {
-				request_id: res.locals.requestId,
-			});
+			logger.error(`${req.method} ${req.originalUrl} Error`, error);
 
 			trackMetric('ConsentTokenResend::Failure');
 		} finally {

--- a/src/server/routes/delete.ts
+++ b/src/server/routes/delete.ts
@@ -97,7 +97,6 @@ router.get(
 			// get the user's attributes from the members data api
 			const userAttributes = await getUserAttributes({
 				accessToken: state.oauthState.accessToken.toString(),
-				request_id: state.requestId,
 			});
 
 			// check if the user has a paid product
@@ -202,9 +201,7 @@ router.get(
 
 			return res.type('html').send(html);
 		} catch (error) {
-			logger.error(`${req.method} ${req.originalUrl}  Error`, error, {
-				request_id: state.requestId,
-			});
+			logger.error(`${req.method} ${req.originalUrl}  Error`, error);
 			const { message, status } =
 				error instanceof ApiError ? error : new ApiError();
 
@@ -268,9 +265,7 @@ router.post(
 				confirmationPagePath: '/delete/complete',
 			});
 		} catch (error) {
-			logger.error(`${req.method} ${req.originalUrl}  Error`, error, {
-				request_id: state.requestId,
-			});
+			logger.error(`${req.method} ${req.originalUrl}  Error`, error);
 			if (
 				error instanceof OktaError &&
 				error.name === 'AuthenticationFailedError'
@@ -342,7 +337,6 @@ router.post(
 			await sendEmailToUnvalidatedUser({
 				id: sub,
 				email: user.profile.email,
-				request_id: state.requestId,
 				ip: req.ip,
 			});
 
@@ -354,9 +348,7 @@ router.post(
 				}),
 			);
 		} catch (error) {
-			logger.error(`${req.method} ${req.originalUrl}  Error`, error, {
-				request_id: state.requestId,
-			});
+			logger.error(`${req.method} ${req.originalUrl}  Error`, error);
 			return res.redirect(
 				303,
 				addQueryParamsToPath('/delete', state.queryParams, {

--- a/src/server/routes/resetPassword.ts
+++ b/src/server/routes/resetPassword.ts
@@ -137,7 +137,6 @@ router.get(
 router.post(
 	'/reset-password/code',
 	handleAsyncErrors(async (req: Request, res: ResponseWithRequestState) => {
-		const { requestId } = res.locals;
 		const { code } = req.body;
 
 		const encryptedState = readEncryptedStateCookie(req);
@@ -152,7 +151,7 @@ router.post(
 					passcode: code,
 					stateHandle,
 					introspectRemediation: 'challenge-authenticator',
-					requestId,
+					challengeAnswerRemediation: 'reset-authenticator',
 					ip: req.ip,
 				});
 

--- a/src/server/routes/resetPassword.ts
+++ b/src/server/routes/resetPassword.ts
@@ -151,7 +151,6 @@ router.post(
 					passcode: code,
 					stateHandle,
 					introspectRemediation: 'challenge-authenticator',
-					challengeAnswerRemediation: 'reset-authenticator',
 					ip: req.ip,
 				});
 

--- a/src/server/routes/signIn.ts
+++ b/src/server/routes/signIn.ts
@@ -87,8 +87,7 @@ router.get(
 
 		// first attempt to get email from IDAPI encryptedEmail if it exists
 		const decryptedEmail =
-			encryptedEmail &&
-			(await decrypt(encryptedEmail, req.ip, res.locals.requestId));
+			encryptedEmail && (await decrypt(encryptedEmail, req.ip));
 
 		// followed by the gateway EncryptedState
 		// if it exists
@@ -131,7 +130,6 @@ router.post(
 	handleAsyncErrors(async (req: Request, res: ResponseWithRequestState) => {
 		const {
 			queryParams: { appClientId },
-			requestId: request_id,
 		} = res.locals;
 
 		try {
@@ -163,7 +161,6 @@ router.post(
 				id,
 				email: user.profile.email,
 				appClientId,
-				request_id,
 				ip: req.ip,
 			});
 			setEncryptedStateCookie(res, {
@@ -177,9 +174,7 @@ router.post(
 				}),
 			);
 		} catch (error) {
-			logger.error('Okta unvalidated user resend email failure', error, {
-				request_id: res.locals.requestId,
-			});
+			logger.error('Okta unvalidated user resend email failure', error);
 			return res.type('html').send(
 				renderer('/signin/email-sent', {
 					pageTitle: 'Check Your Inbox',
@@ -205,8 +200,7 @@ router.get(
 
 		// first attempt to get email from IDAPI encryptedEmail if it exists
 		const decryptedEmail =
-			encryptedEmail &&
-			(await decrypt(encryptedEmail, req.ip, res.locals.requestId));
+			encryptedEmail && (await decrypt(encryptedEmail, req.ip));
 
 		// followed by the gateway EncryptedState
 		// if it exists
@@ -233,7 +227,6 @@ router.post(
 	handleAsyncErrors((req: Request, res: ResponseWithRequestState) => {
 		const {
 			queryParams: { appClientId },
-			requestId: request_id,
 		} = res.locals;
 		// if okta feature switch enabled, use okta authentication
 		return oktaSignInController({
@@ -241,7 +234,6 @@ router.post(
 			res,
 			isReauthenticate: true,
 			appClientId,
-			request_id,
 		});
 	}),
 );
@@ -252,7 +244,6 @@ router.post(
 	handleAsyncErrors((req: Request, res: ResponseWithRequestState) => {
 		const {
 			queryParams: { appClientId },
-			requestId: request_id,
 		} = res.locals;
 		// if okta feature switch enabled, use okta authentication
 		return oktaSignInController({
@@ -260,7 +251,6 @@ router.post(
 			res,
 			isReauthenticate: false,
 			appClientId,
-			request_id,
 		});
 	}),
 );
@@ -285,13 +275,11 @@ const oktaSignInController = async ({
 	res,
 	isReauthenticate = false,
 	appClientId,
-	request_id,
 }: {
 	req: Request;
 	res: ResponseWithRequestState;
 	isReauthenticate?: boolean;
 	appClientId?: string;
-	request_id?: string;
 }) => {
 	// get the email and password from the request body
 	const { email = '', password = '' } = req.body;
@@ -314,7 +302,6 @@ const oktaSignInController = async ({
 			logger.info(
 				'User POSTed to /signin with an invalid `idx` session cookie',
 				undefined,
-				{ request_id: res.locals.requestId },
 			);
 		}
 	}
@@ -349,7 +336,6 @@ const oktaSignInController = async ({
 				'SIGN_IN',
 				'web',
 				res.locals.ophanConfig.consentUUID,
-				res.locals.requestId,
 			);
 		}
 
@@ -388,7 +374,6 @@ const oktaSignInController = async ({
 					id: response._embedded.user.id,
 					email: response._embedded.user.profile.login,
 					appClientId,
-					request_id,
 					ip: req.ip,
 				});
 				setEncryptedStateCookie(res, {
@@ -417,9 +402,7 @@ const oktaSignInController = async ({
 	} catch (error) {
 		trackMetric('OktaSignIn::Failure');
 
-		logger.error('Okta authentication error:', error, {
-			request_id: res.locals.requestId,
-		});
+		logger.error('Okta authentication error:', error);
 
 		const { message, status } = oktaSignInControllerErrorHandler(error);
 
@@ -501,7 +484,6 @@ router.get(
 				'SIGN_IN',
 				req.params.social,
 				res.locals.ophanConfig.consentUUID,
-				res.locals.requestId,
 			);
 		}
 
@@ -517,7 +499,6 @@ router.get(
 				{
 					interactionHandle: interaction_handle,
 				},
-				res.locals.requestId,
 				req.ip,
 			);
 
@@ -550,9 +531,7 @@ router.get(
 			}
 		} catch (error) {
 			trackMetric('OktaIDXSocialSignIn::Failure');
-			logger.error('IDX API - Social sign in error:', error, {
-				request_id: res.locals.requestId,
-			});
+			logger.error('IDX API - Social sign in error:', error);
 		}
 
 		// OKTA LEGACY SOCIAL FLOW

--- a/src/server/routes/signOut.ts
+++ b/src/server/routes/signOut.ts
@@ -129,9 +129,7 @@ const signOutFromOktaLocal = async (
 			trackMetric('OktaSignOut::Success');
 		}
 	} catch (error) {
-		logger.error(`${req.method} ${req.originalUrl}  Error`, error, {
-			request_id: res.locals.requestId,
-		});
+		logger.error(`${req.method} ${req.originalUrl}  Error`, error);
 		trackMetric('OktaSignOut::Failure');
 	} finally {
 		//clear okta cookie
@@ -154,14 +152,12 @@ const signOutFromIDAPIGlobal = async (
 		// attempt log out from Identity if we have a SC_GU_U cookie
 		if (sc_gu_u) {
 			// perform the logout from IDAPI
-			await logoutFromIDAPI(sc_gu_u, req.ip, res.locals.requestId);
+			await logoutFromIDAPI(sc_gu_u, req.ip);
 		}
 
 		trackMetric('SignOutGlobal::Success');
 	} catch (error) {
-		logger.error(`${req.method} ${req.originalUrl}  Error`, error, {
-			request_id: res.locals.requestId,
-		});
+		logger.error(`${req.method} ${req.originalUrl}  Error`, error);
 		trackMetric('SignOutGlobal::Failure');
 	} finally {
 		// we want to clear the IDAPI cookies anyway even if there was an
@@ -199,9 +195,7 @@ const signOutFromOktaGlobal = async (
 			trackMetric('OktaSignOutGlobal::Success');
 		}
 	} catch (error) {
-		logger.error(`${req.method} ${req.originalUrl}  Error`, error, {
-			request_id: res.locals.requestId,
-		});
+		logger.error(`${req.method} ${req.originalUrl}  Error`, error);
 		trackMetric('OktaSignOutGlobal::Failure');
 	} finally {
 		//clear okta cookie

--- a/src/server/routes/subscriptions.ts
+++ b/src/server/routes/subscriptions.ts
@@ -51,7 +51,6 @@ const handler = (action: SubscriptionAction) =>
 				subscriptionData,
 				token,
 				req.ip,
-				res.locals.requestId,
 			);
 
 			trackMetric(`${subscriptionActionName(action)}::Success`);
@@ -65,9 +64,7 @@ const handler = (action: SubscriptionAction) =>
 
 			return res.type('html').send(html);
 		} catch (error) {
-			logger.error(`${req.method} ${req.originalUrl}  Error`, error, {
-				request_id: res.locals.requestId,
-			});
+			logger.error(`${req.method} ${req.originalUrl}  Error`, error);
 
 			trackMetric(`${subscriptionActionName(action)}::Failure`);
 
@@ -95,20 +92,13 @@ router.post(
 		try {
 			const subscriptionData = parseUnsubscribeAllData(data);
 
-			await makeUnsubscribeAllRequest(
-				subscriptionData,
-				token,
-				req.ip,
-				res.locals.requestId,
-			);
+			await makeUnsubscribeAllRequest(subscriptionData, token, req.ip);
 
 			trackMetric(`UnsubscribeAll::Success`);
 
 			return res.status(200).send();
 		} catch (error) {
-			logger.error(`${req.method} ${req.originalUrl}  Error`, error, {
-				request_id: res.locals.requestId,
-			});
+			logger.error(`${req.method} ${req.originalUrl}  Error`, error);
 
 			trackMetric(`UnsubscribeAll::Failure`);
 

--- a/src/server/routes/welcome.ts
+++ b/src/server/routes/welcome.ts
@@ -130,7 +130,6 @@ router.post(
 			await updateRegistrationPlatform({
 				accessToken: state.oauthState.accessToken,
 				appClientId: state.queryParams.appClientId,
-				request_id: state.requestId,
 				ip: req.ip,
 			});
 
@@ -142,7 +141,6 @@ router.post(
 					await updateConsents({
 						accessToken: state.oauthState.accessToken.toString(),
 						payload: registrationConsents.consents,
-						request_id: state.requestId,
 					});
 
 					// since the CODE newsletters API isn't up to date with PROD newsletters API the
@@ -161,9 +159,6 @@ router.post(
 						{
 							error,
 						},
-						{
-							request_id: state.requestId,
-						},
 					);
 				}
 			}
@@ -173,7 +168,6 @@ router.post(
 					await updateNewsletters({
 						accessToken: state.oauthState.accessToken.toString(),
 						payload: registrationConsents.newsletters,
-						request_id: state.requestId,
 					});
 					// since the CODE newsletters API isn't up to date with PROD newsletters API the
 					// review page will not show the correct newsletters on CODE.
@@ -191,17 +185,12 @@ router.post(
 						{
 							error,
 						},
-						{
-							request_id: state.requestId,
-						},
 					);
 				}
 			}
 		} catch (error) {
 			// we don't want to block the user at this point, so we'll just log the error, and go to the finally block
-			logger.error(`${req.method} ${req.originalUrl}  Error`, error, {
-				request_id: state.requestId,
-			});
+			logger.error(`${req.method} ${req.originalUrl}  Error`, error);
 		} finally {
 			// otherwise redirect the user to the review page
 			// eslint-disable-next-line no-unsafe-finally -- we want to redirect and return regardless of any throws
@@ -279,7 +268,6 @@ router.get(
 			const consentsData = {
 				consents: await getUserConsentsForPage({
 					pageConsents: CONSENTS_DATA_PAGE,
-					request_id: state.requestId,
 					accessToken: state.oauthState.accessToken.toString(),
 				}),
 			};
@@ -292,9 +280,7 @@ router.get(
 
 			trackMetric('NewAccountReview::Success');
 		} catch (error) {
-			logger.error(`${req.method} ${req.originalUrl}  Error`, error, {
-				request_id: state.requestId,
-			});
+			logger.error(`${req.method} ${req.originalUrl}  Error`, error);
 
 			const { message } = error instanceof ApiError ? error : new ApiError();
 
@@ -331,7 +317,6 @@ router.get(
 		const geolocation = state.pageData.geolocation;
 		const newsletters = await getUserNewsletterSubscriptions({
 			newslettersOnPage: NewsletterMap.get(geolocation) as string[],
-			request_id: state.requestId,
 			accessToken: state.oauthState.accessToken.toString(),
 		});
 
@@ -379,15 +364,12 @@ router.post(
 			await patchConsents({
 				accessToken: state.oauthState.accessToken.toString(),
 				payload: consents,
-				request_id: state.requestId,
 			});
 
 			trackMetric('NewAccountReviewSubmit::Success');
 		} catch (error) {
 			// Never block the user at this point, so we'll just log the error
-			logger.error(`${req.method} ${req.originalUrl}  Error`, error, {
-				request_id: state.requestId,
-			});
+			logger.error(`${req.method} ${req.originalUrl}  Error`, error);
 
 			trackMetric('NewAccountReviewSubmit::Failure');
 		} finally {
@@ -419,7 +401,6 @@ router.post(
 		try {
 			const userNewsletterSubscriptions = await getUserNewsletterSubscriptions({
 				newslettersOnPage: ALL_NEWSLETTER_IDS,
-				request_id: state.requestId,
 				accessToken: state.oauthState.accessToken.toString(),
 			});
 
@@ -454,7 +435,6 @@ router.post(
 				);
 
 			await updateNewsletters({
-				request_id: state.requestId,
 				accessToken: state.oauthState.accessToken.toString(),
 				payload: newsletterSubscriptionsToUpdate,
 			});
@@ -462,9 +442,7 @@ router.post(
 			trackMetric('NewAccountNewslettersSubmit::Success');
 		} catch (error) {
 			// Never block the user at this point, so we'll just log the error
-			logger.error(`${req.method} ${req.originalUrl}  Error`, error, {
-				request_id: state.requestId,
-			});
+			logger.error(`${req.method} ${req.originalUrl}  Error`, error);
 			trackMetric('NewAccountNewslettersSubmit::Failure');
 		} finally {
 			// eslint-disable-next-line no-unsafe-finally -- we want to redirect and return regardless of any throws
@@ -500,7 +478,6 @@ const OktaResendEmail = async (req: Request, res: ResponseWithRequestState) => {
 			const user = await register({
 				email,
 				appClientId: state.queryParams.appClientId,
-				request_id: state.requestId,
 				ip: req.ip,
 			});
 
@@ -519,9 +496,7 @@ const OktaResendEmail = async (req: Request, res: ResponseWithRequestState) => {
 				message: 'Could not resend welcome email as email was undefined',
 			});
 	} catch (error) {
-		logger.error('Okta Registration resend email failure', error, {
-			request_id: state.requestId,
-		});
+		logger.error('Okta Registration resend email failure', error);
 
 		trackMetric('OktaWelcomeResendEmail::Failure');
 

--- a/src/shared/lib/baseLogger.ts
+++ b/src/shared/lib/baseLogger.ts
@@ -2,8 +2,8 @@
 import { LogLevel, Logger } from '@/shared/model/Logger';
 
 export interface ExtraLogFields {
-	request_id?: string;
-	ip?: string;
+	request_id?: never;
+	ip?: never;
 	[key: string]: any;
 }
 


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Uses Node's somewhat newish [`AsyncLocalStorage`](https://nodejs.org/api/async_context.html#class-asynclocalstorage) (its been Stable since Node 16) to make Request and Response information implicitly available to the logger. For those used to the Scala world this is somewhat like the `implicit` keyword, and for those used to the React world this is somewhat similar to [`useContext`](https://www.w3schools.com/react/react_usecontext.asp) hook.

This allows us to attach information about the request to every log message without having to pass parameters such as `request_id` all the way down the call tree.

In addition to logging the `request_id` I've also started logging the the user IP, which was started in https://github.com/guardian/gateway/pull/2882 but only done on the request logger messages.


## How it works

The way this works is that you create a AsyncLocalStorage instance and invoke the `run` function to create a new "store", any code that is ran inside the run function is then able to access said store.

```js
const state = new AsyncLocalStorage<string>();

state.run("Hello World!", () => {
    setTimeout(() => {
        // Logs "Hello World!"
        console.log(state.getStore());
   }, 5000);
});
```

The coolest feature of `AsyncLocalStorage` is that promises that run asynchronously within the `run` context are also able to access the same context. This is great for us as it means we can create a "store" for each request.

As we use Express all we need to do is create a new middleware which instantiates a `AsyncLocalStorage` and calls `run` with the `next` middleware as the target. Since under the hood Express middlewares form a chain of function calls, as long as 1 middleware has access to the store all of the following middlewares will also get access to the same store.

## What we should probably avoid

Using implicit context can quickly make refactoring and testing a nightmare, as functions that use `context` essentially have hidden parameters now that can make their behaviour unpredictable when not used in the correct scope.

Because of this I suggest we only use `context` for paths that are not business critical, for example logging and _potentially_ error pages/messages (@pvighi could be helpful for some of your work?). 

For example, for Okta IP rate limiting we could get the IP from the request context but since this is a business critical path we should probably just pass the IP down the call tree explicitly to make it clear how and where it is being used.

## How to Test

Ran in CODE.

![image](https://github.com/user-attachments/assets/4e994b64-73d9-4d7a-839f-5c391d04c7ca)


## Previous Work

We previously started using AsyncLocalStorage in DCR for logging: https://github.com/guardian/dotcom-rendering/pull/7670

## How to review

The core part of this PR, where the request context is implemented, can be found in https://github.com/guardian/gateway/pull/2890/commits/eef49518f0602ac970c6dd3e9b2bb62cb75445b0

The following commit is mostly just removing `request_id` from the call tree.
