### PR TITLE
Permissions | Replace "Similar Guardian products" with "Guardian products and services"

### DIFF
--- a/cypress/support/idapi/consent.ts
+++ b/cypress/support/idapi/consent.ts
@@ -86,12 +86,12 @@ export const allConsents = [
 		name: 'Allow personalised advertising using this data - this supports the Guardian',
 	},
 	{
-		id: 'similar_guardian_products',
+		id: 'guardian_products_services',
 		isOptOut: false,
 		isChannel: false,
 		name: 'Guardian products and support',
 		description:
-			'Information on our products and ways to support and enjoy our independent journalism.',
+			'Receive information on our products and ways to support and enjoy our journalism.',
 	},
 ];
 

--- a/src/client/lib/consentsTracking.ts
+++ b/src/client/lib/consentsTracking.ts
@@ -88,11 +88,11 @@ export const registrationFormSubmitOphanTracking = (
 				case Newsletters.US_BUNDLE:
 					trackInputElementInteraction(elem, 'newsletter', 'us-bundle');
 					break;
-				case Consents.SIMILAR_GUARDIAN_PRODUCTS:
+				case Consents.GUARDIAN_PRODUCTS_SERVICES:
 					trackInputElementInteraction(
 						elem,
 						'consent',
-						'similar-guardian-products',
+						'guardian_products_services',
 					);
 					break;
 			}

--- a/src/server/lib/__tests__/registrationConsents.test.ts
+++ b/src/server/lib/__tests__/registrationConsents.test.ts
@@ -15,13 +15,13 @@ jest.mock('@/server/lib/serverSideLogger', () => ({
 describe('registrationConsents#bodyFormFieldsToRegistrationConsents', () => {
 	it('returns expected consents and newsletters for specific IDs', () => {
 		const body = {
-			similar_guardian_products: 'on',
+			guardian_products_services: 'on',
 			[Newsletters.SATURDAY_EDITION]: 'on',
 			[Newsletters.FEAST]: undefined,
 		};
 
 		const expected: RegistrationConsents = {
-			consents: [{ id: 'similar_guardian_products', consented: true }],
+			consents: [{ id: 'guardian_products_services', consented: true }],
 			newsletters: [{ id: Newsletters.SATURDAY_EDITION, subscribed: true }],
 		};
 
@@ -29,13 +29,13 @@ describe('registrationConsents#bodyFormFieldsToRegistrationConsents', () => {
 	});
 	it('returns expected consents and newsletters for bundle IDs', () => {
 		const body = {
-			similar_guardian_products: 'on',
+			guardian_products_services: 'on',
 			[Newsletters.AU_BUNDLE]: 'on',
 			[Newsletters.US_BUNDLE]: undefined,
 		};
 
 		const expected: RegistrationConsents = {
-			consents: [{ id: 'similar_guardian_products', consented: true }],
+			consents: [{ id: 'guardian_products_services', consented: true }],
 			newsletters: [
 				{
 					id: Newsletters.SATURDAY_EDITION,
@@ -56,7 +56,7 @@ describe('registrationConsents#minifyRegistrationConsents', () => {
 	it('minifies registration consents', () => {
 		const registrationConsents: RegistrationConsents = {
 			consents: [
-				{ id: 'similar_guardian_products', consented: true },
+				{ id: 'guardian_products_services', consented: true },
 				{ id: 'holidays', consented: false },
 			],
 			newsletters: [
@@ -66,7 +66,7 @@ describe('registrationConsents#minifyRegistrationConsents', () => {
 		};
 
 		const expected =
-			'similar_guardian_products=true,holidays=false|1234=true,4321=false';
+			'guardian_products_services=true,holidays=false|1234=true,4321=false';
 		expect(minifyRegistrationConsents(registrationConsents)).toEqual(expected);
 
 		expect(JSON.stringify(registrationConsents).length).toBeGreaterThan(
@@ -77,12 +77,12 @@ describe('registrationConsents#minifyRegistrationConsents', () => {
 	it('minifies only consents', () => {
 		const registrationConsents: RegistrationConsents = {
 			consents: [
-				{ id: 'similar_guardian_products', consented: true },
+				{ id: 'guardian_products_services', consented: true },
 				{ id: 'holidays', consented: false },
 			],
 		};
 
-		const expected = 'similar_guardian_products=true,holidays=false|';
+		const expected = 'guardian_products_services=true,holidays=false|';
 
 		expect(minifyRegistrationConsents(registrationConsents)).toEqual(expected);
 
@@ -124,11 +124,11 @@ describe('registrationConsents#minifyRegistrationConsents', () => {
 describe('registrationConsents#expandRegistrationConsents', () => {
 	it('expands registration consents', () => {
 		const input =
-			'similar_guardian_products=true,holidays=false|1234=true,4321=false';
+			'guardian_products_services=true,holidays=false|1234=true,4321=false';
 
 		const expected: RegistrationConsents = {
 			consents: [
-				{ id: 'similar_guardian_products', consented: true },
+				{ id: 'guardian_products_services', consented: true },
 				{ id: 'holidays', consented: false },
 			],
 			newsletters: [
@@ -141,11 +141,11 @@ describe('registrationConsents#expandRegistrationConsents', () => {
 	});
 
 	it('expands only consents', () => {
-		const input = 'similar_guardian_products=true,holidays=false|';
+		const input = 'guardian_products_services=true,holidays=false|';
 
 		const expected: RegistrationConsents = {
 			consents: [
-				{ id: 'similar_guardian_products', consented: true },
+				{ id: 'guardian_products_services', consented: true },
 				{ id: 'holidays', consented: false },
 			],
 			newsletters: [],

--- a/src/shared/model/Consent.ts
+++ b/src/shared/model/Consent.ts
@@ -10,7 +10,7 @@ export enum Consents {
 	// OPT OUT API CONSENTS (modeled as opt ins in Gateway)
 	PROFILING = 'profiling_optin',
 	// PRODUCT CONSENTS
-	SIMILAR_GUARDIAN_PRODUCTS = 'similar_guardian_products',
+	GUARDIAN_PRODUCTS_SERVICES = 'guardian_products_services',
 	JOBS = 'jobs',
 }
 
@@ -21,7 +21,7 @@ export const CONSENTS_DATA_PAGE: string[] = [
 
 export const RegistrationConsentsFormFields = {
 	similarGuardianProducts: {
-		id: Consents.SIMILAR_GUARDIAN_PRODUCTS,
+		id: Consents.GUARDIAN_PRODUCTS_SERVICES,
 		label:
 			'Receive information on our products and ways to support and enjoy our journalism. Toggle to opt out.',
 	},


### PR DESCRIPTION
### What does this PR change?

There is some work to replace the "Similar Guardian products" (`similar_guardian_products`) consent with the "Guardian products and services" (`guardian_products_services`) consent. This PR does just that.

After a backfill is performed to add the `guardian_products_services` consent to users, the `similar_guardian_products` consent will no longer be used, and readers will need a way to opt in to the "Guardian products and services" consent from the create account flow, and no longer be able to set the "Similar Guardian products" permission.

### Next steps/further info

- Do not merge until the backfill is finished
- A sibling PR in MMA updates the marketing page: https://github.com/guardian/manage-frontend/pull/1391

### Tested

- [x] Deploy this build and the MMA build at the same time