### PR TITLE
Passwordless | Make IDX API default for sign in with password flows!

### DIFF
--- a/cypress/fixtures/okta-responses/error/idx-challenge-answer-password-401-response.json
+++ b/cypress/fixtures/okta-responses/error/idx-challenge-answer-password-401-response.json
@@ -1,0 +1,267 @@
+{
+	"code": 401,
+	"response": {
+		"version": "1.0.0",
+		"stateHandle": "02.id.state~c.handle",
+		"expiresAt": "2099-12-31T23:59:59.000Z",
+		"intent": "LOGIN",
+		"remediation": {
+			"type": "array",
+			"value": [
+				{
+					"rel": ["create-form"],
+					"name": "challenge-authenticator",
+					"relatesTo": ["$.currentAuthenticatorEnrollment"],
+					"href": "https://profile.thegulocal.com/idp/idx/challenge/answer",
+					"method": "POST",
+					"produces": "application/ion+json; okta-version=1.0.0",
+					"value": [
+						{
+							"name": "credentials",
+							"type": "object",
+							"form": {
+								"value": [
+									{
+										"name": "passcode",
+										"label": "Password",
+										"secret": true
+									}
+								]
+							},
+							"required": true
+						},
+						{
+							"name": "stateHandle",
+							"required": true,
+							"value": "02.id.state~c.handle",
+							"visible": false,
+							"mutable": false
+						}
+					],
+					"accepts": "application/json; okta-version=1.0.0"
+				},
+				{
+					"rel": ["create-form"],
+					"name": "select-authenticator-authenticate",
+					"href": "https://profile.thegulocal.com/idp/idx/challenge",
+					"method": "POST",
+					"produces": "application/ion+json; okta-version=1.0.0",
+					"value": [
+						{
+							"name": "authenticator",
+							"type": "object",
+							"options": [
+								{
+									"label": "Email",
+									"value": {
+										"form": {
+											"value": [
+												{
+													"name": "id",
+													"required": true,
+													"value": "emailId",
+													"mutable": false
+												},
+												{
+													"name": "methodType",
+													"required": false,
+													"value": "email",
+													"mutable": false
+												}
+											]
+										}
+									},
+									"relatesTo": "$.authenticatorEnrollments.value[0]"
+								},
+								{
+									"label": "Password",
+									"value": {
+										"form": {
+											"value": [
+												{
+													"name": "id",
+													"required": true,
+													"value": "passwordId",
+													"mutable": false
+												},
+												{
+													"name": "methodType",
+													"required": false,
+													"value": "password",
+													"mutable": false
+												}
+											]
+										}
+									},
+									"relatesTo": "$.authenticatorEnrollments.value[1]"
+								}
+							]
+						},
+						{
+							"name": "stateHandle",
+							"required": true,
+							"value": "02.id.state~c.handle",
+							"visible": false,
+							"mutable": false
+						}
+					],
+					"accepts": "application/json; okta-version=1.0.0"
+				}
+			]
+		},
+		"messages": {
+			"type": "array",
+			"value": [
+				{
+					"message": "Authentication failed",
+					"i18n": {
+						"key": "errors.E0000004"
+					},
+					"class": "ERROR"
+				}
+			]
+		},
+		"currentAuthenticatorEnrollment": {
+			"type": "object",
+			"value": {
+				"recover": {
+					"rel": ["create-form"],
+					"name": "recover",
+					"href": "https://profile.thegulocal.com/idp/idx/recover",
+					"method": "POST",
+					"produces": "application/ion+json; okta-version=1.0.0",
+					"value": [
+						{
+							"name": "stateHandle",
+							"required": true,
+							"value": "02.id.state~c.handle",
+							"visible": false,
+							"mutable": false
+						}
+					],
+					"accepts": "application/json; okta-version=1.0.0"
+				},
+				"type": "password",
+				"key": "okta_password",
+				"id": "lae7vln11DDhAnAv30x6",
+				"displayName": "Password",
+				"methods": [
+					{
+						"type": "password"
+					}
+				]
+			}
+		},
+		"authenticators": {
+			"type": "array",
+			"value": [
+				{
+					"type": "email",
+					"key": "okta_email",
+					"id": "emailId",
+					"displayName": "Email",
+					"methods": [
+						{
+							"type": "email"
+						}
+					],
+					"allowedFor": "any"
+				},
+				{
+					"type": "password",
+					"key": "okta_password",
+					"id": "passwordId",
+					"displayName": "Password",
+					"methods": [
+						{
+							"type": "password"
+						}
+					],
+					"allowedFor": "sso"
+				}
+			]
+		},
+		"authenticatorEnrollments": {
+			"type": "array",
+			"value": [
+				{
+					"profile": {
+						"email": "test@example.com"
+					},
+					"type": "email",
+					"key": "okta_email",
+					"id": "emailId",
+					"displayName": "Email",
+					"methods": [
+						{
+							"type": "email"
+						}
+					]
+				},
+				{
+					"type": "password",
+					"key": "okta_password",
+					"id": "passwordId",
+					"displayName": "Password",
+					"methods": [
+						{
+							"type": "password"
+						}
+					]
+				}
+			]
+		},
+		"user": {
+			"type": "object",
+			"value": {
+				"identifier": "test@example.com"
+			}
+		},
+		"cancel": {
+			"rel": ["create-form"],
+			"name": "cancel",
+			"href": "https://profile.thegulocal.com/idp/idx/cancel",
+			"method": "POST",
+			"produces": "application/ion+json; okta-version=1.0.0",
+			"value": [
+				{
+					"name": "stateHandle",
+					"required": true,
+					"value": "02.id.state~c.handle",
+					"visible": false,
+					"mutable": false
+				}
+			],
+			"accepts": "application/json; okta-version=1.0.0"
+		},
+		"app": {
+			"type": "object",
+			"value": {
+				"name": "oidc_client",
+				"label": "sample_application",
+				"id": "clientId"
+			}
+		},
+		"authentication": {
+			"type": "object",
+			"value": {
+				"protocol": "OAUTH2.0",
+				"issuer": {
+					"id": "authServerId",
+					"name": "Guardian Authorization Server",
+					"uri": "https://profile.thegulocal.com/oauth2/authServerId"
+				},
+				"request": {
+					"max_age": -1,
+					"scope": "openid",
+					"response_type": "code",
+					"redirect_uri": "http://localhost:8081/login/callback",
+					"state": "state",
+					"code_challenge_method": "S256",
+					"code_challenge": "test",
+					"response_mode": "query"
+				}
+			}
+		}
+	}
+}

--- a/cypress/fixtures/okta-responses/success/idx-challenge-answer-password-user-response.json
+++ b/cypress/fixtures/okta-responses/success/idx-challenge-answer-password-user-response.json
@@ -1,0 +1,97 @@
+{
+	"code": 200,
+	"response": {
+		"version": "1.0.0",
+		"stateHandle": "02.id.state~c.handle",
+		"expiresAt": "2024-10-07T10:48:48.000Z",
+		"intent": "LOGIN",
+		"user": {
+			"type": "object",
+			"value": {
+				"id": "userId",
+				"identifier": "test@example.com",
+				"profile": {
+					"firstName": "Test",
+					"lastName": "Example",
+					"timeZone": "America/Los_Angeles",
+					"locale": "en_US",
+					"email": "test@example.com"
+				}
+			}
+		},
+		"cancel": {
+			"rel": ["create-form"],
+			"name": "cancel",
+			"href": "https://profile.thegulocal.com/idp/idx/cancel",
+			"method": "POST",
+			"produces": "application/ion+json; okta-version=1.0.0",
+			"value": [
+				{
+					"name": "stateHandle",
+					"required": true,
+					"value": "02.id.state~c.handle",
+					"visible": false,
+					"mutable": false
+				}
+			],
+			"accepts": "application/json; okta-version=1.0.0"
+		},
+		"app": {
+			"type": "object",
+			"value": {
+				"name": "oidc_client",
+				"label": "sample_application",
+				"id": "clientid"
+			}
+		},
+		"successWithInteractionCode": {
+			"rel": ["create-form"],
+			"name": "issue",
+			"href": "https://profile.thegulocal.com/oauth2/aus3v9gla95Toj0EE0x7/v1/token",
+			"method": "POST",
+			"value": [
+				{
+					"name": "grant_type",
+					"required": true,
+					"value": "interaction_code"
+				},
+				{
+					"name": "interaction_code",
+					"required": true,
+					"value": "interaction_code"
+				},
+				{
+					"name": "client_id",
+					"required": true,
+					"value": "clientId"
+				},
+				{
+					"name": "code_verifier",
+					"required": true
+				}
+			],
+			"accepts": "application/x-www-form-urlencoded"
+		},
+		"authentication": {
+			"type": "object",
+			"value": {
+				"protocol": "OAUTH2.0",
+				"issuer": {
+					"id": "authServerId",
+					"name": "Guardian Authorization Server",
+					"uri": "https://profile.thegulocal.com/oauth2/authServerId"
+				},
+				"request": {
+					"max_age": -1,
+					"scope": "openid",
+					"response_type": "code",
+					"redirect_uri": "http://localhost:8081/login/callback",
+					"state": "state",
+					"code_challenge_method": "S256",
+					"code_challenge": "test",
+					"response_mode": "query"
+				}
+			}
+		}
+	}
+}

--- a/cypress/integration/ete/sign_in.1.cy.ts
+++ b/cypress/integration/ete/sign_in.1.cy.ts
@@ -7,7 +7,7 @@ const returnUrl =
 	'https://www.theguardian.com/world/2013/jun/09/edward-snowden-nsa-whistleblower-surveillance';
 
 describe('Sign in flow, Okta enabled', () => {
-	context('Terms and Conditions links', () => {
+	context('Page tests', () => {
 		it('links to the Google terms of service page', () => {
 			const googleTermsUrl = 'https://policies.google.com/terms';
 			// Intercept the external redirect page.
@@ -84,241 +84,569 @@ describe('Sign in flow, Okta enabled', () => {
 				.click();
 			cy.url().should('eq', guardianJobsPrivacyPolicyUrl);
 		});
+		it('navigates to reset password', () => {
+			cy.visit('/signin');
+			cy.contains('Reset password').click();
+			cy.contains('Reset password');
+		});
+		it('navigates to registration', () => {
+			cy.visit('/signin');
+			cy.contains('Create a free account').click();
+			cy.contains('Continue with Google');
+			cy.contains('Continue with Apple');
+			cy.contains('Continue with email');
+		});
+		it('removes encryptedEmail parameter from query string', () => {
+			const encryptedEmailParam = 'encryptedEmail=bhvlabgflbgyil';
+			cy.visit(`/signin?${encryptedEmailParam}`);
+
+			cy.location('search').should('not.contain', encryptedEmailParam);
+		});
+		it('removes encryptedEmail parameter and preserves all other valid parameters', () => {
+			const encryptedEmailParam = 'encryptedEmail=bhvlabgflbgyil';
+			cy.visit(
+				`/signin?returnUrl=${encodeURIComponent(
+					returnUrl,
+				)}&${encryptedEmailParam}&refViewId=12345`,
+			);
+
+			cy.location('search').should('not.contain', encryptedEmailParam);
+			cy.location('search').should('contain', 'refViewId=12345');
+			cy.location('search').should('contain', encodeURIComponent(returnUrl));
+		});
+		it('persists the clientId when navigating away', () => {
+			cy.visit('/signin?clientId=jobs');
+			cy.contains('Create a free account').click();
+			cy.url().should('contain', 'clientId=jobs');
+		});
+		it('applies form validation to email and password input fields', () => {
+			cy.visit('/signin');
+
+			cy.get('form').within(() => {
+				cy.get('input:invalid').should('have.length', 2);
+				cy.get('input[name=email]').type('not an email');
+				cy.get('input:invalid').should('have.length', 2);
+				cy.get('input[name=email]').type('emailaddress@inavalidformat.com');
+				cy.get('input:invalid').should('have.length', 1);
+				cy.get('input[name=password]').type('password');
+				cy.get('input:invalid').should('have.length', 0);
+			});
+		});
 	});
 
-	it('persists the clientId when navigating away', () => {
-		cy.visit('/signin?clientId=jobs');
-		cy.contains('Create a free account').click();
-		cy.url().should('contain', 'clientId=jobs');
-	});
-	it('applies form validation to email and password input fields', () => {
-		cy.visit('/signin');
-
-		cy.get('form').within(() => {
-			cy.get('input:invalid').should('have.length', 2);
-			cy.get('input[name=email]').type('not an email');
-			cy.get('input:invalid').should('have.length', 2);
-			cy.get('input[name=email]').type('emailaddress@inavalidformat.com');
-			cy.get('input:invalid').should('have.length', 1);
+	context('Okta Classic API Sign In', () => {
+		it('shows a message when credentials are invalid', () => {
+			cy.visit('/signin?useOktaClassic=true');
+			cy.get('input[name=email]').type('invalid@doesnotexist.com');
 			cy.get('input[name=password]').type('password');
-			cy.get('input:invalid').should('have.length', 0);
+			cy.get('[data-cy="main-form-submit-button"]').click();
+			cy.contains('Email and password don’t match');
 		});
-	});
-	it('shows a message when credentials are invalid', () => {
-		cy.visit('/signin');
-		cy.get('input[name=email]').type('invalid@doesnotexist.com');
-		cy.get('input[name=password]').type('password');
-		cy.get('[data-cy="main-form-submit-button"]').click();
-		cy.contains('Email and password don’t match');
-	});
-	it('correctly signs in an existing user', () => {
-		// Intercept the external redirect page.
-		// We just want to check that the redirect happens, not that the page loads.
-		cy.intercept('GET', 'https://m.code.dev-theguardian.com/', (req) => {
-			req.reply(200);
-		});
-		cy
-			.createTestUser({
-				isUserEmailValidated: true,
-			})
-			?.then(({ emailAddress, finalPassword }) => {
-				cy.visit('/signin');
-				cy.get('input[name=email]').type(emailAddress);
-				cy.get('input[name=password]').type(finalPassword);
-				cy.get('[data-cy="main-form-submit-button"]').click();
-				cy.url().should('include', 'https://m.code.dev-theguardian.com/');
+
+		it('correctly signs in an existing user', () => {
+			// Intercept the external redirect page.
+			// We just want to check that the redirect happens, not that the page loads.
+			cy.intercept('GET', 'https://m.code.dev-theguardian.com/', (req) => {
+				req.reply(200);
 			});
-	});
-	it('navigates to reset password', () => {
-		cy.visit('/signin');
-		cy.contains('Reset password').click();
-		cy.contains('Reset password');
-	});
-	it('navigates to registration', () => {
-		cy.visit('/signin');
-		cy.contains('Create a free account').click();
-		cy.contains('Continue with Google');
-		cy.contains('Continue with Apple');
-		cy.contains('Continue with email');
-	});
-	it('respects the returnUrl query param', () => {
-		// Intercept the external redirect page.
-		// We just want to check that the redirect happens, not that the page loads.
-		cy.intercept('GET', returnUrl, (req) => {
-			req.reply(200);
+			cy
+				.createTestUser({
+					isUserEmailValidated: true,
+				})
+				?.then(({ emailAddress, finalPassword }) => {
+					cy.visit('/signin?useOktaClassic=true');
+					cy.get('input[name=email]').type(emailAddress);
+					cy.get('input[name=password]').type(finalPassword);
+					cy.get('[data-cy="main-form-submit-button"]').click();
+					cy.url().should('include', 'https://m.code.dev-theguardian.com/');
+				});
 		});
-		cy
-			.createTestUser({
-				isUserEmailValidated: true,
-			})
-			?.then(({ emailAddress, finalPassword }) => {
-				cy.visit(`/signin?returnUrl=${encodeURIComponent(returnUrl)}`);
-				cy.get('input[name=email]').type(emailAddress);
-				cy.get('input[name=password]').type(finalPassword);
-				cy.get('[data-cy="main-form-submit-button"]').click();
-				cy.url().should('eq', returnUrl);
+
+		it('respects the returnUrl query param', () => {
+			// Intercept the external redirect page.
+			// We just want to check that the redirect happens, not that the page loads.
+			cy.intercept('GET', returnUrl, (req) => {
+				req.reply(200);
 			});
-	});
-	it('removes encryptedEmail parameter from query string', () => {
-		const encryptedEmailParam = 'encryptedEmail=bhvlabgflbgyil';
-		cy.visit(`/signin?${encryptedEmailParam}`);
-
-		cy.location('search').should('not.contain', encryptedEmailParam);
-	});
-	it('removes encryptedEmail parameter and preserves all other valid parameters', () => {
-		const encryptedEmailParam = 'encryptedEmail=bhvlabgflbgyil';
-		cy.visit(
-			`/signin?returnUrl=${encodeURIComponent(
-				returnUrl,
-			)}&${encryptedEmailParam}&refViewId=12345`,
-		);
-
-		cy.location('search').should('not.contain', encryptedEmailParam);
-		cy.location('search').should('contain', 'refViewId=12345');
-		cy.location('search').should('contain', encodeURIComponent(returnUrl));
-	});
-	it('shows reCAPTCHA errors when the user tries to sign in offline and allows sign in when back online', () => {
-		// Intercept the external redirect page.
-		// We just want to check that the redirect happens, not that the page loads.
-		cy.intercept('GET', 'https://m.code.dev-theguardian.com/', (req) => {
-			req.reply(200);
+			cy
+				.createTestUser({
+					isUserEmailValidated: true,
+				})
+				?.then(({ emailAddress, finalPassword }) => {
+					cy.visit(
+						`/signin?returnUrl=${encodeURIComponent(returnUrl)}&useOktaClassic=true`,
+					);
+					cy.get('input[name=email]').type(emailAddress);
+					cy.get('input[name=password]').type(finalPassword);
+					cy.get('[data-cy="main-form-submit-button"]').click();
+					cy.url().should('eq', returnUrl);
+				});
 		});
-		cy
-			.createTestUser({
-				isUserEmailValidated: true,
-			})
-			?.then(({ emailAddress, finalPassword }) => {
-				cy.visit('/signin');
 
-				cy.interceptRecaptcha();
-
-				cy.get('input[name=email]').type(emailAddress);
-				cy.get('input[name=password]').type(finalPassword);
-				cy.get('[data-cy="main-form-submit-button"]').click();
-
-				cy.contains('Google reCAPTCHA verification failed.');
-				cy.contains('If the problem persists please try the following:');
-
-				cy.get('[data-cy="main-form-submit-button"]').click();
-
-				cy.contains('Google reCAPTCHA verification failed.').should(
-					'not.exist',
-				);
-
-				cy.url().should('include', 'https://m.code.dev-theguardian.com/');
+		it('hits access token rate limit and recovers token after timeout', () => {
+			// Intercept the external redirect page.
+			// We just want to check that the redirect happens, not that the page loads.
+			cy.intercept('GET', 'https://m.code.dev-theguardian.com/', (req) => {
+				req.reply(200);
 			});
-	});
-	it('hits access token rate limit and recovers token after timeout', () => {
-		// Intercept the external redirect page.
-		// We just want to check that the redirect happens, not that the page loads.
-		cy.intercept('GET', 'https://m.code.dev-theguardian.com/', (req) => {
-			req.reply(200);
+			cy
+				.createTestUser({
+					isUserEmailValidated: true,
+				})
+				?.then(({ emailAddress, finalPassword }) => {
+					cy.visit('/signin?useOktaClassic=true');
+					cy.get('input[name=email]').type(emailAddress);
+					cy.get('input[name=password]').type(finalPassword);
+					cy.get('[data-cy="main-form-submit-button"]').click();
+					cy.url().should('include', 'https://m.code.dev-theguardian.com/');
+
+					// We visit reauthenticate here because if we visit /signin or
+					// /register, the logged in user guard will redirect us away before
+					// the ratelimiter has a chance to work
+					cy.visit('/reauthenticate');
+					cy.contains('Sign');
+					Cypress._.times(6, () => cy.reload());
+					cy.contains('Rate limit exceeded');
+				});
 		});
-		cy
-			.createTestUser({
-				isUserEmailValidated: true,
-			})
-			?.then(({ emailAddress, finalPassword }) => {
-				cy.visit('/signin');
-				cy.get('input[name=email]').type(emailAddress);
-				cy.get('input[name=password]').type(finalPassword);
-				cy.get('[data-cy="main-form-submit-button"]').click();
-				cy.url().should('include', 'https://m.code.dev-theguardian.com/');
 
-				// We visit reauthenticate here because if we visit /signin or
-				// /register, the logged in user guard will redirect us away before
-				// the ratelimiter has a chance to work
-				cy.visit('/reauthenticate');
-				cy.contains('Sign');
-				Cypress._.times(6, () => cy.reload());
-				cy.contains('Rate limit exceeded');
-			});
-	});
+		it('Sends a user with an unvalidated email a reset password email on sign in', () => {
+			cy
+				.createTestUser({
+					isUserEmailValidated: false,
+				})
+				?.then(({ emailAddress, finalPassword }) => {
+					const timeRequestWasMade = new Date();
+					cy.visit('/signin?useOktaClassic=true');
+					cy.get('input[name=email]').type(emailAddress);
+					cy.get('input[name=password]').type(finalPassword);
+					cy.get('[data-cy="main-form-submit-button"]').click();
+					cy.url().should('include', '/signin/email-sent');
+					cy.contains(
+						'For security reasons we need you to change your password.',
+					);
+					cy.contains(emailAddress);
+					cy.contains('send again');
+					cy.contains('try another address');
 
-	it('redirects correctly for social sign in', () => {
-		cy.visit(`/signin?returnUrl=${encodeURIComponent(returnUrl)}`);
-		cy.get('[data-cy="google-sign-in-button"]').should(
-			'have.attr',
-			'href',
-			`/signin/google?returnUrl=${encodeURIComponent(returnUrl)}`,
-		);
-		cy.get('[data-cy="apple-sign-in-button"]').should(
-			'have.attr',
-			'href',
-			`/signin/apple?returnUrl=${encodeURIComponent(returnUrl)}`,
-		);
-	});
-	it('shows an error message and information paragraph when accountLinkingRequired error parameter is present', () => {
-		cy.visit('/signin?error=accountLinkingRequired');
-		cy.contains(
-			'We could not sign you in with your social account credentials. Please sign in with your email below.',
-		);
-		cy.contains('Social sign-in unsuccessful');
-	});
-	it('does not display social buttons when accountLinkingRequired error parameter is present', () => {
-		cy.visit('/signin?error=accountLinkingRequired');
-		cy.get('[data-cy="google-sign-in-button"]').should('not.exist');
-		cy.get('[data-cy="apple-sign-in-button"]').should('not.exist');
-	});
+					// Ensure the user's authentication cookies are not set
+					cy.getCookie('idx').then((idxCookie) => {
+						expect(idxCookie).to.not.exist;
 
-	it('sets emailValidated flag on oauth callback', () => {
-		// this is a specific test case for new user registrations in Okta
-		// In Okta new social registered users are added to the GuardianUser-EmailValidated group
-		// by default, but the custom emailValidated field is not defined/set to false
-		// this causes problems in legacy code, where the emailValidated flag is not set but the group is
-		// so we need to set the flag to true when the user is added to the group
-		// we do this on the oauth callback route /oauth/authorization-code/callback
-		// where we update the user profile with the emailValidated flag if the user is in the GuardianUser-EmailValidated group but the emailValidated is falsy
-
-		// This test checks this behaviour by first getting a user into this state
-		// i.e user.profile.emailValidated = false, and user groups has GuardianUser-EmailValidated
-
-		// first we have to get the id of the GuardianUser-EmailValidated group
-		cy.findEmailValidatedOktaGroupId().then((groupId) => {
-			// next we create a test user
-			cy.createTestUser({}).then(({ emailAddress, finalPassword }) => {
-				// we get the user profile object from Okta
-				cy.getTestOktaUser(emailAddress).then((user) => {
-					const { id, profile } = user;
-					// check the user profile has the emailValidated flag set to false
-					expect(profile.emailValidated).to.be.false;
-					// next check the user groups
-					cy.getOktaUserGroups(id).then((groups) => {
-						// make sure the user is not in the GuardianUser-EmailValidated group
-						const group = groups.find((g) => g.id === groupId);
-						expect(group).not.to.exist;
-
-						// and add them to the group if this is the case
-						cy.addOktaUserToGroup(id, groupId);
-
-						// at this point the user is in the correct state
-						// so we attempt to sign them in
-						cy.visit(
-							`/signin?returnUrl=${encodeURIComponent(
-								`https://${Cypress.env('BASE_URI')}/welcome/review`,
-							)}`,
-						);
-						cy.get('input[name=email]').type(emailAddress);
-						cy.get('input[name=password]').type(finalPassword);
-						cy.get('[data-cy="main-form-submit-button"]').click();
-						cy.url().should('include', '/welcome/review');
-
-						// at this point the oauth callback route will have run, so we can recheck the user profile to see if the emailValidated flag has been set
-						cy.getTestOktaUser(id).then((user) => {
-							const { profile } = user;
-							expect(profile.emailValidated).to.be.true;
+						cy.checkForEmailAndGetDetails(
+							emailAddress,
+							timeRequestWasMade,
+							/reset-password\/([^"]*)/,
+						).then(({ links, body, token }) => {
+							expect(body).to.have.string(
+								'Because your security is extremely important to us, we have changed our password policy.',
+							);
+							expect(body).to.have.string('Reset password');
+							expect(links.length).to.eq(2);
+							const resetPasswordLink = links.find((s) =>
+								s.text?.includes('Reset password'),
+							);
+							expect(resetPasswordLink?.href ?? '').to.have.string(
+								'reset-password',
+							);
+							cy.visit(`/reset-password/${token}`);
+							cy.contains(emailAddress);
+							cy.contains('Create new password');
 						});
+					});
+				});
+		});
 
-						// and the user should also be in the group
+		it('sets emailValidated flag on oauth callback', () => {
+			// this is a specific test case for new user registrations in Okta
+			// In Okta new social registered users are added to the GuardianUser-EmailValidated group
+			// by default, but the custom emailValidated field is not defined/set to false
+			// this causes problems in legacy code, where the emailValidated flag is not set but the group is
+			// so we need to set the flag to true when the user is added to the group
+			// we do this on the oauth callback route /oauth/authorization-code/callback
+			// where we update the user profile with the emailValidated flag if the user is in the GuardianUser-EmailValidated group but the emailValidated is falsy
+
+			// This test checks this behaviour by first getting a user into this state
+			// i.e user.profile.emailValidated = false, and user groups has GuardianUser-EmailValidated
+
+			// first we have to get the id of the GuardianUser-EmailValidated group
+			cy.findEmailValidatedOktaGroupId().then((groupId) => {
+				// next we create a test user
+				cy.createTestUser({}).then(({ emailAddress, finalPassword }) => {
+					// we get the user profile object from Okta
+					cy.getTestOktaUser(emailAddress).then((user) => {
+						const { id, profile } = user;
+						// check the user profile has the emailValidated flag set to false
+						expect(profile.emailValidated).to.be.false;
+						// next check the user groups
 						cy.getOktaUserGroups(id).then((groups) => {
+							// make sure the user is not in the GuardianUser-EmailValidated group
 							const group = groups.find((g) => g.id === groupId);
-							expect(group).to.exist;
+							expect(group).not.to.exist;
+
+							// and add them to the group if this is the case
+							cy.addOktaUserToGroup(id, groupId);
+
+							// at this point the user is in the correct state
+							// so we attempt to sign them in
+							cy.visit(
+								`/signin?returnUrl=${encodeURIComponent(
+									`https://${Cypress.env('BASE_URI')}/welcome/review`,
+								)}`,
+							);
+							cy.get('input[name=email]').type(emailAddress);
+							cy.get('input[name=password]').type(finalPassword);
+							cy.get('[data-cy="main-form-submit-button"]').click();
+							cy.url().should('include', '/welcome/review');
+
+							// at this point the oauth callback route will have run, so we can recheck the user profile to see if the emailValidated flag has been set
+							cy.getTestOktaUser(id).then((user) => {
+								const { profile } = user;
+								expect(profile.emailValidated).to.be.true;
+							});
+
+							// and the user should also be in the group
+							cy.getOktaUserGroups(id).then((groups) => {
+								const group = groups.find((g) => g.id === groupId);
+								expect(group).to.exist;
+							});
 						});
 					});
 				});
 			});
 		});
 	});
+
+	context('Okta IDX API Sign In', () => {
+		it('ACTIVE user - email + password authenticators - successfully sign in', () => {
+			// Intercept the external redirect page.
+			// We just want to check that the redirect happens, not that the page loads.
+			cy.intercept('GET', 'https://m.code.dev-theguardian.com/', (req) => {
+				req.reply(200);
+			});
+			cy
+				.createTestUser({
+					isUserEmailValidated: true,
+				})
+				?.then(({ emailAddress, finalPassword }) => {
+					cy.visit('/signin');
+					cy.get('input[name=email]').type(emailAddress);
+					cy.get('input[name=password]').type(finalPassword);
+					cy.get('[data-cy="main-form-submit-button"]').click();
+					cy.url().should('include', 'https://m.code.dev-theguardian.com/');
+				});
+		});
+
+		it('ACTIVE user - email + password authenticators - successfully sign in - preserve returnUrl', () => {
+			// Intercept the external redirect page.
+			// We just want to check that the redirect happens, not that the page loads.
+			cy.intercept('GET', returnUrl, (req) => {
+				req.reply(200);
+			});
+			cy
+				.createTestUser({
+					isUserEmailValidated: true,
+				})
+				?.then(({ emailAddress, finalPassword }) => {
+					cy.visit(`/signin?returnUrl=${encodeURIComponent(returnUrl)}`);
+					cy.get('input[name=email]').type(emailAddress);
+					cy.get('input[name=password]').type(finalPassword);
+					cy.get('[data-cy="main-form-submit-button"]').click();
+					cy.url().should('eq', returnUrl);
+				});
+		});
+
+		it('ACTIVE user - email + password authenticators - successfully sign in - preserve fromURI', () => {
+			const encodedReturnUrl = encodeURIComponent(returnUrl);
+			const appClientId = 'appClientId1';
+			const fromURI = '/oauth2/v1/authorize';
+
+			// Intercept the external redirect page.
+			// We just want to check that the redirect happens, not that the page loads.
+			cy.intercept(
+				'GET',
+				`https://${Cypress.env('BASE_URI')}${decodeURIComponent(fromURI)}`,
+				(req) => {
+					req.reply(200);
+				},
+			);
+
+			cy
+				.createTestUser({
+					isUserEmailValidated: true,
+				})
+				?.then(({ emailAddress, finalPassword }) => {
+					cy.visit(`/signin?returnUrl=${encodeURIComponent(returnUrl)}`);
+					cy.visit(
+						`/signin?returnUrl=${encodedReturnUrl}&appClientId=${appClientId}&fromURI=${fromURI}`,
+					);
+					cy.get('input[name=email]').type(emailAddress);
+					cy.get('input[name=password]').type(finalPassword);
+					cy.get('[data-cy="main-form-submit-button"]').click();
+
+					// fromURI redirect
+					cy.url().should('contain', decodeURIComponent(fromURI));
+				});
+		});
+
+		it('ACTIVE user - password authenticator only - send OTP reset password security email', () => {
+			const emailAddress = randomMailosaurEmail();
+			cy.visit(`/register/email`);
+
+			const timeRequestWasMade = new Date();
+			cy.get('input[name=email]').type(emailAddress);
+			cy.get('[data-cy="main-form-submit-button"]').click();
+
+			cy.contains('Enter your code');
+			cy.contains(emailAddress);
+
+			cy.checkForEmailAndGetDetails(emailAddress, timeRequestWasMade).then(
+				({ body, codes }) => {
+					// email
+					expect(body).to.have.string('Your verification code');
+					expect(codes?.length).to.eq(1);
+					const code = codes?.[0].value;
+					expect(code).to.match(/^\d{6}$/);
+
+					// passcode page
+					cy.url().should('include', '/register/email-sent');
+
+					// make sure we don't use a passcode
+					// we instead reset their password using classic flow to set a password
+					cy.visit('/reset-password?useOktaClassic=true');
+
+					const timeRequestWasMade = new Date();
+					cy.get('input[name=email]').clear().type(emailAddress);
+					cy.get('[data-cy="main-form-submit-button"]').click();
+
+					cy.checkForEmailAndGetDetails(
+						emailAddress,
+						timeRequestWasMade,
+						/\/set-password\/([^"]*)/,
+					).then(({ links, body }) => {
+						expect(body).to.have.string('Welcome back');
+
+						expect(body).to.have.string('Create password');
+						expect(links.length).to.eq(2);
+						const setPasswordLink = links.find((s) =>
+							s.text?.includes('Create password'),
+						);
+
+						cy.visit(setPasswordLink?.href as string);
+
+						const password = randomPassword();
+						cy.get('input[name=password]').type(password);
+
+						cy.get('[data-cy="main-form-submit-button"]')
+							.click()
+							.should('be.disabled');
+						cy.contains('Password created');
+						cy.contains(emailAddress.toLowerCase());
+
+						// setup complete, now sign in
+						cy.visit('/signin');
+						cy.contains('Sign in with a different email').click();
+						cy.get('input[name=email]').clear().type(emailAddress);
+						cy.get('input[name=password]').type(password);
+
+						const timeRequestWasMade = new Date();
+						cy.get('[data-cy="main-form-submit-button"]').click();
+
+						cy.checkForEmailAndGetDetails(
+							emailAddress,
+							timeRequestWasMade,
+						).then(({ body, codes }) => {
+							// email
+							expect(body).to.have.string('Your verification code');
+							expect(codes?.length).to.eq(1);
+							const code = codes?.[0].value;
+							expect(code).to.match(/^\d{6}$/);
+
+							// passcode page
+							cy.url().should('include', '/signin/email-sent');
+							cy.contains('Enter your verification code');
+							cy.contains(
+								'For security reasons we need you to change your password.',
+							);
+							cy.get('input[name=code]').clear().type(code!);
+							cy.contains('Submit verification code').click();
+
+							cy.url().should('contain', '/set-password');
+
+							cy.get('input[name="password"]').type(randomPassword());
+							cy.get('button[type="submit"]').click();
+
+							cy.url().should('contain', '/set-password/complete');
+						});
+					});
+				},
+			);
+		});
+
+		it('ACTIVE user - email + password authenticators - shows authentication error when password incorrect', () => {
+			// Intercept the external redirect page.
+			// We just want to check that the redirect happens, not that the page loads.
+			cy.intercept('GET', 'https://m.code.dev-theguardian.com/', (req) => {
+				req.reply(200);
+			});
+			cy
+				.createTestUser({
+					isUserEmailValidated: true,
+				})
+				?.then(({ emailAddress, finalPassword }) => {
+					cy.visit('/signin');
+					cy.get('input[name=email]').type(emailAddress);
+					cy.get('input[name=password]').type(`${finalPassword}!`);
+					cy.get('[data-cy="main-form-submit-button"]').click();
+					cy.contains('Email and password don’t match');
+				});
+		});
+
+		it('NON-EXISTENT user - shows authentication error in all scenarios', () => {
+			cy.visit('/signin');
+			cy.get('input[name=email]').type('invalid@doesnotexist.com');
+			cy.get('input[name=password]').type('password');
+			cy.get('[data-cy="main-form-submit-button"]').click();
+			cy.contains('Email and password don’t match');
+		});
+
+		it('NON-ACTIVE user -  shows authentication error', () => {
+			// Intercept the external redirect page.
+			// We just want to check that the redirect happens, not that the page loads.
+			cy.intercept('GET', 'https://m.code.dev-theguardian.com/', (req) => {
+				req.reply(200);
+			});
+			cy
+				.createTestUser({ isGuestUser: true })
+				?.then(({ emailAddress, finalPassword }) => {
+					cy.visit('/signin');
+					cy.get('input[name=email]').type(emailAddress);
+					cy.get('input[name=password]').type(`${finalPassword}`);
+					cy.get('[data-cy="main-form-submit-button"]').click();
+					cy.contains('Email and password don’t match');
+				});
+		});
+
+		it('SOCIAL user - sets emailValidated flag on oauth callback', () => {
+			// this is a specific test case for new user registrations in Okta
+			// In Okta new social registered users are added to the GuardianUser-EmailValidated group
+			// by default, but the custom emailValidated field is not defined/set to false
+			// this causes problems in legacy code, where the emailValidated flag is not set but the group is
+			// so we need to set the flag to true when the user is added to the group
+			// we do this on the oauth callback route /oauth/authorization-code/callback
+			// where we update the user profile with the emailValidated flag if the user is in the GuardianUser-EmailValidated group but the emailValidated is falsy
+
+			// This test checks this behaviour by first getting a user into this state
+			// i.e user.profile.emailValidated = false, and user groups has GuardianUser-EmailValidated
+
+			// first we have to get the id of the GuardianUser-EmailValidated group
+			cy.findEmailValidatedOktaGroupId().then((groupId) => {
+				// next we create a test user
+				cy.createTestUser({}).then(({ emailAddress, finalPassword }) => {
+					// we get the user profile object from Okta
+					cy.getTestOktaUser(emailAddress).then((user) => {
+						const { id, profile } = user;
+						// check the user profile has the emailValidated flag set to false
+						expect(profile.emailValidated).to.be.false;
+						// next check the user groups
+						cy.getOktaUserGroups(id).then((groups) => {
+							// make sure the user is not in the GuardianUser-EmailValidated group
+							const group = groups.find((g) => g.id === groupId);
+							expect(group).not.to.exist;
+
+							// and add them to the group if this is the case
+							cy.addOktaUserToGroup(id, groupId);
+
+							// at this point the user is in the correct state
+							// so we attempt to sign them in
+							cy.visit(
+								`/signin?returnUrl=${encodeURIComponent(
+									`https://${Cypress.env('BASE_URI')}/welcome/review`,
+								)}`,
+							);
+							cy.get('input[name=email]').type(emailAddress);
+							cy.get('input[name=password]').type(finalPassword);
+							cy.get('[data-cy="main-form-submit-button"]').click();
+							cy.url().should('include', '/welcome/review');
+
+							// at this point the oauth callback route will have run, so we can recheck the user profile to see if the emailValidated flag has been set
+							cy.getTestOktaUser(id).then((user) => {
+								const { profile } = user;
+								expect(profile.emailValidated).to.be.true;
+							});
+
+							// and the user should also be in the group
+							cy.getOktaUserGroups(id).then((groups) => {
+								const group = groups.find((g) => g.id === groupId);
+								expect(group).to.exist;
+							});
+						});
+					});
+				});
+			});
+		});
+
+		it('shows reCAPTCHA errors when the user tries to sign in offline and allows sign in when back online', () => {
+			// Intercept the external redirect page.
+			// We just want to check that the redirect happens, not that the page loads.
+			cy.intercept('GET', 'https://m.code.dev-theguardian.com/', (req) => {
+				req.reply(200);
+			});
+			cy
+				.createTestUser({
+					isUserEmailValidated: true,
+				})
+				?.then(({ emailAddress, finalPassword }) => {
+					cy.visit('/signin');
+
+					cy.interceptRecaptcha();
+
+					cy.get('input[name=email]').type(emailAddress);
+					cy.get('input[name=password]').type(finalPassword);
+					cy.get('[data-cy="main-form-submit-button"]').click();
+
+					cy.contains('Google reCAPTCHA verification failed.');
+					cy.contains('If the problem persists please try the following:');
+
+					cy.get('[data-cy="main-form-submit-button"]').click();
+
+					cy.contains('Google reCAPTCHA verification failed.').should(
+						'not.exist',
+					);
+
+					cy.url().should('include', 'https://m.code.dev-theguardian.com/');
+				});
+		});
+	});
+
+	context('Social sign in', () => {
+		it('redirects correctly for social sign in', () => {
+			cy.visit(`/signin?returnUrl=${encodeURIComponent(returnUrl)}`);
+			cy.get('[data-cy="google-sign-in-button"]').should(
+				'have.attr',
+				'href',
+				`/signin/google?returnUrl=${encodeURIComponent(returnUrl)}`,
+			);
+			cy.get('[data-cy="apple-sign-in-button"]').should(
+				'have.attr',
+				'href',
+				`/signin/apple?returnUrl=${encodeURIComponent(returnUrl)}`,
+			);
+		});
+		it('shows an error message and information paragraph when accountLinkingRequired error parameter is present', () => {
+			cy.visit('/signin?error=accountLinkingRequired');
+			cy.contains(
+				'We could not sign you in with your social account credentials. Please sign in with your email below.',
+			);
+			cy.contains('Social sign-in unsuccessful');
+		});
+		it('does not display social buttons when accountLinkingRequired error parameter is present', () => {
+			cy.visit('/signin?error=accountLinkingRequired');
+			cy.get('[data-cy="google-sign-in-button"]').should('not.exist');
+			cy.get('[data-cy="apple-sign-in-button"]').should('not.exist');
+		});
+	});
+
 	context('Okta session refresh', () => {
 		it('refreshes a valid Okta session', () => {
 			// Create a validated test user
@@ -506,55 +834,6 @@ describe('Sign in flow, Okta enabled', () => {
 		});
 	});
 
-	context('Okta unvalidated email flow', () => {
-		it('Sends a user with an unvalidated email a reset password email on sign in', () => {
-			cy
-				.createTestUser({
-					isUserEmailValidated: false,
-				})
-				?.then(({ emailAddress, finalPassword }) => {
-					const timeRequestWasMade = new Date();
-					cy.visit('/signin');
-					cy.get('input[name=email]').type(emailAddress);
-					cy.get('input[name=password]').type(finalPassword);
-					cy.get('[data-cy="main-form-submit-button"]').click();
-					cy.url().should('include', '/signin/email-sent');
-					cy.contains(
-						'For security reasons we need you to change your password.',
-					);
-					cy.contains(emailAddress);
-					cy.contains('send again');
-					cy.contains('try another address');
-
-					// Ensure the user's authentication cookies are not set
-					cy.getCookie('idx').then((idxCookie) => {
-						expect(idxCookie).to.not.exist;
-
-						cy.checkForEmailAndGetDetails(
-							emailAddress,
-							timeRequestWasMade,
-							/reset-password\/([^"]*)/,
-						).then(({ links, body, token }) => {
-							expect(body).to.have.string(
-								'Because your security is extremely important to us, we have changed our password policy.',
-							);
-							expect(body).to.have.string('Reset password');
-							expect(links.length).to.eq(2);
-							const resetPasswordLink = links.find((s) =>
-								s.text?.includes('Reset password'),
-							);
-							expect(resetPasswordLink?.href ?? '').to.have.string(
-								'reset-password',
-							);
-							cy.visit(`/reset-password/${token}`);
-							cy.contains(emailAddress);
-							cy.contains('Create new password');
-						});
-					});
-				});
-		});
-	});
-
 	context('Okta session exists on /signin', () => {
 		beforeEach(() => {
 			// Intercept the external redirect page.
@@ -648,280 +927,6 @@ describe('Sign in flow, Okta enabled', () => {
 						});
 					});
 				});
-		});
-	});
-
-	context('Okta IDX API Sign In', () => {
-		it('ACTIVE user - email + password authenticators - successfully sign in', () => {
-			// Intercept the external redirect page.
-			// We just want to check that the redirect happens, not that the page loads.
-			cy.intercept('GET', 'https://m.code.dev-theguardian.com/', (req) => {
-				req.reply(200);
-			});
-			cy
-				.createTestUser({
-					isUserEmailValidated: true,
-				})
-				?.then(({ emailAddress, finalPassword }) => {
-					cy.visit('/signin?useIdxSignIn=true');
-					cy.get('input[name=email]').type(emailAddress);
-					cy.get('input[name=password]').type(finalPassword);
-					cy.get('[data-cy="main-form-submit-button"]').click();
-					cy.url().should('include', 'https://m.code.dev-theguardian.com/');
-				});
-		});
-
-		it('ACTIVE user - email + password authenticators - successfully sign in - preserve returnUrl', () => {
-			// Intercept the external redirect page.
-			// We just want to check that the redirect happens, not that the page loads.
-			cy.intercept('GET', returnUrl, (req) => {
-				req.reply(200);
-			});
-			cy
-				.createTestUser({
-					isUserEmailValidated: true,
-				})
-				?.then(({ emailAddress, finalPassword }) => {
-					cy.visit(
-						`/signin?returnUrl=${encodeURIComponent(returnUrl)}&useIdxSignIn=true`,
-					);
-					cy.get('input[name=email]').type(emailAddress);
-					cy.get('input[name=password]').type(finalPassword);
-					cy.get('[data-cy="main-form-submit-button"]').click();
-					cy.url().should('eq', returnUrl);
-				});
-		});
-
-		it('ACTIVE user - email + password authenticators - successfully sign in - preserve fromURI', () => {
-			const encodedReturnUrl = encodeURIComponent(returnUrl);
-			const appClientId = 'appClientId1';
-			const fromURI = '/oauth2/v1/authorize';
-
-			// Intercept the external redirect page.
-			// We just want to check that the redirect happens, not that the page loads.
-			cy.intercept(
-				'GET',
-				`https://${Cypress.env('BASE_URI')}${decodeURIComponent(fromURI)}`,
-				(req) => {
-					req.reply(200);
-				},
-			);
-
-			cy
-				.createTestUser({
-					isUserEmailValidated: true,
-				})
-				?.then(({ emailAddress, finalPassword }) => {
-					cy.visit(
-						`/signin?returnUrl=${encodeURIComponent(returnUrl)}&useIdxSignIn=true`,
-					);
-					cy.visit(
-						`/signin?returnUrl=${encodedReturnUrl}&appClientId=${appClientId}&fromURI=${fromURI}&useIdxSignIn=true`,
-					);
-					cy.get('input[name=email]').type(emailAddress);
-					cy.get('input[name=password]').type(finalPassword);
-					cy.get('[data-cy="main-form-submit-button"]').click();
-
-					// fromURI redirect
-					cy.url().should('contain', decodeURIComponent(fromURI));
-				});
-		});
-
-		it('ACTIVE user - password authenticator only - send OTP reset password security email', () => {
-			const emailAddress = randomMailosaurEmail();
-			cy.visit(`/register/email`);
-
-			const timeRequestWasMade = new Date();
-			cy.get('input[name=email]').type(emailAddress);
-			cy.get('[data-cy="main-form-submit-button"]').click();
-
-			cy.contains('Enter your code');
-			cy.contains(emailAddress);
-
-			cy.checkForEmailAndGetDetails(emailAddress, timeRequestWasMade).then(
-				({ body, codes }) => {
-					// email
-					expect(body).to.have.string('Your verification code');
-					expect(codes?.length).to.eq(1);
-					const code = codes?.[0].value;
-					expect(code).to.match(/^\d{6}$/);
-
-					// passcode page
-					cy.url().should('include', '/register/email-sent');
-
-					// make sure we don't use a passcode
-					// we instead reset their password using classic flow to set a password
-					cy.visit('/reset-password?useOktaClassic=true');
-
-					const timeRequestWasMade = new Date();
-					cy.get('input[name=email]').clear().type(emailAddress);
-					cy.get('[data-cy="main-form-submit-button"]').click();
-
-					cy.checkForEmailAndGetDetails(
-						emailAddress,
-						timeRequestWasMade,
-						/\/set-password\/([^"]*)/,
-					).then(({ links, body }) => {
-						expect(body).to.have.string('Welcome back');
-
-						expect(body).to.have.string('Create password');
-						expect(links.length).to.eq(2);
-						const setPasswordLink = links.find((s) =>
-							s.text?.includes('Create password'),
-						);
-
-						cy.visit(setPasswordLink?.href as string);
-
-						const password = randomPassword();
-						cy.get('input[name=password]').type(password);
-
-						cy.get('[data-cy="main-form-submit-button"]')
-							.click()
-							.should('be.disabled');
-						cy.contains('Password created');
-						cy.contains(emailAddress.toLowerCase());
-
-						// setup complete, now sign in
-						cy.visit('/signin?useIdxSignIn=true');
-						cy.contains('Sign in with a different email').click();
-						cy.get('input[name=email]').clear().type(emailAddress);
-						cy.get('input[name=password]').type(password);
-
-						const timeRequestWasMade = new Date();
-						cy.get('[data-cy="main-form-submit-button"]').click();
-
-						cy.checkForEmailAndGetDetails(
-							emailAddress,
-							timeRequestWasMade,
-						).then(({ body, codes }) => {
-							// email
-							expect(body).to.have.string('Your verification code');
-							expect(codes?.length).to.eq(1);
-							const code = codes?.[0].value;
-							expect(code).to.match(/^\d{6}$/);
-
-							// passcode page
-							cy.url().should('include', '/signin/email-sent');
-							cy.contains('Enter your verification code');
-							cy.contains(
-								'For security reasons we need you to change your password.',
-							);
-							cy.get('input[name=code]').clear().type(code!);
-							cy.contains('Submit verification code').click();
-
-							cy.url().should('contain', '/set-password');
-
-							cy.get('input[name="password"]').type(randomPassword());
-							cy.get('button[type="submit"]').click();
-
-							cy.url().should('contain', '/set-password/complete');
-						});
-					});
-				},
-			);
-		});
-
-		it('ACTIVE user - email + password authenticators - shows authentication error when password incorrect', () => {
-			// Intercept the external redirect page.
-			// We just want to check that the redirect happens, not that the page loads.
-			cy.intercept('GET', 'https://m.code.dev-theguardian.com/', (req) => {
-				req.reply(200);
-			});
-			cy
-				.createTestUser({
-					isUserEmailValidated: true,
-				})
-				?.then(({ emailAddress, finalPassword }) => {
-					cy.visit('/signin?useIdxSignIn=true');
-					cy.get('input[name=email]').type(emailAddress);
-					cy.get('input[name=password]').type(`${finalPassword}!`);
-					cy.get('[data-cy="main-form-submit-button"]').click();
-					cy.contains('Email and password don’t match');
-				});
-		});
-
-		it('NON-EXISTENT user - shows authentication error in all scenarios', () => {
-			cy.visit('/signin?useIdxSignIn=true');
-			cy.get('input[name=email]').type('invalid@doesnotexist.com');
-			cy.get('input[name=password]').type('password');
-			cy.get('[data-cy="main-form-submit-button"]').click();
-			cy.contains('Email and password don’t match');
-		});
-
-		it('NON-ACTIVE user -  shows authentication error', () => {
-			// Intercept the external redirect page.
-			// We just want to check that the redirect happens, not that the page loads.
-			cy.intercept('GET', 'https://m.code.dev-theguardian.com/', (req) => {
-				req.reply(200);
-			});
-			cy
-				.createTestUser({ isGuestUser: true })
-				?.then(({ emailAddress, finalPassword }) => {
-					cy.visit('/signin?useIdxSignIn=true');
-					cy.get('input[name=email]').type(emailAddress);
-					cy.get('input[name=password]').type(`${finalPassword}`);
-					cy.get('[data-cy="main-form-submit-button"]').click();
-					cy.contains('Email and password don’t match');
-				});
-		});
-
-		it('SOCIAL user - sets emailValidated flag on oauth callback', () => {
-			// this is a specific test case for new user registrations in Okta
-			// In Okta new social registered users are added to the GuardianUser-EmailValidated group
-			// by default, but the custom emailValidated field is not defined/set to false
-			// this causes problems in legacy code, where the emailValidated flag is not set but the group is
-			// so we need to set the flag to true when the user is added to the group
-			// we do this on the oauth callback route /oauth/authorization-code/callback
-			// where we update the user profile with the emailValidated flag if the user is in the GuardianUser-EmailValidated group but the emailValidated is falsy
-
-			// This test checks this behaviour by first getting a user into this state
-			// i.e user.profile.emailValidated = false, and user groups has GuardianUser-EmailValidated
-
-			// first we have to get the id of the GuardianUser-EmailValidated group
-			cy.findEmailValidatedOktaGroupId().then((groupId) => {
-				// next we create a test user
-				cy.createTestUser({}).then(({ emailAddress, finalPassword }) => {
-					// we get the user profile object from Okta
-					cy.getTestOktaUser(emailAddress).then((user) => {
-						const { id, profile } = user;
-						// check the user profile has the emailValidated flag set to false
-						expect(profile.emailValidated).to.be.false;
-						// next check the user groups
-						cy.getOktaUserGroups(id).then((groups) => {
-							// make sure the user is not in the GuardianUser-EmailValidated group
-							const group = groups.find((g) => g.id === groupId);
-							expect(group).not.to.exist;
-
-							// and add them to the group if this is the case
-							cy.addOktaUserToGroup(id, groupId);
-
-							// at this point the user is in the correct state
-							// so we attempt to sign them in
-							cy.visit(
-								`/signin?returnUrl=${encodeURIComponent(
-									`https://${Cypress.env('BASE_URI')}/welcome/review`,
-								)}&useIdxSignIn=true`,
-							);
-							cy.get('input[name=email]').type(emailAddress);
-							cy.get('input[name=password]').type(finalPassword);
-							cy.get('[data-cy="main-form-submit-button"]').click();
-							cy.url().should('include', '/welcome/review');
-
-							// at this point the oauth callback route will have run, so we can recheck the user profile to see if the emailValidated flag has been set
-							cy.getTestOktaUser(id).then((user) => {
-								const { profile } = user;
-								expect(profile.emailValidated).to.be.true;
-							});
-
-							// and the user should also be in the group
-							cy.getOktaUserGroups(id).then((groups) => {
-								const group = groups.find((g) => g.id === groupId);
-								expect(group).to.exist;
-							});
-						});
-					});
-				});
-			});
 		});
 	});
 });

--- a/cypress/integration/mocked/okta_sign_in.6.cy.ts
+++ b/cypress/integration/mocked/okta_sign_in.6.cy.ts
@@ -229,8 +229,8 @@ describe('Sign in flow', () => {
 			cy.contains('Sign in with a different email');
 		});
 
-		it('shows an error message when okta authentication fails', function () {
-			cy.visit('/signin');
+		it('shows an error message when okta authentication fails - useOktaClassic', function () {
+			cy.visit('/signin?useOktaClassic=true');
 			cy.get('input[name="email"]').type('example@example.com');
 			cy.get('input[name="password"]').type('password');
 			cy.mockNext(401, {
@@ -244,8 +244,8 @@ describe('Sign in flow', () => {
 			cy.contains('Email and password don’t match');
 		});
 
-		it('shows a generic error message when okta rate limited', function () {
-			cy.visit('/signin');
+		it('shows a generic error message when okta rate limited - useOktaClassic', function () {
+			cy.visit('/signin?useOktaClassic=true');
 			cy.get('input[name="email"]').type('example@example.com');
 			cy.get('input[name="password"]').type('password');
 			cy.mockNext(429, {
@@ -259,8 +259,8 @@ describe('Sign in flow', () => {
 			cy.contains('There was a problem signing in, please try again.');
 		});
 
-		it('shows a generic error message when okta api response unknown', function () {
-			cy.visit('/signin');
+		it('shows a generic error message when okta api response unknown - useOktaClassic', function () {
+			cy.visit('/signin?useOktaClassic=true');
 			cy.get('input[name="email"]').type('example@example.com');
 			cy.get('input[name="password"]').type('password');
 			cy.mockNext(403, {
@@ -274,8 +274,10 @@ describe('Sign in flow', () => {
 			cy.contains('There was a problem signing in, please try again.');
 		});
 
-		it('loads the redirectUrl upon successful authentication for validated user', function () {
-			cy.visit('/signin?returnUrl=https%3A%2F%2Fwww.theguardian.com%2Fabout');
+		it('loads the redirectUrl upon successful authentication for validated user - useOktaClassic', function () {
+			cy.visit(
+				'/signin?returnUrl=https%3A%2F%2Fwww.theguardian.com%2Fabout&useOktaClassic=true',
+			);
 			cy.get('input[name="email"]').type('example@example.com');
 			cy.get('input[name="password"]').type('password');
 			cy.mockNext(200, {
@@ -324,8 +326,8 @@ describe('Sign in flow', () => {
 			});
 		});
 
-		it('redirects to the default url if no redirectUrl given', function () {
-			cy.visit('/signin');
+		it('redirects to the default url if no redirectUrl given - useOktaClassic', function () {
+			cy.visit('/signin?useOktaClassic=true');
 			cy.get('input[name="email"]').type('example@example.com');
 			cy.get('input[name="password"]').type('password');
 			cy.mockNext(200, {

--- a/cypress/integration/mocked/signInController.2.cy.ts
+++ b/cypress/integration/mocked/signInController.2.cy.ts
@@ -1,13 +1,19 @@
 import authenticationFailedError from '../../fixtures/okta-responses/error/authentication-failed.json';
 import validUserResponse from '../../fixtures/okta-responses/success/valid-user.json';
 import validUserGroupsResponse from '../../fixtures/okta-responses/success/valid-user-groups.json';
+import { baseIdxPasscodeResetPasswordMocks } from './resetPasswordController.4.cy';
+import { identifyResponse } from '../../fixtures/okta-responses/success/idx-identify-response';
+import idxChallengeResponsePassword from '../../fixtures/okta-responses/success/idx-challenge-response-password.json';
+import idxChallengeAnswerPasswordUserResponse from '../../fixtures/okta-responses/success/idx-challenge-answer-password-user-response.json';
+import idxChallengeAnswerPassword401Response from '../..//fixtures/okta-responses/error/idx-challenge-answer-password-401-response.json';
+import userResponse from '../../fixtures/okta-responses/success/user.json';
 
 beforeEach(() => {
 	cy.mockPurge();
 });
-context('When I submit the form on /signin', () => {
+context('When I submit the form on /signin - useOktaClassic', () => {
 	beforeEach(() => {
-		cy.visit(`/signin`);
+		cy.visit(`/signin?useOktaClassic=true`);
 		cy.get('input[name="email"]').type('example@example.com');
 		cy.get('input[name="password"]').type('password');
 	});
@@ -41,9 +47,66 @@ context('When I submit the form on /signin', () => {
 	});
 });
 
-context('When I submit the form on /reauthenticate', () => {
+context('When I submit the form on /signin - idx api', () => {
 	beforeEach(() => {
-		cy.visit(`/reauthenticate`);
+		cy.visit(`/signin`);
+		cy.get('input[name="email"]').type('example@example.com');
+		cy.get('input[name="password"]').type('password');
+	});
+	//This is expected for non existent, non active users or when the email and password are incorrect
+	specify(
+		'if okta authentication fails then I should be shown an "Email or password incorrect" error. ',
+		() => {
+			const response = { ...userResponse.response, status: 'ACTIVE' };
+			cy.mockNext(userResponse.code, response);
+			baseIdxPasscodeResetPasswordMocks();
+			cy.mockNext(200, identifyResponse(true, true));
+			cy.mockNext(
+				idxChallengeResponsePassword.code,
+				idxChallengeResponsePassword.response,
+			);
+			cy.mockNext(
+				idxChallengeAnswerPassword401Response.code,
+				idxChallengeAnswerPassword401Response.response,
+			);
+			cy.get('button[type=submit]').click();
+			cy.contains('Email and password don’t match');
+		},
+	);
+	specify('if okta authentication succeeds then I should be signed in.', () => {
+		const response = { ...userResponse.response, status: 'ACTIVE' };
+		cy.mockNext(userResponse.code, response);
+		baseIdxPasscodeResetPasswordMocks();
+		cy.mockNext(200, identifyResponse(true, true));
+		cy.mockNext(
+			idxChallengeResponsePassword.code,
+			idxChallengeResponsePassword.response,
+		);
+		cy.mockNext(
+			idxChallengeResponsePassword.code,
+			idxChallengeResponsePassword.response,
+		);
+		cy.mockNext(
+			idxChallengeAnswerPasswordUserResponse.code,
+			idxChallengeAnswerPasswordUserResponse.response,
+		);
+		cy.mockNext(validUserGroupsResponse.code, validUserGroupsResponse.response);
+
+		cy.get('button[type=submit]').click();
+		// we can't actually check the authorization code flow
+		// so simply intercept the request and verify that it contains
+		// the mocked response
+		cy.intercept(
+			`https://profile.thegulocal.com/login/token/redirect?stateToken=02.id.state`,
+			'OAuth',
+		);
+		cy.contains('OAuth');
+	});
+});
+
+context('When I submit the form on /reauthenticate - useOktaClassic', () => {
+	beforeEach(() => {
+		cy.visit(`/reauthenticate?useOktaClassic=true`);
 		cy.get('input[name="email"]').type('example@example.com');
 		cy.get('input[name="password"]').type('password');
 	});
@@ -82,4 +145,61 @@ context('When I submit the form on /reauthenticate', () => {
 			cy.contains('OAuth');
 		},
 	);
+});
+
+context('When I submit the form on /reauthenticate - idx api', () => {
+	beforeEach(() => {
+		cy.visit(`/reauthenticate`);
+		cy.get('input[name="email"]').type('example@example.com');
+		cy.get('input[name="password"]').type('password');
+	});
+	//This is expected for non existent, non active users or when the email and password are incorrect
+	specify(
+		'if okta authentication fails then I should be shown an "Email or password incorrect" error. ',
+		() => {
+			const response = { ...userResponse.response, status: 'ACTIVE' };
+			cy.mockNext(userResponse.code, response);
+			baseIdxPasscodeResetPasswordMocks();
+			cy.mockNext(200, identifyResponse(true, true));
+			cy.mockNext(
+				idxChallengeResponsePassword.code,
+				idxChallengeResponsePassword.response,
+			);
+			cy.mockNext(
+				idxChallengeAnswerPassword401Response.code,
+				idxChallengeAnswerPassword401Response.response,
+			);
+			cy.get('button[type=submit]').click();
+			cy.contains('Email and password don’t match');
+		},
+	);
+	specify('if okta authentication succeeds then I should be signed in.', () => {
+		const response = { ...userResponse.response, status: 'ACTIVE' };
+		cy.mockNext(userResponse.code, response);
+		baseIdxPasscodeResetPasswordMocks();
+		cy.mockNext(200, identifyResponse(true, true));
+		cy.mockNext(
+			idxChallengeResponsePassword.code,
+			idxChallengeResponsePassword.response,
+		);
+		cy.mockNext(
+			idxChallengeResponsePassword.code,
+			idxChallengeResponsePassword.response,
+		);
+		cy.mockNext(
+			idxChallengeAnswerPasswordUserResponse.code,
+			idxChallengeAnswerPasswordUserResponse.response,
+		);
+		cy.mockNext(validUserGroupsResponse.code, validUserGroupsResponse.response);
+
+		cy.get('button[type=submit]').click();
+		// we can't actually check the authorization code flow
+		// so simply intercept the request and verify that it contains
+		// the mocked response
+		cy.intercept(
+			`https://profile.thegulocal.com/login/token/redirect?stateToken=02.id.state`,
+			'OAuth',
+		);
+		cy.contains('OAuth');
+	});
 });

--- a/src/server/lib/queryParams.ts
+++ b/src/server/lib/queryParams.ts
@@ -52,7 +52,6 @@ export const parseExpressQueryParams = (
 		appClientId,
 		maxAge,
 		useOktaClassic,
-		useIdxSignIn,
 	}: Record<keyof QueryParams, string | undefined>, // parameters from req.query
 	// some parameters may be manually passed in req.body too,
 	// generally for tracking purposes
@@ -77,7 +76,6 @@ export const parseExpressQueryParams = (
 		appClientId,
 		maxAge: stringToNumber(maxAge),
 		useOktaClassic: isStringBoolean(useOktaClassic),
-		useIdxSignIn: isStringBoolean(useIdxSignIn),
 	};
 };
 

--- a/src/server/routes/signIn.ts
+++ b/src/server/routes/signIn.ts
@@ -319,12 +319,6 @@ const oktaIdxApiSignInController = async ({
 	req: Request;
 	res: ResponseWithRequestState;
 }) => {
-	// TODO: remove when the useIdxSignIn feature flag is removed
-	// placeholder warning message
-	logger.warn(
-		'IDX API password authentication flow is not fully implemented yet',
-	);
-
 	// get the email and password from the request body
 	const { email = '', password = '' } = req.body;
 
@@ -604,7 +598,7 @@ const oktaSignInController = async ({
 
 	try {
 		// idx api flow
-		if (passcodesEnabled && res.locals.queryParams.useIdxSignIn) {
+		if (passcodesEnabled && !res.locals.queryParams.useOktaClassic) {
 			// try to start the IDX flow to sign in the user with a password
 			await oktaIdxApiSignInController({
 				req,

--- a/src/shared/__tests__/queryParams.test.ts
+++ b/src/shared/__tests__/queryParams.test.ts
@@ -37,7 +37,6 @@ describe('getPersistableQueryParams', () => {
 			appClientId: 'appClientId',
 			useOktaClassic: undefined,
 			listName: undefined,
-			useIdxSignIn: undefined,
 		};
 
 		expect(output).toStrictEqual(expected);

--- a/src/shared/lib/queryParams.ts
+++ b/src/shared/lib/queryParams.ts
@@ -42,7 +42,6 @@ export const getPersistableQueryParams = (
 	fromURI: params.fromURI,
 	appClientId: params.appClientId,
 	useOktaClassic: params.useOktaClassic,
-	useIdxSignIn: params.useIdxSignIn,
 });
 
 /**

--- a/src/shared/model/QueryParams.ts
+++ b/src/shared/model/QueryParams.ts
@@ -47,8 +47,6 @@ export interface PersistableQueryParams
 	appClientId?: string;
 	// fallback to Okta Classic if needed
 	useOktaClassic?: boolean;
-	// temporary flag to enable the use of the idx api for sign in
-	useIdxSignIn?: boolean;
 }
 
 /**


### PR DESCRIPTION
## What does this change?

As it says on the tin!

In https://github.com/guardian/gateway/pull/2926 we implemented using the Okta IDX API for sign in with a password behind the `useIdxSignIn` feature flag.

This PR makes the Okta IDX API the default option when a user attempts to sign in with a password.

We do this by removing the check for the `useIdxSignIn` query parameter.

We also update the code, so that if the `useOktaClassic` query parameter is provided, it uses the legacy behaviour instead (sends an email with a link).

Most of this PR is updating the tests to check and handle both behaviours.

## Tested

- [x] CODE