### PR TITLE
Passcodes | Fix user enumeration bugs

### DIFF
--- a/cypress/integration/ete/reset_password_passcode.7.cy.ts
+++ b/cypress/integration/ete/reset_password_passcode.7.cy.ts
@@ -348,6 +348,68 @@ describe('Password reset recovery flows - with Passcodes', () => {
 			});
 		});
 
+		it('should redirect with error when multiple passcode attempts fail', () => {
+			cy
+				.createTestUser({
+					isUserEmailValidated: true,
+				})
+				?.then(({ emailAddress }) => {
+					cy.visit(`/reset-password`);
+
+					const timeRequestWasMade = new Date();
+					cy.get('input[name=email]').type(emailAddress);
+					cy.get('[data-cy="main-form-submit-button"]').click();
+
+					cy.contains('Enter your one-time code');
+					cy.contains(emailAddress);
+					cy.contains('send again');
+					cy.contains('try another address');
+
+					cy.checkForEmailAndGetDetails(emailAddress, timeRequestWasMade).then(
+						({ body, codes }) => {
+							// email
+							expect(body).to.have.string('Your one-time passcode');
+							expect(codes?.length).to.eq(1);
+							const code = codes?.[0].value;
+							expect(code).to.match(/^\d{6}$/);
+
+							// passcode page
+							cy.url().should('include', '/reset-password/email-sent');
+							cy.contains('Enter your one-time code');
+
+							// attempt 1 - auto submit
+							cy.contains('Submit one-time code');
+							cy.get('input[name=code]').type(`${+code! + 1}`);
+							cy.url().should('include', '/reset-password/code');
+							cy.contains('Incorrect code');
+
+							// attempt 2 - manual submit
+							cy.get('input[name=code]').type(`${+code! + 1}`);
+							cy.contains('Submit one-time code').click();
+							cy.url().should('include', '/reset-password/code');
+							cy.contains('Incorrect code');
+
+							// attempt 3 - manual submit
+							cy.get('input[name=code]').type(`${+code! + 1}`);
+							cy.contains('Submit one-time code').click();
+							cy.url().should('include', '/reset-password/code');
+							cy.contains('Incorrect code');
+
+							// attempt 4 - manual submit
+							cy.get('input[name=code]').type(`${+code! + 1}`);
+							cy.contains('Submit one-time code').click();
+							cy.url().should('include', '/reset-password/code');
+							cy.contains('Incorrect code');
+
+							// attempt 5 - manual submit
+							cy.get('input[name=code]').type(`${+code! + 1}`);
+							cy.contains('Submit one-time code').click();
+							cy.url().should('include', '/reset-password/expired');
+						},
+					);
+				});
+		});
+
 		it('ACTIVE user with only password authenticator - allow the user to change thier password and authenticate', () => {
 			const emailAddress = randomMailosaurEmail();
 			cy.visit(`/register/email`);
@@ -740,6 +802,49 @@ describe('Password reset recovery flows - with Passcodes', () => {
 			cy.contains('Don’t have an account?');
 
 			cy.contains('Incorrect code');
+		});
+
+		it('should redirect with error when multiple passcode attempts fail', () => {
+			const emailAddress = randomMailosaurEmail();
+			cy.visit(`/reset-password`);
+
+			cy.contains('Reset password');
+			cy.get('input[name=email]').type(emailAddress);
+			cy.get('[data-cy="main-form-submit-button"]').click();
+
+			// passcode page
+			cy.url().should('include', '/reset-password/email-sent');
+			cy.contains('Enter your one-time code');
+			cy.contains('Don’t have an account?');
+
+			// attempt 1
+			cy.contains('Submit one-time code');
+			cy.get('input[name=code]').type('123456');
+			cy.url().should('include', '/reset-password/code');
+			cy.contains('Incorrect code');
+
+			// attempt 2
+			cy.get('input[name=code]').type('123456');
+			cy.contains('Submit one-time code').click();
+			cy.url().should('include', '/reset-password/code');
+			cy.contains('Incorrect code');
+
+			// attempt 3
+			cy.get('input[name=code]').type('123456');
+			cy.contains('Submit one-time code').click();
+			cy.url().should('include', '/reset-password/code');
+			cy.contains('Incorrect code');
+
+			// attempt 4
+			cy.get('input[name=code]').type('123456');
+			cy.contains('Submit one-time code').click();
+			cy.url().should('include', '/reset-password/code');
+			cy.contains('Incorrect code');
+
+			// attempt 5
+			cy.get('input[name=code]').type('123456');
+			cy.contains('Submit one-time code').click();
+			cy.url().should('include', '/reset-password/expired');
 		});
 	});
 });

--- a/cypress/integration/ete/sign_in_passcode.8.cy.ts
+++ b/cypress/integration/ete/sign_in_passcode.8.cy.ts
@@ -252,6 +252,64 @@ describe('Sign In flow, with passcode', () => {
 					});
 				});
 		});
+
+		it('should redirect with error when multiple passcode attempts fail', () => {
+			cy
+				.createTestUser({
+					isUserEmailValidated: true,
+				})
+				?.then(({ emailAddress }) => {
+					cy.visit(`/signin?usePasscodeSignIn=true`);
+					cy.get('input[name=email]').clear().type(emailAddress);
+
+					const timeRequestWasMade = new Date();
+					cy.get('[data-cy="main-form-submit-button"]').click();
+
+					cy.checkForEmailAndGetDetails(emailAddress, timeRequestWasMade).then(
+						({ body, codes }) => {
+							// email
+							expect(body).to.have.string('Your one-time passcode');
+							expect(codes?.length).to.eq(1);
+							const code = codes?.[0].value;
+							expect(code).to.match(/^\d{6}$/);
+
+							// passcode page
+							cy.url().should('include', '/signin/code');
+							cy.contains('Enter your one-time code');
+
+							// attempt 1
+							cy.contains('Sign in');
+							cy.get('input[name=code]').type(`${+code! + 1}`);
+							cy.url().should('include', '/signin/code');
+							cy.contains('Incorrect code');
+
+							// attempt 2
+							cy.get('input[name=code]').type(`${+code! + 1}`);
+							cy.contains('Sign in').click();
+							cy.url().should('include', '/signin/code');
+							cy.contains('Incorrect code');
+
+							// attempt 3
+							cy.get('input[name=code]').type(`${+code! + 1}`);
+							cy.contains('Sign in').click();
+							cy.url().should('include', '/signin/code');
+							cy.contains('Incorrect code');
+
+							// attempt 4
+							cy.get('input[name=code]').type(`${+code! + 1}`);
+							cy.contains('Sign in').click();
+							cy.url().should('include', '/signin/code');
+							cy.contains('Incorrect code');
+
+							// attempt 5
+							cy.get('input[name=code]').type(`${+code! + 1}`);
+							cy.contains('Sign in').click();
+							cy.url().should('include', '/signin');
+							cy.contains('Your code has expired');
+						},
+					);
+				});
+		});
 	});
 
 	context('ACTIVE user - with only password authenticator', () => {
@@ -397,6 +455,50 @@ describe('Sign In flow, with passcode', () => {
 			cy.contains('Don’t have an account?');
 
 			cy.contains('Incorrect code');
+		});
+
+		it('NON_EXISTENT user - should redirect with error when multiple passcode attempts fail', () => {
+			const emailAddress = randomMailosaurEmail();
+			cy.visit(`/signin?usePasscodeSignIn=true`);
+
+			cy.contains('Sign in');
+			cy.get('input[name=email]').type(emailAddress);
+			cy.get('[data-cy="main-form-submit-button"]').click();
+
+			// passcode page
+			cy.url().should('include', '/signin/code');
+			cy.contains('Enter your one-time code');
+			cy.contains('Don’t have an account?');
+
+			// attempt 1
+			cy.contains('Sign in');
+			cy.get('input[name=code]').type('123456');
+			cy.url().should('include', '/signin/code');
+			cy.contains('Incorrect code');
+
+			// attempt 2
+			cy.get('input[name=code]').type('123456');
+			cy.contains('Sign in').click();
+			cy.url().should('include', '/signin/code');
+			cy.contains('Incorrect code');
+
+			// attempt 3
+			cy.get('input[name=code]').type('123456');
+			cy.contains('Sign in').click();
+			cy.url().should('include', '/signin/code');
+			cy.contains('Incorrect code');
+
+			// attempt 4
+			cy.get('input[name=code]').type('123456');
+			cy.contains('Sign in').click();
+			cy.url().should('include', '/signin/code');
+			cy.contains('Incorrect code');
+
+			// attempt 5
+			cy.get('input[name=code]').type('123456');
+			cy.contains('Sign in').click();
+			cy.url().should('include', '/signin');
+			cy.contains('Your code has expired');
 		});
 	});
 });

--- a/src/server/lib/okta/idx/shared/errorHandling.ts
+++ b/src/server/lib/okta/idx/shared/errorHandling.ts
@@ -21,6 +21,25 @@ type HandlePasscodeErrorParams = {
 };
 
 /**
+ * @name clearIdxStateInEncrytpedStateCookie
+ * @description Clear the IDX state in the encrypted state cookie on a redirect to the expired page to reset the state
+ * @param {Request} req - The express request object
+ * @param {ResponseWithRequestState} res - The express response object
+ */
+const clearIdxStateInEncryptedStateCookie = (
+	req: Request,
+	res: ResponseWithRequestState,
+) => {
+	updateEncryptedStateCookie(req, res, {
+		passcodeUsed: undefined,
+		stateHandle: undefined,
+		stateHandleExpiresAt: undefined,
+		userState: undefined,
+		passcodeFailedCount: undefined,
+	});
+};
+
+/**
  * @name handlePasscodeError
  * @description Handles errors from the IDX API when the user is entering a passcode.
  *
@@ -65,6 +84,7 @@ export const handlePasscodeError = ({
 
 			// if the passcode failed count is 5 or more, redirect to expired page
 			if (updatedPasscodeFailedCount >= 5) {
+				clearIdxStateInEncryptedStateCookie(req, res);
 				return res.redirect(
 					303,
 					addQueryParamsToPath(expiredPage, state.queryParams),

--- a/src/shared/model/EncryptedState.ts
+++ b/src/shared/model/EncryptedState.ts
@@ -16,4 +16,6 @@ export interface EncryptedState {
 	passcodeUsed?: boolean;
 	// Okta IDX API - State of the user in the Okta determines if we can send passcodes to the user when resetting the password
 	userState?: InternalOktaUserState;
+	// Okta IDX API - Count of failed passcode attempts
+	passcodeFailedCount?: number;
 }


### PR DESCRIPTION
## What does this change?

Okta will only allow a maximum of 5 attempts for passcodes before giving an error where the user will be redirected to an expired page.

However if a user doesn’t exist in Okta, we fake this functionality to always show an passcode error, however we don’t keep track of the number of attempts.

This means that you can work out if an account exists or not, by attempting to submit a passcode more that 5 times on the sign in/password reset flow. If you’re able to submit the code more than 5 times, then the user doesn’t exist in Okta, if you’re not able to submit more than 5 times then the user exists in Okta.

Essentially we need to replicate this behaviour for user’s who don’t exist in Okta, by keeping track of how many times the code was submitted.

This commit does this by adding and incrementing a `passcodeFailedCount` on the `EncryptedState` cookie. Then when we reach 5 attempts (or more), we redirect to the expired page, in order to replicate this behaviour for all scenarios.

We also make sure we use this functionality regardless of the passcode error, as this prevents any cookie replay attacks as all scenarios will see the same behaviour.

## Tested

- [x] DEV
- [x] CODE
