### PR TITLE
Add `ExistingUserInCreateAccountFlow` metric

### DIFF
--- a/src/server/models/Metrics.ts
+++ b/src/server/models/Metrics.ts
@@ -85,7 +85,8 @@ type UnconditionalMetrics =
 	| `User-${'EmailValidated' | 'EmailNotValidated'}-${
 			| 'WeakPassword'
 			| 'StrongPassword'}`
-	| `PasscodePasswordNotCompleteRemediation-${'ResetPassword' | 'Register'}-${'STAGED' | 'PROVISIONED'}-${'Start' | 'Complete'}`;
+	| `PasscodePasswordNotCompleteRemediation-${'ResetPassword' | 'Register'}-${'STAGED' | 'PROVISIONED'}-${'Start' | 'Complete'}`
+	| `ExistingUserInCreateAccountFlow`;
 
 // Combine all the metrics above together into a type
 export type Metrics =

--- a/src/server/routes/register.ts
+++ b/src/server/routes/register.ts
@@ -446,6 +446,7 @@ const oktaIdxCreateAccount = async (
 			if (error.name === 'registration.error.notUniqueWithinOrg') {
 				// case for user already exists
 				// will implement when full passwordless is implemented
+				trackMetric('ExistingUserInCreateAccountFlow');
 			}
 		}
 


### PR DESCRIPTION
## What does this change?

Adds a `ExistingUserInCreateAccountFlow` metric to track the number of users who already have a Guardian account that attempt to go through the create account flow.