### PR TITLE
Cloudformation | Add `OktaIDXSignIn` to sign in alarm

### DIFF
--- a/cdk/lib/__snapshots__/identity-gateway.test.ts.snap
+++ b/cdk/lib/__snapshots__/identity-gateway.test.ts.snap
@@ -1649,7 +1649,7 @@ systemctl start identity-gateway
         ],
         "Metrics": [
           {
-            "Expression": "oktaSignInCount",
+            "Expression": "oktaSignInCount + oktaIdxSignInCount",
             "Id": "totalSignInCount",
             "Label": "Total sign-ins in Okta",
           },
@@ -1670,6 +1670,31 @@ systemctl start identity-gateway
                   },
                 ],
                 "MetricName": "OktaSignIn::Success",
+                "Namespace": "Gateway",
+              },
+              "Period": 1200,
+              "Stat": "Sum",
+              "Unit": "Count",
+            },
+            "ReturnData": false,
+          },
+          {
+            "Id": "oktaIdxSignInCount",
+            "MetricStat": {
+              "Metric": {
+                "Dimensions": [
+                  {
+                    "Name": "Stage",
+                    "Value": {
+                      "Ref": "Stage",
+                    },
+                  },
+                  {
+                    "Name": "ApiMode",
+                    "Value": "identity-gateway",
+                  },
+                ],
+                "MetricName": "OktaIDXSignIn::Success",
                 "Namespace": "Gateway",
               },
               "Period": 1200,

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -621,13 +621,27 @@ Resources:
       AlarmDescription: No one has successfully signed ins in the last 20 minutes.
       Metrics:
         - Id: totalSignInCount
-          Expression: oktaSignInCount
+          Expression: oktaSignInCount + oktaIdxSignInCount
           Label: 'Total sign-ins in Okta'
         - Id: oktaSignInCount
           MetricStat:
             Metric:
               Namespace: Gateway
               MetricName: 'OktaSignIn::Success'
+              Dimensions:
+                - Name: Stage
+                  Value: !Ref 'Stage'
+                - Name: ApiMode
+                  Value: identity-gateway
+            Period: 1200
+            Stat: Sum
+            Unit: Count
+          ReturnData: false
+        - Id: oktaIdxSignInCount
+          MetricStat:
+            Metric:
+              Namespace: Gateway
+              MetricName: 'OktaIDXSignIn::Success'
               Dimensions:
                 - Name: Stage
                   Value: !Ref 'Stage'


### PR DESCRIPTION
## What does this change?

The sign in inactivity alarm was only looking for the `OktaSignIn::Success` metric, which is no longer the default after #2931 was merged.

It now uses and checks for the `OktaIdxSignIn::Success` metric too in order to make sure this alarm is up to date
