### PR TITLE
Passwordless | YMIAR (Yet more IDX API Refactors)

### DIFF
--- a/cypress/integration/mocked/resendEmailController.3.cy.ts
+++ b/cypress/integration/mocked/resendEmailController.3.cy.ts
@@ -46,7 +46,6 @@ userStatuses.forEach((status) => {
 				// env variable to be set, otherwise it won't be able to read the cookie.
 				cy.setEncryptedStateCookie({
 					email: 'example@example.com',
-					status: String(status),
 				});
 				cy.visit(`/register/email-sent`);
 			});
@@ -174,7 +173,6 @@ userStatuses.forEach((status) => {
 				// env variable to be set, otherwise it won't be able to read the cookie.
 				cy.setEncryptedStateCookie({
 					email: 'example@example.com',
-					status: String(status),
 				});
 				cy.visit(`/welcome/email-sent`);
 			});

--- a/cypress/integration/mocked/resetPasswordController.4.cy.ts
+++ b/cypress/integration/mocked/resetPasswordController.4.cy.ts
@@ -134,7 +134,6 @@ userStatuses.forEach((status) => {
 				// env variable to be set, otherwise it won't be able to read the cookie.
 				cy.setEncryptedStateCookie({
 					email: 'example@example.com',
-					status: String(status),
 				});
 				cy.visit(`/reset-password/email-sent`);
 			});
@@ -354,7 +353,6 @@ userStatuses.forEach((status) => {
 				// env variable to be set, otherwise it won't be able to read the cookie.
 				cy.setEncryptedStateCookie({
 					email: 'example@example.com',
-					status: String(status),
 				});
 				cy.visit(`/set-password/email-sent`);
 			});

--- a/src/client/pages/ResetPasswordEmailSentPage.tsx
+++ b/src/client/pages/ResetPasswordEmailSentPage.tsx
@@ -52,7 +52,7 @@ export const ResetPasswordEmailSentPage = () => {
 			email={email}
 			queryString={queryString}
 			changeEmailPage={buildUrl('/reset-password')}
-			resendEmailAction={buildUrl('/register/email-sent/resend')}
+			resendEmailAction={buildUrl('/reset-password/resend')}
 			instructionContext="verify and complete creating your account"
 			showSuccess={emailSentSuccess}
 			errorMessage={error}

--- a/src/server/lib/__tests__/okta/idx/validateRemediation.test.ts
+++ b/src/server/lib/__tests__/okta/idx/validateRemediation.test.ts
@@ -1,11 +1,17 @@
 import {
+	ChallengeResponse,
+	validateChallengeRemediation,
+} from '@/server/lib/okta/idx/challenge';
+import {
 	ExtractLiteralRemediationNames,
 	validateRemediation,
 } from '@/server/lib/okta/idx/shared/schemas';
 
 // mocked configuration
 jest.mock('@/server/lib/getConfiguration', () => ({
-	getConfiguration: () => ({}),
+	getConfiguration: () => ({
+		baseUri: 'localhost',
+	}),
 }));
 
 // mocked logger
@@ -117,5 +123,401 @@ describe('okta#idx#validateRemediation', () => {
 				false,
 			),
 		).toBe(false);
+	});
+});
+
+const responseWithPassword: ChallengeResponse = {
+	expiresAt: '2024-09-11T14:03:26.000Z',
+	stateHandle: 'stateHandle',
+	version: '1.0.0',
+	remediation: {
+		type: 'array',
+		value: [
+			{
+				name: 'challenge-authenticator',
+				value: [
+					{
+						name: 'credentials',
+						form: {
+							value: [{ name: 'passcode' }],
+						},
+					},
+					{
+						name: 'stateHandle',
+					},
+				],
+			},
+		],
+	},
+	currentAuthenticatorEnrollment: {
+		type: 'object',
+		value: {
+			type: 'password',
+			recover: {
+				name: 'recover',
+			},
+		},
+	},
+};
+
+const responseWithEmail: ChallengeResponse = {
+	expiresAt: '2024-09-11T14:03:26.000Z',
+	stateHandle: 'stateHandle',
+	version: '1.0.0',
+	remediation: {
+		type: 'array',
+		value: [
+			{
+				name: 'challenge-authenticator',
+				value: [
+					{
+						name: 'credentials',
+						form: {
+							value: [{ name: 'passcode' }],
+						},
+					},
+					{
+						name: 'stateHandle',
+					},
+				],
+			},
+		],
+	},
+	currentAuthenticatorEnrollment: {
+		type: 'object',
+		value: {
+			type: 'email',
+			resend: {
+				name: 'resend',
+			},
+		},
+	},
+};
+
+describe('okta#idx#validateChallengeRemediation', () => {
+	test('should validate the remediation object of a given ChallengeResponse', () => {
+		expect(
+			validateChallengeRemediation(
+				responseWithPassword,
+				'challenge-authenticator',
+				'password',
+				true,
+			),
+		).toBe(true);
+	});
+
+	test('should throw an error if the remediation object is not found in the response', () => {
+		expect(() =>
+			validateChallengeRemediation(
+				responseWithPassword,
+				'select-authenticator-enroll' as 'challenge-authenticator', // hack to test the error
+				'password',
+				true,
+			),
+		).toThrow(
+			'IDX response does not contain the expected remediation: select-authenticator-enroll',
+		);
+	});
+
+	test('should return true if the remediation object is found in the response and useThrow is false', () => {
+		expect(
+			validateChallengeRemediation(
+				responseWithPassword,
+				'challenge-authenticator',
+				'password',
+				true,
+				false,
+			),
+		).toBe(true);
+	});
+
+	test('should return false if the remediation object is not found in the response and useThrow is false', () => {
+		expect(
+			validateChallengeRemediation(
+				responseWithPassword,
+				'select-authenticator-enroll' as 'challenge-authenticator', // hack to test the error
+				'password',
+				true,
+				false,
+			),
+		).toBe(false);
+	});
+
+	test('should throw if authenticator type is not in the remediation object', () => {
+		expect(() =>
+			validateChallengeRemediation(
+				responseWithPassword,
+				'challenge-authenticator',
+				'email',
+				true,
+			),
+		).toThrow(
+			'The challenge response does not contain the expected email authenticator',
+		);
+
+		expect(() =>
+			validateChallengeRemediation(
+				responseWithEmail,
+				'challenge-authenticator',
+				'password',
+				true,
+			),
+		).toThrow(
+			'The challenge response does not contain the expected password authenticator',
+		);
+	});
+
+	test('should return false if authenticator type is not in the remediation object and useThrow is false', () => {
+		expect(
+			validateChallengeRemediation(
+				responseWithPassword,
+				'challenge-authenticator',
+				'email',
+				true,
+				false,
+			),
+		).toBe(false);
+
+		expect(
+			validateChallengeRemediation(
+				responseWithEmail,
+				'challenge-authenticator',
+				'password',
+				true,
+				false,
+			),
+		).toBe(false);
+	});
+
+	test('should throw if checkForResendOrRecover fails to match authenticator', () => {
+		const responseWithPassword: ChallengeResponse = {
+			expiresAt: '2024-09-11T14:03:26.000Z',
+			stateHandle: 'stateHandle',
+			version: '1.0.0',
+			remediation: {
+				type: 'array',
+				value: [
+					{
+						name: 'challenge-authenticator',
+						value: [
+							{
+								name: 'credentials',
+								form: {
+									value: [{ name: 'passcode' }],
+								},
+							},
+							{
+								name: 'stateHandle',
+							},
+						],
+					},
+				],
+			},
+			currentAuthenticatorEnrollment: {
+				type: 'object',
+				value: {
+					type: 'password',
+					// @ts-expect-error - hack to test the error
+					resend: {
+						name: 'resend',
+					},
+				},
+			},
+		};
+
+		const responseWithEmail: ChallengeResponse = {
+			expiresAt: '2024-09-11T14:03:26.000Z',
+			stateHandle: 'stateHandle',
+			version: '1.0.0',
+			remediation: {
+				type: 'array',
+				value: [
+					{
+						name: 'challenge-authenticator',
+						value: [
+							{
+								name: 'credentials',
+								form: {
+									value: [{ name: 'passcode' }],
+								},
+							},
+							{
+								name: 'stateHandle',
+							},
+						],
+					},
+				],
+			},
+			currentAuthenticatorEnrollment: {
+				type: 'object',
+				value: {
+					type: 'email',
+					// @ts-expect-error - hack to test the error
+					recover: {
+						name: 'recover',
+					},
+				},
+			},
+		};
+
+		expect(() =>
+			validateChallengeRemediation(
+				responseWithPassword,
+				'challenge-authenticator',
+				'password',
+				true,
+			),
+		).toThrow(
+			'The challenge response does not contain the expected recover functionality for the password authenticator',
+		);
+
+		expect(() =>
+			validateChallengeRemediation(
+				responseWithEmail,
+				'challenge-authenticator',
+				'email',
+				true,
+			),
+		).toThrow(
+			'The challenge response does not contain the expected resend functionality for the email authenticator',
+		);
+	});
+
+	test('should return false if checkForResendOrRecover fails to match authenticator and useThrow is false', () => {
+		const responseWithPassword: ChallengeResponse = {
+			expiresAt: '2024-09-11T14:03:26.000Z',
+			stateHandle: 'stateHandle',
+			version: '1.0.0',
+			remediation: {
+				type: 'array',
+				value: [
+					{
+						name: 'challenge-authenticator',
+						value: [
+							{
+								name: 'credentials',
+								form: {
+									value: [{ name: 'passcode' }],
+								},
+							},
+							{
+								name: 'stateHandle',
+							},
+						],
+					},
+				],
+			},
+			currentAuthenticatorEnrollment: {
+				type: 'object',
+				value: {
+					type: 'password',
+					// @ts-expect-error - hack to test the error
+					resend: {
+						name: 'resend',
+					},
+				},
+			},
+		};
+
+		const responseWithEmail: ChallengeResponse = {
+			expiresAt: '2024-09-11T14:03:26.000Z',
+			stateHandle: 'stateHandle',
+			version: '1.0.0',
+			remediation: {
+				type: 'array',
+				value: [
+					{
+						name: 'challenge-authenticator',
+						value: [
+							{
+								name: 'credentials',
+								form: {
+									value: [{ name: 'passcode' }],
+								},
+							},
+							{
+								name: 'stateHandle',
+							},
+						],
+					},
+				],
+			},
+			currentAuthenticatorEnrollment: {
+				type: 'object',
+				value: {
+					type: 'email',
+					// @ts-expect-error - hack to test the error
+					recover: {
+						name: 'recover',
+					},
+				},
+			},
+		};
+
+		expect(
+			validateChallengeRemediation(
+				responseWithPassword,
+				'challenge-authenticator',
+				'password',
+				true,
+				false,
+			),
+		).toBe(false);
+
+		expect(
+			validateChallengeRemediation(
+				responseWithEmail,
+				'challenge-authenticator',
+				'email',
+				true,
+				false,
+			),
+		).toBe(false);
+	});
+
+	test('should skip checkForResendOrRecover if set to false', () => {
+		const responseWithPassword: ChallengeResponse = {
+			expiresAt: '2024-09-11T14:03:26.000Z',
+			stateHandle: 'stateHandle',
+			version: '1.0.0',
+			remediation: {
+				type: 'array',
+				value: [
+					{
+						name: 'challenge-authenticator',
+						value: [
+							{
+								name: 'credentials',
+								form: {
+									value: [{ name: 'passcode' }],
+								},
+							},
+							{
+								name: 'stateHandle',
+							},
+						],
+					},
+				],
+			},
+			currentAuthenticatorEnrollment: {
+				type: 'object',
+				value: {
+					type: 'password',
+					// @ts-expect-error - hack to test the error
+					resend: {
+						name: 'resend',
+					},
+				},
+			},
+		};
+
+		expect(
+			validateChallengeRemediation(
+				responseWithPassword,
+				'challenge-authenticator',
+				'password',
+				false,
+			),
+		).toBe(true);
 	});
 });

--- a/src/server/lib/okta/dangerouslySetPlaceholderPassword.ts
+++ b/src/server/lib/okta/dangerouslySetPlaceholderPassword.ts
@@ -14,11 +14,14 @@ import { dangerouslyResetPassword } from './api/users';
  * After these operations, we can send the user a password reset email.
  * @param id The Okta user ID
  * @param id The IP address of the user
+ * @param returnPlaceholderPassword If true, return the placeholder password
+ * @returns The placeholder password if returnPlaceholderPassword is true, otherwise void (undefined)
  */
 const dangerouslySetPlaceholderPassword = async (
 	id: string,
 	ip?: string,
-): Promise<void> => {
+	returnPlaceholderPassword = false,
+): Promise<string | void> => {
 	try {
 		// Generate an recoveryToken OTT and put user into RECOVERY state
 		const recoveryToken = await dangerouslyResetPassword(id, ip);
@@ -35,13 +38,18 @@ const dangerouslySetPlaceholderPassword = async (
 			});
 		}
 		// Set the placeholder password as a cryptographically secure UUID
+		const placeholderPassword = crypto.randomUUID();
 		await resetPassword(
 			{
 				stateToken,
-				newPassword: crypto.randomUUID(),
+				newPassword: placeholderPassword,
 			},
 			ip,
 		);
+
+		if (returnPlaceholderPassword) {
+			return placeholderPassword;
+		}
 	} catch (error) {
 		logger.error(
 			`dangerouslySetPlaceholderPassword failed: Error setting placeholder password for user ${id}`,

--- a/src/server/lib/okta/idx/challenge.ts
+++ b/src/server/lib/okta/idx/challenge.ts
@@ -141,7 +141,7 @@ export type ChallengeAnswerResponse = z.infer<
 >;
 
 // Body type for the challenge/answer request - passcode can refer to a OTP code or a password
-type ChallengeAnswerPasswordBody = IdxStateHandleBody<{
+type ChallengeAnswerBody = IdxStateHandleBody<{
 	credentials: {
 		passcode: string;
 	};
@@ -157,13 +157,13 @@ type ChallengeAnswerPasswordBody = IdxStateHandleBody<{
  * @param ip - The ip address
  * @returns Promise<ChallengeAnswerResponse> - The challenge answer response
  */
-export const challengeAnswerPasscode = (
+export const challengeAnswer = (
 	stateHandle: IdxBaseResponse['stateHandle'],
-	body: ChallengeAnswerPasswordBody['credentials'],
+	body: ChallengeAnswerBody['credentials'],
 	request_id?: string,
 	ip?: string,
 ): Promise<ChallengeAnswerResponse> => {
-	return idxFetch<ChallengeAnswerResponse, ChallengeAnswerPasswordBody>({
+	return idxFetch<ChallengeAnswerResponse, ChallengeAnswerBody>({
 		path: 'challenge/answer',
 		body: {
 			stateHandle,
@@ -220,7 +220,7 @@ export const setPasswordAndRedirect = async ({
 	ip,
 }: {
 	stateHandle: IdxBaseResponse['stateHandle'];
-	body: ChallengeAnswerPasswordBody['credentials'];
+	body: ChallengeAnswerBody['credentials'];
 	expressReq: Request;
 	expressRes: ResponseWithRequestState;
 	path?: string;
@@ -228,7 +228,7 @@ export const setPasswordAndRedirect = async ({
 	ip?: string;
 }): Promise<void> => {
 	const [completionResponse, redirectUrl] =
-		await idxFetchCompletion<ChallengeAnswerPasswordBody>({
+		await idxFetchCompletion<ChallengeAnswerBody>({
 			path: 'challenge/answer',
 			body: {
 				stateHandle,

--- a/src/server/lib/okta/idx/challenge.ts
+++ b/src/server/lib/okta/idx/challenge.ts
@@ -8,6 +8,8 @@ import { setupJobsUserInOkta } from '@/server/lib/jobs';
 import { trackMetric } from '@/server/lib/trackMetric';
 import { sendOphanComponentEventFromQueryParamsServer } from '@/server/lib/ophan';
 import {
+	CompleteLoginResponse,
+	completeLoginResponseSchema,
 	idxFetch,
 	idxFetchCompletion,
 } from '@/server/lib/okta/idx/shared/idxFetch';
@@ -162,14 +164,17 @@ export const challengeAnswer = (
 	body: ChallengeAnswerBody['credentials'],
 	request_id?: string,
 	ip?: string,
-): Promise<ChallengeAnswerResponse> => {
-	return idxFetch<ChallengeAnswerResponse, ChallengeAnswerBody>({
+): Promise<ChallengeAnswerResponse | CompleteLoginResponse> => {
+	return idxFetch<
+		ChallengeAnswerResponse | CompleteLoginResponse,
+		ChallengeAnswerBody
+	>({
 		path: 'challenge/answer',
 		body: {
 			stateHandle,
 			credentials: body,
 		},
-		schema: challengeAnswerResponseSchema,
+		schema: challengeAnswerResponseSchema.or(completeLoginResponseSchema),
 		request_id,
 		ip,
 	});
@@ -312,3 +317,27 @@ export const validateChallengeAnswerRemediation = validateRemediation<
 	ChallengeAnswerResponse,
 	ChallengeAnswerRemediationNames
 >;
+
+/**
+ * @name isChallengeAnswerResponse
+ * @description Type guard to check if the response is a challenge answer response
+ *
+ * @param {ChallengeAnswerResponse | CompleteLoginResponse} response - The challenge answer response
+ * @returns {response is ChallengeAnswerResponse} - Whether the response is a challenge answer response
+ */
+export const isChallengeAnswerResponse = (
+	response: ChallengeAnswerResponse | CompleteLoginResponse,
+): response is ChallengeAnswerResponse =>
+	challengeAnswerResponseSchema.safeParse(response).success;
+
+/**
+ * @name isChallengeAnswerCompleteLoginResponse
+ * @description Type guard to check if the challenge answer response is a complete login response
+ *
+ * @param {ChallengeAnswerResponse | CompleteLoginResponse} response - The challenge answer response
+ * @returns	{response is CompleteLoginResponse} - Whether the response is a complete login response
+ */
+export const isChallengeAnswerCompleteLoginResponse = (
+	response: ChallengeAnswerResponse | CompleteLoginResponse,
+): response is CompleteLoginResponse =>
+	completeLoginResponseSchema.safeParse(response).success;

--- a/src/server/lib/okta/idx/challenge.ts
+++ b/src/server/lib/okta/idx/challenge.ts
@@ -234,7 +234,6 @@ export const setPasswordAndRedirect = async ({
 				stateHandle,
 				credentials: body,
 			},
-			expressRes,
 			request_id,
 			ip,
 		});

--- a/src/server/lib/okta/idx/enroll.ts
+++ b/src/server/lib/okta/idx/enroll.ts
@@ -60,6 +60,25 @@ export const enroll = (
 	});
 };
 
+// Type to extract all the remediation names from the enroll response
+export type EnrollRemediationNames = ExtractLiteralRemediationNames<
+	EnrollResponse['remediation']['value'][number]
+>;
+
+/**
+ * @name validateEnrollRemediation
+ * @description Validates that the enroll response contains a remediation with the given name, throwing an error if it does not. This is useful for ensuring that the remediation we want to perform is available in the enroll/new response, and the state is correct.
+ * @param enrollResponse - The enroll response
+ * @param remediationName - The name of the remediation to validate
+ * @param useThrow - Whether to throw an error if the remediation is not found
+ * @throws OAuthError - If the remediation is not found in the enroll response
+ * @returns boolean | void - Whether the remediation was found in the response
+ */
+export const validateEnrollRemediation = validateRemediation<
+	EnrollResponse,
+	EnrollRemediationNames
+>;
+
 // Request body type for the enroll/new endpoint
 type EnrollNewWithEmailBody = IdxStateHandleBody<{
 	userProfile: {

--- a/src/server/lib/okta/idx/shared/findAuthenticatorId.ts
+++ b/src/server/lib/okta/idx/shared/findAuthenticatorId.ts
@@ -1,7 +1,7 @@
 import { selectAuthenticationAuthenticateSchema } from '../identify';
 import { IntrospectRemediationNames, IntrospectResponse } from '../introspect';
 import { authenticatorVerificationDataRemediationSchema } from '../recover';
-import { selectAuthenticationEnrollSchema } from './schemas';
+import { Authenticators, selectAuthenticationEnrollSchema } from './schemas';
 
 type Params = {
 	response: IntrospectResponse; // all responses regardless of api call will overlap with the introspect response
@@ -11,7 +11,7 @@ type Params = {
 		| 'select-authenticator-authenticate'
 		| 'select-authenticator-enroll'
 	>;
-	authenticator: 'email' | 'password';
+	authenticator: Authenticators;
 };
 
 /**

--- a/src/server/lib/okta/idx/shared/idxFetch.ts
+++ b/src/server/lib/okta/idx/shared/idxFetch.ts
@@ -10,7 +10,7 @@ import { IDXPath } from '@/server/lib/okta/idx/shared/paths';
 const { okta } = getConfiguration();
 
 // Schema for when the authentication process is completed, and we return a base user object
-const completeLoginResponseSchema = idxBaseResponseSchema.merge(
+export const completeLoginResponseSchema = idxBaseResponseSchema.merge(
 	z.object({
 		user: z.object({
 			type: z.literal('object'),
@@ -25,7 +25,7 @@ const completeLoginResponseSchema = idxBaseResponseSchema.merge(
 		}),
 	}),
 );
-type CompleteLoginResponse = z.infer<typeof completeLoginResponseSchema>;
+export type CompleteLoginResponse = z.infer<typeof completeLoginResponseSchema>;
 
 // Schema for the error object in the IDX API response
 const idxErrorObjectSchema = z.object({

--- a/src/server/lib/okta/idx/shared/schemas.ts
+++ b/src/server/lib/okta/idx/shared/schemas.ts
@@ -2,6 +2,9 @@ import { z } from 'zod';
 import { logger } from '@/client/lib/clientSideLogger';
 import { trackMetric } from '@/server/lib/trackMetric';
 
+// Define the authenticators that can be used with the IDX API
+export type Authenticators = 'email' | 'password';
+
 // Schema to check the version of the IDX API, and warn if it's not 1.0.0
 const idxVersionSchema = z.string().refine((val) => {
 	// warn if the version is not 1.0.0
@@ -102,7 +105,7 @@ export const challengeAuthenticatorSchema = baseRemediationValueSchema.merge(
 export type AuthenticatorBody = IdxStateHandleBody<{
 	authenticator: {
 		id: string;
-		methodType: 'email' | 'password';
+		methodType: Authenticators;
 	};
 }>;
 

--- a/src/server/lib/okta/idx/shared/submitPasscode.ts
+++ b/src/server/lib/okta/idx/shared/submitPasscode.ts
@@ -5,7 +5,7 @@ import {
 	validateIntrospectRemediation,
 } from '@/server/lib/okta/idx/introspect';
 import {
-	challengeAnswerPasscode,
+	challengeAnswer,
 	ChallengeAnswerRemediationNames,
 	ChallengeAnswerResponse,
 	validateChallengeAnswerRemediation,
@@ -65,7 +65,7 @@ export const submitPasscode = async ({
 	validateIntrospectRemediation(introspectResponse, introspectRemediation);
 
 	// attempt to answer the passcode challenge, if this fails, it falls through to the catch block where we handle the error
-	const challengeAnswerResponse = await challengeAnswerPasscode(
+	const challengeAnswerResponse = await challengeAnswer(
 		stateHandle,
 		{ passcode },
 		requestId,

--- a/src/server/routes/register.ts
+++ b/src/server/routes/register.ts
@@ -313,7 +313,6 @@ export const setEncryptedStateCookieForOktaRegistration = (
 ) => {
 	setEncryptedStateCookie(res, {
 		email: user.profile.email,
-		status: user.status,
 		// We set queryParams here to allow state to be persisted as part of the registration flow,
 		// because we are unable to pass these query parameters via the email activation link in Okta email templates
 		queryParams: getPersistableQueryParamsWithoutOktaParams(
@@ -513,7 +512,6 @@ export const OktaRegistration = async (
 
 		setEncryptedStateCookie(res, {
 			email: user.profile.email,
-			status: user.status,
 			// We set queryParams here to allow state to be persisted as part of the registration flow,
 			// because we are unable to pass these query parameters via the email activation link in Okta email templates
 			queryParams: getPersistableQueryParamsWithoutOktaParams(

--- a/src/server/routes/register.ts
+++ b/src/server/routes/register.ts
@@ -36,6 +36,7 @@ import {
 	enroll,
 	enrollNewWithEmail,
 	validateEnrollNewRemediation,
+	validateEnrollRemediation,
 } from '@/server/lib/okta/idx/enroll';
 import {
 	introspect,
@@ -376,19 +377,7 @@ const oktaIdxCreateAccount = async (
 
 		// if we don't have the `enroll-profile` remediation property
 		// throw an error and fall back to the legacy Okta registration flow
-		if (
-			!enrollResponse.remediation.value.find(
-				({ name }) => name === 'enroll-profile',
-			)
-		) {
-			throw new OAuthError(
-				{
-					error: 'idx_error',
-					error_description: '`enroll-profile` remediation not found',
-				},
-				404,
-			);
-		}
+		validateEnrollRemediation(enrollResponse, 'enroll-profile');
 
 		// call the enroll/new endpoint to attempt to register the user with email
 		const enrollNewWithEmailResponse = await enrollNewWithEmail(

--- a/src/server/routes/register.ts
+++ b/src/server/routes/register.ts
@@ -321,6 +321,168 @@ export const setEncryptedStateCookieForOktaRegistration = (
 	});
 };
 
+/**
+ * @name oktaIdxCreateAccount
+ * @description Attempt to create an account for the user using the Okta IDX API, and use passcodes to verify the user.
+ *
+ * NB. This currently only supports creating account for new users, and verifying them with a passcode.
+ * Currently if an existing user who tries to register, will fall back to the legacy Okta registration flow, where they
+ * will be sent a link instead to either sign in or reset their password.
+ * However the behaviour of this flow should be the same regardless of whether the user is new or existing, in either case
+ * they should be sent a passcode to verify their account (for new users), or sign in (existing users).
+ * TODO: This flow SHOULD be updated to support existing users in the future, once we have finished implementing passcodes
+ * for sign in and reset password flows.
+ *
+ * @param {Request} req - Express request object
+ * @param {ResponseWithRequestState} res - Express response object
+ * @returns {Promise<void | ResponseWithRequestState>}
+ */
+const oktaIdxCreateAccount = async (
+	req: Request,
+	res: ResponseWithRequestState,
+) => {
+	const { email = '' } = req.body;
+
+	const {
+		queryParams: { appClientId },
+		requestId: request_id,
+	} = res.locals;
+
+	const consents = bodyFormFieldsToRegistrationConsents(req.body);
+
+	const registrationLocation: RegistrationLocation | undefined =
+		getRegistrationLocation(req);
+
+	try {
+		const introspectResponse = await startIdxFlow({
+			req,
+			res,
+			authorizationCodeFlowOptions: {
+				confirmationPagePath: '/welcome/review',
+			},
+			consents,
+			request_id,
+		});
+
+		// check if we have the `select-enroll-profile` remediation property which means registration is allowed
+		validateIntrospectRemediation(introspectResponse, 'select-enroll-profile');
+
+		// call the enroll endpoint to attempt to start the registration process
+		const enrollResponse = await enroll(
+			introspectResponse.stateHandle,
+			request_id,
+			req.ip,
+		);
+
+		// if we don't have the `enroll-profile` remediation property
+		// throw an error and fall back to the legacy Okta registration flow
+		if (
+			!enrollResponse.remediation.value.find(
+				({ name }) => name === 'enroll-profile',
+			)
+		) {
+			throw new OAuthError(
+				{
+					error: 'idx_error',
+					error_description: '`enroll-profile` remediation not found',
+				},
+				404,
+			);
+		}
+
+		// call the enroll/new endpoint to attempt to register the user with email
+		const enrollNewWithEmailResponse = await enrollNewWithEmail(
+			enrollResponse.stateHandle,
+			{
+				email,
+				isGuardianUser: true,
+				registrationLocation: registrationLocation,
+				registrationPlatform: await getRegistrationPlatform(appClientId),
+			},
+			request_id,
+			req.ip,
+		);
+
+		// we need to check if the email has been sent to the user, or if
+		// we need to select an authenticator to enroll
+		const hasSelectAuthenticator = validateEnrollNewRemediation(
+			enrollNewWithEmailResponse,
+			'select-authenticator-enroll',
+			false,
+		);
+
+		// if we have the `select-authenticator-enroll` remediation property
+		// we need to handle this by selecting the authenticator email
+		// to send the passcode to the user
+		if (hasSelectAuthenticator) {
+			const emailAuthenticatorId = findAuthenticatorId({
+				response: enrollNewWithEmailResponse,
+				remediationName: 'select-authenticator-enroll',
+				authenticator: 'email',
+			});
+
+			if (!emailAuthenticatorId) {
+				throw new OAuthError(
+					{
+						error: 'idx_error',
+						error_description: 'Email authenticator id not found',
+					},
+					400,
+				);
+			}
+
+			// start the credential enroll flow
+			await credentialEnroll(
+				enrollNewWithEmailResponse.stateHandle,
+				{ id: emailAuthenticatorId, methodType: 'email' },
+				request_id,
+				req.ip,
+			);
+		}
+
+		// at this point the user will have been sent an email with a passcode
+
+		// set the encrypted state cookie to persist the email and stateHandle
+		setEncryptedStateCookie(res, {
+			email,
+			stateHandle: enrollNewWithEmailResponse.stateHandle,
+			stateHandleExpiresAt: enrollNewWithEmailResponse.expiresAt,
+		});
+
+		// fire ophan component event if applicable
+		if (res.locals.queryParams.componentEventParams) {
+			void sendOphanComponentEventFromQueryParamsServer(
+				res.locals.queryParams.componentEventParams,
+				'CREATE_ACCOUNT',
+				'web',
+				res.locals.ophanConfig.consentUUID,
+				res.locals.requestId,
+			);
+		}
+
+		trackMetric('OktaIDXRegister::Success');
+
+		// redirect to the email sent page
+		return res.redirect(
+			303,
+			addQueryParamsToPath('/register/email-sent', res.locals.queryParams),
+		);
+	} catch (error) {
+		if (error instanceof OAuthError) {
+			if (error.name === 'registration.error.notUniqueWithinOrg') {
+				// case for user already exists
+				// will implement when full passwordless is implemented
+			}
+		}
+
+		// track and log the failure, and fall back to the legacy Okta registration flow if there is an error
+		trackMetric('OktaIDXRegister::Failure');
+		logger.error('IDX API - registration error:', error, {
+			request_id,
+		});
+	}
+};
+
 export const OktaRegistration = async (
 	req: Request,
 	res: ResponseWithRequestState,
@@ -342,148 +504,13 @@ export const OktaRegistration = async (
 	// and specifically using passcodes.
 	// If there are specific failures, we fall back to the legacy Okta registration flow
 	if (passcodesEnabled && !useOktaClassic) {
-		try {
-			const introspectResponse = await startIdxFlow({
-				req,
-				res,
-				authorizationCodeFlowOptions: {
-					confirmationPagePath: '/welcome/review',
-				},
-				consents,
-				request_id,
-			});
+		// try to start the IDX flow to create an account for the user
+		await oktaIdxCreateAccount(req, res);
 
-			// check if we have the `select-enroll-profile` remediation property which means registration is allowed
-			const introspectEnrollProfileCheck =
-				introspectResponse.remediation.value.find(
-					({ name }) => name === 'select-enroll-profile',
-				);
-
-			// if we don't have the `select-enroll-profile` remediation property
-			// throw an error and fall back to the legacy Okta registration flow
-			if (!introspectEnrollProfileCheck) {
-				throw new OAuthError(
-					{
-						error: 'idx_error',
-						error_description: '`select-enroll-profile` remediation not found',
-					},
-					404,
-				);
-			}
-
-			// call the enroll endpoint to attempt to start the registration process
-			const enrollResponse = await enroll(
-				introspectResponse.stateHandle,
-				request_id,
-				req.ip,
-			);
-
-			// if we don't have the `enroll-profile` remediation property
-			// throw an error and fall back to the legacy Okta registration flow
-			if (
-				!enrollResponse.remediation.value.find(
-					({ name }) => name === 'enroll-profile',
-				)
-			) {
-				throw new OAuthError(
-					{
-						error: 'idx_error',
-						error_description: '`enroll-profile` remediation not found',
-					},
-					404,
-				);
-			}
-
-			// call the enroll/new endpoint to attempt to register the user with email
-			const enrollNewWithEmailResponse = await enrollNewWithEmail(
-				enrollResponse.stateHandle,
-				{
-					email,
-					isGuardianUser: true,
-					registrationLocation: registrationLocation,
-					registrationPlatform: await getRegistrationPlatform(appClientId),
-				},
-				request_id,
-				req.ip,
-			);
-
-			// we need to check if the email has been sent to the user, or if
-			// we need to select an authenticator to enroll
-			const hasSelectAuthenticator = validateEnrollNewRemediation(
-				enrollNewWithEmailResponse,
-				'select-authenticator-enroll',
-				false,
-			);
-
-			// if we have the `select-authenticator-enroll` remediation property
-			// we need to handle this by selecting the authenticator email
-			// to send the passcode to the user
-			if (hasSelectAuthenticator) {
-				const emailAuthenticatorId = findAuthenticatorId({
-					response: enrollNewWithEmailResponse,
-					remediationName: 'select-authenticator-enroll',
-					authenticator: 'email',
-				});
-
-				if (!emailAuthenticatorId) {
-					throw new OAuthError(
-						{
-							error: 'idx_error',
-							error_description: 'Email authenticator id not found',
-						},
-						400,
-					);
-				}
-
-				// start the credential enroll flow
-				await credentialEnroll(
-					enrollNewWithEmailResponse.stateHandle,
-					{ id: emailAuthenticatorId, methodType: 'email' },
-					request_id,
-					req.ip,
-				);
-			}
-
-			// at this point the user will have been sent an email with a passcode
-
-			// set the encrypted state cookie to persist the email and stateHandle
-			setEncryptedStateCookie(res, {
-				email,
-				stateHandle: enrollNewWithEmailResponse.stateHandle,
-				stateHandleExpiresAt: enrollNewWithEmailResponse.expiresAt,
-			});
-
-			// fire ophan component event if applicable
-			if (res.locals.queryParams.componentEventParams) {
-				void sendOphanComponentEventFromQueryParamsServer(
-					res.locals.queryParams.componentEventParams,
-					'CREATE_ACCOUNT',
-					'web',
-					res.locals.ophanConfig.consentUUID,
-					res.locals.requestId,
-				);
-			}
-
-			trackMetric('OktaIDXRegister::Success');
-
-			// redirect to the email sent page
-			return res.redirect(
-				303,
-				addQueryParamsToPath('/register/email-sent', res.locals.queryParams),
-			);
-		} catch (error) {
-			if (error instanceof OAuthError) {
-				if (error.name === 'registration.error.notUniqueWithinOrg') {
-					// case for user already exists
-					// will implement when full passwordless is implemented
-				}
-			}
-
-			// track and log the failure, and fall back to the legacy Okta registration flow if there is an error
-			trackMetric('OktaIDXRegister::Failure');
-			logger.error('IDX API - registration error:', error, {
-				request_id,
-			});
+		// if successful, the user will be redirected to the email sent page
+		// so we need to check if the headers have been sent to prevent further processing
+		if (res.headersSent) {
+			return;
 		}
 	}
 

--- a/src/shared/model/EncryptedState.ts
+++ b/src/shared/model/EncryptedState.ts
@@ -1,12 +1,16 @@
 import { PersistableQueryParams } from './QueryParams';
 
 export interface EncryptedState {
+	// Email to persist across requests
 	email?: string;
+	// Flag to determine if the password was already set
 	passwordSetOnWelcomePage?: boolean;
-	status?: string;
-	signInRedirect?: boolean; // TODO: possibly rename for clarity
+	// Query params to persist across requests
 	queryParams?: PersistableQueryParams;
-	stateHandle?: string; // part of the Okta IDX flow
-	stateHandleExpiresAt?: string; // part of the Okta IDX flow
-	passcodeUsed?: boolean; // part of the Okta IDX flow, determines if the passcode has been used
+	// Okta IDX API - State handle to persist across requests
+	stateHandle?: string;
+	// Okta IDX API - Time when the state handle expires
+	stateHandleExpiresAt?: string;
+	// Okta IDX API - Flag to determine if the user has used a passcode
+	passcodeUsed?: boolean;
 }


### PR DESCRIPTION
## What does this change?

In https://github.com/guardian/gateway/pull/2852 we implemented passcodes for reset password for some "ACTIVE" users. Namely the ones with both the "password" and "email" authenticator, and users with just the "email" authenticator.

The next step was to implement this for users who only had the "password" authenticator, this is being completed in https://github.com/guardian/gateway/pull/2889, see more information about those users in that PR.

In order to support some of these features we refactor and add some features in the IDX API implementation in Gateway.

Each commit is independent of each other, and rather than reviewing this PR as a whole, the reviewer is asked to go through the PR commit by commit, and review this PR that way.

This is done to avoid me potentially opening a number of smaller PRs with each individual change, which would be difficult to organise.

Each commit has additional context attached to it, and I've also laid out below what each commit achieves.

---

## Changes

---

**Use correct resendEmailAction**
*Type: Fix*

We were using the wrong resend email action on the reset password page, where clicking "resend" would actually use the "register/create account" (`POST /register/email-sent/resend`) resend action instead of the correct one (`POST /reset-password/resend`)

---

**Update challenge/answer API type/variable naming**
*Type: Refactor*

Updates the variables in `src/server/lib/okta/idx/challenge.ts` related to the `/challenge/answer` endpoint to better reflect the API, and to bring it in line with naming elsewhere in the IDX API implementation within Gateway

---

**Remove `idx` cookie from `idxFetch` methods**
*Type: Refactor*

While testing the IDX API flow, it turns out we don't actually need to get the `idx` cookie from the `idxFetchCompletion` method.

What actually happens is that the `idx` cookie will be automatically set by Okta when we redirect the user to the `/login/token/redirect` endpoint which completes the authentication process.

By removing this code, we can make the `idxFetch` methods easier to reason about, and actually `idxFetchCompletion` is removed in a later commit altogether

---

**Make `challenge/answer` API response either `ChallengeAnswerResponse` or `CompleteLoginResponse`**
*Type: Refactor/Feature*

When using the IDX API, the `challenge/answer` endpoint returns different things depending on the context. This could also potentially include a `CompleteLoginResponse`.

This would happen, for example, if using the IDX API to sign in a user with a password or OTP, where no additional steps are required after calling the `challenge/answer` endpoint.

This is required for https://github.com/guardian/gateway/pull/2889 as we need to authenticate the user with a password in order to determine whether we need to enroll the user in the email authenticator or not.

So this commit refactors usages of the `challengeAnswer` method to make sure we check the correct response type we're expecting in a particular scenario.

---

**Add `submitPassword` method**
*Type: Feature*

This is similar to the `submitPasscode` method, but takes a password instead.

It submit a password to Okta to answer the password challenge using the `challenge/answer` endpoint and return the response.

Validation can be enabled as needed through the params, `validatePasswordLength` and `validateBreachedPassword` (both default to false) where if validation fails then the method will throw.

This is required for https://github.com/guardian/gateway/pull/2889 as we need to authenticate the user with a password in order to determine whether we need to enroll the user in the email authenticator or not.

---

**Add parameter to return placeholder password if true**
*Type: Refactor/Feature*

> [!WARNING]
> Since this is passing around a password, even a placeholder one, care should be taken how it is used. Thankfully the name of the function, `dangerouslySetPlaceholderPassword`, already helps with that, but making the point here too.

In some cases, e.g. for ACTIVE users with only the "password" authenticator (state 2), we actually need to set a placeholder password for these users that is then used to authenticate the user in order for them to be able to verify their email.

To do this we need to return the placeholder password so we can use it in the Okta IDX authentication process.

---

**Add `Authenticators` type**
*Type: Feature*

Adds the `Authenticators` type which can either be `email` or `password`.

This is a helper type, which is used in a few places makes it easier to identify the authenticators that users can currently have.

---

**Add `validateChallengeRemediation` method for the `challenge` API response**
*Type: Feature*

`validateChallengeRemediation` is a function that validates that the challenge response contains a remediation with the given name and authenticator.

This is slightly more complicated compared to the other `validateRemediation` methods, as we don't just want to check if the response has a specific remediation name, we also want to check if it has a specific authenticator, and possibly also a given resend/recover method.

---

**Remove `signInRedirect` and `status` from `EncryptedState` as no longer used and update comments accordingly**
*Type: Refactor*

Clean up the `EncryptedState` cookie by removing unused things, and updating comments to better reflect the usages.

---

**Create `oktaIdxCreateAccount` controller**
*Type: Refactor*

Move the code for creating a user using the Okta IDX API out of the `OktaRegistration` method, and into it's own controller instead.

This makes the code easier to reason about, and separates the IDX flow from the classic flow!

Also leaves a `TODO` about updating this in the future once we have finished developing passcodes for sign in and reset password to come back and make sure that user behaviour is the same regardless of if their a new or existing user when going through the create account process.

---

**Add `validateEnrollRemediation` for `enrollResponse`**
*Type: Feature*

As we've done elsewhere, add an validate remediation for the EnrollResponse, making it easier to check whether we're in the correct state.

---

**Remove `idxFetchCompletion` and update `setPasswordAndRedirect` to use `submitPassword` instead**
*Type: Refactor*

In Okta IDX API, it is difficult to determine the exact scenarios where we get a `CompleteLoginResponse`, and thus when to use the `idxFetchCompletion` method vs the `idxFetch` method.

We previously refactored `challenge/answer` to be either `ChallengeAnswerResponse` or `CompleteLoginResponse`, and added the `isChallengeAnswerCompleteLoginResponse` and `isChallengeAnswerResponse` type guards which should be used to check which response we recieved.

We also made a new `submitPassword` function, which abstracts away everything to do with submiting the password to the Okta API and any additional validation.

We can then update the `setPasswordAndRedirect` method to use `submitPassword` instead of the `idxFetchCompletion` method, and use the new `getLoginRedirectUrl` to determine where the user needs to go to get a global session set after authenticating.

---