### PR TITLE
Passwordless | Passcodes for reset password - non-ACTIVE users

### DIFF
--- a/cypress/fixtures/okta-responses/success/update-user.json
+++ b/cypress/fixtures/okta-responses/success/update-user.json
@@ -1,0 +1,13 @@
+{
+	"code": 200,
+	"response": {
+		"id": "12345",
+		"status": "SUCCESS",
+		"profile": {
+			"login": "test@example.com",
+			"email": "test@example.com",
+			"isGuardianUser": true
+		},
+		"credentials": {}
+	}
+}

--- a/cypress/integration/ete/reset_password_passcode.7.cy.ts
+++ b/cypress/integration/ete/reset_password_passcode.7.cy.ts
@@ -1,3 +1,4 @@
+import { Status } from '../../../src/server/models/okta/User';
 import {
 	randomMailosaurEmail,
 	randomPassword,
@@ -441,6 +442,318 @@ describe('Password reset recovery flows - with Passcodes', () => {
 					});
 				},
 			);
+		});
+	});
+
+	context('STAGED user', () => {
+		it('allows the user to change their password - STAGED - No Passcode Verified', () => {
+			const emailAddress = randomMailosaurEmail();
+			cy.visit(`/register/email`);
+
+			const timeRequestWasMade = new Date();
+			cy.get('input[name=email]').type(emailAddress);
+			cy.get('[data-cy="main-form-submit-button"]').click();
+
+			cy.contains('Enter your code');
+			cy.contains(emailAddress);
+
+			cy.checkForEmailAndGetDetails(emailAddress, timeRequestWasMade).then(
+				({ body, codes }) => {
+					// email
+					expect(body).to.have.string('Your verification code');
+					expect(codes?.length).to.eq(1);
+					const code = codes?.[0].value;
+					expect(code).to.match(/^\d{6}$/);
+
+					// passcode page
+					cy.url().should('include', '/register/email-sent');
+
+					cy.getTestOktaUser(emailAddress).then((oktaUser) => {
+						expect(oktaUser.status).to.eq(Status.STAGED);
+						// make sure we don't use a passcode
+						// we instead reset their password using passcodes
+						cy.visit('/reset-password?usePasscodesResetPassword=true');
+
+						const timeRequestWasMade = new Date();
+						cy.contains('Reset password');
+						cy.get('[data-cy="main-form-submit-button"]').click();
+
+						cy.checkForEmailAndGetDetails(
+							emailAddress,
+							timeRequestWasMade,
+						).then(({ body, codes }) => {
+							// email
+							expect(body).to.have.string('Your verification code');
+							expect(codes?.length).to.eq(1);
+							const code = codes?.[0].value;
+							expect(code).to.match(/^\d{6}$/);
+
+							// passcode page
+							cy.url().should('include', '/reset-password/email-sent');
+							cy.contains('Enter your one-time code');
+
+							cy.get('input[name=code]').clear().type(code!);
+							cy.contains('Submit one-time code').click();
+
+							cy.url().should('contain', '/set-password');
+
+							cy.get('input[name="password"]').type(randomPassword());
+							cy.get('button[type="submit"]').click();
+
+							cy.url().should('contain', '/set-password/complete');
+						});
+					});
+				},
+			);
+		});
+
+		it('allows the user to change their password - STAGED - Passcode Verified - No Password', () => {
+			const emailAddress = randomMailosaurEmail();
+			cy.visit(`/register/email`);
+
+			const timeRequestWasMade = new Date();
+			cy.get('input[name=email]').type(emailAddress);
+			cy.get('[data-cy="main-form-submit-button"]').click();
+
+			cy.contains('Enter your code');
+			cy.contains(emailAddress);
+
+			cy.checkForEmailAndGetDetails(emailAddress, timeRequestWasMade).then(
+				({ body, codes }) => {
+					// email
+					expect(body).to.have.string('Your verification code');
+					expect(codes?.length).to.eq(1);
+					const code = codes?.[0].value;
+					expect(code).to.match(/^\d{6}$/);
+
+					// passcode page, use passcode
+					cy.url().should('include', '/register/email-sent');
+					cy.get('input[name=code]').type(code!);
+					cy.contains('Submit verification code').click();
+
+					// password page, don't set password
+					cy.url().should('include', '/welcome/password');
+
+					cy.getTestOktaUser(emailAddress).then((oktaUser) => {
+						expect(oktaUser.status).to.eq(Status.STAGED);
+
+						// redirect to reset password with passcodes
+						cy.visit('/reset-password?usePasscodesResetPassword=true');
+
+						const timeRequestWasMade = new Date();
+						cy.contains('Reset password');
+						cy.get('[data-cy="main-form-submit-button"]').click();
+
+						cy.checkForEmailAndGetDetails(
+							emailAddress,
+							timeRequestWasMade,
+						).then(({ body, codes }) => {
+							// email
+							expect(body).to.have.string('Your one-time passcode');
+							expect(codes?.length).to.eq(1);
+							const code = codes?.[0].value;
+							expect(code).to.match(/^\d{6}$/);
+
+							// passcode page
+							cy.url().should('include', '/reset-password/email-sent');
+							cy.contains('Enter your one-time code');
+
+							cy.get('input[name=code]').clear().type(code!);
+							cy.contains('Submit one-time code').click();
+
+							// password page
+							cy.url().should('include', '/reset-password/password');
+
+							cy.get('input[name="password"]').type(randomPassword());
+							cy.get('button[type="submit"]').click();
+
+							// password complete page
+							cy.url().should('include', '/reset-password/complete');
+
+							cy.contains('Password updated');
+						});
+					});
+				},
+			);
+		});
+
+		it('allows the user to change their password - STAGED - Created via Classic API (i.e guest user)', () => {
+			cy.createTestUser({ isGuestUser: true })?.then(({ emailAddress }) => {
+				cy.getTestOktaUser(emailAddress).then((oktaUser) => {
+					expect(oktaUser.status).to.eq(Status.STAGED);
+					cy.visit('/reset-password?usePasscodesResetPassword=true');
+
+					const timeRequestWasMade = new Date();
+					cy.get('input[name=email]').type(emailAddress);
+					cy.get('[data-cy="main-form-submit-button"]').click();
+
+					cy.checkForEmailAndGetDetails(emailAddress, timeRequestWasMade).then(
+						({ body, codes }) => {
+							// email
+							expect(body).to.have.string('Your one-time passcode');
+							expect(codes?.length).to.eq(1);
+							const code = codes?.[0].value;
+							expect(code).to.match(/^\d{6}$/);
+
+							// passcode page
+							cy.url().should('include', '/reset-password/email-sent');
+							cy.contains('Enter your one-time code');
+
+							cy.get('input[name=code]').clear().type(code!);
+							cy.contains('Submit one-time code').click();
+
+							// password page
+							cy.url().should('include', '/reset-password/password');
+
+							cy.get('input[name="password"]').type(randomPassword());
+							cy.get('button[type="submit"]').click();
+
+							// password complete page
+							cy.url().should('include', '/reset-password/complete');
+
+							cy.contains('Password updated');
+						},
+					);
+				});
+			});
+		});
+	});
+
+	context('PROVISIONED user', () => {
+		it('allows the user to change their password - PROVISIONED', () => {
+			cy.createTestUser({ isGuestUser: true })?.then(({ emailAddress }) => {
+				cy.activateTestOktaUser(emailAddress).then(() => {
+					cy.getTestOktaUser(emailAddress).then((oktaUser) => {
+						expect(oktaUser.status).to.eq(Status.PROVISIONED);
+						cy.visit('/reset-password?usePasscodesResetPassword=true');
+
+						const timeRequestWasMade = new Date();
+						cy.get('input[name=email]').type(emailAddress);
+						cy.get('[data-cy="main-form-submit-button"]').click();
+
+						cy.checkForEmailAndGetDetails(
+							emailAddress,
+							timeRequestWasMade,
+						).then(({ body, codes }) => {
+							// email
+							expect(body).to.have.string('Your one-time passcode');
+							expect(codes?.length).to.eq(1);
+							const code = codes?.[0].value;
+							expect(code).to.match(/^\d{6}$/);
+
+							// passcode page
+							cy.url().should('include', '/reset-password/email-sent');
+							cy.contains('Enter your one-time code');
+
+							cy.get('input[name=code]').clear().type(code!);
+							cy.contains('Submit one-time code').click();
+
+							// password page
+							cy.url().should('include', '/reset-password/password');
+
+							cy.get('input[name="password"]').type(randomPassword());
+							cy.get('button[type="submit"]').click();
+
+							// password complete page
+							cy.url().should('include', '/reset-password/complete');
+
+							cy.contains('Password updated');
+						});
+					});
+				});
+			});
+		});
+	});
+
+	context('RECOVERY user', () => {
+		it('allows the user to change their password - RECOVERY', () => {
+			cy.createTestUser({ isGuestUser: false })?.then(({ emailAddress }) => {
+				cy.resetOktaUserPassword(emailAddress).then(() => {
+					cy.getTestOktaUser(emailAddress).then((oktaUser) => {
+						expect(oktaUser.status).to.eq(Status.RECOVERY);
+						cy.visit('/reset-password?usePasscodesResetPassword=true');
+
+						const timeRequestWasMade = new Date();
+						cy.get('input[name=email]').type(emailAddress);
+						cy.get('[data-cy="main-form-submit-button"]').click();
+
+						cy.checkForEmailAndGetDetails(
+							emailAddress,
+							timeRequestWasMade,
+						).then(({ body, codes }) => {
+							// email
+							expect(body).to.have.string('Your one-time passcode');
+							expect(codes?.length).to.eq(1);
+							const code = codes?.[0].value;
+							expect(code).to.match(/^\d{6}$/);
+
+							// passcode page
+							cy.url().should('include', '/reset-password/email-sent');
+							cy.contains('Enter your one-time code');
+
+							cy.get('input[name=code]').clear().type(code!);
+							cy.contains('Submit one-time code').click();
+
+							// password page
+							cy.url().should('include', '/reset-password/password');
+
+							cy.get('input[name="password"]').type(randomPassword());
+							cy.get('button[type="submit"]').click();
+
+							// password complete page
+							cy.url().should('include', '/reset-password/complete');
+
+							cy.contains('Password updated');
+						});
+					});
+				});
+			});
+		});
+	});
+
+	context('PASSWORD_EXPIRED user', () => {
+		it('allows the user to change their password - PASSWORD_EXPIRED', () => {
+			cy.createTestUser({ isGuestUser: false })?.then(({ emailAddress }) => {
+				cy.expireOktaUserPassword(emailAddress).then(() => {
+					cy.getTestOktaUser(emailAddress).then((oktaUser) => {
+						expect(oktaUser.status).to.eq(Status.PASSWORD_EXPIRED);
+						cy.visit('/reset-password?usePasscodesResetPassword=true');
+
+						const timeRequestWasMade = new Date();
+						cy.get('input[name=email]').type(emailAddress);
+						cy.get('[data-cy="main-form-submit-button"]').click();
+
+						cy.checkForEmailAndGetDetails(
+							emailAddress,
+							timeRequestWasMade,
+						).then(({ body, codes }) => {
+							// email
+							expect(body).to.have.string('Your one-time passcode');
+							expect(codes?.length).to.eq(1);
+							const code = codes?.[0].value;
+							expect(code).to.match(/^\d{6}$/);
+
+							// passcode page
+							cy.url().should('include', '/reset-password/email-sent');
+							cy.contains('Enter your one-time code');
+
+							cy.get('input[name=code]').clear().type(code!);
+							cy.contains('Submit one-time code').click();
+
+							// password page
+							cy.url().should('include', '/reset-password/password');
+
+							cy.get('input[name="password"]').type(randomPassword());
+							cy.get('button[type="submit"]').click();
+
+							// password complete page
+							cy.url().should('include', '/reset-password/complete');
+
+							cy.contains('Password updated');
+						});
+					});
+				});
+			});
 		});
 	});
 });

--- a/cypress/integration/mocked/okta_send_reset_password.1.cy.ts
+++ b/cypress/integration/mocked/okta_send_reset_password.1.cy.ts
@@ -1,4 +1,5 @@
 import { UserResponse } from '@/server/models/okta/User';
+import updateUser from '../../fixtures/okta-responses/success/update-user.json';
 
 describe('Send password reset email in Okta', () => {
 	const email = 'mrtest@theguardian.com';
@@ -166,6 +167,7 @@ describe('Send password reset email in Okta', () => {
 					},
 				},
 			});
+			cy.mockNext(updateUser.code, updateUser.response);
 			cy.mockNext(200, mockUserActiveWithoutPassword);
 			cy.mockNext(200, {
 				resetPasswordUrl:

--- a/cypress/integration/mocked/registerController.1.cy.ts
+++ b/cypress/integration/mocked/registerController.1.cy.ts
@@ -11,6 +11,7 @@ import idxEnrollResponse from '../../fixtures/okta-responses/success/idx-enroll-
 import idxEnrollNewResponse from '../../fixtures/okta-responses/success/idx-enroll-new-response.json';
 import idxEnrollNewSelectAuthenticatorResponse from '../../fixtures/okta-responses/success/idx-enroll-new-response-select-authenticator.json';
 import idxEnrollNewExistingUserResponse from '../../fixtures/okta-responses/error/idx-enroll-new-existing-user-response.json';
+import updateUser from '../../fixtures/okta-responses/success/update-user.json';
 
 beforeEach(() => {
 	cy.mockPurge();
@@ -110,6 +111,8 @@ userStatuses.forEach((status) => {
 							});
 							// authenticationResetPassword()
 							cy.mockNext(200, {});
+							// set email validated/password set securely flags to false
+							cy.mockNext(updateUser.code, updateUser.response);
 							// from sendEmailToUnvalidatedUser() --> forgotPassword()
 							cy.mockNext(200, {
 								resetPasswordUrl:
@@ -141,6 +144,8 @@ userStatuses.forEach((status) => {
 							});
 							// authenticationResetPassword()
 							cy.mockNext(200, {});
+							// set email validated/password set securely flags to false
+							cy.mockNext(updateUser.code, updateUser.response);
 							// from sendEmailToUnvalidatedUser() --> forgotPassword()
 							cy.mockNext(200, {
 								resetPasswordUrl:
@@ -183,6 +188,8 @@ userStatuses.forEach((status) => {
 							});
 							// authenticationResetPassword()
 							cy.mockNext(200, {});
+							// set email validated/password set securely flags to false
+							cy.mockNext(updateUser.code, updateUser.response);
 							// from sendEmailToUnvalidatedUser() --> forgotPassword()
 							cy.mockNext(200, {
 								resetPasswordUrl:

--- a/cypress/integration/mocked/resendEmailController.3.cy.ts
+++ b/cypress/integration/mocked/resendEmailController.3.cy.ts
@@ -11,6 +11,7 @@ import idxEnrollResponse from '../../fixtures/okta-responses/success/idx-enroll-
 import idxEnrollNewResponse from '../../fixtures/okta-responses/success/idx-enroll-new-response.json';
 import idxEnrollNewSelectAuthenticatorResponse from '../../fixtures/okta-responses/success/idx-enroll-new-response-select-authenticator.json';
 import idxEnrollNewExistingUserResponse from '../../fixtures/okta-responses/error/idx-enroll-new-existing-user-response.json';
+import updateUser from '../../fixtures/okta-responses/success/update-user.json';
 
 beforeEach(() => {
 	cy.mockPurge();
@@ -357,6 +358,8 @@ userStatuses.forEach((status) => {
 							});
 							// authenticationResetPassword()
 							cy.mockNext(200, {});
+							// set email validated/password set securely flags to false
+							cy.mockNext(updateUser.code, updateUser.response);
 							// from sendEmailToUnvalidatedUser() --> forgotPassword()
 							cy.mockNext(200, {
 								resetPasswordUrl:
@@ -476,6 +479,8 @@ userStatuses.forEach((status) => {
 							});
 							// authenticationResetPassword()
 							cy.mockNext(200, {});
+							// set email validated/password set securely flags to false
+							cy.mockNext(updateUser.code, updateUser.response);
 							// from sendEmailToUnvalidatedUser() --> forgotPassword()
 							cy.mockNext(200, {
 								resetPasswordUrl:

--- a/cypress/integration/mocked/resetPasswordController.4.cy.ts
+++ b/cypress/integration/mocked/resetPasswordController.4.cy.ts
@@ -7,6 +7,7 @@ import tokenResponse from '../../fixtures/okta-responses/success/token.json';
 import resetPasswordResponse from '../../fixtures/okta-responses/success/reset-password.json';
 import verifyRecoveryTokenReponse from '../../fixtures/okta-responses/success/verify-recovery-token.json';
 import authResetPasswordResponse from '../../fixtures/okta-responses/success/auth-reset-password.json';
+import updateUser from '../../fixtures/okta-responses/success/update-user.json';
 
 beforeEach(() => {
 	cy.mockPurge();
@@ -42,6 +43,8 @@ const setupMocksForSocialUserPasswordReset = () => {
 		authResetPasswordResponse.code,
 		authResetPasswordResponse.response,
 	);
+	// set email validated/password set securely flags to false
+	cy.mockNext(updateUser.code, updateUser.response);
 
 	// retry sending the email now that the user is "fixed"
 	// so we need to mock the same as for the non social user

--- a/src/server/controllers/changePassword.ts
+++ b/src/server/controllers/changePassword.ts
@@ -194,7 +194,10 @@ export const setPasswordController = (
 
 				const { id } = _embedded?.user ?? {};
 				if (id) {
-					await validateEmailAndPasswordSetSecurely(id, req.ip);
+					await validateEmailAndPasswordSetSecurely({
+						id,
+						ip: req.ip,
+					});
 				} else {
 					logger.error(
 						'Failed to set validation flags in Okta as there was no id',

--- a/src/server/controllers/sendChangePasswordEmail.ts
+++ b/src/server/controllers/sendChangePasswordEmail.ts
@@ -52,6 +52,7 @@ import {
 	resetPassword,
 	validateRecoveryToken,
 } from '@/server/lib/okta/api/authentication';
+import { validateEmailAndPasswordSetSecurely } from '@/server/lib/okta/validateEmail';
 
 const { passcodesEnabled } = getConfiguration();
 
@@ -463,6 +464,13 @@ const changePasswordEmailIdx = async (
 						},
 						req.ip,
 					);
+
+					// Unset the emailValidated and passwordSetSecurely flags
+					await validateEmailAndPasswordSetSecurely({
+						id: user.id,
+						ip: req.ip,
+						flagStatus: false,
+					});
 
 					// now that the placeholder password has been set, the user will be in
 					// 1. ACTIVE users - has email + password authenticator (okta idx email verified)

--- a/src/server/controllers/sendChangePasswordEmail.ts
+++ b/src/server/controllers/sendChangePasswordEmail.ts
@@ -1,3 +1,4 @@
+import crypto from 'crypto';
 import { Request } from 'express';
 import { ResponseWithRequestState } from '@/server/models/Express';
 import { setEncryptedStateCookie } from '@/server/lib/encryptedStateCookie';
@@ -47,6 +48,10 @@ import { recover } from '@/server/lib/okta/idx/recover';
 import { findAuthenticatorId } from '@/server/lib/okta/idx/shared/findAuthenticatorId';
 import { submitPassword } from '@/server/lib/okta/idx/shared/submitPasscode';
 import { credentialEnroll } from '@/server/lib/okta/idx/credential';
+import {
+	resetPassword,
+	validateRecoveryToken,
+} from '@/server/lib/okta/api/authentication';
 
 const { passcodesEnabled } = getConfiguration();
 
@@ -87,13 +92,14 @@ const setEncryptedCookieOkta = (
  * @name changePasswordEmailIdx
  * @description Start the Okta IDX flow to change the user's password
  *
- * NB: This is a WIP and is not fully implemented yet, it should be used behind the `usePasscodesResetPassword` query param flag
+ * NB: This is currently in testing and is not fully implemented yet, it should be used behind the `usePasscodesResetPassword` query param flag
  * Current status:
  *   - [x] ACTIVE users
  * 	   - [x] With email + password authenticator
- *     - [ ] With only password authenticator
+ *     - [x] With only password authenticator
  *     - [x] With only email authenticator
- *   - [ ] Non-ACTIVE user states
+ *   - [x] Non-ACTIVE user states
+ *   - [ ] Non-Existent users
  *
  * @param {Request} req - Express request object
  * @param {ResponseWithRequestState} res - Express response object
@@ -393,10 +399,88 @@ const changePasswordEmailIdx = async (
 				}
 			}
 			// eslint-disable-next-line no-fallthrough -- allow fallthrough for time being for cases we haven't implemented yet
-			default:
-				throw new OktaError({
-					message: `Okta changePasswordEmailIdx failed with unaccepted Okta user status: ${user.status}`,
-				});
+			default: {
+				// For users in a non-ACTIVE state, we should first get them into one of the ACTIVE states
+				// The best way to do this is to first deactivate the user, which works on all user states and puts them into the DEPROVISIONED state
+				// Then we can activate the user, which will put them into the PROVISIONED state and return us a recovery token
+				// We then use the recovery token to set a placeholder password for the user, which transitions them into the ACTIVE state
+				// and then we can call this method again to send the user a passcode as they'll be in one of the ACTIVE states
+
+				// if a loop is detected, then throw early to prevent infinite loop
+				if (loopDetectionFlag) {
+					throw new OktaError({
+						message: `Okta changePasswordEmailIdx failed with loop detection flag under non-ACTIVE user state ${user.status}`,
+					});
+				}
+
+				// 1. deactivate the user
+				try {
+					await deactivateUser({
+						id: user.id,
+						ip: req.ip,
+					});
+					trackMetric('OktaDeactivateUser::Success');
+				} catch (error) {
+					trackMetric('OktaDeactivateUser::Failure');
+					logger.error(
+						'Okta user deactivation failed',
+						error instanceof OktaError ? error.message : error,
+					);
+					throw error;
+				}
+
+				// 2. activate the user
+				try {
+					const tokenResponse = await activateUser({
+						id: user.id,
+						ip: req.ip,
+					});
+					if (!tokenResponse?.token.length) {
+						throw new OktaError({
+							message: `Okta user activation failed: missing activation token`,
+						});
+					}
+
+					// 3. use the recovery token to set a placeholder password for the user
+					// Validate the token
+					const { stateToken } = await validateRecoveryToken({
+						recoveryToken: tokenResponse.token,
+						ip: req.ip,
+					});
+					// Check if state token is defined
+					if (!stateToken) {
+						throw new OktaError({
+							message:
+								'Okta set placeholder password failed: state token is undefined',
+						});
+					}
+					// Set the placeholder password as a cryptographically secure UUID
+					const placeholderPassword = crypto.randomUUID();
+					await resetPassword(
+						{
+							stateToken,
+							newPassword: placeholderPassword,
+						},
+						req.ip,
+					);
+
+					// now that the placeholder password has been set, the user will be in
+					// 1. ACTIVE users - has email + password authenticator (okta idx email verified)
+					// or 2. ACTIVE users - has only password authenticator (okta idx email not verified)
+					// so we can call this method again to send the user a passcode
+					// They can't be in the 3. ACTIVE users - has only email authenticator (SOCIAL users, no password)
+					// as we've just set a placeholder password for them
+					// but we first need to get the updated user object
+					const updatedUser = await getUser(user.id, req.ip);
+					return changePasswordEmailIdx(req, res, updatedUser, true);
+				} catch (error) {
+					logger.error(
+						'Okta user activation failed',
+						error instanceof OktaError ? error.message : error,
+					);
+					throw error;
+				}
+			}
 		}
 	} catch (error) {
 		trackMetric('OktaIDXResetPasswordSend::Failure');

--- a/src/server/lib/okta/dangerouslySetPlaceholderPassword.ts
+++ b/src/server/lib/okta/dangerouslySetPlaceholderPassword.ts
@@ -3,6 +3,7 @@ import { OktaError } from '@/server/models/okta/Error';
 import { logger } from '@/server/lib/serverSideLogger';
 import { validateRecoveryToken, resetPassword } from './api/authentication';
 import { dangerouslyResetPassword } from './api/users';
+import { validateEmailAndPasswordSetSecurely } from './validateEmail';
 
 // Define the parameter object type
 interface PlaceholderPasswordParams {
@@ -61,6 +62,13 @@ async function dangerouslySetPlaceholderPassword({
 			},
 			ip,
 		);
+
+		// Unset the emailValidated and passwordSetSecurely flags
+		await validateEmailAndPasswordSetSecurely({
+			id,
+			ip,
+			flagStatus: false,
+		});
 
 		if (returnPlaceholderPassword) {
 			return placeholderPassword;

--- a/src/server/lib/okta/idx/challenge.ts
+++ b/src/server/lib/okta/idx/challenge.ts
@@ -337,7 +337,10 @@ export const setPasswordAndRedirect = async ({
 	// set the validation flags in Okta
 	const { id } = challengeAnswerResponse.user.value;
 	if (id) {
-		await validateEmailAndPasswordSetSecurely(id, ip);
+		await validateEmailAndPasswordSetSecurely({
+			id,
+			ip,
+		});
 	} else {
 		logger.error(
 			'Failed to set validation flags in Okta as there was no id',

--- a/src/server/lib/okta/validateEmail.ts
+++ b/src/server/lib/okta/validateEmail.ts
@@ -10,12 +10,18 @@ import { trackMetric } from '@/server/lib/trackMetric';
  *
  * @param {string} id accepts the Okta user ID, email address (login) or login shortname (as long as it is unambiguous)
  * @param {string} ip The IP address of the user
+ * @param {boolean} flagStatus Default is true. If true, the flags are set to true, if false, the flags are set to false
  * @returns {Promise<UserResponse>} Promise that resolves to the user object
  */
-export const validateEmailAndPasswordSetSecurely = async (
-	id: string,
-	ip?: string,
-): Promise<UserResponse> => {
+export const validateEmailAndPasswordSetSecurely = async ({
+	id,
+	ip,
+	flagStatus = true,
+}: {
+	id: string;
+	ip?: string;
+	flagStatus?: boolean;
+}): Promise<UserResponse> => {
 	try {
 		const timestamp = new Date().toISOString();
 
@@ -23,9 +29,9 @@ export const validateEmailAndPasswordSetSecurely = async (
 			id,
 			{
 				profile: {
-					emailValidated: true,
+					emailValidated: flagStatus,
 					lastEmailValidatedTimestamp: timestamp,
-					passwordSetSecurely: true,
+					passwordSetSecurely: flagStatus,
 					lastPasswordSetSecurelyTimestamp: timestamp,
 				},
 			},


### PR DESCRIPTION
## What does this change?

In https://github.com/guardian/gateway/pull/2852 we implemented passcodes for reset password for some "ACTIVE" users. Namely the ones with both the "password" and "email" authenticator, and users with just the "email" authenticator.

In https://github.com/guardian/gateway/pull/2889 we implemented passcode for reset password for the remaining active users, i.e the ones with only the "password" authenticator.

This PR adds the ability for all except non-existent users to reset their passcodes using passwords.

For users in a non-`ACTIVE` state, we should first get them into one of the `ACTIVE` states in order to send them an email which allows them to reset their password with a passcode.

The best way to do this is to first `deactivate` the user, which works on all user states and puts them into the `DEPROVISIONED` state.

Then we can activate the user, which will put them into the `PROVISIONED` state and return us a recovery token.

We then use the recovery token to set a placeholder password for the user, which transitions them into the `ACTIVE` state and then we can call `changePasswordEmailIdx` method again to send the user a passcode as they'll be in one of the `ACTIVE` states, namely the one with the "email" and "password" authenticator, or the one with only the "password" authenticator.

From there the existing functionality for `ACTIVE` users takes over and we send the users a passcode!

We also modify the `validateEmailAndPasswordSetSecurely` method to do the exact reverse depending on a flag. The `flagStatus` parameter was added in to set these flags `emailValidated` and `passwordSetSecurely` to `false` if `flagStatus` is provided as `false`. `flagStatus` defaults to `true` to retain existing behaviour.

A whole lotta cypress tests are included to make sure this functionality works.

## Tested
- [x] CODE