### PR TITLE
Passwordless | Update create account flows for existing users

### DIFF
--- a/cypress/integration/ete/registration_2.6.cy.ts
+++ b/cypress/integration/ete/registration_2.6.cy.ts
@@ -6,7 +6,7 @@ import { Status } from '../../../src/server/models/okta/User';
 
 describe('Registration flow - Split 2/2', () => {
 	context(
-		'Existing users asking for an email to be resent after attempting to register with Okta',
+		'Existing users asking for an email to be resent after attempting to register with Okta - useOktaClassic',
 		() => {
 			it('should resend a STAGED user a set password email with an Okta activation token', () => {
 				cy
@@ -18,7 +18,7 @@ describe('Registration flow - Split 2/2', () => {
 						cy.getTestOktaUser(emailAddress).then((oktaUser) => {
 							expect(oktaUser.status).to.eq(Status.STAGED);
 
-							cy.visit('/register/email');
+							cy.visit('/register/email?useOktaClassic=true');
 
 							const timeRequestWasMade = new Date();
 
@@ -75,7 +75,7 @@ describe('Registration flow - Split 2/2', () => {
 							cy.getTestOktaUser(emailAddress).then((oktaUser) => {
 								expect(oktaUser.status).to.eq(Status.PROVISIONED);
 
-								cy.visit('/register/email');
+								cy.visit('/register/email?useOktaClassic=true');
 
 								const timeRequestWasMade = new Date();
 
@@ -128,7 +128,7 @@ describe('Registration flow - Split 2/2', () => {
 						cy.getTestOktaUser(emailAddress).then((oktaUser) => {
 							expect(oktaUser.status).to.eq(Status.ACTIVE);
 
-							cy.visit('/register/email');
+							cy.visit('/register/email?useOktaClassic=true');
 							const timeRequestWasMade = new Date();
 
 							cy.get('input[name=email]').type(emailAddress);
@@ -180,7 +180,7 @@ describe('Registration flow - Split 2/2', () => {
 							cy.getTestOktaUser(emailAddress).then((oktaUser) => {
 								expect(oktaUser.status).to.eq(Status.RECOVERY);
 
-								cy.visit('/register/email');
+								cy.visit('/register/email?useOktaClassic=true');
 								const timeRequestWasMade = new Date();
 
 								cy.get('input[name=email]').type(emailAddress);
@@ -233,7 +233,7 @@ describe('Registration flow - Split 2/2', () => {
 							cy.getTestOktaUser(emailAddress).then((oktaUser) => {
 								expect(oktaUser.status).to.eq(Status.PASSWORD_EXPIRED);
 
-								cy.visit('/register/email');
+								cy.visit('/register/email?useOktaClassic=true');
 								const timeRequestWasMade = new Date();
 
 								cy.get('input[name=email]').type(emailAddress);
@@ -335,7 +335,7 @@ describe('Registration flow - Split 2/2', () => {
 					cy.getTestOktaUser(emailAddress).then((oktaUser) => {
 						expect(oktaUser.status).to.eq(Status.STAGED);
 
-						cy.visit('/welcome/resend');
+						cy.visit('/welcome/resend?useOktaClassic=true');
 
 						const timeRequestWasMade = new Date();
 
@@ -391,7 +391,7 @@ describe('Registration flow - Split 2/2', () => {
 						cy.getTestOktaUser(emailAddress).then((oktaUser) => {
 							expect(oktaUser.status).to.eq(Status.PROVISIONED);
 
-							cy.visit('/welcome/resend');
+							cy.visit('/welcome/resend?useOktaClassic=true');
 
 							const timeRequestWasMade = new Date();
 
@@ -444,7 +444,7 @@ describe('Registration flow - Split 2/2', () => {
 					cy.getTestOktaUser(emailAddress).then((oktaUser) => {
 						expect(oktaUser.status).to.eq(Status.ACTIVE);
 
-						cy.visit('/welcome/resend');
+						cy.visit('/welcome/resend?useOktaClassic=true');
 						const timeRequestWasMade = new Date();
 
 						cy.get('input[name=email]').type(emailAddress);
@@ -496,7 +496,7 @@ describe('Registration flow - Split 2/2', () => {
 						cy.getTestOktaUser(emailAddress).then((oktaUser) => {
 							expect(oktaUser.status).to.eq(Status.RECOVERY);
 
-							cy.visit('/welcome/resend');
+							cy.visit('/welcome/resend?useOktaClassic=true');
 							const timeRequestWasMade = new Date();
 
 							cy.get('input[name=email]').type(emailAddress);
@@ -549,7 +549,7 @@ describe('Registration flow - Split 2/2', () => {
 						cy.getTestOktaUser(emailAddress).then((oktaUser) => {
 							expect(oktaUser.status).to.eq(Status.PASSWORD_EXPIRED);
 
-							cy.visit('/welcome/resend');
+							cy.visit('/welcome/resend?useOktaClassic=true');
 							const timeRequestWasMade = new Date();
 
 							cy.get('input[name=email]').type(emailAddress);
@@ -651,7 +651,7 @@ describe('Registration flow - Split 2/2', () => {
 	});
 
 	// a few tests to check if the Okta Classic flow is still working using the useOktaClassic flag
-	context('Okta Classic Flow', () => {
+	context('Okta Classic Flow - new user', () => {
 		it('create account - successfully registers using an email with no existing account', () => {
 			const encodedReturnUrl =
 				'https%3A%2F%2Fm.code.dev-theguardian.com%2Ftravel%2F2019%2Fdec%2F18%2Ffood-culture-tour-bethlehem-palestine-east-jerusalem-photo-essay';
@@ -839,6 +839,416 @@ describe('Registration flow - Split 2/2', () => {
 		});
 	});
 
+	context(
+		'Existing users attempting to register with Okta - useOktaClassic',
+		() => {
+			it('should send a STAGED user a set password email with an Okta activation token', () => {
+				// Test users created via IDAPI-with-Okta do not have the activation
+				// lifecycle run at creation, so they don't transition immediately from
+				// STAGED to PROVISIONED (c.f.
+				// https://developer.okta.com/docs/reference/api/users/#create-user) .
+				// This is useful for us as we can test STAGED users first, then test
+				// PROVISIONED users in the next test by activating a STAGED user. Users
+				// created through Gateway-with-Okta do have this lifecycle run, so if we
+				// rebuild these tests to not use IDAPI at all, we need to figure out a
+				// way to test STAGED and PROVISIONED users (probably by just passing an
+				// optional `activate` prop to a createUser function).
+				cy
+					.createTestUser({
+						isGuestUser: true,
+						isUserEmailValidated: true,
+					})
+					?.then(({ emailAddress }) => {
+						cy.getTestOktaUser(emailAddress).then((oktaUser) => {
+							expect(oktaUser.status).to.eq(Status.STAGED);
+
+							cy.visit('/register/email?useOktaClassic=true');
+							const timeRequestWasMade = new Date();
+
+							cy.get('input[name=email]').type(emailAddress);
+							cy.get('[data-cy="main-form-submit-button"]').click();
+
+							cy.contains('Check your inbox');
+							cy.contains(emailAddress);
+							cy.contains('send again');
+							cy.contains('try another address');
+
+							cy.checkForEmailAndGetDetails(
+								emailAddress,
+								timeRequestWasMade,
+								/\/set-password\/([^"]*)/,
+							).then(({ links, body }) => {
+								expect(body).to.have.string('This account already exists');
+
+								expect(body).to.have.string('Create password');
+								expect(links.length).to.eq(2);
+								const setPasswordLink = links.find((s) =>
+									s.text?.includes('Create password'),
+								);
+								expect(setPasswordLink?.href).not.to.have.string(
+									'useOkta=true',
+								);
+								cy.visit(setPasswordLink?.href as string);
+								cy.contains('Create password');
+								cy.contains(emailAddress);
+							});
+						});
+					});
+			});
+
+			it('should send a STAGED user a set password email with an Okta activation token, and has a prefixed activation token when using a native app', () => {
+				// Test users created via IDAPI-with-Okta do not have the activation
+				// lifecycle run at creation, so they don't transition immediately from
+				// STAGED to PROVISIONED (c.f.
+				// https://developer.okta.com/docs/reference/api/users/#create-user) .
+				// This is useful for us as we can test STAGED users first, then test
+				// PROVISIONED users in the next test by activating a STAGED user. Users
+				// created through Gateway-with-Okta do have this lifecycle run, so if we
+				// rebuild these tests to not use IDAPI at all, we need to figure out a
+				// way to test STAGED and PROVISIONED users (probably by just passing an
+				// optional `activate` prop to a createUser function).
+				cy
+					.createTestUser({
+						isGuestUser: true,
+						isUserEmailValidated: true,
+					})
+					?.then(({ emailAddress }) => {
+						cy.getTestOktaUser(emailAddress).then((oktaUser) => {
+							expect(oktaUser.status).to.eq(Status.STAGED);
+
+							const appClientId = Cypress.env('OKTA_ANDROID_CLIENT_ID');
+							const fromURI = 'fromURI1';
+
+							cy.visit(
+								`/register/email?appClientId=${appClientId}&fromURI=${fromURI}&useOktaClassic=true`,
+							);
+							const timeRequestWasMade = new Date();
+
+							cy.get('input[name=email]').type(emailAddress);
+							cy.get('[data-cy="main-form-submit-button"]').click();
+
+							cy.contains('Check your inbox');
+							cy.contains(emailAddress);
+							cy.contains('send again');
+							cy.contains('try another address');
+
+							cy.checkForEmailAndGetDetails(
+								emailAddress,
+								timeRequestWasMade,
+								/\/set-password\/([^"]*)/,
+							).then(({ links, body }) => {
+								expect(body).to.have.string('This account already exists');
+
+								expect(body).to.have.string('Create password');
+								expect(links.length).to.eq(2);
+								const setPasswordLink = links.find((s) =>
+									s.text?.includes('Create password'),
+								);
+								expect(setPasswordLink?.href ?? '')
+									.to.have.string('al_')
+									.and.not.to.have.string('useOkta=true');
+								cy.visit(setPasswordLink?.href as string);
+								cy.contains('Create password');
+								cy.contains(emailAddress);
+							});
+						});
+					});
+			});
+
+			it('should send a PROVISIONED user a set password email with an Okta activation token', () => {
+				cy
+					.createTestUser({
+						isGuestUser: true,
+						isUserEmailValidated: true,
+					})
+					?.then(({ emailAddress }) => {
+						cy.activateTestOktaUser(emailAddress).then(() => {
+							cy.getTestOktaUser(emailAddress).then((oktaUser) => {
+								expect(oktaUser.status).to.eq(Status.PROVISIONED);
+
+								cy.visit('/register/email?useOktaClassic=true');
+								const timeRequestWasMade = new Date();
+
+								cy.get('input[name=email]').type(emailAddress);
+								cy.get('[data-cy="main-form-submit-button"]').click();
+
+								cy.contains('Check your inbox');
+								cy.contains(emailAddress);
+								cy.contains('send again');
+								cy.contains('try another address');
+
+								cy.checkForEmailAndGetDetails(
+									emailAddress,
+									timeRequestWasMade,
+									/\/set-password\/([^"]*)/,
+								).then(({ links, body }) => {
+									expect(body).to.have.string('This account already exists');
+									expect(body).to.have.string('Create password');
+									expect(links.length).to.eq(2);
+									const setPasswordLink = links.find((s) =>
+										s.text?.includes('Create password'),
+									);
+									expect(setPasswordLink?.href).not.to.have.string(
+										'useOkta=true',
+									);
+									cy.visit(setPasswordLink?.href as string);
+									cy.contains('Create password');
+									cy.contains(emailAddress);
+								});
+							});
+						});
+					});
+			});
+			it('should send an ACTIVE UNvalidated user with a password a security email with activation token', () => {
+				cy
+					.createTestUser({
+						isGuestUser: false,
+						isUserEmailValidated: false,
+					})
+					?.then(({ emailAddress }) => {
+						cy.getTestOktaUser(emailAddress).then((oktaUser) => {
+							expect(oktaUser.status).to.eq(Status.ACTIVE);
+
+							cy.visit('/register/email?useOktaClassic=true');
+							const timeRequestWasMade = new Date();
+
+							cy.get('input[name=email]').type(emailAddress);
+							cy.get('[data-cy="main-form-submit-button"]').click();
+
+							// Make sure that we don't get sent to the 'security reasons' page
+							cy.url().should('include', '/register/email-sent');
+							cy.contains(
+								'For security reasons we need you to change your password.',
+							).should('not.exist');
+							cy.contains(emailAddress);
+							cy.contains('send again');
+							cy.contains('try another address');
+
+							cy.checkForEmailAndGetDetails(
+								emailAddress,
+								timeRequestWasMade,
+								/reset-password\/([^"]*)/,
+							).then(({ links, body }) => {
+								expect(body).to.have.string(
+									'Because your security is extremely important to us, we have changed our password policy.',
+								);
+								expect(body).to.have.string('Reset password');
+								expect(links.length).to.eq(2);
+								const resetPasswordLink = links.find((s) =>
+									s.text?.includes('Reset password'),
+								);
+								cy.visit(resetPasswordLink?.href as string);
+								cy.contains(emailAddress);
+								cy.contains('Create new password');
+							});
+						});
+					});
+			});
+			it('should send an ACTIVE validated user WITH a password a reset password email with an activation token', () => {
+				cy
+					.createTestUser({
+						isGuestUser: false,
+						isUserEmailValidated: true,
+					})
+					?.then(({ emailAddress }) => {
+						cy.getTestOktaUser(emailAddress).then((oktaUser) => {
+							expect(oktaUser.status).to.eq(Status.ACTIVE);
+
+							cy.visit('/register/email?useOktaClassic=true');
+							const timeRequestWasMade = new Date();
+
+							cy.get('input[name=email]').type(emailAddress);
+							cy.get('[data-cy="main-form-submit-button"]').click();
+
+							cy.contains('Check your inbox');
+							cy.contains(emailAddress);
+							cy.contains('send again');
+							cy.contains('try another address');
+
+							cy.checkForEmailAndGetDetails(
+								emailAddress,
+								timeRequestWasMade,
+								/reset-password\/([^"]*)/,
+							).then(({ links, body }) => {
+								expect(body).to.have.string('This account already exists');
+								expect(body).to.have.string('Sign in');
+								expect(body).to.have.string('Reset password');
+								expect(links.length).to.eq(3);
+								const resetPasswordLink = links.find((s) =>
+									s.text?.includes('Reset password'),
+								);
+								expect(resetPasswordLink?.href ?? '').not.to.have.string(
+									'useOkta=true',
+								);
+								cy.visit(resetPasswordLink?.href as string);
+								cy.contains(emailAddress);
+								cy.contains('Create new password');
+							});
+						});
+					});
+			});
+			it('should send an ACTIVE validated user WITH a password a reset password email with an activation token, and prefixed activation token if using native app', () => {
+				cy
+					.createTestUser({
+						isGuestUser: false,
+						isUserEmailValidated: true,
+					})
+					?.then(({ emailAddress }) => {
+						cy.getTestOktaUser(emailAddress).then((oktaUser) => {
+							expect(oktaUser.status).to.eq(Status.ACTIVE);
+
+							const appClientId = Cypress.env('OKTA_ANDROID_CLIENT_ID');
+							const fromURI = 'fromURI1';
+
+							cy.visit(
+								`/register/email?appClientId=${appClientId}&fromURI=${fromURI}&useOktaClassic=true`,
+							);
+							const timeRequestWasMade = new Date();
+
+							cy.get('input[name=email]').type(emailAddress);
+							cy.get('[data-cy="main-form-submit-button"]').click();
+
+							cy.contains('Check your inbox');
+							cy.contains(emailAddress);
+							cy.contains('send again');
+							cy.contains('try another address');
+
+							cy.checkForEmailAndGetDetails(
+								emailAddress,
+								timeRequestWasMade,
+								/reset-password\/([^"]*)/,
+							).then(({ links, body }) => {
+								expect(body).to.have.string('This account already exists');
+								expect(body).to.have.string('Sign in');
+								expect(body).to.have.string('Reset password');
+								expect(links.length).to.eq(3);
+								const resetPasswordLink = links.find((s) =>
+									s.text?.includes('Reset password'),
+								);
+								expect(resetPasswordLink?.href ?? '')
+									.to.have.string('al_')
+									.and.not.to.have.string('useOkta=true');
+								cy.visit(resetPasswordLink?.href as string);
+								cy.contains(emailAddress);
+								cy.contains('Create new password');
+							});
+						});
+					});
+			});
+			it('should send a RECOVERY user a reset password email with an Okta activation token', () => {
+				cy
+					.createTestUser({
+						isGuestUser: false,
+						isUserEmailValidated: true,
+					})
+					?.then(({ emailAddress }) => {
+						cy.resetOktaUserPassword(emailAddress).then(() => {
+							cy.getTestOktaUser(emailAddress).then((oktaUser) => {
+								expect(oktaUser.status).to.eq(Status.RECOVERY);
+
+								cy.visit('/register/email?useOktaClassic=true');
+								const timeRequestWasMade = new Date();
+
+								cy.get('input[name=email]').type(emailAddress);
+								cy.get('[data-cy="main-form-submit-button"]').click();
+
+								cy.contains('Check your inbox');
+								cy.contains(emailAddress);
+								cy.contains('send again');
+								cy.contains('try another address');
+
+								cy.checkForEmailAndGetDetails(
+									emailAddress,
+									timeRequestWasMade,
+									/reset-password\/([^"]*)/,
+								).then(({ links, body }) => {
+									expect(body).to.have.string('Password reset');
+									expect(body).to.have.string('Reset password');
+									expect(links.length).to.eq(3);
+									const resetPasswordLink = links.find((s) =>
+										s.text?.includes('Reset password'),
+									);
+									expect(resetPasswordLink?.href ?? '').not.to.have.string(
+										'useOkta=true',
+									);
+									cy.visit(resetPasswordLink?.href as string);
+									cy.contains('Create new password');
+									cy.contains(emailAddress);
+								});
+							});
+						});
+					});
+			});
+			it('should send a PASSWORD_EXPIRED user a reset password email with an Okta activation token', () => {
+				cy
+					.createTestUser({
+						isGuestUser: false,
+						isUserEmailValidated: true,
+					})
+					?.then(({ emailAddress }) => {
+						cy.expireOktaUserPassword(emailAddress).then(() => {
+							cy.getTestOktaUser(emailAddress).then((oktaUser) => {
+								expect(oktaUser.status).to.eq(Status.PASSWORD_EXPIRED);
+
+								cy.visit('/register/email?useOktaClassic=true');
+								const timeRequestWasMade = new Date();
+
+								cy.get('input[name=email]').type(emailAddress);
+								cy.get('[data-cy="main-form-submit-button"]').click();
+
+								cy.contains('Check your inbox');
+								cy.contains(emailAddress);
+								cy.contains('send again');
+								cy.contains('try another address');
+
+								cy.checkForEmailAndGetDetails(
+									emailAddress,
+									timeRequestWasMade,
+									/reset-password\/([^"]*)/,
+								).then(({ links, body }) => {
+									expect(body).to.have.string('Password reset');
+									expect(body).to.have.string('Reset password');
+									expect(links.length).to.eq(3);
+									const resetPasswordLink = links.find((s) =>
+										s.text?.includes('Reset password'),
+									);
+									expect(resetPasswordLink?.href ?? '').not.to.have.string(
+										'useOkta=true',
+									);
+									cy.visit(resetPasswordLink?.href as string);
+									cy.contains('Create new password');
+									cy.contains(emailAddress);
+								});
+							});
+						});
+					});
+			});
+			it('should display an error if a SUSPENDED user attempts to register', () => {
+				cy
+					.createTestUser({
+						isGuestUser: false,
+						isUserEmailValidated: true,
+					})
+					?.then(({ emailAddress }) => {
+						cy.suspendOktaUser(emailAddress).then(() => {
+							cy.getTestOktaUser(emailAddress).then((oktaUser) => {
+								expect(oktaUser.status).to.eq(Status.SUSPENDED);
+
+								cy.visit('/register/email?useOktaClassic=true');
+
+								cy.get('input[name=email]').type(emailAddress);
+								cy.get('[data-cy="main-form-submit-button"]').click();
+
+								cy.contains(
+									'There was a problem registering, please try again.',
+								);
+							});
+						});
+					});
+			});
+		},
+	);
+
 	context('Extra checks', () => {
 		it('should navigate back to the correct page when change email is clicked', () => {
 			cy.visit('/register/email-sent');
@@ -866,7 +1276,7 @@ describe('Registration flow - Split 2/2', () => {
 
 					cy.get('[data-cy="main-form-submit-button"]').click();
 
-					cy.contains('Check your inbox');
+					cy.contains('Enter your code');
 					cy.contains(emailAddress);
 					cy.contains('send again');
 					cy.contains('try another address');
@@ -889,7 +1299,7 @@ describe('Registration flow - Split 2/2', () => {
 						'not.exist',
 					);
 
-					cy.contains('Check your inbox');
+					cy.contains('Enter your code');
 					cy.contains(emailAddress);
 
 					cy.checkForEmailAndGetDetails(emailAddress, timeRequestWasMade);

--- a/src/client/pages/WelcomeExisting.stories.tsx
+++ b/src/client/pages/WelcomeExisting.stories.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { Meta } from '@storybook/react';
+
+import {
+	WelcomeExisting,
+	WelcomeExistingProps,
+} from '@/client/pages/WelcomeExisting';
+
+export default {
+	title: 'Pages/WelcomeExisting',
+	component: WelcomeExisting,
+	args: {
+		queryParams: {
+			returnUrl: 'https://www.theguardian.com/uk',
+		},
+	},
+} as Meta<WelcomeExistingProps>;
+
+export const Default = (args: WelcomeExistingProps) => (
+	<WelcomeExisting {...args} />
+);
+Default.story = {
+	name: 'default',
+};
+
+export const WithEmail = (args: WelcomeExistingProps) => (
+	<WelcomeExisting {...args} email="test@example.com" />
+);
+WithEmail.story = {
+	name: 'with email',
+};

--- a/src/client/pages/WelcomeExisting.tsx
+++ b/src/client/pages/WelcomeExisting.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import { MinimalLayout } from '@/client/layouts/MinimalLayout';
+import { QueryParams } from '@/shared/model/QueryParams';
+import {
+	primaryButtonStyles,
+	secondaryButtonStyles,
+} from '@/client/styles/Shared';
+import { ExternalLinkButton } from '@/client/components/ExternalLink';
+import { MainBodyText } from '../components/MainBodyText';
+
+export interface WelcomeExistingProps {
+	queryParams: QueryParams;
+	accountManagementUrl?: string;
+	email?: string;
+}
+
+export const WelcomeExisting = ({
+	queryParams,
+	email,
+	accountManagementUrl = 'https://manage.theguardian.com',
+}: WelcomeExistingProps) => {
+	return (
+		<MinimalLayout
+			pageHeader="Welcome back. You're signed in!"
+			imageId="welcome"
+		>
+			<MainBodyText>
+				We noticed you already have a Guardian account
+				{email && (
+					<>
+						{' '}
+						with <b>{email}</b>
+					</>
+				)}
+				.
+			</MainBodyText>
+			<MainBodyText>
+				You're now signed in and can access all the benefits of your Guardian
+				account.
+			</MainBodyText>
+			<ExternalLinkButton
+				cssOverrides={primaryButtonStyles()}
+				href={queryParams.returnUrl}
+			>
+				Return to the Guardian
+			</ExternalLinkButton>
+			<ExternalLinkButton
+				priority="tertiary"
+				cssOverrides={secondaryButtonStyles()}
+				href={accountManagementUrl}
+			>
+				Manage my Guardian account
+			</ExternalLinkButton>
+		</MinimalLayout>
+	);
+};

--- a/src/client/pages/WelcomeExistingPage.tsx
+++ b/src/client/pages/WelcomeExistingPage.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import useClientState from '@/client/lib/hooks/useClientState';
+
+import { WelcomeExisting } from '@/client/pages/WelcomeExisting';
+
+export const WelcomeExistingPage = () => {
+	const clientState = useClientState();
+	const { pageData: { accountManagementUrl, email } = {}, queryParams } =
+		clientState;
+
+	return (
+		<WelcomeExisting
+			queryParams={queryParams}
+			accountManagementUrl={accountManagementUrl}
+			email={email}
+		/>
+	);
+};

--- a/src/client/routes.tsx
+++ b/src/client/routes.tsx
@@ -42,6 +42,7 @@ import { NewAccountNewslettersPage } from '@/client/pages/NewAccountNewslettersP
 import { VerifyEmailResetPasswordPage } from '@/client/pages/VerifyEmailResetPasswordPage';
 import { ResetPasswordEmailSentPage } from '@/client/pages/ResetPasswordEmailSentPage';
 import { SignInPasscodeEmailSentPage } from '@/client/pages/SignInPasscodeEmailSentPage';
+import { WelcomeExistingPage } from '@/client/pages/WelcomeExistingPage';
 
 export type RoutingConfig = {
 	clientState: ClientState;
@@ -137,6 +138,10 @@ const routes: Array<{
 	{
 		path: '/welcome/resend',
 		element: <WelcomeResendPage />,
+	},
+	{
+		path: '/welcome/existing',
+		element: <WelcomeExistingPage />,
 	},
 	{
 		path: '/welcome/expired',

--- a/src/server/lib/okta/idx/startIdxFlow.ts
+++ b/src/server/lib/okta/idx/startIdxFlow.ts
@@ -13,7 +13,7 @@ import { ResponseWithRequestState } from '@/server/models/Express';
 import { PerformAuthorizationCodeFlowOptions } from '@/server/lib/okta/oauth';
 import { RegistrationConsents } from '@/shared/model/RegistrationConsents';
 
-type StartIdxFlowParams = {
+export type StartIdxFlowParams = {
 	req: Request;
 	res: ResponseWithRequestState;
 	authorizationCodeFlowOptions: Pick<

--- a/src/server/models/okta/User.ts
+++ b/src/server/models/okta/User.ts
@@ -138,7 +138,7 @@ export type SessionResponse = z.infer<typeof sessionResponseSchema>;
  *	@values ACTIVE_EMAIL_PASSWORD - ACTIVE - user has email + password authenticator (okta idx email verified)
  *	@values ACTIVE_PASSWORD_ONLY - ACTIVE - user has only password authenticator (okta idx email not verified)
  *	@values ACTIVE_EMAIL_ONLY - ACTIVE - user has only email authenticator (okta idx email verified) - not currently used in any code
- *	@values NOT_ACTIVE - user not in ACTIVE state - not currently used in any code
+ *	@values NOT_ACTIVE - user not in ACTIVE state - likely a new user
  */
 export type InternalOktaUserState =
 	| 'NON_EXISTENT'

--- a/src/server/routes/signIn.ts
+++ b/src/server/routes/signIn.ts
@@ -310,7 +310,9 @@ router.get(
 router.post(
 	'/signin/code',
 	redirectIfLoggedIn,
-	oktaIdxApiSubmitPasscodeController,
+	handleAsyncErrors(async (req: Request, res: ResponseWithRequestState) => {
+		return await oktaIdxApiSubmitPasscodeController({ req, res });
+	}),
 );
 
 router.get(

--- a/src/server/routes/welcome.ts
+++ b/src/server/routes/welcome.ts
@@ -451,6 +451,22 @@ router.post(
 	},
 );
 
+// existing user using create account flow page
+router.get(
+	'/welcome/existing',
+	(req: Request, res: ResponseWithRequestState) => {
+		const html = renderer('/welcome/existing', {
+			requestState: mergeRequestState(res.locals, {
+				pageData: {
+					email: readEmailCookie(req),
+				},
+			}),
+			pageTitle: 'Welcome back',
+		});
+		return res.type('html').send(html);
+	},
+);
+
 // welcome page, check token and display set password page
 router.get(
 	'/welcome/:token',

--- a/src/shared/model/PageTitle.ts
+++ b/src/shared/model/PageTitle.ts
@@ -35,7 +35,8 @@ export type PageTitle =
 	| 'Account Deletion'
 	| 'Account Deletion Complete'
 	| 'Account Deletion Blocked'
-	| 'Choose Newsletters';
+	| 'Choose Newsletters'
+	| 'Welcome back';
 
 export type PasswordPageTitle = Extract<
 	'Welcome' | 'Create Password' | 'Change Password',

--- a/src/shared/model/Routes.ts
+++ b/src/shared/model/Routes.ts
@@ -76,6 +76,7 @@ export const ValidRoutePathsArray = [
 	'/welcome/:app/complete',
 	'/welcome/complete',
 	'/welcome/email-sent',
+	'/welcome/existing',
 	'/welcome/expired',
 	'/welcome/resend',
 	'/welcome/google',


### PR DESCRIPTION
## What does this change?

Currently when a reader who already has a Guardian account goes through the "create account" flow (`/register/email`), they will not be sent a passcode, but instead an email saying they already have a Guardian account and to sign in or reset their password, and shown a generic "Check your inbox" page. This differs from how it works for new users, who get a passcode after entering their email on the create account page.

This isn't ideal. Firstly the user experience is different and unexpected, especially as we use passcodes in all other scenarios now (sign in + reset password). It also a small security/user data risk, specifically for username enumeration, where an attacker can find out if a given account exists depending on which page the attacker sees after entering their email.

This PR fixes this behaviour by making sure we use passcodes for all users who go through the create account flow. For new users the behaviour is exactly the same. For existing users we now send them a passcode that allows them to sign in, which piggybacks of the work done in #2942 for sign in with passcodes.

We modify the sign in with passcode controllers to allow us to display the correct email sent page (`/register/email-sent`) and a different page after verifying their code (`confirmationPagePath`), other than that the logic/behaviour is the same as for sign in with passcodes.

Existing users will see a new page after going through the create account flow, specifically the `WelcomeExisting` page on the `/welcome/existing` route, which lets the user know that they already have a Guardian account, they've now signed in, and they can return to the Guardian or manage their account.

Finally a whole lotta tests were added and updated in order to take into account the new create account flow for existing users.

### `WelcomeExisting`

<table>
<tr>
<th>`WelcomeExisting` page</th>
</tr>
<tr>
<td>

![Screen Shot 2025-01-23 at 14 37 09](https://github.com/user-attachments/assets/6e745932-3b61-4c94-917e-b6171e6e259d)

</td>
</tr>
</table>

### Demo

<table>
<tr>
<th>
New User
</th>
<th>
Existing User - Old behaviour
</th>
<th>
Existing User - New behaviour
</th>
</tr>
<tr>
<td>

https://github.com/user-attachments/assets/957c39e0-f799-4d00-a144-173c8bab04de

</td>
<td>

https://github.com/user-attachments/assets/7a1d524e-e96e-47f9-8ff0-dd2e4b234539

</td>
<td>

https://github.com/user-attachments/assets/6ec75498-4970-430e-988a-187230cb8511

</td>
</tr>
</table>

## Tested

- [x] DEV
- [x] CODE