### PR TITLE
Fix | Reauthenticate flow now working with passcodes

### DIFF
--- a/src/server/lib/middleware/redirectIfLoggedIn.ts
+++ b/src/server/lib/middleware/redirectIfLoggedIn.ts
@@ -88,13 +88,15 @@ export const redirectIfLoggedIn = async (
 		});
 
 		return res.type('html').send(html);
-	} catch {
+	} catch (error) {
 		// if the cookie exists, but the session is invalid, we remove the cookie
 		clearOktaCookies(res);
 		// we also clear the identity cookies, to keep the parity
 		clearIDAPICookies(res);
-		logger.info(
+		// error is a warning, as it doesn't affect the user experience
+		logger.warn(
 			'User attempting to access signed-out-only route had an existing Okta session cookie, but it was invalid',
+			error,
 		);
 		//we redirect to /reauthenticate to make sure the cookies has been removed
 		return res.redirect(


### PR DESCRIPTION
## What does this change?

When a reader visits the reauthenticate page and chooses to sign in with a passcode, they receive a passcode via email, but the screen still shows the reauthenticate page, until they send themselves another passcode email.

This doesn't prove for a great reader experience.

Since this was only affecting `/reauthenticate` something must've been happening on that page to cause this behaviour.

The server would show the following warning error message:

```
{"ip":"::1","level":"info","message":"User attempting to access signed-out-only route had an existing Okta session cookie, but it was invalid","requestId":"cd729d22-a109-4a17-a634-68e543b4f062"}
```

That error is only present in the [`redirectIfLoggedIn`](https://github.com/guardian/gateway/blob/34311cdf8524f247a11841fbf7bdf9568f5829ea/src/server/lib/middleware/redirectIfLoggedIn.ts#L97) function.

The functionality of the `redirectIfLoggedIn` method clears any signed in cookies the reader might have and redirects the reader to the `/reauthenticate` page if they're already logged in.

This is how the reader ends up not seeing the passcode input page:

1. Visits `/reauthenticate` e.g. by going to manage over 30mins after last sign in
2. Enters their email, and clicks "Continue with email"
3. Reader gets sent a code, tried being redirected to the passcode input page, but the `redirectIfLoggedIn` method blocks this somewhere, clears any cookies, and the user gets redirected to `/reauthenticate`
4. The reader ends up on `/reauthenticate` again, confused, as they have a code, but no where to input it
5. The reader clicks "Continue with email" again, gets sent a code, because their cookies have been cleared by `redirectIfLoggedIn` they don't get blocked, and see the passcode input page
6. The user has to choose the correct passcode sent to them to input on this page before they can continue

You can see this in the "previous behaviour" video below.

This occured because any route related to sign in with passcodes, e.g. `/signin/code` had the `redirectIfLoggedIn` middlware as part of its functionality.

e.g.

https://github.com/guardian/gateway/blob/fd10fce21e4ebfa8800c5c9bd11425cad0b6c272/src/server/routes/signIn.ts#L279-L282

To fix this we simply remove `redirectIfLoggedIn` from any `/signin/code` route.

You might then ask, "what about users who are already signed in now try visiting /signin/code?". Well they wouldn't be able to do anything, as you need to have a valid `stateHandle` that hasn't expired or been used as part of the sign in with passcode flow from the Okta IDX API. If they don't have this, then they'll just redirected to the `/signin` page, which will show that they're already signed in! 

We also improve the error message on `redirectIfLoggedIn` to spit out the whole error rather than just the custom message in the catch block.

<table>
<tr>
<th>
Previous behaviour
<th>
New behaviour
<tr>
<td>

https://github.com/user-attachments/assets/26768307-f988-4cbe-98f0-fe6739eef7a8

<td>

https://github.com/user-attachments/assets/54aa8c74-e8c6-4d34-ae92-166633fe05a4

</table>

## Tested

- [x] DEV
- [x] CODE

## Future improvements

The only reason we have the reauthenticate functionality is for [manage my account](https://manage.theguardian.com), and users have to reauthenticate after 30 mins since they last signed in.

Could we remove the reauthenticate functionality entirely, and allow anyone with a valid session to visit MMA, or extend this to a longer period of time so users aren't asked to reauthenticate as much?