### PR TITLE
Passcodes | Use new sign in ux for passcodes behind flag

### DIFF
--- a/cypress/integration/ete/sign_in_passcode.8.cy.ts
+++ b/cypress/integration/ete/sign_in_passcode.8.cy.ts
@@ -60,7 +60,7 @@ describe('Sign In flow, with passcode', () => {
 								expect(code).to.match(/^\d{6}$/);
 
 								cy.get('input[name=code]').type(code!);
-								cy.contains('Submit one-time code').click();
+								cy.contains('Sign in').click();
 
 								cy.url().should('include', expectedReturnUrl);
 
@@ -79,14 +79,14 @@ describe('Sign In flow, with passcode', () => {
 					case 'passcode-incorrect':
 						cy.get('input[name=code]').type(`${+code! + 1}`);
 
-						cy.contains('Submit one-time code').click();
+						cy.contains('Sign in').click();
 
 						cy.url().should('include', '/signin/code');
 
 						cy.contains('Incorrect code');
 						cy.get('input[name=code]').clear().type(code!);
 
-						cy.contains('Submit one-time code').click();
+						cy.contains('Sign in').click();
 
 						cy.url().should('include', expectedReturnUrl);
 
@@ -97,7 +97,7 @@ describe('Sign In flow, with passcode', () => {
 						break;
 					default: {
 						cy.get('input[name=code]').type(code!);
-						cy.contains('Submit one-time code').click();
+						cy.contains('Sign in').click();
 
 						cy.url().should('include', expectedReturnUrl);
 
@@ -178,7 +178,15 @@ describe('Sign In flow, with passcode', () => {
 				?.then(({ emailAddress, finalPassword }) => {
 					cy.visit(`/signin?usePasscodeSignIn=true`);
 					cy.get('input[name=email]').type(emailAddress);
-					cy.contains('Use a password to sign in instead').click();
+					cy.get('[data-cy="main-form-submit-button"]').click();
+
+					// passcode page
+					cy.url().should('include', '/signin/code');
+					cy.contains('Enter your one-time code');
+					cy.contains('Sign in with password instead').click();
+
+					cy.url().should('include', '/signin/password');
+					cy.get('input[name=email]').should('have.value', emailAddress);
 					cy.get('input[name=password]').type(finalPassword);
 					cy.get('[data-cy="main-form-submit-button"]').click();
 					cy.url().should('include', 'https://m.code.dev-theguardian.com/');
@@ -361,7 +369,7 @@ describe('Sign In flow, with passcode', () => {
 			cy.contains('Don’t have an account?');
 
 			cy.get('input[name=code]').clear().type('123456');
-			cy.contains('Submit one-time code').click();
+			cy.contains('Sign in').click();
 
 			cy.url().should('include', '/signin/code');
 			cy.contains('Enter your one-time code');

--- a/src/client/components/PasscodeInput.stories.tsx
+++ b/src/client/components/PasscodeInput.stories.tsx
@@ -12,20 +12,26 @@ export default {
 } as Meta;
 
 export const Default = () => {
-	return <PasscodeInput />;
+	return <PasscodeInput label="Verification code" />;
 };
 Default.storyName = 'default';
 
 export const WithFieldError = () => (
-	<PasscodeInput fieldErrors={[{ field: 'code', message: 'Invalid code' }]} />
+	<PasscodeInput
+		label="Verification code"
+		fieldErrors={[{ field: 'code', message: 'Invalid code' }]}
+	/>
 );
 WithFieldError.storyName = 'with field error';
 
-export const WithDefaultPasscode = () => <PasscodeInput passcode="424242" />;
+export const WithDefaultPasscode = () => (
+	<PasscodeInput label="Verification code" passcode="424242" />
+);
 WithDefaultPasscode.storyName = 'with default passcode';
 
 export const WithFieldErrorAndDefaultPasscode = () => (
 	<PasscodeInput
+		label="Verification code"
 		passcode="424242"
 		fieldErrors={[{ field: 'code', message: 'Invalid code' }]}
 	/>

--- a/src/client/components/PasscodeInput.tsx
+++ b/src/client/components/PasscodeInput.tsx
@@ -5,7 +5,7 @@ import { css } from '@emotion/react';
 import ThemedTextInput from '@/client/components/ThemedTextInput';
 import { remSpace } from '@guardian/source/foundations';
 
-interface PasscodeInputProps extends Omit<TextInputProps, 'label'> {
+interface PasscodeInputProps extends TextInputProps {
 	passcode?: string;
 	fieldErrors?: FieldError[];
 }
@@ -16,6 +16,7 @@ const passcodeInputStyles = css`
 `;
 
 export const PasscodeInput = ({
+	label,
 	passcode = '',
 	fieldErrors,
 }: PasscodeInputProps) => {
@@ -57,7 +58,7 @@ export const PasscodeInput = ({
 	return (
 		<div>
 			<ThemedTextInput
-				label="Verification code"
+				label={label}
 				type="text"
 				pattern="\d{6}"
 				name="code"

--- a/src/client/pages/PasscodeEmailSent.stories.tsx
+++ b/src/client/pages/PasscodeEmailSent.stories.tsx
@@ -331,3 +331,125 @@ export const WithErrorMessageSecurity = () => (
 WithErrorMessageVerification.story = {
 	name: 'with error message - security',
 };
+
+export const DefaultsSignIn = () => (
+	<PasscodeEmailSent passcodeAction="#" expiredPage="#" textType="signin" />
+);
+DefaultsVerification.story = {
+	name: 'with defaults - signin',
+};
+
+export const ChangeEmailSignIn = () => (
+	<PasscodeEmailSent
+		passcodeAction="#"
+		expiredPage="#"
+		changeEmailPage="#"
+		textType="signin"
+	/>
+);
+ChangeEmailVerification.story = {
+	name: 'with changeEmailPage - signin',
+};
+
+export const WithEmailSignIn = () => (
+	<PasscodeEmailSent
+		passcodeAction="#"
+		expiredPage="#"
+		changeEmailPage="#"
+		email="example@theguardian.com"
+		textType="signin"
+	/>
+);
+WithEmailVerification.story = {
+	name: 'with email - signin',
+};
+
+export const WithPasscodeSignIn = () => (
+	<PasscodeEmailSent
+		passcodeAction="#"
+		expiredPage="#"
+		changeEmailPage="#"
+		email="example@theguardian.com"
+		passcode="123456"
+		textType="signin"
+	/>
+);
+WithPasscodeVerification.story = {
+	name: 'with passcode - signin',
+};
+
+export const WithPasscodeErrorSignIn = () => (
+	<PasscodeEmailSent
+		shortRequestId="123e4567"
+		passcodeAction="#"
+		expiredPage="#"
+		changeEmailPage="#"
+		email="example@theguardian.com"
+		passcode="123456"
+		fieldErrors={[
+			{
+				field: 'code',
+				message: 'Invalid code',
+			},
+		]}
+		textType="signin"
+	/>
+);
+WithPasscodeErrorVerification.story = {
+	name: 'with passcode error - signin',
+};
+
+export const WithRecaptchaErrorSignIn = () => (
+	<PasscodeEmailSent
+		shortRequestId="123e4567"
+		passcodeAction="#"
+		expiredPage="#"
+		changeEmailPage="#"
+		email="example@theguardian.com"
+		recaptchaSiteKey="invalid-key"
+		textType="signin"
+	/>
+);
+WithRecaptchaErrorVerification.story = {
+	name: 'with reCAPTCHA error - signin',
+};
+
+export const WithSuccessMessageSignIn = () => (
+	<PasscodeEmailSent
+		passcodeAction="#"
+		expiredPage="#"
+		showSuccess={true}
+		textType="signin"
+	/>
+);
+WithSuccessMessageVerification.story = {
+	name: 'with success message - signin',
+};
+
+export const WithErrorMessageSignIn = () => (
+	<PasscodeEmailSent
+		shortRequestId="123e4567"
+		passcodeAction="#"
+		expiredPage="#"
+		errorMessage="•⩊• UwU"
+		textType="signin"
+	/>
+);
+WithErrorMessageVerification.story = {
+	name: 'with error message - signin',
+};
+
+export const WithSignInWithPasswordOption = () => (
+	<PasscodeEmailSent
+		passcodeAction="#"
+		expiredPage="#"
+		changeEmailPage="#"
+		email="example@theguardian.com"
+		noAccountInfo
+		showSignInWithPasswordOption
+		textType="signin"
+	/>
+);
+WithSignInWithPasswordOption.story = {
+	name: 'with sign in with password option - signin',
+};

--- a/src/client/pages/PasscodeEmailSent.tsx
+++ b/src/client/pages/PasscodeEmailSent.tsx
@@ -7,8 +7,10 @@ import { MinimalLayout } from '@/client/layouts/MinimalLayout';
 import { PasscodeInput } from '@/client/components/PasscodeInput';
 import { EmailSentInformationBox } from '@/client/components/EmailSentInformationBox';
 import { EmailSentProps } from '@/client/pages/EmailSent';
+import { buildUrl } from '@/shared/lib/routeUtils';
+import ThemedLink from '@/client/components/ThemedLink';
 
-type TextType = 'verification' | 'security' | 'generic';
+type TextType = 'verification' | 'security' | 'generic' | 'signin';
 
 type Props = {
 	passcodeAction: string;
@@ -19,6 +21,7 @@ type Props = {
 	timeUntilTokenExpiry?: number;
 	noAccountInfo?: boolean;
 	textType?: TextType;
+	showSignInWithPasswordOption?: boolean;
 };
 
 type PasscodeEmailSentProps = EmailSentProps & Props;
@@ -29,6 +32,7 @@ type Text = {
 	sentTextWithEmail: string;
 	sentTextWithoutEmail: string;
 	securityText: string;
+	passcodeInputLabel: string;
 	submitButtonText: string;
 };
 
@@ -43,6 +47,7 @@ const getText = (textType: TextType): Text => {
 					'We’ve sent you a temporary verification code. Please check your inbox.',
 				securityText:
 					'For your security, the verification code will expire in 30 minutes.',
+				passcodeInputLabel: 'Verification code',
 				submitButtonText: 'Submit verification code',
 			};
 		case 'security':
@@ -54,7 +59,19 @@ const getText = (textType: TextType): Text => {
 				sentTextWithoutEmail:
 					'For security reasons we need you to change your password. We’ve sent you a 6-digit verification code. Please check your inbox.',
 				securityText: 'For your security, the code will expire in 30 minutes.',
+				passcodeInputLabel: 'Verification code',
 				submitButtonText: 'Submit verification code',
+			};
+		case 'signin':
+			return {
+				title: 'Enter your one-time code to sign in',
+				successOverride: 'Email with one time code sent',
+				sentTextWithEmail: 'We’ve sent a 6-digit code to',
+				sentTextWithoutEmail:
+					'We’ve sent you a 6-digit code. Please check your inbox.',
+				securityText: 'For your security, the code will expire in 30 minutes.',
+				passcodeInputLabel: 'One-time code',
+				submitButtonText: 'Sign in',
 			};
 		case 'generic':
 		default:
@@ -65,6 +82,7 @@ const getText = (textType: TextType): Text => {
 				sentTextWithoutEmail:
 					'We’ve sent you a 6-digit code. Please check your inbox.',
 				securityText: 'For your security, the code will expire in 30 minutes.',
+				passcodeInputLabel: 'One-time code',
 				submitButtonText: 'Submit one-time code',
 			};
 	}
@@ -87,6 +105,7 @@ export const PasscodeEmailSent = ({
 	shortRequestId,
 	noAccountInfo,
 	textType = 'generic',
+	showSignInWithPasswordOption,
 }: PasscodeEmailSentProps) => {
 	const [recaptchaErrorMessage, setRecaptchaErrorMessage] = useState('');
 	const [recaptchaErrorContext, setRecaptchaErrorContext] =
@@ -153,8 +172,19 @@ export const PasscodeEmailSent = ({
 				disableOnSubmit
 				shortRequestId={shortRequestId}
 			>
-				<PasscodeInput passcode={passcode} fieldErrors={fieldErrors} />
+				<PasscodeInput
+					passcode={passcode}
+					fieldErrors={fieldErrors}
+					label={text.passcodeInputLabel}
+				/>
 			</MainForm>
+			{showSignInWithPasswordOption && (
+				<MainBodyText>
+					<ThemedLink href={`${buildUrl('/signin/password')}${queryString}`}>
+						Sign in with password instead
+					</ThemedLink>
+				</MainBodyText>
+			)}
 			<EmailSentInformationBox
 				setRecaptchaErrorContext={setRecaptchaErrorContext}
 				setRecaptchaErrorMessage={setRecaptchaErrorMessage}

--- a/src/client/pages/SignIn.stories.tsx
+++ b/src/client/pages/SignIn.stories.tsx
@@ -126,66 +126,38 @@ IsReauthenticate.story = {
 	name: 'showing /reauthenticate page',
 };
 
-export const WithPasscodeSelectedDefaultPassword = (args: SignInProps) => (
-	<SignIn
-		{...{
-			...args,
-			defaultView: 'password',
-			currentView: 'passcode',
-			usePasscodeSignIn: true,
-		}}
-	/>
+export const SignInWithPasscode = (args: SignInProps) => (
+	<SignIn {...{ ...args, usePasscodeSignIn: true }} />
 );
-WithPasscodeSelectedDefaultPassword.story = {
-	name: 'with passcode checkbox checked',
+SignInWithPasscode.story = {
+	name: 'sign in with passcode',
 };
 
-export const WithPasscodeSelectedDefaultPasswordError = (args: SignInProps) => (
+export const SignInWithPasscodeError = (args: SignInProps) => (
 	<SignIn
 		{...{
 			...args,
-			defaultView: 'password',
-			currentView: 'passcode',
 			usePasscodeSignIn: true,
 			pageError: SignInErrors.PASSCODE_EXPIRED,
 		}}
 	/>
 );
-WithPasscodeSelectedDefaultPassword.story = {
-	name: 'with passcode checkbox checked',
+SignInWithPasscodeError.story = {
+	name: 'sign in with passcode error',
 };
 
-export const WithPasscodeSelectedDefaultPasscode = (args: SignInProps) => (
-	<SignIn {...{ ...args, defaultView: 'passcode', usePasscodeSignIn: true }} />
+export const NoSocialButtons = (args: SignInProps) => (
+	<SignIn {...{ ...args, hideSocialButtons: true }} />
 );
-WithPasscodeSelectedDefaultPasscode.story = {
-	name: 'with passcode checkbox checked',
+NoSocialButtons.story = {
+	name: 'no social buttons',
 };
 
-export const WithPasscodeSelectedDefaultPasscodeError = (args: SignInProps) => (
+export const NoSocialButtonsEmail = (args: SignInProps) => (
 	<SignIn
-		{...{
-			...args,
-			defaultView: 'passcode',
-			usePasscodeSignIn: true,
-			pageError: SignInErrors.PASSCODE_EXPIRED,
-		}}
+		{...{ ...args, hideSocialButtons: true, email: 'test@example.com' }}
 	/>
 );
-WithPasscodeSelectedDefaultPasscodeError.story = {
-	name: 'with passcode checkbox checked',
-};
-
-export const WithPasswordSelectedDefaultPasscode = (args: SignInProps) => (
-	<SignIn
-		{...{
-			...args,
-			defaultView: 'passcode',
-			currentView: 'password',
-			usePasscodeSignIn: true,
-		}}
-	/>
-);
-WithPasswordSelectedDefaultPasscode.story = {
-	name: 'with password checkbox checked',
+NoSocialButtonsEmail.story = {
+	name: 'no social buttons with email',
 };

--- a/src/client/pages/SignInPage.tsx
+++ b/src/client/pages/SignInPage.tsx
@@ -5,9 +5,15 @@ import { useRemoveEncryptedEmailParam } from '@/client/lib/hooks/useRemoveEncryp
 
 interface Props {
 	isReauthenticate?: boolean;
+	hideSocialButtons?: boolean;
+	forcePasswordPage?: boolean;
 }
 
-export const SignInPage = ({ isReauthenticate = false }: Props) => {
+export const SignInPage = ({
+	isReauthenticate = false,
+	hideSocialButtons = false,
+	forcePasswordPage = false,
+}: Props) => {
 	const clientState = useClientState();
 	const {
 		pageData = {},
@@ -30,8 +36,10 @@ export const SignInPage = ({ isReauthenticate = false }: Props) => {
 			recaptchaSiteKey={recaptchaSiteKey}
 			isReauthenticate={isReauthenticate}
 			shortRequestId={clientState.shortRequestId}
-			usePasscodeSignIn={queryParams.usePasscodeSignIn}
-			currentView={queryParams.signInCurrentView}
+			usePasscodeSignIn={
+				forcePasswordPage ? false : queryParams.usePasscodeSignIn
+			}
+			hideSocialButtons={hideSocialButtons}
 		/>
 	);
 };

--- a/src/client/pages/SignInPage.tsx
+++ b/src/client/pages/SignInPage.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { SignIn } from '@/client/pages/SignIn';
 import useClientState from '@/client/lib/hooks/useClientState';
 import { useRemoveEncryptedEmailParam } from '@/client/lib/hooks/useRemoveEncryptedEmailParam';
+import { useAB } from '@/client/components/ABReact';
 
 interface Props {
 	isReauthenticate?: boolean;
@@ -14,6 +15,7 @@ export const SignInPage = ({
 	hideSocialButtons = false,
 	forcePasswordPage = false,
 }: Props) => {
+	const ABTestAPI = useAB();
 	const clientState = useClientState();
 	const {
 		pageData = {},
@@ -27,6 +29,19 @@ export const SignInPage = ({
 
 	// we use the encryptedEmail parameter to pre-fill the email field, but then want to remove it from the url
 	useRemoveEncryptedEmailParam();
+
+	const usePasscodeSignIn: boolean = (() => {
+		if (forcePasswordPage) {
+			return false;
+		}
+
+		if (ABTestAPI.isUserInVariant('PasscodeSignInTest', 'variant')) {
+			return true;
+		}
+
+		return !!queryParams.usePasscodeSignIn;
+	})();
+
 	return (
 		<SignIn
 			email={email}
@@ -36,9 +51,7 @@ export const SignInPage = ({
 			recaptchaSiteKey={recaptchaSiteKey}
 			isReauthenticate={isReauthenticate}
 			shortRequestId={clientState.shortRequestId}
-			usePasscodeSignIn={
-				forcePasswordPage ? false : queryParams.usePasscodeSignIn
-			}
+			usePasscodeSignIn={usePasscodeSignIn}
 			hideSocialButtons={hideSocialButtons}
 		/>
 	);

--- a/src/client/pages/SignInPasscodeEmailSentPage.tsx
+++ b/src/client/pages/SignInPasscodeEmailSentPage.tsx
@@ -42,8 +42,9 @@ export const SignInPasscodeEmailSentPage = () => {
 			passcode={token}
 			expiredPage={buildUrl('/signin/code/expired')}
 			noAccountInfo
-			textType="generic"
+			textType="signin"
 			shortRequestId={shortRequestId}
+			showSignInWithPasswordOption
 		/>
 	);
 };

--- a/src/client/routes.tsx
+++ b/src/client/routes.tsx
@@ -71,6 +71,10 @@ const routes: Array<{
 		element: <SignInPasscodeEmailSentPage />,
 	},
 	{
+		path: '/signin/password',
+		element: <SignInPage hideSocialButtons forcePasswordPage />,
+	},
+	{
 		path: '/reauthenticate',
 		element: <SignInPage isReauthenticate />,
 	},

--- a/src/server/controllers/signInControllers.ts
+++ b/src/server/controllers/signInControllers.ts
@@ -384,10 +384,14 @@ export const oktaIdxApiSignInController = async ({
 	// get the email and password from the request body
 	const { email = '', password = '', passcode } = req.body;
 
+	const usePasscodeSignInFlag =
+		res.locals.queryParams.usePasscodeSignIn ||
+		res.locals.abTestAPI.isUserInVariant('PasscodeSignInTest', 'variant');
+
 	try {
 		// only attempt to sign in with a passcode if the user currently has the query parameter set
 		// this should be removed when we're ready to enable this for all users
-		if (res.locals.queryParams.usePasscodeSignIn) {
+		if (usePasscodeSignInFlag) {
 			// if the value exists, we're using passcodes
 			const usePasscode = !!passcode;
 
@@ -588,7 +592,7 @@ export const oktaIdxApiSignInController = async ({
 
 		// if we're using passcodes, and the user is attempting to sign in with a password
 		// on error show the password sign in page
-		const errorPage: RoutePaths = res.locals.queryParams.usePasscodeSignIn
+		const errorPage: RoutePaths = usePasscodeSignInFlag
 			? '/signin/password'
 			: '/signin';
 

--- a/src/server/controllers/signInControllers.ts
+++ b/src/server/controllers/signInControllers.ts
@@ -51,6 +51,7 @@ import {
 	forceUserIntoActiveState,
 	sendVerifyEmailAuthenticatorIdx,
 } from '@/server/controllers/oktaIdxShared';
+import { RoutePaths } from '@/shared/model/Routes';
 
 /**
  * @name SignInError
@@ -585,7 +586,13 @@ export const oktaIdxApiSignInController = async ({
 
 		const { status, gatewayError } = oktaSignInControllerErrorHandler(error);
 
-		const html = renderer('/signin', {
+		// if we're using passcodes, and the user is attempting to sign in with a password
+		// on error show the password sign in page
+		const errorPage: RoutePaths = res.locals.queryParams.usePasscodeSignIn
+			? '/signin/password'
+			: '/signin';
+
+		const html = renderer(errorPage, {
 			requestState: mergeRequestState(res.locals, {
 				pageData: {
 					email,

--- a/src/server/lib/middleware/requestState.ts
+++ b/src/server/lib/middleware/requestState.ts
@@ -46,7 +46,7 @@ const getRequestState = async (
 	const [abTesting, abTestAPI] = getABTesting(req, tests);
 
 	// tracking parameters might be from body too
-	const { ref, refViewId, passcode } = req.body;
+	const { ref, refViewId } = req.body;
 
 	const queryParams = parseExpressQueryParams(
 		req.method,
@@ -58,7 +58,6 @@ const getRequestState = async (
 		{
 			ref,
 			refViewId,
-			signInCurrentView: passcode ? 'passcode' : undefined,
 		},
 	);
 

--- a/src/server/lib/queryParams.ts
+++ b/src/server/lib/queryParams.ts
@@ -3,7 +3,6 @@ import { validateReturnUrl, validateRefUrl } from '@/server/lib/validateUrl';
 import { validateClientId } from '@/server/lib/validateClientId';
 import { isStringBoolean } from './isStringBoolean';
 import { validateFromUri } from './validateFromUri';
-import { SignInView } from '@/shared/model/ClientState';
 
 const validateGetOnlyError = (
 	method: string,
@@ -14,18 +13,6 @@ const validateGetOnlyError = (
 	// On POST with the error, we redirect to the GET URL of the form with the error parameter
 	if (method === 'GET' && error === 'true') {
 		return true;
-	}
-};
-
-const validateSignInView = (
-	signInCurrentView?: string,
-): SignInView | undefined => {
-	if (signInCurrentView === 'password') {
-		return 'password';
-	}
-
-	if (signInCurrentView === 'passcode') {
-		return 'passcode';
 	}
 };
 
@@ -66,7 +53,6 @@ export const parseExpressQueryParams = (
 		maxAge,
 		useOktaClassic,
 		usePasscodeSignIn,
-		signInCurrentView,
 	}: Record<keyof QueryParams, string | undefined>, // parameters from req.query
 	// some parameters may be manually passed in req.body too,
 	// generally for tracking purposes
@@ -92,9 +78,6 @@ export const parseExpressQueryParams = (
 		maxAge: stringToNumber(maxAge),
 		useOktaClassic: isStringBoolean(useOktaClassic),
 		usePasscodeSignIn: isStringBoolean(usePasscodeSignIn),
-		signInCurrentView: validateSignInView(
-			bodyParams.signInCurrentView || signInCurrentView,
-		),
 	};
 };
 

--- a/src/server/routes/signIn.ts
+++ b/src/server/routes/signIn.ts
@@ -546,6 +546,22 @@ router.get(
 );
 
 router.get(
+	'/signin/password',
+	(req: Request, res: ResponseWithRequestState) => {
+		const state = res.locals;
+		const html = renderer('/signin/password', {
+			requestState: mergeRequestState(state, {
+				pageData: {
+					email: readEncryptedStateCookie(req)?.email,
+				},
+			}),
+			pageTitle: 'Sign in',
+		});
+		return res.type('html').send(html);
+	},
+);
+
+router.get(
 	'/signin/:social',
 	handleAsyncErrors(async (req: Request, res: ResponseWithRequestState) => {
 		const socialIdp = req.params.social as SocialProvider;

--- a/src/shared/model/ClientState.ts
+++ b/src/shared/model/ClientState.ts
@@ -26,9 +26,6 @@ interface GlobalMessage {
 
 export type IsNativeApp = 'android' | 'ios' | undefined;
 
-// determine what the sign in page view should be
-export type SignInView = 'passcode' | 'password';
-
 export interface PageData {
 	// general page data
 	returnUrl?: string;

--- a/src/shared/model/QueryParams.ts
+++ b/src/shared/model/QueryParams.ts
@@ -47,7 +47,7 @@ export interface PersistableQueryParams
 	appClientId?: string;
 	// fallback to Okta Classic if needed
 	useOktaClassic?: boolean;
-	// Flag to enable sign in with passcode
+	// Flag to force enable sign in with passcode
 	usePasscodeSignIn?: boolean;
 }
 

--- a/src/shared/model/QueryParams.ts
+++ b/src/shared/model/QueryParams.ts
@@ -1,5 +1,4 @@
 import { ValidClientId } from '@/shared/lib/clientId';
-import { SignInView } from '@/shared/model/ClientState';
 
 type Stringifiable = string | boolean | number | null | undefined;
 
@@ -27,9 +26,6 @@ export interface TrackingQueryParams {
 	// as well as getting confused with other parameters, so we thought it best to pass it as a URL encoded string, and then do the decoding once it gets to IDAPI
 	componentEventParams?: string;
 	listName?: string;
-	// tracks the view that the user had selected on the sign in page, i.e password or passcode, so that we can show the last selected view
-	// if the user navigated back to the sign in page
-	signInCurrentView?: SignInView;
 }
 
 /**

--- a/src/shared/model/Routes.ts
+++ b/src/shared/model/Routes.ts
@@ -56,6 +56,7 @@ export const ValidRoutePathsArray = [
 	'/signin/code',
 	'/signin/code/resend',
 	'/signin/code/expired',
+	'/signin/password',
 	'/signin/refresh',
 	'/signin/:social',
 	'/signin/email-sent',

--- a/src/shared/model/experiments/abSwitches.ts
+++ b/src/shared/model/experiments/abSwitches.ts
@@ -1,3 +1,4 @@
 export const abSwitches = {
 	abExampleTest: false,
+	abPasscodeSignInTest: true,
 };

--- a/src/shared/model/experiments/abTests.ts
+++ b/src/shared/model/experiments/abTests.ts
@@ -1,5 +1,6 @@
 import { AB, ABTest, Participations } from '@guardian/ab-core';
 import { abSwitches } from './abSwitches';
+import { passcodeSignInTest } from './tests/passcode-signin-test';
 
 interface ABTestConfiguration {
 	abTestSwitches: Record<string, boolean>;
@@ -9,7 +10,7 @@ interface ABTestConfiguration {
 }
 
 // Add AB tests to run in this array
-export const tests: ABTest[] = [];
+export const tests: ABTest[] = [passcodeSignInTest];
 
 const getDefaultABTestConfiguration = (): ABTestConfiguration => ({
 	abTestSwitches: abSwitches,

--- a/src/shared/model/experiments/tests/passcode-signin-test.ts
+++ b/src/shared/model/experiments/tests/passcode-signin-test.ts
@@ -1,0 +1,25 @@
+import { ABTest } from '@guardian/ab-core';
+
+export const passcodeSignInTest: ABTest = {
+	id: 'PasscodeSignInTest', // This ID must match the Server Side AB Test
+	start: '2025-01-13',
+	expiry: '2025-01-31', // Remember that the server side test expiry can be different
+	author: 'mahesh.makani@theguardian.com',
+	description:
+		'Testing the release of one time passcodes as the default sign in option',
+	audience: 0.1, // 10% (1 is 100%)
+	audienceOffset: 0, // 0% (1 is 100%). Prevent overlapping with other tests.
+	successMeasure: 'Users sign in successfully with passcodes',
+	audienceCriteria: 'Everyone',
+	idealOutcome: 'Users sign in successfully with passcodes',
+	showForSensitive: true, // Should this A/B test run on sensitive articles?
+	canRun: () => true, // Check for things like user or page sections
+	variants: [
+		{
+			id: 'variant',
+			test: (): string => {
+				return 'variant';
+			},
+		},
+	],
+};


### PR DESCRIPTION
## What does this change?

In #2942 we implemented sign in using a one time passcode behind a feature flag (query parameter) `?usePasscodeSignIn=true`.

The UX in that example wasn't particularly ideal, where we used a toggle to allow the reader to switch between sign in via passcodes or sign in via passwords.

In this PR we change the UX to remove the toggle, and instead when using the feature flag, we make passcodes the default option.

In this scenario, the reader has to just enter their email address and click "Continue with email". We then send the user a passcode, and show the passcode input page as before. However we've added an additional button here which allows the reader to "Sign in with password instead".

This button will take them to a sign in page with the password input, where they can use a password to sign in.

<table>
<tr>
<th>Passcode</th>
<th>Password</th>
</tr>
<tr>
<td>

https://github.com/user-attachments/assets/b342cd0b-0d54-4976-9de5-56dfee08ff6c

</td>
<td>

https://github.com/user-attachments/assets/3800d929-3067-4ce1-805f-000ee2e65370

</td>
</tr>
</table>

This PR also sets up an AB test for passcodes, which rather than used for AB testing, we use it to release passcodes to 10% of the audience so we can test out the flow and look for any issues that may occur.

## Tested

- [x] CODE
