### PR TITLE
Fix | Show correct error page on password incorrect

### DIFF
--- a/cypress/integration/ete/sign_in_passcode.8.cy.ts
+++ b/cypress/integration/ete/sign_in_passcode.8.cy.ts
@@ -186,12 +186,32 @@ describe('Sign In flow, with passcode', () => {
 					cy.contains('Enter your one-time code');
 					cy.contains('Sign in with password instead').click();
 
+					// password page
 					cy.url().should('include', '/signin/password');
 					cy.get('input[name=email]').should('have.value', emailAddress);
 					cy.get('input[name=password]').type(finalPassword);
 					cy.get('[data-cy="main-form-submit-button"]').click();
 					cy.url().should('include', 'https://m.code.dev-theguardian.com/');
 				});
+		});
+
+		it('selects password option to sign in and show correct error page on incorrect password', () => {
+			const emailAddress = randomMailosaurEmail();
+			cy.visit(`/signin?usePasscodeSignIn=true`);
+			cy.get('input[name=email]').type(emailAddress);
+			cy.get('[data-cy="main-form-submit-button"]').click();
+			// passcode page
+			cy.url().should('include', '/signin/code');
+			cy.contains('Enter your one-time code');
+			cy.contains('Sign in with password instead').click();
+
+			// password page
+			cy.url().should('include', '/signin/password');
+			cy.get('input[name=email]').should('have.value', emailAddress);
+			cy.get('input[name=password]').type(randomPassword());
+			cy.get('[data-cy="main-form-submit-button"]').click();
+			cy.url().should('include', '/signin/password');
+			cy.contains('Email and password don’t match');
 		});
 
 		it('should sign in with passcode - resend email', () => {

--- a/src/server/controllers/signInControllers.ts
+++ b/src/server/controllers/signInControllers.ts
@@ -618,7 +618,7 @@ export const oktaIdxApiSignInController = async ({
 
 		// if we're using passcodes, and the user is attempting to sign in with a password
 		// on error show the password sign in page
-		const errorPage: RoutePaths = usePasscode ? '/signin/password' : '/signin';
+		const errorPage: RoutePaths = usePasscode ? '/signin' : '/signin/password';
 
 		const html = renderer(errorPage, {
 			requestState: mergeRequestState(res.locals, {


### PR DESCRIPTION
## What does this change?

When using the password option instead of passcodes, this occurs on the `/signin/password` page now.

However we made a mistake in the error handling ternary operator to determine the error page.

We've fixed it so that `usePasscode` is falsy, then go to `/signin/password` as the error page, as the user is using password to sign in.

## Tested

- [x] DEV
- [x] CODE
