### PR TITLE
Cloudformation | Use correct sign in metric

### DIFF
--- a/cdk/lib/__snapshots__/identity-gateway.test.ts.snap
+++ b/cdk/lib/__snapshots__/identity-gateway.test.ts.snap
@@ -1694,7 +1694,7 @@ systemctl start identity-gateway
                     "Value": "identity-gateway",
                   },
                 ],
-                "MetricName": "OktaIDXSignIn::Success",
+                "MetricName": "OktaIdxSignIn::Success",
                 "Namespace": "Gateway",
               },
               "Period": 1200,

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -641,7 +641,7 @@ Resources:
           MetricStat:
             Metric:
               Namespace: Gateway
-              MetricName: 'OktaIDXSignIn::Success'
+              MetricName: 'OktaIdxSignIn::Success'
               Dimensions:
                 - Name: Stage
                   Value: !Ref 'Stage'


### PR DESCRIPTION
## What does this change?

It's `OktaIdxSignIn` and not `OktaIDXSignIn` as used in https://github.com/guardian/gateway/pull/2932 🤦🏾 