### PR TITLE
Passwordless | Add countdown timer to "send again" functionality

### DIFF
--- a/cypress/integration/ete/registration_1.2.cy.ts
+++ b/cypress/integration/ete/registration_1.2.cy.ts
@@ -24,6 +24,8 @@ const existingUserSendEmailAndValidatePasscode = ({
 	expectedEmailBody?: 'Your one-time passcode' | 'Your verification code';
 	additionalTests?: 'passcode-incorrect' | 'resend-email' | 'change-email';
 }) => {
+	cy.setCookie('cypress-mock-state', '1'); // passcode send again timer
+
 	cy.visit(`/register/email?${params}`);
 	cy.get('input[name=email]').clear().type(emailAddress);
 
@@ -46,6 +48,7 @@ const existingUserSendEmailAndValidatePasscode = ({
 				case 'resend-email':
 					{
 						const timeRequestWasMade2 = new Date();
+						cy.wait(1000); // wait for the send again button to be enabled
 						cy.contains('send again').click();
 
 						cy.checkForEmailAndGetDetails(
@@ -430,6 +433,7 @@ describe('Registration flow - Split 1/2', () => {
 		});
 
 		it('resend email functionality', () => {
+			cy.setCookie('cypress-mock-state', '1'); // passcode send again timer
 			const unregisteredEmail = randomMailosaurEmail();
 			cy.visit(`/register/email`);
 
@@ -455,6 +459,7 @@ describe('Registration flow - Split 1/2', () => {
 				// passcode page
 				cy.url().should('include', '/register/email-sent');
 				const timeRequestWasMade2 = new Date();
+				cy.wait(1000); // wait for the send again button to be enabled
 				cy.contains('send again').click();
 				cy.checkForEmailAndGetDetails(
 					unregisteredEmail,

--- a/cypress/integration/ete/registration_2.6.cy.ts
+++ b/cypress/integration/ete/registration_2.6.cy.ts
@@ -1264,6 +1264,7 @@ describe('Registration flow - Split 2/2', () => {
 		});
 
 		it('shows reCAPTCHA errors when the request fails', () => {
+			cy.setCookie('cypress-mock-state', '1'); // passcode send again timer
 			cy
 				.createTestUser({
 					isUserEmailValidated: false,
@@ -1287,12 +1288,13 @@ describe('Registration flow - Split 2/2', () => {
 					);
 
 					cy.interceptRecaptcha();
-
+					cy.wait(1000); // wait for the send again button to be enabled
 					cy.contains('send again').click();
 					cy.contains('Google reCAPTCHA verification failed.');
 					cy.contains('If the problem persists please try the following:');
 
 					const timeRequestWasMade = new Date();
+					cy.wait(1000); // wait for the send again button to be enabled
 					cy.contains('send again').click();
 
 					cy.contains('Google reCAPTCHA verification failed.').should(

--- a/cypress/integration/ete/reset_password_passcode.7.cy.ts
+++ b/cypress/integration/ete/reset_password_passcode.7.cy.ts
@@ -257,6 +257,7 @@ describe('Password reset recovery flows - with Passcodes', () => {
 			cy.createTestUser({
 				isUserEmailValidated: true,
 			}).then(({ emailAddress }) => {
+				cy.setCookie('cypress-mock-state', '1'); // passcode send again timer
 				cy.visit(`/reset-password`);
 
 				const timeRequestWasMade = new Date();
@@ -282,6 +283,7 @@ describe('Password reset recovery flows - with Passcodes', () => {
 
 						// resend email
 						const timeRequestWasMade2 = new Date();
+						cy.wait(1000); // wait for the send again button to be enabled
 						cy.contains('send again').click();
 
 						cy.checkForEmailAndGetDetails(

--- a/cypress/integration/ete/sign_in_passcode.8.cy.ts
+++ b/cypress/integration/ete/sign_in_passcode.8.cy.ts
@@ -25,6 +25,7 @@ describe('Sign In flow, with passcode', () => {
 		expectedEmailBody?: 'Your one-time passcode' | 'Your verification code';
 		additionalTests?: 'passcode-incorrect' | 'resend-email' | 'change-email';
 	}) => {
+		cy.setCookie('cypress-mock-state', '1'); // passcode send again timer
 		cy.visit(`/signin?${params ? `${params}&` : ''}usePasscodeSignIn=true`);
 		cy.get('input[name=email]').clear().type(emailAddress);
 
@@ -47,6 +48,7 @@ describe('Sign In flow, with passcode', () => {
 					case 'resend-email':
 						{
 							const timeRequestWasMade2 = new Date();
+							cy.wait(1000); // wait for the send again button to be enabled
 							cy.contains('send again').click();
 
 							cy.checkForEmailAndGetDetails(

--- a/cypress/integration/mocked/resetPasswordController.4.cy.ts
+++ b/cypress/integration/mocked/resetPasswordController.4.cy.ts
@@ -916,6 +916,7 @@ userStatuses.forEach((status) => {
 					).toISOString(),
 					email: 'test@example.com',
 				});
+				cy.setCookie('cypress-mock-state', '0'); // passcode send again timer
 				cy.visit(`/reset-password/email-sent`);
 			});
 			switch (status) {

--- a/src/client/components/EmailSentInformationBox.stories.tsx
+++ b/src/client/components/EmailSentInformationBox.stories.tsx
@@ -82,3 +82,18 @@ export const WithNoAccountInfo = () => {
 	);
 };
 WithNoAccountInfo.storyName = 'with noAccountInfo';
+
+export const WithTimer = () => {
+	return (
+		<EmailSentInformationBox
+			setRecaptchaErrorContext={() => {}}
+			setRecaptchaErrorMessage={() => {}}
+			changeEmailPage="#"
+			email="test@example.com"
+			resendEmailAction="#"
+			noAccountInfo
+			sendAgainTimerInSeconds={10}
+		/>
+	);
+};
+WithTimer.storyName = 'with timer';

--- a/src/client/components/EmailSentInformationBox.tsx
+++ b/src/client/components/EmailSentInformationBox.tsx
@@ -12,6 +12,7 @@ import {
 import { css } from '@emotion/react';
 import ThemedLink from '@/client/components/ThemedLink';
 import { EmailSentProps } from '@/client/pages/EmailSent';
+import { useCountdownTimer } from '@/client/lib/hooks/useCountdownTimer';
 
 type EmailSentInformationBoxProps = Pick<
 	EmailSentProps,
@@ -29,6 +30,7 @@ type EmailSentInformationBoxProps = Pick<
 		React.SetStateAction<React.ReactNode>
 	>;
 	setRecaptchaErrorMessage: React.Dispatch<React.SetStateAction<string>>;
+	sendAgainTimerInSeconds?: number;
 };
 
 const sendAgainFormWrapperStyles = css`
@@ -47,56 +49,70 @@ export const EmailSentInformationBox = ({
 	setRecaptchaErrorMessage,
 	queryString,
 	shortRequestId,
-}: EmailSentInformationBoxProps) => (
-	<InformationBox>
-		<InformationBoxText>
-			Didn’t get the email? Check your spam&#8288;
-			{email && resendEmailAction && (
-				<span css={sendAgainFormWrapperStyles}>
-					,{!changeEmailPage ? <> or </> : <> </>}
-					<MainForm
-						formAction={`${resendEmailAction}${queryString}`}
-						submitButtonText={'send again'}
-						recaptchaSiteKey={recaptchaSiteKey}
-						setRecaptchaErrorContext={setRecaptchaErrorContext}
-						setRecaptchaErrorMessage={setRecaptchaErrorMessage}
-						formTrackingName={formTrackingName}
-						disableOnSubmit
-						formErrorMessageFromParent={formError}
-						displayInline
-						submitButtonLink
-						hideRecaptchaMessage
-						shortRequestId={shortRequestId}
-					>
-						<EmailInput defaultValue={email} hidden hideLabel />
-					</MainForm>
-				</span>
-			)}
-			{changeEmailPage && (
-				<>
-					, or{' '}
-					<ThemedLink href={`${changeEmailPage}${queryString}`}>
-						try another address
-					</ThemedLink>
-				</>
-			)}
-			.
-		</InformationBoxText>
-		{noAccountInfo && (
+	sendAgainTimerInSeconds,
+}: EmailSentInformationBoxProps) => {
+	const timer = useCountdownTimer(sendAgainTimerInSeconds || 0);
+
+	return (
+		<InformationBox>
 			<InformationBoxText>
-				If you don’t receive an email within 2 minutes you may not have an
-				account. Don’t have an account?{' '}
-				<ThemedLink href={`${buildUrl('/register')}${queryString}`}>
-					Create an account for free
-				</ThemedLink>
+				Didn’t get the email? Check your spam&#8288;
+				{email && resendEmailAction && (
+					<span css={sendAgainFormWrapperStyles}>
+						,{!changeEmailPage ? <> or </> : <> </>}
+						{sendAgainTimerInSeconds && !timer.isComplete ? (
+							<span>
+								{' '}
+								send again after {timer.timeRemaining} second
+								{timer.timeRemaining > 1 ? 's' : ''}
+							</span>
+						) : (
+							<MainForm
+								formAction={`${resendEmailAction}${queryString}`}
+								submitButtonText={'send again'}
+								recaptchaSiteKey={recaptchaSiteKey}
+								setRecaptchaErrorContext={setRecaptchaErrorContext}
+								setRecaptchaErrorMessage={setRecaptchaErrorMessage}
+								formTrackingName={formTrackingName}
+								disableOnSubmit
+								formErrorMessageFromParent={formError}
+								displayInline
+								submitButtonLink
+								hideRecaptchaMessage
+								shortRequestId={shortRequestId}
+								disabled={!!(sendAgainTimerInSeconds && !timer.isComplete)}
+							>
+								<EmailInput defaultValue={email} hidden hideLabel />
+							</MainForm>
+						)}
+					</span>
+				)}
+				{changeEmailPage && (
+					<>
+						, or{' '}
+						<ThemedLink href={`${changeEmailPage}${queryString}`}>
+							try another address
+						</ThemedLink>
+					</>
+				)}
 				.
 			</InformationBoxText>
-		)}
-		<InformationBoxText>
-			For further assistance, email our customer service team at{' '}
-			<ExternalLink href={locations.SUPPORT_EMAIL_MAILTO}>
-				{SUPPORT_EMAIL}
-			</ExternalLink>
-		</InformationBoxText>
-	</InformationBox>
-);
+			{noAccountInfo && (
+				<InformationBoxText>
+					If you don’t receive an email within 2 minutes you may not have an
+					account. Don’t have an account?{' '}
+					<ThemedLink href={`${buildUrl('/register')}${queryString}`}>
+						Create an account for free
+					</ThemedLink>
+					.
+				</InformationBoxText>
+			)}
+			<InformationBoxText>
+				For further assistance, email our customer service team at{' '}
+				<ExternalLink href={locations.SUPPORT_EMAIL_MAILTO}>
+					{SUPPORT_EMAIL}
+				</ExternalLink>
+			</InformationBoxText>
+		</InformationBox>
+	);
+};

--- a/src/client/components/MainForm.tsx
+++ b/src/client/components/MainForm.tsx
@@ -70,6 +70,7 @@ export interface MainFormProps {
 	hideRecaptchaMessage?: boolean;
 	additionalTerms?: ReactNode;
 	shortRequestId?: string;
+	disabled?: boolean;
 }
 
 const formStyles = (displayInline: boolean) => css`
@@ -110,6 +111,7 @@ export const MainForm = ({
 	hideRecaptchaMessage,
 	additionalTerms,
 	shortRequestId,
+	disabled = false,
 }: PropsWithChildren<MainFormProps>) => {
 	const recaptchaEnabled = !!recaptchaSiteKey;
 
@@ -129,7 +131,7 @@ export const MainForm = ({
 	const [recaptchaState, setRecaptchaState] =
 		useState<UseRecaptchaReturnValue>();
 
-	const [isFormDisabled, setIsFormDisabled] = useState(false);
+	const [isFormDisabled, setIsFormDisabled] = useState(disabled);
 
 	const showFormLevelReportUrl = !!formLevelErrorContext;
 

--- a/src/client/lib/hooks/useCountdownTimer.ts
+++ b/src/client/lib/hooks/useCountdownTimer.ts
@@ -1,0 +1,30 @@
+import { useEffect, useState } from 'react';
+
+interface CountdownTimer {
+	timeRemaining: number;
+	isComplete: boolean;
+}
+
+export const useCountdownTimer = (
+	durationInSeconds: number,
+): CountdownTimer => {
+	const [timeRemaining, setTimeRemaining] = useState(durationInSeconds);
+	const [isComplete, setIsComplete] = useState(false);
+
+	useEffect(() => {
+		const timer = setInterval(() => {
+			setTimeRemaining((prevTime) => {
+				if (prevTime <= 1) {
+					clearInterval(timer);
+					setIsComplete(true);
+					return 0;
+				}
+				return prevTime - 1;
+			});
+		}, 1000);
+
+		return () => clearInterval(timer);
+	}, []);
+
+	return { timeRemaining, isComplete };
+};

--- a/src/client/pages/PasscodeEmailSent.tsx
+++ b/src/client/pages/PasscodeEmailSent.tsx
@@ -22,6 +22,7 @@ type Props = {
 	noAccountInfo?: boolean;
 	textType?: TextType;
 	showSignInWithPasswordOption?: boolean;
+	sendAgainTimerInSeconds?: number;
 };
 
 type PasscodeEmailSentProps = EmailSentProps & Props;
@@ -106,6 +107,7 @@ export const PasscodeEmailSent = ({
 	noAccountInfo,
 	textType = 'generic',
 	showSignInWithPasswordOption,
+	sendAgainTimerInSeconds,
 }: PasscodeEmailSentProps) => {
 	const [recaptchaErrorMessage, setRecaptchaErrorMessage] = useState('');
 	const [recaptchaErrorContext, setRecaptchaErrorContext] =
@@ -197,6 +199,7 @@ export const PasscodeEmailSent = ({
 				queryString={queryString}
 				shortRequestId={shortRequestId}
 				noAccountInfo={noAccountInfo}
+				sendAgainTimerInSeconds={sendAgainTimerInSeconds}
 			/>
 		</MinimalLayout>
 	);

--- a/src/client/pages/RegistrationEmailSentPage.tsx
+++ b/src/client/pages/RegistrationEmailSentPage.tsx
@@ -15,7 +15,14 @@ export const RegistrationEmailSentPage = () => {
 		recaptchaConfig,
 		shortRequestId,
 	} = clientState;
-	const { email, hasStateHandle, fieldErrors, token, passcodeUsed } = pageData;
+	const {
+		email,
+		hasStateHandle,
+		fieldErrors,
+		token,
+		passcodeUsed,
+		passcodeSendAgainTimer,
+	} = pageData;
 	const { emailSentSuccess } = queryParams;
 	const { error } = globalMessage;
 	const { recaptchaSiteKey } = recaptchaConfig;
@@ -51,6 +58,7 @@ export const RegistrationEmailSentPage = () => {
 				shortRequestId={shortRequestId}
 				expiredPage={buildUrl('/welcome/expired')}
 				textType="verification"
+				sendAgainTimerInSeconds={passcodeSendAgainTimer}
 			/>
 		);
 	}

--- a/src/client/pages/ResetPasswordEmailSentPage.tsx
+++ b/src/client/pages/ResetPasswordEmailSentPage.tsx
@@ -14,7 +14,14 @@ export const ResetPasswordEmailSentPage = () => {
 		globalMessage = {},
 		recaptchaConfig,
 	} = clientState;
-	const { email, hasStateHandle, fieldErrors, token, passcodeUsed } = pageData;
+	const {
+		email,
+		hasStateHandle,
+		fieldErrors,
+		token,
+		passcodeUsed,
+		passcodeSendAgainTimer,
+	} = pageData;
 	const { emailSentSuccess } = queryParams;
 	const { error } = globalMessage;
 	const { recaptchaSiteKey } = recaptchaConfig;
@@ -44,6 +51,7 @@ export const ResetPasswordEmailSentPage = () => {
 				expiredPage={buildUrl('/reset-password/expired')}
 				noAccountInfo
 				textType="generic"
+				sendAgainTimerInSeconds={passcodeSendAgainTimer}
 			/>
 		);
 	}

--- a/src/client/pages/SignInPasscodeEmailSentPage.tsx
+++ b/src/client/pages/SignInPasscodeEmailSentPage.tsx
@@ -14,7 +14,8 @@ export const SignInPasscodeEmailSentPage = () => {
 		recaptchaConfig,
 		shortRequestId,
 	} = clientState;
-	const { email, fieldErrors, token, passcodeUsed } = pageData;
+	const { email, fieldErrors, token, passcodeUsed, passcodeSendAgainTimer } =
+		pageData;
 	const { emailSentSuccess } = queryParams;
 	const { error } = globalMessage;
 	const { recaptchaSiteKey } = recaptchaConfig;
@@ -45,6 +46,7 @@ export const SignInPasscodeEmailSentPage = () => {
 			textType="signin"
 			shortRequestId={shortRequestId}
 			showSignInWithPasswordOption
+			sendAgainTimerInSeconds={passcodeSendAgainTimer}
 		/>
 	);
 };

--- a/src/client/pages/UnvalidatedEmailEmailSentPage.tsx
+++ b/src/client/pages/UnvalidatedEmailEmailSentPage.tsx
@@ -20,7 +20,14 @@ export const UnvalidatedEmailEmailSentPage = ({ formTrackingName }: Props) => {
 		recaptchaConfig,
 		shortRequestId,
 	} = clientState;
-	const { email, hasStateHandle, fieldErrors, token, passcodeUsed } = pageData;
+	const {
+		email,
+		hasStateHandle,
+		fieldErrors,
+		token,
+		passcodeUsed,
+		passcodeSendAgainTimer,
+	} = pageData;
 	const { emailSentSuccess } = queryParams;
 	const { error } = globalMessage;
 	const { recaptchaSiteKey } = recaptchaConfig;
@@ -51,6 +58,7 @@ export const UnvalidatedEmailEmailSentPage = ({ formTrackingName }: Props) => {
 				noAccountInfo
 				textType="security"
 				shortRequestId={shortRequestId}
+				sendAgainTimerInSeconds={passcodeSendAgainTimer}
 			/>
 		);
 	}

--- a/src/server/lib/middleware/requestState.ts
+++ b/src/server/lib/middleware/requestState.ts
@@ -23,6 +23,7 @@ import {
 	isAppLabel,
 } from '@/shared/lib/appNameUtils';
 import { readEncryptedStateCookie } from '@/server/lib/encryptedStateCookie';
+import { getPasscodeSendAgainTimer } from '@/server/lib/passcodeSendAgainTimer';
 
 const {
 	idapiBaseUrl,
@@ -107,6 +108,7 @@ const getRequestState = async (
 			appName,
 			hasStateHandle: !!encryptedState?.stateHandle,
 			passcodeUsed: !!encryptedState?.passcodeUsed,
+			passcodeSendAgainTimer: getPasscodeSendAgainTimer(req),
 		},
 		globalMessage: {},
 		csrf: {

--- a/src/server/lib/passcodeSendAgainTimer.ts
+++ b/src/server/lib/passcodeSendAgainTimer.ts
@@ -1,0 +1,15 @@
+import { Request } from 'express';
+
+export const getPasscodeSendAgainTimer = (req: Request): number => {
+	// if we're running in cypress, we want to use the cypress mock state cookie to set the timer for testing
+	const runningInCypress = process.env.RUNNING_IN_CYPRESS === 'true';
+	if (runningInCypress) {
+		const cypressMockStateCookie = req.cookies['cypress-mock-state'];
+
+		if (cypressMockStateCookie && !isNaN(+cypressMockStateCookie)) {
+			return +cypressMockStateCookie;
+		}
+	}
+
+	return 30; // 30 seconds
+};

--- a/src/shared/model/ClientState.ts
+++ b/src/shared/model/ClientState.ts
@@ -73,6 +73,9 @@ export interface PageData {
 	// okta idx api specific
 	hasStateHandle?: boolean; // determines if the state handle is present in the encrypted state, so we know if we're in an Okta IDX flow
 	passcodeUsed?: boolean; // determines if the passcode has been used in the Okta IDX flow, so don't show the passcode page again
+
+	// passcode specific
+	passcodeSendAgainTimer?: number;
 }
 
 export interface RecaptchaConfig {


### PR DESCRIPTION
## What does this change?

A number of users are complaining that they're getting multiple passcodes to their email, each time with a different code, and the original code no longer valid.

We think this is due to delays in the user receiving the email

So rather than allow the user to resend the passcode straight away, we added a countdown timer so that they can only do it after a specificed amount of time, currently set to 30 seconds.

We've only enabled this for passcode users, as the same problem doesn't occur with links.

We also update the `MainForm` component to take a `disabled` value.

A new hook provides the countdown functionality on the client side: `useCountdownTimer`
This hook takes a `durationInSeconds` parameter to start the countdown, and returns the `timeRemaining` in seconds, and an `isComplete` boolean.

This is then integrated withing the `EmailSentInformationBox` component, which houses the "send again" functionality. Where it takes a new `sendAgainTimerInSeconds` prop in order to control it.

In turn the same thing was applied to `PasscodeEmailSent` component which uses the `EmailSentInformationBox`, followed by the pages that use the `PasscodeEmailSent` component.

Finally in order to set the timer, rather than harcode the value everywhere, we add it to the `ClientState` and `PageData` objects. This allows us to only set it in one place (through `getRequestState`), but also lets us modify the value specifically for tests, i.e Cypress. A `getPasscodeSendAgainTimer` helper function helps with this.

<table>
<tr>
<th>Video</th>
</tr>
<tr>
<td>

https://github.com/user-attachments/assets/33077a80-269d-4974-b250-efad3e569281

</td>
</tr>
</table>

## Tested

- [x] DEV
- [x] CODE