### PR TITLE
chore: Update marketing analysis copy with clarified language on signed-in data

### DIFF
--- a/src/client/pages/NewAccountReview.tsx
+++ b/src/client/pages/NewAccountReview.tsx
@@ -120,13 +120,10 @@ export const NewAccountReview = ({
 					What we mean by signed-in data
 				</MainBodyText>
 				<MainBodyText>
+					Information you provide when you register with us e.g.
 					<ul css={listStyles}>
-						<li>Information you provide e.g. email address</li>
-						<li>Products or services you buy from us</li>
-						<li>
-							Pages you view on theguardian.com or other Guardian websites when
-							signed in
-						</li>
+						<li>First name and last name</li>
+						<li>Email address</li>
 					</ul>
 				</MainBodyText>
 				<InformationBox>

--- a/src/client/pages/NewAccountReview.tsx
+++ b/src/client/pages/NewAccountReview.tsx
@@ -120,7 +120,7 @@ export const NewAccountReview = ({
 					What we mean by signed-in data
 				</MainBodyText>
 				<MainBodyText>
-					Information you provide when you register with us e.g.
+					Information you provide when you create an account with us e.g.
 					<ul css={listStyles}>
 						<li>First name and last name</li>
 						<li>Email address</li>


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

We've had a request to update the copy for what signed in data we use, this PR updates the registration page to use this new language.

See https://github.com/guardian/manage-frontend/pull/1428 for a similar change.


## Images

| Before | After |
|--------|--------|
| <img width="449" alt="image" src="https://github.com/user-attachments/assets/558590da-4606-4896-bb3c-0f00fed0e2e9" /> | <img width="450" alt="image" src="https://github.com/user-attachments/assets/dfda0486-d5ef-4dcc-bc76-095a8240d2a6" /> | 
