### PR TITLE
Passwordless | Move sign in with password instead option

### DIFF
--- a/cypress/integration/ete/sign_in_passcode.8.cy.ts
+++ b/cypress/integration/ete/sign_in_passcode.8.cy.ts
@@ -171,7 +171,42 @@ describe('Sign In flow, with passcode', () => {
 				});
 		});
 
-		it('selects password option to sign in', () => {
+		it('selects password option to sign in from initial sign in page', () => {
+			cy
+				.createTestUser({
+					isUserEmailValidated: true,
+				})
+				?.then(({ emailAddress, finalPassword }) => {
+					cy.visit(`/signin`);
+					cy.get('input[name=email]').type(emailAddress);
+
+					cy.contains('Sign in with a password instead').click();
+
+					// password page
+					cy.url().should('include', '/signin/password');
+					cy.get('input[name=email]').should('have.value', emailAddress);
+					cy.get('input[name=password]').type(finalPassword);
+					cy.get('[data-cy="main-form-submit-button"]').click();
+					cy.url().should('include', 'https://m.code.dev-theguardian.com/');
+				});
+		});
+
+		it('selects password option to sign in from the initial sign in page and show correct error page on incorrect password', () => {
+			const emailAddress = randomMailosaurEmail();
+			cy.visit(`/signin`);
+			cy.get('input[name=email]').type(emailAddress);
+			cy.contains('Sign in with a password instead').click();
+
+			// password page
+			cy.url().should('include', '/signin/password');
+			cy.get('input[name=email]').should('have.value', emailAddress);
+			cy.get('input[name=password]').type(randomPassword());
+			cy.get('[data-cy="main-form-submit-button"]').click();
+			cy.url().should('include', '/signin/password');
+			cy.contains('Email and password don’t match');
+		});
+
+		it('selects password option to sign in from passcode page', () => {
 			cy
 				.createTestUser({
 					isUserEmailValidated: true,
@@ -184,7 +219,7 @@ describe('Sign In flow, with passcode', () => {
 					// passcode page
 					cy.url().should('include', '/signin/code');
 					cy.contains('Enter your one-time code');
-					cy.contains('Sign in with password instead').click();
+					cy.contains('sign in with a password instead').click();
 
 					// password page
 					cy.url().should('include', '/signin/password');
@@ -195,7 +230,7 @@ describe('Sign In flow, with passcode', () => {
 				});
 		});
 
-		it('selects password option to sign in and show correct error page on incorrect password', () => {
+		it('selects password option to sign in from passcode page and show correct error page on incorrect password', () => {
 			const emailAddress = randomMailosaurEmail();
 			cy.visit(`/signin?usePasscodeSignIn=true`);
 			cy.get('input[name=email]').type(emailAddress);
@@ -203,7 +238,7 @@ describe('Sign In flow, with passcode', () => {
 			// passcode page
 			cy.url().should('include', '/signin/code');
 			cy.contains('Enter your one-time code');
-			cy.contains('Sign in with password instead').click();
+			cy.contains('sign in with a password instead').click();
 
 			// password page
 			cy.url().should('include', '/signin/password');

--- a/src/client/components/EmailSentInformationBox.stories.tsx
+++ b/src/client/components/EmailSentInformationBox.stories.tsx
@@ -83,6 +83,22 @@ export const WithNoAccountInfo = () => {
 };
 WithNoAccountInfo.storyName = 'with noAccountInfo';
 
+export const WithShowSignInWithPasswordOption = () => {
+	return (
+		<EmailSentInformationBox
+			setRecaptchaErrorContext={() => {}}
+			setRecaptchaErrorMessage={() => {}}
+			changeEmailPage="#"
+			email="test@example.com"
+			resendEmailAction="#"
+			noAccountInfo
+			showSignInWithPasswordOption
+		/>
+	);
+};
+WithShowSignInWithPasswordOption.storyName =
+	'with showSignInWithPasswordOption';
+
 export const WithTimer = () => {
 	return (
 		<EmailSentInformationBox

--- a/src/client/components/EmailSentInformationBox.tsx
+++ b/src/client/components/EmailSentInformationBox.tsx
@@ -31,6 +31,7 @@ type EmailSentInformationBoxProps = Pick<
 	>;
 	setRecaptchaErrorMessage: React.Dispatch<React.SetStateAction<string>>;
 	sendAgainTimerInSeconds?: number;
+	showSignInWithPasswordOption?: boolean;
 };
 
 const sendAgainFormWrapperStyles = css`
@@ -50,6 +51,7 @@ export const EmailSentInformationBox = ({
 	queryString,
 	shortRequestId,
 	sendAgainTimerInSeconds,
+	showSignInWithPasswordOption,
 }: EmailSentInformationBoxProps) => {
 	const timer = useCountdownTimer(sendAgainTimerInSeconds || 0);
 
@@ -89,9 +91,17 @@ export const EmailSentInformationBox = ({
 				)}
 				{changeEmailPage && (
 					<>
-						, or{' '}
+						,{!showSignInWithPasswordOption ? <> or </> : <> </>}
 						<ThemedLink href={`${changeEmailPage}${queryString}`}>
 							try another address
+						</ThemedLink>
+					</>
+				)}
+				{showSignInWithPasswordOption && (
+					<>
+						, or{' '}
+						<ThemedLink href={`${buildUrl('/signin/password')}${queryString}`}>
+							sign in with a password instead
 						</ThemedLink>
 					</>
 				)}

--- a/src/client/components/PasscodeInput.tsx
+++ b/src/client/components/PasscodeInput.tsx
@@ -21,6 +21,7 @@ export const PasscodeInput = ({
 	passcode = '',
 	fieldErrors,
 	formRef,
+	autoFocus,
 }: PasscodeInputProps) => {
 	/**
 	 * In gateway we normally avoid using client side javascript, but in this case
@@ -103,6 +104,7 @@ export const PasscodeInput = ({
 				value={input.value}
 				onChange={onChange}
 				onPaste={onPaste}
+				autoFocus={autoFocus}
 			/>
 		</div>
 	);

--- a/src/client/components/PasswordInput.tsx
+++ b/src/client/components/PasswordInput.tsx
@@ -27,6 +27,7 @@ export type PasswordInputProps = {
 	supporting?: string;
 	onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
 	autoComplete?: PasswordAutoComplete;
+	autoFocus?: boolean;
 };
 
 // hide the microsoft password reveal eye if we're using
@@ -171,6 +172,7 @@ export const PasswordInput = ({
 	onChange,
 	displayEye = true,
 	autoComplete,
+	autoFocus,
 }: PasswordInputProps) => {
 	const [passwordVisible, setPasswordVisible] = useState(false);
 	const [fieldIsFocused, setFieldIsFocused] = useState(false);
@@ -203,6 +205,7 @@ export const PasswordInput = ({
 						hideMsReveal(displayEye),
 					]}
 					id="password"
+					autoFocus={autoFocus}
 				/>
 
 				{displayEye && (

--- a/src/client/pages/EmailSent.tsx
+++ b/src/client/pages/EmailSent.tsx
@@ -1,9 +1,4 @@
-import React, {
-	PropsWithChildren,
-	ReactNode,
-	useState,
-	useEffect,
-} from 'react';
+import React, { PropsWithChildren, ReactNode, useState } from 'react';
 import { MainBodyText } from '@/client/components/MainBodyText';
 import { MinimalLayout } from '@/client/layouts/MinimalLayout';
 import { EmailSentInformationBox } from '@/client/components/EmailSentInformationBox';
@@ -43,18 +38,6 @@ export const EmailSent = ({
 	const [recaptchaErrorMessage, setRecaptchaErrorMessage] = useState('');
 	const [recaptchaErrorContext, setRecaptchaErrorContext] =
 		useState<ReactNode>(null);
-
-	// autofocus the code input field when the page loads
-	useEffect(() => {
-		if (typeof window !== 'undefined') {
-			const codeInput: HTMLInputElement | null =
-				window.document.querySelector('input[name="code"]');
-
-			if (codeInput) {
-				codeInput.focus();
-			}
-		}
-	}, []);
 
 	return (
 		<MinimalLayout

--- a/src/client/pages/PasscodeEmailSent.tsx
+++ b/src/client/pages/PasscodeEmailSent.tsx
@@ -7,8 +7,6 @@ import { MinimalLayout } from '@/client/layouts/MinimalLayout';
 import { PasscodeInput } from '@/client/components/PasscodeInput';
 import { EmailSentInformationBox } from '@/client/components/EmailSentInformationBox';
 import { EmailSentProps } from '@/client/pages/EmailSent';
-import { buildUrl } from '@/shared/lib/routeUtils';
-import ThemedLink from '@/client/components/ThemedLink';
 
 type TextType = 'verification' | 'security' | 'generic' | 'signin';
 
@@ -183,13 +181,6 @@ export const PasscodeEmailSent = ({
 					formRef={formRef}
 				/>
 			</MainForm>
-			{showSignInWithPasswordOption && (
-				<MainBodyText>
-					<ThemedLink href={`${buildUrl('/signin/password')}${queryString}`}>
-						Sign in with password instead
-					</ThemedLink>
-				</MainBodyText>
-			)}
 			<EmailSentInformationBox
 				setRecaptchaErrorContext={setRecaptchaErrorContext}
 				setRecaptchaErrorMessage={setRecaptchaErrorMessage}
@@ -203,6 +194,7 @@ export const PasscodeEmailSent = ({
 				shortRequestId={shortRequestId}
 				noAccountInfo={noAccountInfo}
 				sendAgainTimerInSeconds={sendAgainTimerInSeconds}
+				showSignInWithPasswordOption={showSignInWithPasswordOption}
 			/>
 		</MinimalLayout>
 	);

--- a/src/client/pages/PasscodeEmailSent.tsx
+++ b/src/client/pages/PasscodeEmailSent.tsx
@@ -135,18 +135,6 @@ export const PasscodeEmailSent = ({
 		}
 	}, [timeUntilTokenExpiry, expiredPage, queryString]);
 
-	// autofocus the code input field when the page loads
-	useEffect(() => {
-		if (typeof window !== 'undefined') {
-			const codeInput: HTMLInputElement | null =
-				window.document.querySelector('input[name="code"]');
-
-			if (codeInput) {
-				codeInput.focus();
-			}
-		}
-	}, []);
-
 	return (
 		<MinimalLayout
 			shortRequestId={shortRequestId}
@@ -179,6 +167,7 @@ export const PasscodeEmailSent = ({
 					fieldErrors={fieldErrors}
 					label={text.passcodeInputLabel}
 					formRef={formRef}
+					autoFocus
 				/>
 			</MainForm>
 			<EmailSentInformationBox

--- a/src/client/pages/SignIn.tsx
+++ b/src/client/pages/SignIn.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import {
 	extractMessage,
 	GatewayError,
@@ -150,19 +150,6 @@ export const SignIn = ({
 }: SignInProps) => {
 	const [currentEmail, setCurrentEmail] = React.useState(email);
 
-	// autofocus the password input field when the page loads if it exists
-	// and the focusPasswordField flag is set to true and a default email exists
-	useEffect(() => {
-		if (typeof window !== 'undefined' && focusPasswordField && email) {
-			const passwordInput: HTMLInputElement | null =
-				window.document.querySelector('input[name="password"]');
-
-			if (passwordInput) {
-				passwordInput.focus();
-			}
-		}
-	}, [focusPasswordField, email]);
-
 	// status of the OTP checkbox
 	const selectedView = usePasscodeSignIn ? 'passcode' : 'password';
 
@@ -216,7 +203,11 @@ export const SignIn = ({
 				/>
 				{selectedView === 'password' && (
 					<>
-						<PasswordInput label="Password" autoComplete="current-password" />
+						<PasswordInput
+							label="Password"
+							autoComplete="current-password"
+							autoFocus={!!(focusPasswordField && email)}
+						/>
 						<ThemedLink
 							href={buildUrlWithQueryParams('/reset-password', {}, queryParams)}
 							cssOverrides={resetPassword}

--- a/src/client/pages/SignInPage.tsx
+++ b/src/client/pages/SignInPage.tsx
@@ -21,7 +21,7 @@ export const SignInPage = ({
 		queryParams,
 		recaptchaConfig,
 	} = clientState;
-	const { email, formError } = pageData;
+	const { email, formError, focusPasswordField } = pageData;
 	const { error: pageError } = globalMessage;
 	const { recaptchaSiteKey } = recaptchaConfig;
 
@@ -31,7 +31,7 @@ export const SignInPage = ({
 	// determines if the passcode view of the sign in page should be shown
 	const usePasscodeSignIn: boolean = (() => {
 		// if the forcePasswordPage flag is set, we should always show the password view
-		// for example when the user clicks "sign in with password instead"
+		// for example when the user clicks "sign in with a password instead"
 		if (forcePasswordPage) {
 			return false;
 		}
@@ -62,6 +62,7 @@ export const SignInPage = ({
 			shortRequestId={clientState.shortRequestId}
 			usePasscodeSignIn={usePasscodeSignIn}
 			hideSocialButtons={hideSocialButtons}
+			focusPasswordField={focusPasswordField}
 		/>
 	);
 };

--- a/src/server/lib/queryParams.ts
+++ b/src/server/lib/queryParams.ts
@@ -53,6 +53,7 @@ export const parseExpressQueryParams = (
 		maxAge,
 		useOktaClassic,
 		usePasswordSignIn,
+		signInEmail,
 	}: Record<keyof QueryParams, string | undefined>, // parameters from req.query
 	// some parameters may be manually passed in req.body too,
 	// generally for tracking purposes
@@ -78,6 +79,7 @@ export const parseExpressQueryParams = (
 		maxAge: stringToNumber(maxAge),
 		useOktaClassic: isStringBoolean(useOktaClassic),
 		usePasswordSignIn: isStringBoolean(usePasswordSignIn),
+		signInEmail,
 	};
 };
 

--- a/src/shared/lib/routeUtils.ts
+++ b/src/shared/lib/routeUtils.ts
@@ -69,9 +69,10 @@ export const buildUrlWithQueryParams = <P extends AllRoutes>(
 	path: P,
 	params: PathParams<P> = <PathParams<P>>{},
 	queryParams: QueryParams,
+	queryParamOverrides?: Partial<QueryParams>,
 ): string => {
 	const url = buildUrl(path, params);
-	return addQueryParamsToUntypedPath(url, queryParams);
+	return addQueryParamsToUntypedPath(url, queryParams, queryParamOverrides);
 };
 
 /**

--- a/src/shared/model/ClientState.ts
+++ b/src/shared/model/ClientState.ts
@@ -76,6 +76,9 @@ export interface PageData {
 
 	// passcode specific
 	passcodeSendAgainTimer?: number;
+
+	// sign in with password specific
+	focusPasswordField?: boolean;
 }
 
 export interface RecaptchaConfig {

--- a/src/shared/model/QueryParams.ts
+++ b/src/shared/model/QueryParams.ts
@@ -70,4 +70,7 @@ export interface QueryParams
 	error?: string;
 	error_description?: string;
 	maxAge?: number;
+	// only use this to prefill the email input on either sign in page, for passcode or password
+	// don't rely on this for any other purpose, or to be a valid email
+	signInEmail?: string;
 }


### PR DESCRIPTION
## What does this change?

Recently we deployed sign in with passcodes to all users.

While we noticed that overall sign in numbers remained consistent, we did get a few user complaints saying that they did not like how the "sign in with password" option was only available after getting the one time code sent to their email. Other users complained that they thought they could input a password into the passcode field box and sign in with a password directly.

To improve the UX, we've made some minor adjustments to the sign in flow.

Firstly we added a "sign in with a password instead" link to the sign in landing page, which takes the email from the email input, and redirects the user to `/signin/password` with the email option prefilled, or directly to the page if there is no email. We also moved the "sign in with a password instead" option on the passcode input page to the information box, as an additional option if a user is having trouble with passcodes.

We belive that this should alleviate some of the issues users are having, even as we're prioritising sign in with passcodes.

We also rename the passcode CTA from "Continue with email" to Sign in with email" instead.

<table>
<tr>
<th>Sign In page</th>
<th>Passcode page</th> 
</tr>
<tr>
<td>

https://github.com/user-attachments/assets/64e343b1-adf7-46c2-bdd4-571ddc0497ee

</td>
<td>

https://github.com/user-attachments/assets/88e49500-451c-4bcd-ba11-d59f5eeb3307

</td>
</table>

## Tested

- [x] DEV
- [x] CODE