### PR TITLE
Pressreader Editions | Native App / OS Detection

### DIFF
--- a/src/server/lib/middleware/requestState.ts
+++ b/src/server/lib/middleware/requestState.ts
@@ -16,7 +16,12 @@ import Bowser from 'bowser';
 import { logger } from '@/server/lib/serverSideLogger';
 import { getApp } from '@/server/lib/okta/api/apps';
 import { IsNativeApp } from '@/shared/model/ClientState';
-import { AppName, getAppName, isAppLabel } from '@/shared/lib/appNameUtils';
+import {
+	AppName,
+	getAppName,
+	getIsNativeAppFromBowser,
+	isAppLabel,
+} from '@/shared/lib/appNameUtils';
 import { readEncryptedStateCookie } from '@/server/lib/encryptedStateCookie';
 
 const {
@@ -79,6 +84,10 @@ const getRequestState = async (
 					isNativeApp = 'android';
 				} else if (label.startsWith('ios_')) {
 					isNativeApp = 'ios';
+				} else {
+					// if we can't determine the os from the label, use bowser
+					// e.g. for the editions app
+					isNativeApp = getIsNativeAppFromBowser(browser);
 				}
 
 				appName = getAppName(label);

--- a/src/shared/__tests__/appNameUtils.test.ts
+++ b/src/shared/__tests__/appNameUtils.test.ts
@@ -1,0 +1,49 @@
+import Bowser from 'bowser';
+import { getIsNativeAppFromBowser } from '../lib/appNameUtils';
+
+describe('appNameUtils', () => {
+	describe('getIsNativeAppFromBowser', () => {
+		test('returns android if the browser is Android', () => {
+			const chrome = Bowser.getParser(
+				`Mozilla/5.0 (Linux; Android 15) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.6778.104 Mobile Safari/537.36`,
+			);
+			const firefox = Bowser.getParser(
+				`Mozilla/5.0 (Android 15; Mobile; rv:68.0) Gecko/68.0 Firefox/133.0`,
+			);
+			expect(getIsNativeAppFromBowser(chrome)).toEqual('android');
+			expect(getIsNativeAppFromBowser(firefox)).toEqual('android');
+		});
+
+		test('returns ios if the browser is iOS', () => {
+			const safari = Bowser.getParser(
+				`Mozilla/5.0 (iPhone; CPU iPhone OS 17_7_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4.1 Mobile/15E148 Safari/604.1`,
+			);
+			const chrome = Bowser.getParser(
+				`Mozilla/5.0 (iPhone; CPU iPhone OS 17_7_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/132.0.6834.31 Mobile/15E148 Safari/604.1`,
+			);
+			const firefox = Bowser.getParser(
+				`Mozilla/5.0 (iPhone; CPU iPhone OS 17_7_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) FxiOS/133.0 Mobile/15E148 Safari/605.1.15`,
+			);
+
+			expect(getIsNativeAppFromBowser(safari)).toEqual('ios');
+			expect(getIsNativeAppFromBowser(chrome)).toEqual('ios');
+			expect(getIsNativeAppFromBowser(firefox)).toEqual('ios');
+		});
+
+		test('returns undefined if the browser is not a native app', () => {
+			const macOsSafari = Bowser.getParser(
+				`Mozilla/5.0 (Macintosh; Intel Mac OS X 14_7_1) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4.1 Safari/605.1.15`,
+			);
+			const win10Chrome = Bowser.getParser(
+				`Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36`,
+			);
+			const linuxFirefox = Bowser.getParser(
+				`Mozilla/5.0 (X11; Linux i686; rv:133.0) Gecko/20100101 Firefox/133.0`,
+			);
+
+			expect(getIsNativeAppFromBowser(macOsSafari)).toBeUndefined();
+			expect(getIsNativeAppFromBowser(win10Chrome)).toBeUndefined();
+			expect(getIsNativeAppFromBowser(linuxFirefox)).toBeUndefined();
+		});
+	});
+});

--- a/src/shared/lib/appNameUtils.ts
+++ b/src/shared/lib/appNameUtils.ts
@@ -1,4 +1,6 @@
 import { isOneOf } from '@guardian/libs';
+import Bowser from 'bowser';
+import { IsNativeApp } from '@/shared/model/ClientState';
 
 /**
  * list of app prefixes and labels that is used by native apps to determine
@@ -22,6 +24,7 @@ export const apps = [
 	['ios_live_app', 'il_'],
 	['android_feast_app', 'af_'],
 	['ios_feast_app', 'if_'],
+	['editions_pressreader', 'ed_'],
 ] as const;
 
 type AppLabel = (typeof apps)[number][0];
@@ -34,7 +37,7 @@ export const isAppPrefix = isOneOf(appPrefixes);
 const appLabels = apps.map(([label]) => label);
 export const isAppLabel = isOneOf(appLabels);
 
-export type AppName = 'Guardian' | 'Feast';
+export type AppName = 'Guardian' | 'Feast' | 'Editions';
 
 /**
  * @name getAppPrefix
@@ -46,6 +49,12 @@ export type AppName = 'Guardian' | 'Feast';
 export const getAppPrefix = (token: string): AppPrefix | undefined =>
 	appPrefixes.find((prefix) => token.startsWith(prefix));
 
+/**
+ * @name getAppName
+ * @description To get the name of the application from the prefix or label.
+ * @param labelOrPrefix - AppLabel or AppPrefix
+ * @returns {AppName} - 'Guardian', 'Feast', 'Editions' or undefined
+ */
 export const getAppName = (
 	labelOrPrefix: AppLabel | AppPrefix,
 ): AppName | undefined => {
@@ -60,5 +69,28 @@ export const getAppName = (
 		case 'if_':
 		case 'ios_feast_app':
 			return 'Feast';
+		case 'ed_':
+		case 'editions_pressreader':
+			return 'Editions';
+	}
+};
+
+/**
+ * @name getIsNativeAppFromBowser
+ * @description Use a Bowser instance to determine if the browser is a native os.
+ * @param browser - Bowser instance
+ * @returns {IsNativeApp} - 'android' or 'ios' if the browser matches Android or iOS, otherwise undefined
+ */
+export const getIsNativeAppFromBowser = (
+	browser: Bowser.Parser.Parser,
+): IsNativeApp | undefined => {
+	const os = browser.getOSName();
+
+	if (os === 'Android') {
+		return 'android';
+	}
+
+	if (os === 'iOS') {
+		return 'ios';
 	}
 };


### PR DESCRIPTION
## What does this change?

Unlike other apps, within Okta, the Pressreader Editions app for both Android and iOS is set up as a single application, this was done to mirror the already existing Editions app.

However we need to know whether the user is using the iOS or Android version of the app (`isNativeApp` variable) to show app specific design variants and hide the CMP banner, as well as displaying the name of the app if the user is signed in already (`appName` variable).

Thankfully we already use [`Bowser`](https://github.com/bowser-js/bowser) to parse the `user-agent` header we get from the client.

So we can use a combination of the `appLabel` (`editions_pressreader`) and the user agent to determine whether we're on iOS or Android, and derive the correct app name!

## Tested

- [x] CODE