### PR TITLE
Refactor | `dangerouslySetPlaceholderPassword` | Use overload signatures to get correct return type

### DIFF
--- a/src/server/controllers/sendChangePasswordEmail.ts
+++ b/src/server/controllers/sendChangePasswordEmail.ts
@@ -278,7 +278,10 @@ const changePasswordEmailIdx = async (
 					}
 
 					// set a placeholder password for the user
-					await dangerouslySetPlaceholderPassword(user.id, req.ip);
+					await dangerouslySetPlaceholderPassword({
+						id: user.id,
+						ip: req.ip,
+					});
 
 					// now that the placeholder password has been set, the user will be in
 					// 1. ACTIVE users - has email + password authenticator (okta idx email verified)
@@ -381,7 +384,10 @@ export const sendEmailInOkta = async (
 						// check for user does not have a password set
 						// (to make sure we don't override any existing password)
 						if (!user.credentials.password) {
-							await dangerouslySetPlaceholderPassword(user.id, req.ip);
+							await dangerouslySetPlaceholderPassword({
+								id: user.id,
+								ip: req.ip,
+							});
 							// now that the placeholder password has been set, the user behaves like a
 							// normal user (provider = OKTA) and we can send the email by calling this method again
 							return sendEmailInOkta(req, res, true);

--- a/src/server/lib/okta/dangerouslySetPlaceholderPassword.ts
+++ b/src/server/lib/okta/dangerouslySetPlaceholderPassword.ts
@@ -4,6 +4,13 @@ import { logger } from '@/server/lib/serverSideLogger';
 import { validateRecoveryToken, resetPassword } from './api/authentication';
 import { dangerouslyResetPassword } from './api/users';
 
+// Define the parameter object type
+interface PlaceholderPasswordParams {
+	id: string;
+	ip?: string;
+	returnPlaceholderPassword?: boolean;
+}
+
 /**
  * This function is used ONLY for users who do not have a password set at all
  * (i.e. social users or users imported from IDAPI). It does the following:
@@ -17,11 +24,19 @@ import { dangerouslyResetPassword } from './api/users';
  * @param returnPlaceholderPassword If true, return the placeholder password
  * @returns The placeholder password if returnPlaceholderPassword is true, otherwise void (undefined)
  */
-const dangerouslySetPlaceholderPassword = async (
-	id: string,
-	ip?: string,
+// Overload signatures
+async function dangerouslySetPlaceholderPassword(
+	params: PlaceholderPasswordParams & { returnPlaceholderPassword: true },
+): Promise<string>;
+async function dangerouslySetPlaceholderPassword(
+	params: PlaceholderPasswordParams & { returnPlaceholderPassword?: false },
+): Promise<void>;
+// Implementation
+async function dangerouslySetPlaceholderPassword({
+	id,
+	ip,
 	returnPlaceholderPassword = false,
-): Promise<string | void> => {
+}: PlaceholderPasswordParams): Promise<string | void> {
 	try {
 		// Generate an recoveryToken OTT and put user into RECOVERY state
 		const recoveryToken = await dangerouslyResetPassword(id, ip);
@@ -57,6 +72,6 @@ const dangerouslySetPlaceholderPassword = async (
 		);
 		throw error;
 	}
-};
+}
 
 export default dangerouslySetPlaceholderPassword;

--- a/src/server/lib/okta/register.ts
+++ b/src/server/lib/okta/register.ts
@@ -304,7 +304,10 @@ const sendRegistrationEmailByUserState = async ({
 			if (doesNotHavePassword) {
 				// The user does not have a password set, so we set a placeholder
 				// password first, then proceed with the rest of the operation.
-				await dangerouslySetPlaceholderPassword(user.id, ip);
+				await dangerouslySetPlaceholderPassword({
+					id: user.id,
+					ip,
+				});
 			}
 			// Now the user has a password set, so we can get a reset password token
 			// and send them an email which contains it, allowing them to immediately

--- a/src/server/routes/delete.ts
+++ b/src/server/routes/delete.ts
@@ -332,7 +332,10 @@ router.post(
 
 			// if the user doesn't have a password set, set a placeholder password
 			if (!user.credentials.password) {
-				await dangerouslySetPlaceholderPassword(user.id, req.ip);
+				await dangerouslySetPlaceholderPassword({
+					id: user.id,
+					ip: req.ip,
+				});
 			}
 
 			// attempt to send the email


### PR DESCRIPTION
## What does this change?

Since `dangerouslySetPlaceholderPassword` returns either a `string` or `void`/`undefined` depending on what parameters are provided to it, specifically the `returnPlaceholderPassword` parameter.

The problem was that even if `returnPlaceholderPassword` was set to true, typescript would still think the return type was `string | void`.

We can fix this to make sure that when `returnPlaceholderPassword` is true, we always return the `string` type.

We can use [overload signatures](https://www.typescriptlang.org/docs/handbook/2/functions.html#function-overloads) to specify exactly hat the output of a function is depending on it's input.

In our case if `returnPlaceholderPassword` is `undefined` or `false`, then the function returns `void`.

If `returnPlaceholderPassword` is `true`, then the function returns a `string`.