### PR TITLE
Passcodes | Auto submit form on paste or change when valid

### DIFF
--- a/cypress/integration/ete/new_account_review.3.cy.ts
+++ b/cypress/integration/ete/new_account_review.3.cy.ts
@@ -44,9 +44,8 @@ describe('New account review page', () => {
 
 				// passcode page
 				cy.url().should('include', '/register/email-sent');
+				cy.contains('Submit verification code');
 				cy.get('input[name=code]').type(code!);
-
-				cy.contains('Submit verification code').click();
 
 				cy.contains('Complete creating account');
 				cy.get('input[name="password"]').type(randomPassword());
@@ -128,9 +127,9 @@ describe('New account review page', () => {
 
 				// passcode page
 				cy.url().should('include', '/register/email-sent');
+				cy.contains('Submit verification code');
 				cy.get('input[name=code]').type(code!);
 
-				cy.contains('Submit verification code').click();
 				cy.contains('Complete creating account');
 				cy.get('input[name="password"]').type(randomPassword());
 				cy.get('button[type="submit"]').click();
@@ -204,9 +203,9 @@ describe('New account newsletters page', () => {
 
 				// passcode page
 				cy.url().should('include', '/register/email-sent');
+				cy.contains('Submit verification code');
 				cy.get('input[name=code]').type(code!);
 
-				cy.contains('Submit verification code').click();
 				cy.contains('Complete creating account');
 				cy.get('input[name="password"]').type(randomPassword());
 				cy.get('button[type="submit"]').click();
@@ -249,9 +248,9 @@ describe('New account newsletters page', () => {
 
 				// passcode page
 				cy.url().should('include', '/register/email-sent');
+				cy.contains('Submit verification code');
 				cy.get('input[name=code]').type(code!);
 
-				cy.contains('Submit verification code').click();
 				cy.contains('Complete creating account');
 				cy.get('input[name="password"]').type(randomPassword());
 				cy.get('button[type="submit"]').click();
@@ -296,9 +295,9 @@ describe('New account newsletters page', () => {
 
 				// passcode page
 				cy.url().should('include', '/register/email-sent');
+				cy.contains('Submit verification code');
 				cy.get('input[name=code]').type(code!);
 
-				cy.contains('Submit verification code').click();
 				cy.contains('Complete creating account');
 				cy.get('input[name="password"]').type(randomPassword());
 				cy.get('button[type="submit"]').click();

--- a/cypress/integration/ete/registration_1.2.cy.ts
+++ b/cypress/integration/ete/registration_1.2.cy.ts
@@ -61,8 +61,8 @@ const existingUserSendEmailAndValidatePasscode = ({
 							const code = codes?.[0].value;
 							expect(code).to.match(/^\d{6}$/);
 
+							cy.contains('Submit verification code');
 							cy.get('input[name=code]').type(code!);
-							cy.contains('Submit verification code').click();
 
 							cy.contains('Return to the Guardian')
 								.should('have.attr', 'href')
@@ -82,9 +82,8 @@ const existingUserSendEmailAndValidatePasscode = ({
 				}
 				case 'passcode-incorrect':
 					{
+						cy.contains('Submit verification code');
 						cy.get('input[name=code]').type(`123456`);
-
-						cy.contains('Submit verification code').click();
 
 						cy.url().should('include', '/register/code');
 
@@ -105,8 +104,8 @@ const existingUserSendEmailAndValidatePasscode = ({
 					}
 					break;
 				default: {
+					cy.contains('Submit verification code');
 					cy.get('input[name=code]').type(code!);
-					cy.contains('Submit verification code').click();
 
 					if (params?.includes('fromURI')) {
 						cy.url().should('include', expectedReturnUrl);
@@ -160,8 +159,6 @@ describe('Registration flow - Split 1/2', () => {
 
 					// passcode page
 					cy.url().should('include', '/register/email-sent');
-					cy.get('input[name=code]').type(code!);
-
 					cy.get('form')
 						.should('have.attr', 'action')
 						.and('match', new RegExp(encodedReturnUrl))
@@ -169,7 +166,9 @@ describe('Registration flow - Split 1/2', () => {
 						.and('match', new RegExp(encodedRef))
 						.and('match', new RegExp(clientId));
 
-					cy.contains('Submit verification code').click();
+					cy.contains('Submit verification code');
+
+					cy.get('input[name=code]').type(code!);
 
 					// password page
 					cy.url().should('include', '/welcome/password');
@@ -239,8 +238,6 @@ describe('Registration flow - Split 1/2', () => {
 
 					// passcode page
 					cy.url().should('include', '/register/email-sent');
-					cy.get('input[name=code]').type(code!);
-
 					cy.get('form')
 						.should('have.attr', 'action')
 						.and('match', new RegExp(encodedReturnUrl))
@@ -249,7 +246,8 @@ describe('Registration flow - Split 1/2', () => {
 						.and('match', new RegExp(appClientId))
 						.and('match', new RegExp(encodeURIComponent(fromURI)));
 
-					cy.contains('Submit verification code').click();
+					cy.contains('Submit verification code');
+					cy.get('input[name=code]').type(code!);
 
 					// password page
 					cy.url().should('include', '/welcome/password');
@@ -336,8 +334,8 @@ describe('Registration flow - Split 1/2', () => {
 
 					// passcode page
 					cy.url().should('include', '/register/email-sent');
+					cy.contains('Submit verification code');
 					cy.get('input[name=code]').type(code!);
-					cy.contains('Submit verification code').click();
 
 					cy.contains('Complete creating account');
 
@@ -374,9 +372,8 @@ describe('Registration flow - Split 1/2', () => {
 
 					// passcode page
 					cy.url().should('include', '/register/email-sent');
+					cy.contains('Submit verification code');
 					cy.get('input[name=code]').type(`${+code! + 1}`);
-
-					cy.contains('Submit verification code').click();
 
 					cy.url().should('include', '/register/code');
 
@@ -412,8 +409,8 @@ describe('Registration flow - Split 1/2', () => {
 					expect(code).to.match(/^\d{6}$/);
 
 					// passcode page
+					cy.contains('Submit verification code');
 					cy.get('input[name=code]').clear().type(code!);
-					cy.contains('Submit verification code').click();
 
 					cy.url().should('contain', '/welcome/password');
 
@@ -475,8 +472,8 @@ describe('Registration flow - Split 1/2', () => {
 					cy.url().should('include', '/register/email-sent');
 					cy.contains('Email with verification code sent');
 
+					cy.contains('Submit verification code');
 					cy.get('input[name=code]').type(code!);
-					cy.contains('Submit verification code').click();
 
 					cy.url().should('contain', '/welcome/password');
 				});
@@ -756,9 +753,8 @@ describe('Registration flow - Split 1/2', () => {
 
 						// passcode page
 						cy.url().should('include', '/register/email-sent');
+						cy.contains('Submit verification code');
 						cy.get('input[name=code]').type(code!);
-
-						cy.contains('Submit verification code').click();
 
 						// password page
 						cy.url().should('include', '/welcome/password');
@@ -827,9 +823,8 @@ describe('Registration flow - Split 1/2', () => {
 
 						// passcode page
 						cy.url().should('include', '/register/email-sent');
+						cy.contains('Submit verification code');
 						cy.get('input[name=code]').type(code!);
-
-						cy.contains('Submit verification code').click();
 
 						// password page
 						cy.url().should('include', '/welcome/password');

--- a/cypress/integration/ete/registration_2.6.cy.ts
+++ b/cypress/integration/ete/registration_2.6.cy.ts
@@ -305,9 +305,8 @@ describe('Registration flow - Split 2/2', () => {
 
 					// passcode page
 					cy.url().should('include', '/register/email-sent');
+					cy.contains('Submit verification code');
 					cy.get('input[name=code]').type(code!);
-
-					cy.contains('Submit verification code').click();
 
 					cy.contains('Complete creating account');
 

--- a/cypress/integration/ete/reset_password_2.5.cy.ts
+++ b/cypress/integration/ete/reset_password_2.5.cy.ts
@@ -37,9 +37,8 @@ describe('Password reset recovery flows', () => {
 
 						// passcode page
 						cy.url().should('include', '/register/email-sent');
+						cy.contains('Submit verification code');
 						cy.get('input[name=code]').type(code!);
-
-						cy.contains('Submit verification code').click();
 
 						// password page
 						cy.url().should('include', '/welcome/password');
@@ -66,8 +65,8 @@ describe('Password reset recovery flows', () => {
 							cy.url().should('include', '/reset-password/email-sent');
 							cy.contains('Enter your one-time code');
 
+							cy.contains('Submit one-time code');
 							cy.get('input[name=code]').clear().type(code!);
-							cy.contains('Submit one-time code').click();
 
 							// password page
 							cy.url().should('include', '/reset-password/password');
@@ -107,9 +106,8 @@ describe('Password reset recovery flows', () => {
 
 						// passcode page
 						cy.url().should('include', '/register/email-sent');
+						cy.contains('Submit verification code');
 						cy.get('input[name=code]').type(code!);
-
-						cy.contains('Submit verification code').click();
 
 						// password page
 						cy.url().should('include', '/welcome/password');
@@ -138,8 +136,8 @@ describe('Password reset recovery flows', () => {
 								cy.url().should('include', '/reset-password/email-sent');
 								cy.contains('Enter your one-time code');
 
+								cy.contains('Submit one-time code');
 								cy.get('input[name=code]').clear().type(code!);
-								cy.contains('Submit one-time code').click();
 
 								// password page
 								cy.url().should('include', '/reset-password/password');

--- a/cypress/integration/ete/reset_password_passcode.7.cy.ts
+++ b/cypress/integration/ete/reset_password_passcode.7.cy.ts
@@ -37,8 +37,6 @@ describe('Password reset recovery flows - with Passcodes', () => {
 						// passcode page
 						cy.url().should('include', '/reset-password/email-sent');
 						cy.contains('Enter your one-time code');
-						cy.get('input[name=code]').type(code!);
-
 						cy.get('form')
 							.should('have.attr', 'action')
 							.and('match', new RegExp(encodedReturnUrl))
@@ -46,7 +44,9 @@ describe('Password reset recovery flows - with Passcodes', () => {
 							.and('match', new RegExp(encodedRef))
 							.and('match', new RegExp(clientId));
 
-						cy.contains('Submit one-time code').click();
+						cy.contains('Submit one-time code');
+
+						cy.get('input[name=code]').type(code!);
 
 						// password page
 						cy.url().should('include', '/reset-password/password');
@@ -123,8 +123,6 @@ describe('Password reset recovery flows - with Passcodes', () => {
 						// passcode page
 						cy.url().should('include', '/reset-password/email-sent');
 						cy.contains('Enter your one-time code');
-						cy.get('input[name=code]').type(code!);
-
 						cy.get('form')
 							.should('have.attr', 'action')
 							.and('match', new RegExp(encodedReturnUrl))
@@ -134,7 +132,9 @@ describe('Password reset recovery flows - with Passcodes', () => {
 							.and('match', new RegExp(appClientId))
 							.and('match', new RegExp(encodeURIComponent(fromURI)));
 
-						cy.contains('Submit one-time code').click();
+						cy.contains('Submit one-time code');
+
+						cy.get('input[name=code]').type(code!);
 
 						// password page
 						cy.url().should('include', '/reset-password/password');
@@ -183,9 +183,9 @@ describe('Password reset recovery flows - with Passcodes', () => {
 						// passcode page
 						cy.url().should('include', '/reset-password/email-sent');
 						cy.contains('Enter your one-time code');
-						cy.get('input[name=code]').type(`${+code! + 1}`);
+						cy.contains('Submit one-time code');
 
-						cy.contains('Submit one-time code').click();
+						cy.get('input[name=code]').type(`${+code! + 1}`);
 
 						cy.url().should('include', '/reset-password/code');
 
@@ -232,8 +232,8 @@ describe('Password reset recovery flows - with Passcodes', () => {
 						cy.url().should('include', '/reset-password/email-sent');
 						cy.contains('Enter your one-time code');
 
+						cy.contains('Submit one-time code');
 						cy.get('input[name=code]').clear().type(code!);
-						cy.contains('Submit one-time code').click();
 
 						cy.url().should('contain', '/reset-password/password');
 
@@ -300,8 +300,8 @@ describe('Password reset recovery flows - with Passcodes', () => {
 							cy.url().should('include', '/reset-password/email-sent');
 							cy.contains('Enter your one-time code');
 
+							cy.contains('Submit one-time code');
 							cy.get('input[name=code]').clear().type(code!);
-							cy.contains('Submit one-time code').click();
 
 							cy.url().should('contain', '/reset-password/password');
 
@@ -390,8 +390,8 @@ describe('Password reset recovery flows - with Passcodes', () => {
 							cy.url().should('include', '/reset-password/email-sent');
 							cy.contains('Enter your one-time code');
 
+							cy.contains('Submit one-time code');
 							cy.get('input[name=code]').clear().type(code!);
-							cy.contains('Submit one-time code').click();
 
 							cy.url().should('contain', '/set-password');
 
@@ -453,8 +453,8 @@ describe('Password reset recovery flows - with Passcodes', () => {
 							cy.url().should('include', '/reset-password/email-sent');
 							cy.contains('Enter your one-time code');
 
+							cy.contains('Submit one-time code');
 							cy.get('input[name=code]').clear().type(code!);
-							cy.contains('Submit one-time code').click();
 
 							cy.url().should('contain', '/set-password');
 
@@ -489,8 +489,8 @@ describe('Password reset recovery flows - with Passcodes', () => {
 
 					// passcode page, use passcode
 					cy.url().should('include', '/register/email-sent');
+					cy.contains('Submit verification code');
 					cy.get('input[name=code]').type(code!);
-					cy.contains('Submit verification code').click();
 
 					// password page, don't set password
 					cy.url().should('include', '/welcome/password');
@@ -519,8 +519,8 @@ describe('Password reset recovery flows - with Passcodes', () => {
 							cy.url().should('include', '/reset-password/email-sent');
 							cy.contains('Enter your one-time code');
 
+							cy.contains('Submit one-time code');
 							cy.get('input[name=code]').clear().type(code!);
-							cy.contains('Submit one-time code').click();
 
 							// password page
 							cy.url().should('include', '/reset-password/password');
@@ -560,8 +560,8 @@ describe('Password reset recovery flows - with Passcodes', () => {
 							cy.url().should('include', '/reset-password/email-sent');
 							cy.contains('Enter your one-time code');
 
+							cy.contains('Submit one-time code');
 							cy.get('input[name=code]').clear().type(code!);
-							cy.contains('Submit one-time code').click();
 
 							// password page
 							cy.url().should('include', '/reset-password/password');
@@ -606,8 +606,8 @@ describe('Password reset recovery flows - with Passcodes', () => {
 							cy.url().should('include', '/reset-password/email-sent');
 							cy.contains('Enter your one-time code');
 
+							cy.contains('Submit one-time code');
 							cy.get('input[name=code]').clear().type(code!);
-							cy.contains('Submit one-time code').click();
 
 							// password page
 							cy.url().should('include', '/reset-password/password');
@@ -652,8 +652,8 @@ describe('Password reset recovery flows - with Passcodes', () => {
 							cy.url().should('include', '/reset-password/email-sent');
 							cy.contains('Enter your one-time code');
 
+							cy.contains('Submit one-time code');
 							cy.get('input[name=code]').clear().type(code!);
-							cy.contains('Submit one-time code').click();
 
 							// password page
 							cy.url().should('include', '/reset-password/password');
@@ -698,8 +698,8 @@ describe('Password reset recovery flows - with Passcodes', () => {
 							cy.url().should('include', '/reset-password/email-sent');
 							cy.contains('Enter your one-time code');
 
+							cy.contains('Submit one-time code');
 							cy.get('input[name=code]').clear().type(code!);
-							cy.contains('Submit one-time code').click();
 
 							// password page
 							cy.url().should('include', '/reset-password/password');
@@ -732,8 +732,8 @@ describe('Password reset recovery flows - with Passcodes', () => {
 			cy.contains('Enter your one-time code');
 			cy.contains('Don’t have an account?');
 
+			cy.contains('Submit one-time code');
 			cy.get('input[name=code]').clear().type('123456');
-			cy.contains('Submit one-time code').click();
 
 			cy.url().should('include', '/reset-password/code');
 			cy.contains('Enter your one-time code');

--- a/cypress/integration/ete/sign_in.1.cy.ts
+++ b/cypress/integration/ete/sign_in.1.cy.ts
@@ -472,8 +472,8 @@ describe('Sign in flow, Okta enabled', () => {
 							cy.contains(
 								'For security reasons we need you to change your password.',
 							);
+							cy.contains('Submit verification code');
 							cy.get('input[name=code]').clear().type(code!);
-							cy.contains('Submit verification code').click();
 
 							cy.url().should('contain', '/set-password');
 

--- a/cypress/integration/ete/sign_in_passcode.8.cy.ts
+++ b/cypress/integration/ete/sign_in_passcode.8.cy.ts
@@ -61,8 +61,8 @@ describe('Sign In flow, with passcode', () => {
 								const code = codes?.[0].value;
 								expect(code).to.match(/^\d{6}$/);
 
+								cy.contains('Sign in');
 								cy.get('input[name=code]').type(code!);
-								cy.contains('Sign in').click();
 
 								cy.url().should('include', expectedReturnUrl);
 
@@ -79,9 +79,8 @@ describe('Sign In flow, with passcode', () => {
 						cy.url().should('include', '/signin');
 						break;
 					case 'passcode-incorrect':
+						cy.contains('Sign in');
 						cy.get('input[name=code]').type(`${+code! + 1}`);
-
-						cy.contains('Sign in').click();
 
 						cy.url().should('include', '/signin/code');
 
@@ -98,8 +97,8 @@ describe('Sign In flow, with passcode', () => {
 						});
 						break;
 					default: {
+						cy.contains('Sign in');
 						cy.get('input[name=code]').type(code!);
-						cy.contains('Sign in').click();
 
 						cy.url().should('include', expectedReturnUrl);
 
@@ -370,8 +369,8 @@ describe('Sign In flow, with passcode', () => {
 			cy.contains('Enter your one-time code');
 			cy.contains('Don’t have an account?');
 
+			cy.contains('Sign in');
 			cy.get('input[name=code]').clear().type('123456');
-			cy.contains('Sign in').click();
 
 			cy.url().should('include', '/signin/code');
 			cy.contains('Enter your one-time code');

--- a/src/client/components/MainForm.tsx
+++ b/src/client/components/MainForm.tsx
@@ -1,9 +1,9 @@
 import React, {
-	createRef,
 	PropsWithChildren,
 	ReactNode,
 	useCallback,
 	useEffect,
+	useRef,
 	useState,
 } from 'react';
 import { css } from '@emotion/react';
@@ -71,6 +71,7 @@ export interface MainFormProps {
 	additionalTerms?: ReactNode;
 	shortRequestId?: string;
 	disabled?: boolean;
+	formRef?: React.RefObject<HTMLFormElement | null>;
 }
 
 const formStyles = (displayInline: boolean) => css`
@@ -112,6 +113,8 @@ export const MainForm = ({
 	additionalTerms,
 	shortRequestId,
 	disabled = false,
+	// eslint-disable-next-line react-hooks/rules-of-hooks -- allow a formRef to be passed in or use a default value, either way a ref will be defined
+	formRef = useRef(null),
 }: PropsWithChildren<MainFormProps>) => {
 	const recaptchaEnabled = !!recaptchaSiteKey;
 
@@ -127,7 +130,6 @@ export const MainForm = ({
 	const formError = formLevelErrorMessage || formErrorMessageFromParent;
 	const errorContext = formLevelErrorContext || formErrorContextFromParent;
 
-	const formRef = createRef<HTMLFormElement>();
 	const [recaptchaState, setRecaptchaState] =
 		useState<UseRecaptchaReturnValue>();
 

--- a/src/client/components/PasscodeInput.stories.tsx
+++ b/src/client/components/PasscodeInput.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import { Meta } from '@storybook/react';
 
 import { PasscodeInput } from '@/client/components/PasscodeInput';
@@ -12,12 +12,13 @@ export default {
 } as Meta;
 
 export const Default = () => {
-	return <PasscodeInput label="Verification code" />;
+	return <PasscodeInput formRef={useRef(null)} label="Verification code" />;
 };
 Default.storyName = 'default';
 
 export const WithFieldError = () => (
 	<PasscodeInput
+		formRef={useRef(null)}
 		label="Verification code"
 		fieldErrors={[{ field: 'code', message: 'Invalid code' }]}
 	/>
@@ -25,12 +26,17 @@ export const WithFieldError = () => (
 WithFieldError.storyName = 'with field error';
 
 export const WithDefaultPasscode = () => (
-	<PasscodeInput label="Verification code" passcode="424242" />
+	<PasscodeInput
+		formRef={useRef(null)}
+		label="Verification code"
+		passcode="424242"
+	/>
 );
 WithDefaultPasscode.storyName = 'with default passcode';
 
 export const WithFieldErrorAndDefaultPasscode = () => (
 	<PasscodeInput
+		formRef={useRef(null)}
 		label="Verification code"
 		passcode="424242"
 		fieldErrors={[{ field: 'code', message: 'Invalid code' }]}

--- a/src/client/components/PasscodeInput.tsx
+++ b/src/client/components/PasscodeInput.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { FieldError } from '@/shared/model/ClientState';
 import { TextInputProps } from '@guardian/source/react-components';
 import { css } from '@emotion/react';
@@ -8,6 +8,7 @@ import { remSpace } from '@guardian/source/foundations';
 interface PasscodeInputProps extends TextInputProps {
 	passcode?: string;
 	fieldErrors?: FieldError[];
+	formRef: React.RefObject<HTMLFormElement | null>;
 }
 
 const passcodeInputStyles = css`
@@ -19,13 +20,13 @@ export const PasscodeInput = ({
 	label,
 	passcode = '',
 	fieldErrors,
+	formRef,
 }: PasscodeInputProps) => {
 	/**
 	 * In gateway we normally avoid using client side javascript, but in this case
 	 * we allow it as it an enhancement to the user experience and not required for
 	 * the form to work.
 	 */
-
 	// This function removes all non-numeric characters from the input
 	const sanitiseCode = (code: string) => {
 		return code.replace(/\D*/g, '');
@@ -35,8 +36,37 @@ export const PasscodeInput = ({
 	// whenever there is an user input, rather than only when the state changes
 	const [input, setInput] = useState({ value: sanitiseCode(passcode) });
 
+	// Track if the user has interacted with the input, used for auto-submitting the form
+	const [userInteracted, setUserInteracted] = useState(false);
+
+	// Auto-submit the form when the input is 6 digits long and the user has interacted with the input
+	// but not if there is an error in the field, where the user has to manually submit the form
+	// e.g after a previously failed attempt
+	useEffect(() => {
+		if (
+			!fieldErrors?.length &&
+			formRef?.current &&
+			userInteracted &&
+			/^\d{6}$/.test(input.value)
+		) {
+			// find the submit button
+			const button =
+				formRef.current.querySelector<HTMLElement>('[type="submit"]');
+
+			// if requestSubmit is available use it, otherwise dispatch a click event
+			// mainly because of Safari not supporting requestSubmit until v16
+			if (formRef.current.requestSubmit) {
+				formRef.current.requestSubmit(button);
+			} else {
+				button?.dispatchEvent(new MouseEvent('click'));
+			}
+		}
+	}, [fieldErrors, formRef, input.value, userInteracted]);
+
 	// Update the input value on user input
 	const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+		setUserInteracted(true);
+
 		setInput({
 			value: sanitiseCode(e.target.value),
 		});
@@ -44,6 +74,8 @@ export const PasscodeInput = ({
 
 	// Update the input value on paste
 	const onPaste = (e: React.ClipboardEvent<HTMLInputElement>) => {
+		setUserInteracted(true);
+
 		const paste = e.clipboardData.getData('text/plain');
 
 		if (!paste) {

--- a/src/client/pages/PasscodeEmailSent.tsx
+++ b/src/client/pages/PasscodeEmailSent.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, useState, useEffect } from 'react';
+import React, { ReactNode, useState, useEffect, useRef } from 'react';
 import { MainBodyText } from '@/client/components/MainBodyText';
 import { MainForm } from '@/client/components/MainForm';
 import { FieldError } from '@/shared/model/ClientState';
@@ -112,6 +112,7 @@ export const PasscodeEmailSent = ({
 	const [recaptchaErrorMessage, setRecaptchaErrorMessage] = useState('');
 	const [recaptchaErrorContext, setRecaptchaErrorContext] =
 		useState<ReactNode>(null);
+	const formRef = useRef<HTMLFormElement>(null);
 
 	const text = getText(textType);
 
@@ -173,11 +174,13 @@ export const PasscodeEmailSent = ({
 				submitButtonText={text.submitButtonText}
 				disableOnSubmit
 				shortRequestId={shortRequestId}
+				formRef={formRef}
 			>
 				<PasscodeInput
 					passcode={passcode}
 					fieldErrors={fieldErrors}
 					label={text.passcodeInputLabel}
+					formRef={formRef}
 				/>
 			</MainForm>
 			{showSignInWithPasswordOption && (


### PR DESCRIPTION
## What does this change?

Currently the reader has to manually submit the code after typing it in or pasting it in.

To make it faster for the reader, this PR updates the functionality to automatically submit the code when it reaches 6 digits long or pasting it in.

We added checks to make sure that the auto-submission is disabled for specifc scenarios
- If there is an error on the field
- If the reader hasn't previously interacted with the field
- If the value isn't a 6 digit number

It is also disabled in scenarios where `formRef` isn't passed in.

Speaking of which, a minor refactor had to be performed on the `MainForm` to make `formRef` a parameter instead. This allows us to pass in a `ref` for the `MainForm`, so it can be used in other components, specifically in this scenario the `PasscodeInput` component.

Finally `PasscodeEmailSent` page was updated to create the new `formRef` and pass it to both `MainForm` and `PasscodeInput`

<table>
<tr>
<th>Previous</th>
<th>Auto submit - onChange</th>
<th>Auto submit - onPaste</th>
<th>Auto submit - disabled after error</th>
</tr>
<tr>
<td>

https://github.com/user-attachments/assets/a33c9752-95c3-44c0-8573-e7c5268358e5

</td>
<td>

https://github.com/user-attachments/assets/217a3543-8f86-4cd4-a203-372a4134cd93

</td>
<td>

https://github.com/user-attachments/assets/361b648d-c492-41f7-a3af-ab687f66dc40

</td>
<td>

https://github.com/user-attachments/assets/7cdd726b-bf84-48fa-b0ed-28a6e9cca59f

</td>
</tr>
</table>

## Tested

- [x] DEV
- [x] CODE
  - [x] Chrome Web
  - [x] Chrome Mobile
  - [x] Firefox Web
  - [x] Firefox Mobile 
  - [x] Safari Web
  - [x] Safari Mobile