### PR TITLE
Fix | NoScript | Clashing styles with other components

### DIFF
--- a/src/client/components/NoScript.stories.tsx
+++ b/src/client/components/NoScript.stories.tsx
@@ -1,23 +1,15 @@
 import React from 'react';
 import { Meta } from '@storybook/react';
 
-import { NoScriptContext } from '@/client/components/NoScript';
-import { ErrorSummary } from '@guardian/source-development-kitchen/react-components';
-import { errorMessageStyles } from '@/client/styles/Shared';
+import { NoScript } from '@/client/components/NoScript';
 
 export default {
-	title: 'Components/NoScriptContext',
-	component: NoScriptContext,
+	title: 'Components/NoScript',
+	component: NoScript,
 	parameters: {
 		layout: 'padded',
 	},
 } as Meta;
 
-export const Default = () => (
-	<ErrorSummary
-		message="Please enable JavaScript in your browser"
-		context={<NoScriptContext />}
-		cssOverrides={errorMessageStyles}
-	/>
-);
+export const Default = () => <NoScript />;
 Default.storyName = 'default';

--- a/src/client/components/NoScript.tsx
+++ b/src/client/components/NoScript.tsx
@@ -1,44 +1,116 @@
 import React from 'react';
-import { ErrorSummary } from '@guardian/source-development-kitchen/react-components';
 import locations from '@/shared/lib/locations';
 import { SUPPORT_EMAIL } from '@/shared/model/Configuration';
+import { css } from '@emotion/react';
 import {
-	errorContextSpacing,
-	errorContextLastTypeSpacing,
-	errorMessageStyles,
-} from '@/client/styles/Shared';
+	remSpace,
+	size,
+	space,
+	textSans17,
+	textSansBold17,
+} from '@guardian/source/foundations';
+import { error as errorColors } from '@guardian/source/foundations';
+import { SvgAlertRound } from '@guardian/source/react-components';
 
-// don't use any non-default html tags, or react components,
-// inside the context within the noscript tag, as this
-// has the possibility to break styling outside of the noscript tag
-export const NoScriptContext = () => (
-	<>
-		<p css={errorContextSpacing}>
-			We use JavaScript to provide a seamless and secure authentication
-			experience. Please{' '}
-			<a
-				href="https://www.whatismybrowser.com/guides/how-to-enable-javascript/"
-				rel="noopener noreferrer"
-			>
-				enable JavaScript
-			</a>{' '}
-			in your browser settings and reload the page.
-		</p>
-		<p css={[errorContextSpacing, errorContextLastTypeSpacing]}>
-			For further help please contact our customer service team at{' '}
-			<a href={locations.SUPPORT_EMAIL_MAILTO}>{SUPPORT_EMAIL}</a>
-		</p>
-	</>
-);
+const wrapperStyles = css`
+	border: 2px solid ${errorColors[400]};
+	border-radius: 4px;
+	padding: ${space[1]}px;
+	display: flex;
+`;
 
+const iconStyles = css`
+	display: flex;
+	flex: 0 1 auto;
+	margin-top: 1px;
+	svg {
+		fill: ${errorColors[400]};
+		height: ${size.xsmall}px;
+		width: ${size.xsmall}px;
+	}
+`;
+
+const messageStyles = css`
+	${textSansBold17};
+	line-height: 1.4;
+	color: ${errorColors[400]};
+`;
+
+const messageWrapperStyles = css`
+	margin-left: ${space[1]}px;
+`;
+
+const contextStyles = css`
+	${textSans17};
+`;
+
+const errorContextSpacing = css`
+	margin: 0;
+	margin-top: ${space[2]}px;
+`;
+
+const errorContextLastTypeSpacing = css`
+	margin-bottom: 0;
+	&:last-child {
+		margin-bottom: ${remSpace[3]};
+	}
+`;
+
+const errorMessageStyles = css`
+	border-color: var(--color-alert-error);
+	color: var(--color-alert-error);
+	div {
+		color: var(--color-alert-error);
+	}
+	svg {
+		fill: var(--color-alert-error) !important;
+	}
+	a {
+		${textSansBold17};
+		color: var(--color-alert-error);
+	}
+`;
+
+/**
+ * @name NoScript
+ * @description This component is used to display a message to the user when JavaScript is disabled in the browser.
+ *
+ * Note: This component shouldn't used any shared styles or components as this causes issues with with any other components that are rendered on the page.
+ * Which we're guessing is related to css-in-js and noscript interactions.
+ * So all styles must be defined in this file, so that they are SSR rendered and don't clash with other components.
+ *
+ * The styles are based on the ErrorSummary component from the Source design system: https://github.com/guardian/csnx/blob/main/libs/%40guardian/source-development-kitchen/src/react-components/summary/ErrorSummary.tsx
+ */
 export const NoScript = () => {
 	return (
 		<noscript>
-			<ErrorSummary
-				message="Please enable JavaScript in your browser"
-				context={<NoScriptContext />}
-				cssOverrides={errorMessageStyles}
-			/>
+			<div css={[wrapperStyles, errorMessageStyles]}>
+				<div css={iconStyles}>
+					<SvgAlertRound />
+				</div>
+				<div css={messageWrapperStyles}>
+					<div css={messageStyles}>
+						Please enable JavaScript in your browser
+					</div>
+					<div css={contextStyles}>
+						<p css={errorContextSpacing}>
+							We use JavaScript to provide a seamless and secure authentication
+							experience. Please{' '}
+							<a
+								href="https://www.whatismybrowser.com/guides/how-to-enable-javascript/"
+								rel="noopener noreferrer"
+							>
+								enable JavaScript
+							</a>{' '}
+							in your browser settings and reload the page.
+						</p>
+						<p css={[errorContextSpacing, errorContextLastTypeSpacing]}>
+							For further help please contact our customer service team at{' '}
+							<a href={locations.SUPPORT_EMAIL_MAILTO}>{SUPPORT_EMAIL}</a>
+						</p>
+					</div>
+				</div>
+			</div>
 		</noscript>
 	);
 };


### PR DESCRIPTION
## What does this change?

The styling on the error messages on some forms was broken, e.g. for incorrect email/password.

This was due to the `<noscript>` tag styles sharing styles with the error message component on the page.

Our assumption is that `<noscript>` has some weird behaviour with `emotion` (css-in-js), as it's trying to execute js inside of the `<noscript>` tag, which wouldn't work, so no styles are generated.

This means that anything else sharing styles with the noscript tag, would also fail, as emotion would think the shared styles have already been generated, e.g. the error component.

To fix this we have to separate out the styles used by the noscript tag so that all the styles are only used by that, and not share any styles with other components. Thanks to SSR, if the user has javascript disabled, all the styles will still get rendered, and the component looks okay.

As it's now no longer sharing any styles with other components, the other components also look okay too, which we're assuming is that it's not sharing styles with the noscript tag!

<table>
<tr>
<th> Before - Error
<th> After - Error
<th> Before - NoScript
<th> After - NoScript
<tr>
<td>

![Screen Shot 2025-02-28 at 11 11 48](https://github.com/user-attachments/assets/e8931857-e2d0-4c37-8b1f-7903c44309c7)

<td>

![Screen Shot 2025-02-28 at 11 11 51](https://github.com/user-attachments/assets/32a818e4-9bff-4dbf-9a82-7a3b8c2e52b9)

<td>

![Screen Shot 2025-02-28 at 11 22 42](https://github.com/user-attachments/assets/65009b8a-cc3d-4f87-9dec-296abaabcce8)

<td>

![Screen Shot 2025-02-28 at 11 22 52](https://github.com/user-attachments/assets/81d95a6a-f349-4d03-9043-6d523629e54a)

</table>

## Tested

- [x] CODE