### PR TITLE
Chromatic | Turn on TurboSnap for `main`

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -38,4 +38,4 @@ jobs:
           # Turn on Turbosnap, so we try to check only components that
           # have changed using the webpack dependency graph.
           # https://www.chromatic.com/docs/turbosnap
-          onlyChanged: '!(main)' # only turbosnap on non-main branches
+          onlyChanged: true


### PR DESCRIPTION
## What does this change?

While reviewing our chromatic usage for gateway, I noticed that our full snapshots outweighed the faster and cheaper TurboSnaps every month

e.g. Aug-Sep 2024 we had `56,408` full snapshots in gateway, and an additional `39,768` TurboSnaps. 2nd in number of changes behind DCR!

All the other applications which had TurboSnap enabled had more TurboSnaps than full snapshots too.

This was strange to me, as I assumed we had Turbosnap on in all cases, and we hadn't made many UI changes recently so it was strange that the full snapshots outweighed the TurboSnaps.

Intestigating this I found that TurboSnaps were only turned on for non-`main` branches, which meant every time we merged a PR into `main` - even when there hadn't been any UI changes - it would do a full chromatic rebuild, which is unnecessary.

This PR changes this so that TurboSnap always run, even on a `main` branch.

Although, this is less relevant now, as we've switched to Enterprise billing in Chromatic, this should still be enabled for faster main builds, and a possible reduction of costs when the plan comes to be re-evaluated.