### PR TITLE
Fix NoScript breaking styling

### DIFF
--- a/scripts/okta/okta-login.html
+++ b/scripts/okta/okta-login.html
@@ -16,9 +16,48 @@
 			#okta-login-container {
 				visibility: hidden;
 			}
+			/* basic noscript styling */
+			#noscript {
+				color: #121212;
+				font-family:
+					'Guardian Text Sans Web', 'Helvetica Neue', Helvetica, Arial,
+					sans-serif;
+				font-size: 16px;
+				line-height: 1.5;
+				margin: 10px auto;
+				max-width: 600px;
+				padding: 20px;
+			}
 		</style>
 	</head>
 	<body>
+		<noscript>
+			<div id="noscript">
+				<p>
+					<b>The Guardian</b>
+				</p>
+				<p>
+					<b>
+						Please
+						<a
+							href="https://www.whatismybrowser.com/guides/how-to-enable-javascript/"
+							>enable JavaScript</a
+						>
+						in your browser/device settings and try again.
+					</b>
+				</p>
+				<p>
+					We use JavaScript to provide a seamless and secure authentication
+					experience.
+				</p>
+				<p>
+					For further help please contact our customer service team at
+					<a href="mailto:signinsupport@theguardian.com"
+						>signinsupport@theguardian.com</a
+					>.
+				</p>
+			</div>
+		</noscript>
 		<div id="okta-login-container"></div>
 		{{{OktaUtil}}}
 		<script src="https://cdn.jsdelivr.net/gh/guardian/gateway@main/scripts/okta/okta-login.min.js"></script>

--- a/src/client/components/MainForm.tsx
+++ b/src/client/components/MainForm.tsx
@@ -35,6 +35,7 @@ import {
 } from '@/client/styles/Shared';
 import locations from '@/shared/lib/locations';
 import { GatewayErrorSummary } from '@/client/components/GatewayErrorSummary';
+import { NoScript } from './NoScript';
 
 export interface MainFormProps {
 	wideLayout?: boolean;
@@ -278,6 +279,7 @@ export const MainForm = ({
 			onInvalid={(e) => onInvalid && onInvalid(e)}
 			data-testid="main-form"
 		>
+			{recaptchaEnabled && <NoScript />}
 			{formError && (
 				<GatewayErrorSummary
 					gatewayError={formError}

--- a/src/client/components/NoScript.stories.tsx
+++ b/src/client/components/NoScript.stories.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { Meta } from '@storybook/react';
+
+import { NoScriptContext } from '@/client/components/NoScript';
+import { ErrorSummary } from '@guardian/source-development-kitchen/react-components';
+import { errorMessageStyles } from '@/client/styles/Shared';
+
+export default {
+	title: 'Components/NoScriptContext',
+	component: NoScriptContext,
+	parameters: {
+		layout: 'padded',
+	},
+} as Meta;
+
+export const Default = () => (
+	<ErrorSummary
+		message="Please enable JavaScript in your browser"
+		context={<NoScriptContext />}
+		cssOverrides={errorMessageStyles}
+	/>
+);
+Default.storyName = 'default';

--- a/src/client/components/NoScript.tsx
+++ b/src/client/components/NoScript.tsx
@@ -7,16 +7,21 @@ import {
 	errorContextLastTypeSpacing,
 	errorMessageStyles,
 } from '@/client/styles/Shared';
-import { ExternalLink } from './ExternalLink';
 
+// don't use any non-default html tags, or react components,
+// inside the context within the noscript tag, as this
+// has the possibility to break styling outside of the noscript tag
 export const NoScriptContext = () => (
 	<>
 		<p css={errorContextSpacing}>
 			We use JavaScript to provide a seamless and secure authentication
 			experience. Please{' '}
-			<ExternalLink href="https://www.whatismybrowser.com/guides/how-to-enable-javascript/">
+			<a
+				href="https://www.whatismybrowser.com/guides/how-to-enable-javascript/"
+				rel="noopener noreferrer"
+			>
 				enable JavaScript
-			</ExternalLink>{' '}
+			</a>{' '}
 			in your browser settings and reload the page.
 		</p>
 		<p css={[errorContextSpacing, errorContextLastTypeSpacing]}>

--- a/src/client/components/NoScript.tsx
+++ b/src/client/components/NoScript.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { ErrorSummary } from '@guardian/source-development-kitchen/react-components';
+import locations from '@/shared/lib/locations';
+import { SUPPORT_EMAIL } from '@/shared/model/Configuration';
+import {
+	errorContextSpacing,
+	errorContextLastTypeSpacing,
+	errorMessageStyles,
+} from '@/client/styles/Shared';
+import { ExternalLink } from './ExternalLink';
+
+export const NoScriptContext = () => (
+	<>
+		<p css={errorContextSpacing}>
+			We use JavaScript to provide a seamless and secure authentication
+			experience. Please{' '}
+			<ExternalLink href="https://www.whatismybrowser.com/guides/how-to-enable-javascript/">
+				enable JavaScript
+			</ExternalLink>{' '}
+			in your browser settings and reload the page.
+		</p>
+		<p css={[errorContextSpacing, errorContextLastTypeSpacing]}>
+			For further help please contact our customer service team at{' '}
+			<a href={locations.SUPPORT_EMAIL_MAILTO}>{SUPPORT_EMAIL}</a>
+		</p>
+	</>
+);
+
+export const NoScript = () => {
+	return (
+		<noscript>
+			<ErrorSummary
+				message="Please enable JavaScript in your browser"
+				context={<NoScriptContext />}
+				cssOverrides={errorMessageStyles}
+			/>
+		</noscript>
+	);
+};


### PR DESCRIPTION
## What does this change?

In #3072 we reverted #3062 as that was breaking link styling on certain pages, e.g. reset password/sign in with password page.

While I wasn't able to figure exactly why this was happening, I did pin it down to the fact we were using the `ExternalLink` component inside the `noscript` tag.

For some reason, when using `ExternalLink` inside `noscript`, some stylings wouldn't be applied to anything else using `ExternalLink` on the page. My educated guess would be a weird emotion-preact interplay bug causing this.

So I just changed this to a standard `a` tag with the correct attributes and this fixed styling on the page. I also left a comment to indicate to future developers of this quirk.

Commit: [`722334d` (#3073)](https://github.com/guardian/gateway/pull/3073/commits/722334d109c81660bc0f1115093c7653e8c3b60c)

<table>
<tr>
<th> Before
<th> After
<tr>
<td>
<img width="569" alt="Screenshot 2025-02-18 at 12 09 05" src="https://github.com/user-attachments/assets/70c505ae-8be2-4fab-962c-f044a0f7bc99" />
<td>
<img width="702" alt="Screenshot 2025-02-18 at 13 53 53" src="https://github.com/user-attachments/assets/40d13f28-e664-45ea-8a0a-01c49713b990" />
</table>

## Tested

- [x] DEV
- [x] CODE