### PR TITLE
NoScript messaging

### DIFF
--- a/scripts/okta/okta-login.html
+++ b/scripts/okta/okta-login.html
@@ -16,9 +16,48 @@
 			#okta-login-container {
 				visibility: hidden;
 			}
+			/* basic noscript styling */
+			#noscript {
+				color: #121212;
+				font-family:
+					'Guardian Text Sans Web', 'Helvetica Neue', Helvetica, Arial,
+					sans-serif;
+				font-size: 16px;
+				line-height: 1.5;
+				margin: 10px auto;
+				max-width: 600px;
+				padding: 20px;
+			}
 		</style>
 	</head>
 	<body>
+		<noscript>
+			<div id="noscript">
+				<p>
+					<b>The Guardian</b>
+				</p>
+				<p>
+					<b>
+						Please
+						<a
+							href="https://www.whatismybrowser.com/guides/how-to-enable-javascript/"
+							>enable JavaScript</a
+						>
+						in your browser/device settings and try again.
+					</b>
+				</p>
+				<p>
+					We use JavaScript to provide a seamless and secure authentication
+					experience.
+				</p>
+				<p>
+					For further help please contact our customer service team at
+					<a href="mailto:signinsupport@theguardian.com"
+						>signinsupport@theguardian.com</a
+					>.
+				</p>
+			</div>
+		</noscript>
 		<div id="okta-login-container"></div>
 		{{{OktaUtil}}}
 		<script src="https://cdn.jsdelivr.net/gh/guardian/gateway@main/scripts/okta/okta-login.min.js"></script>

--- a/src/client/components/MainForm.tsx
+++ b/src/client/components/MainForm.tsx
@@ -35,6 +35,7 @@ import {
 } from '@/client/styles/Shared';
 import locations from '@/shared/lib/locations';
 import { GatewayErrorSummary } from '@/client/components/GatewayErrorSummary';
+import { NoScript } from './NoScript';
 
 export interface MainFormProps {
 	wideLayout?: boolean;
@@ -278,6 +279,7 @@ export const MainForm = ({
 			onInvalid={(e) => onInvalid && onInvalid(e)}
 			data-testid="main-form"
 		>
+			{recaptchaEnabled && <NoScript />}
 			{formError && (
 				<GatewayErrorSummary
 					gatewayError={formError}

--- a/src/client/components/NoScript.stories.tsx
+++ b/src/client/components/NoScript.stories.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { Meta } from '@storybook/react';
+
+import { NoScriptContext } from '@/client/components/NoScript';
+import { ErrorSummary } from '@guardian/source-development-kitchen/react-components';
+import { errorMessageStyles } from '@/client/styles/Shared';
+
+export default {
+	title: 'Components/NoScriptContext',
+	component: NoScriptContext,
+	parameters: {
+		layout: 'padded',
+	},
+} as Meta;
+
+export const Default = () => (
+	<ErrorSummary
+		message="Please enable JavaScript in your browser"
+		context={<NoScriptContext />}
+		cssOverrides={errorMessageStyles}
+	/>
+);
+Default.storyName = 'default';

--- a/src/client/components/NoScript.tsx
+++ b/src/client/components/NoScript.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { ErrorSummary } from '@guardian/source-development-kitchen/react-components';
+import locations from '@/shared/lib/locations';
+import { SUPPORT_EMAIL } from '@/shared/model/Configuration';
+import {
+	errorContextSpacing,
+	errorContextLastTypeSpacing,
+	errorMessageStyles,
+} from '@/client/styles/Shared';
+import { ExternalLink } from './ExternalLink';
+
+export const NoScriptContext = () => (
+	<>
+		<p css={errorContextSpacing}>
+			We use JavaScript to provide a seamless and secure authentication
+			experience. Please{' '}
+			<ExternalLink href="https://www.whatismybrowser.com/guides/how-to-enable-javascript/">
+				enable JavaScript
+			</ExternalLink>{' '}
+			in your browser settings and reload the page.
+		</p>
+		<p css={[errorContextSpacing, errorContextLastTypeSpacing]}>
+			For further help please contact our customer service team at{' '}
+			<a href={locations.SUPPORT_EMAIL_MAILTO}>{SUPPORT_EMAIL}</a>
+		</p>
+	</>
+);
+
+export const NoScript = () => {
+	return (
+		<noscript>
+			<ErrorSummary
+				message="Please enable JavaScript in your browser"
+				context={<NoScriptContext />}
+				cssOverrides={errorMessageStyles}
+			/>
+		</noscript>
+	);
+};


### PR DESCRIPTION
## What does this change?

Adds some basic messaging to the page when JavaScript is disabled through `<noscript>` tags applied to the `MainForm` component, and the Okta hosted login page.

We also link to https://www.whatismybrowser.com/guides/how-to-enable-javascript/ to help users enable JavaScript in their devices, and include an email for support.

<table>
<tr>
<th>`MainForm`</th>
<th>Okta hosted sign in page</th>
</tr>
<tr>
<td>

![Screenshot 2025-02-17 at 09 44 53](https://github.com/user-attachments/assets/8ab75faf-b357-4318-b263-bc179b9e87e6)

</td>
<td>
<img width="438" alt="Screenshot 2025-02-17 at 09 41 10" src="https://github.com/user-attachments/assets/be26b8bb-5a56-4a34-b363-e31942b7e1a7" />
</td>
</tr>
</table>

## Tested

- [x] CODE - Okta hosted
- [x] CODE - Sign in page