### PR TITLE
Additional text on Delete Your Account Page

### DIFF
--- a/src/client/pages/DeleteAccount.tsx
+++ b/src/client/pages/DeleteAccount.tsx
@@ -52,13 +52,24 @@ export const DeleteAccount = ({
 			pageHeader="Delete your Guardian account"
 			errorOverride={error}
 			leadText={
-				<MainBodyText>
-					Please read the following paragraphs carefully to understand how
-					account deletion affects any Guardian products you may have. If at any
-					point you require further clarification please visit our{' '}
-					<ExternalLink href={locations.REPORT_ISSUE}>help centre</ExternalLink>
-					.
-				</MainBodyText>
+				<>
+					<MainBodyText>
+						To unsubscribe from email newsletters instead,{' '}
+						<ExternalLink href={locations.MMA_EMAIL_PREFERENCES}>
+							manage your preferences
+						</ExternalLink>
+						.
+					</MainBodyText>
+					<MainBodyText>
+						Please read the following paragraphs carefully to understand how
+						account deletion affects any Guardian products you may have. If at
+						any point you require further clarification please visit our{' '}
+						<ExternalLink href={locations.REPORT_ISSUE}>
+							help centre
+						</ExternalLink>
+						.
+					</MainBodyText>
+				</>
 			}
 		>
 			{/* Identity Account */}


### PR DESCRIPTION
## What does this change?

Added a sentence added under the heading.

“To unsubscribe from email newsletters instead, manage your preferences.” with manage your preferences linking to the email/newsletters page in MMA: https://manage.theguardian.com/email-prefs

<table>
<tr>
<th>Before</th>
<th>After</th>
</tr>
<tr>
<td>

![Screenshot 2025-02-03 at 11 29 51](https://github.com/user-attachments/assets/f45f55de-9c03-4d38-9108-276ee2b6d141)

</td>
<td>

![Screenshot 2025-02-03 at 11 30 20](https://github.com/user-attachments/assets/a70047f2-0a9b-40c1-81ef-f7ba891194f2)

</td>
</tr>
</table>