### PR TITLE
Fix - Metrics that were missing or werent firing

### DIFF
--- a/src/server/controllers/signInControllers.ts
+++ b/src/server/controllers/signInControllers.ts
@@ -487,13 +487,9 @@ export const oktaIdxApiSignInController = async ({
 		});
 
 		// if the user has made it here, they've successfully authenticated
+		// with a password
 		trackMetric('OktaIdxSignIn::Success');
-
-		// if the usePasscodeSignInFlag is set, but we're at this point, then the user has signed in with a password instead
-		// so we want to track that case user's take that action
-		if (usePasscode) {
-			trackMetric('OktaPasswordSignInFlow::Success');
-		}
+		trackMetric('OktaPasswordSignInFlow::Success');
 
 		// check the response from the challenge/answer endpoint
 		// if not a "CompleteLoginResponse" then Okta is in the state
@@ -616,12 +612,7 @@ export const oktaIdxApiSignInController = async ({
 		logger.error('Okta oktaIdxApiSignInController failed', error);
 
 		trackMetric('OktaIdxSignIn::Failure');
-
-		// if the usePasscode is set, but we're at this point, then the we've failed to send the user a passcode
-		// so we want to track that case
-		if (usePasscode) {
-			trackMetric('OktaPasswordSignInFlow::Failure');
-		}
+		trackMetric('OktaPasswordSignInFlow::Failure');
 
 		const { status, gatewayError } = oktaSignInControllerErrorHandler(error);
 

--- a/src/server/routes/oauth.ts
+++ b/src/server/routes/oauth.ts
@@ -731,6 +731,10 @@ router.get(
 			},
 		);
 
+		// basic checks successful, so track the success metric
+		// before handing off to the specific handler
+		trackMetric('OAuthAuthorization::Success');
+
 		// call the appropriate handler depending on the callbackParam
 		switch (req.params.callbackParam) {
 			case 'application-callback':


### PR DESCRIPTION
## What does this change?

After launching passcodes and looing at the metrics dashboard, I noticed a couple that were missing or not firing.

This PR fixes that.

Firstly `OktaPasswordSignInFlow` metric no longer needs a `usePasscode` check, as this is always the case now, and hadn't been firing since https://github.com/guardian/gateway/pull/3035

Next `OAuthAuthorization::Success` had been missing since May 2024 when it had been accidentally removed in https://github.com/guardian/gateway/pull/2722
