### PR TITLE
Fix | `useOktaClassic` query param on sign in page

### DIFF
--- a/src/client/pages/SignInPage.tsx
+++ b/src/client/pages/SignInPage.tsx
@@ -30,15 +30,30 @@ export const SignInPage = ({
 	// we use the encryptedEmail parameter to pre-fill the email field, but then want to remove it from the url
 	useRemoveEncryptedEmailParam();
 
+	// determines if the passcode view of the sign in page should be shown
 	const usePasscodeSignIn: boolean = (() => {
+		// if the forcePasswordPage flag is set, we should always show the password view
+		// for example when the user clicks "sign in with password instead"
 		if (forcePasswordPage) {
 			return false;
 		}
 
+		// if the useOktaClassic flag is set, we should always show the password view
+		// to maintain the existing behaviour
+		if (queryParams.useOktaClassic) {
+			return false;
+		}
+
+		// if the user is in the PasscodeSignInTest variant, we should show the passcode view
+		// to test the new sign in flow
+		// eventually this will be removed and the passcode view will be shown by default
 		if (ABTestAPI.isUserInVariant('PasscodeSignInTest', 'variant')) {
 			return true;
 		}
 
+		// if the usePasscodeSignIn query param is set, we should show the passcode view
+		// this is used for testing the new sign in flow
+		// eventually this will be removed and the passcode view will be shown by default
 		return !!queryParams.usePasscodeSignIn;
 	})();
 


### PR DESCRIPTION
## What does this change?

In #3025 we updated the ux of the sign in with passcode flow, and also released the flow to 10% of users via an AB test.

The behaviour when the user had the `useOktaClassic=true` query parameter didn't work as expected. When this flag is provided the user should always be shown the password page in order to support the old methods of authentication. 

However if the user was assigned the test, and had this flag, then they wouldn't see the password field, and thus wouldn't be able to sign in.

This PR fixes this by making sure to check for the flag when determining what view of the sign in page should be used.

We also add some comments in explaining what each of the different options do.