### PR TITLE
Fix | Reauthentication with password

### DIFF
--- a/cypress/integration/ete/reauthenticate.4.cy.ts
+++ b/cypress/integration/ete/reauthenticate.4.cy.ts
@@ -1,4 +1,4 @@
-describe('Reauthenticate flow, Okta enabled', () => {
+describe('Reauthenticate flow, Okta enabled, password default', () => {
 	it('keeps User A signed in when User A attempts to reauthenticate', () => {
 		cy
 			.createTestUser({ isUserEmailValidated: true })
@@ -85,6 +85,220 @@ describe('Reauthenticate flow, Okta enabled', () => {
 								});
 							},
 						);
+				},
+			);
+	});
+});
+
+describe('Reauthenticate flow, Okta enabled, passcode default', () => {
+	it('keeps User A signed in when User A attempts to reauthenticate - with password', () => {
+		cy
+			.createTestUser({ isUserEmailValidated: true })
+			?.then(({ emailAddress, finalPassword }) => {
+				// First, sign in
+				cy.visit(
+					`/signin/password?returnUrl=${encodeURIComponent(
+						`https://${Cypress.env('BASE_URI')}/welcome/review`,
+					)}`,
+				);
+				cy.get('input[name=email]').type(emailAddress);
+				cy.get('input[name=password]').type(finalPassword);
+				cy.get('[data-cy="main-form-submit-button"]').click();
+				cy.url().should('include', '/welcome/review');
+
+				// Then, try to reauthenticate
+				cy.visit(
+					`/reauthenticate?returnUrl=${encodeURIComponent(
+						`https://${Cypress.env('BASE_URI')}/welcome/review`,
+					)}`,
+				);
+				cy.contains('Sign in with a password instead').click();
+				cy.get('input[name=email]').type(emailAddress);
+				cy.get('input[name=password]').type(finalPassword);
+				cy.get('[data-cy="main-form-submit-button"]').click();
+				cy.url().should('include', '/welcome/review');
+
+				// Get the current session data
+				cy.getCookie('idx').then((idxCookie) => {
+					const idx = idxCookie?.value;
+					expect(idx).to.exist;
+					if (idx) {
+						cy.getCurrentOktaSession({ idx }).then((session) => {
+							expect(session.login).to.equal(emailAddress);
+						});
+					}
+				});
+			});
+	});
+
+	it('keeps User A signed in when User A attempts to reauthenticate - with passcode', () => {
+		cy
+			.createTestUser({ isUserEmailValidated: true })
+			?.then(({ emailAddress, finalPassword }) => {
+				// First, sign in
+				cy.visit(
+					`/signin/password?returnUrl=${encodeURIComponent(
+						`https://${Cypress.env('BASE_URI')}/welcome/review`,
+					)}`,
+				);
+				cy.get('input[name=email]').type(emailAddress);
+				cy.get('input[name=password]').type(finalPassword);
+				cy.get('[data-cy="main-form-submit-button"]').click();
+				cy.url().should('include', '/welcome/review');
+
+				// Then, try to reauthenticate
+				cy.visit(
+					`/reauthenticate?returnUrl=${encodeURIComponent(
+						`https://${Cypress.env('BASE_URI')}/welcome/review`,
+					)}`,
+				);
+				cy.get('input[name=email]').type(emailAddress);
+				const timeRequestWasMade = new Date();
+				cy.get('[data-cy="main-form-submit-button"]').click();
+
+				cy.checkForEmailAndGetDetails(emailAddress, timeRequestWasMade).then(
+					({ codes }) => {
+						// email
+						expect(codes?.length).to.eq(1);
+						const code = codes?.[0].value;
+						expect(code).to.match(/^\d{6}$/);
+
+						// passcode page
+						cy.url().should('include', '/signin/code');
+						cy.contains('Enter your one-time code');
+						cy.contains('Sign in');
+						cy.get('input[name=code]').type(code!);
+
+						cy.url().should('include', '/welcome/review');
+
+						// Get the current session data
+						cy.getCookie('idx').then((idxCookie) => {
+							const idx = idxCookie?.value;
+							expect(idx).to.exist;
+							if (idx) {
+								cy.getCurrentOktaSession({ idx }).then((session) => {
+									expect(session.login).to.equal(emailAddress);
+								});
+							}
+						});
+					},
+				);
+			});
+	});
+
+	it('signs in User B when User B attempts to reauthenticate while User A is logged in - with password', () => {
+		// Create User A
+		cy
+			.createTestUser({ isUserEmailValidated: true })
+			?.then(
+				({ emailAddress: emailAddressA, finalPassword: finalPasswordA }) => {
+					// First, sign in as User A
+					cy.visit(
+						`/signin/password?returnUrl=${encodeURIComponent(
+							`https://${Cypress.env('BASE_URI')}/welcome/review`,
+						)}`,
+					);
+					cy.get('input[name=email]').type(emailAddressA);
+					cy.get('input[name=password]').type(finalPasswordA);
+					cy.get('[data-cy="main-form-submit-button"]').click();
+					cy.url().should('include', '/welcome/review');
+
+					// Create User B
+					cy
+						.createTestUser({ isUserEmailValidated: true })
+						?.then(
+							({
+								emailAddress: emailAddressB,
+								finalPassword: finalPasswordB,
+							}) => {
+								// Then, try to reauthenticate as User B
+								cy.visit(
+									`/reauthenticate?returnUrl=${encodeURIComponent(
+										`https://${Cypress.env('BASE_URI')}/welcome/review`,
+									)}`,
+								);
+								cy.contains('Sign in with a password instead').click();
+								cy.get('input[name=email]').type(emailAddressB);
+								cy.get('input[name=password]').type(finalPasswordB);
+								cy.get('[data-cy="main-form-submit-button"]').click();
+								cy.url().should('include', '/welcome/review');
+
+								// Get the current session data
+								cy.getCookie('idx').then((idxCookie) => {
+									const idx = idxCookie?.value;
+									expect(idx).to.exist;
+									if (idx) {
+										cy.getCurrentOktaSession({ idx }).then((session) => {
+											expect(session.login).to.equal(emailAddressB);
+										});
+									}
+								});
+							},
+						);
+				},
+			);
+	});
+
+	it('signs in User B when User B attempts to reauthenticate while User A is logged in - with passcode', () => {
+		// Create User A
+		cy
+			.createTestUser({ isUserEmailValidated: true })
+			?.then(
+				({ emailAddress: emailAddressA, finalPassword: finalPasswordA }) => {
+					// First, sign in as User A
+					cy.visit(
+						`/signin/password?returnUrl=${encodeURIComponent(
+							`https://${Cypress.env('BASE_URI')}/welcome/review`,
+						)}`,
+					);
+					cy.get('input[name=email]').type(emailAddressA);
+					cy.get('input[name=password]').type(finalPasswordA);
+					cy.get('[data-cy="main-form-submit-button"]').click();
+					cy.url().should('include', '/welcome/review');
+
+					// Create User B
+					cy
+						.createTestUser({ isUserEmailValidated: true })
+						?.then(({ emailAddress: emailAddressB }) => {
+							// Then, try to reauthenticate as User B
+							cy.visit(
+								`/reauthenticate?returnUrl=${encodeURIComponent(
+									`https://${Cypress.env('BASE_URI')}/welcome/review`,
+								)}`,
+							);
+							cy.get('input[name=email]').type(emailAddressB);
+							const timeRequestWasMade = new Date();
+							cy.get('[data-cy="main-form-submit-button"]').click();
+
+							cy.checkForEmailAndGetDetails(
+								emailAddressB,
+								timeRequestWasMade,
+							).then(({ codes }) => {
+								// email
+								expect(codes?.length).to.eq(1);
+								const code = codes?.[0].value;
+								expect(code).to.match(/^\d{6}$/);
+
+								// passcode page
+								cy.url().should('include', '/signin/code');
+								cy.contains('Enter your one-time code');
+								cy.contains('Sign in');
+								cy.get('input[name=code]').type(code!);
+
+								cy.url().should('include', '/welcome/review');
+
+								// Get the current session data
+								cy.getCookie('idx').then((idxCookie) => {
+									const idx = idxCookie?.value;
+									expect(idx).to.exist;
+									if (idx) {
+										cy.getCurrentOktaSession({ idx }).then((session) => {
+											expect(session.login).to.equal(emailAddressB);
+										});
+									}
+								});
+							});
+						});
 				},
 			);
 	});

--- a/src/client/pages/SignIn.tsx
+++ b/src/client/pages/SignIn.tsx
@@ -230,7 +230,9 @@ export const SignIn = ({
 						<MainBodyText>
 							<ThemedLink
 								href={buildUrlWithQueryParams(
-									'/signin/password',
+									isReauthenticate
+										? '/reauthenticate/password'
+										: '/signin/password',
 									{},
 									queryParams,
 									{

--- a/src/client/routes.tsx
+++ b/src/client/routes.tsx
@@ -80,6 +80,12 @@ const routes: Array<{
 		element: <SignInPage isReauthenticate />,
 	},
 	{
+		path: '/reauthenticate/password',
+		element: (
+			<SignInPage isReauthenticate hideSocialButtons forcePasswordPage />
+		),
+	},
+	{
 		path: '/register',
 		element: <RegistrationPage />,
 	},

--- a/src/server/controllers/signInControllers.ts
+++ b/src/server/controllers/signInControllers.ts
@@ -396,9 +396,11 @@ export const oktaIdxApiSignInPasscodeController = async ({
 export const oktaIdxApiSignInController = async ({
 	req,
 	res,
+	isReauthenticate = false,
 }: {
 	req: Request;
 	res: ResponseWithRequestState;
+	isReauthenticate?: boolean;
 }) => {
 	// get the email and password from the request body if using passwords
 	// or the "passcode" parameter is a hidden input, which is to determine if the
@@ -621,7 +623,12 @@ export const oktaIdxApiSignInController = async ({
 
 		// if we're using passcodes, and the user is attempting to sign in with a password
 		// on error show the password sign in page
-		const errorPage: RoutePaths = usePasscode ? '/signin' : '/signin/password';
+		const errorPage: RoutePaths = (() => {
+			if (isReauthenticate) {
+				return usePasscode ? '/reauthenticate' : '/reauthenticate/password';
+			}
+			return usePasscode ? '/signin' : '/signin/password';
+		})();
 
 		const html = renderer(errorPage, {
 			requestState: mergeRequestState(res.locals, {

--- a/src/server/routes/signIn.ts
+++ b/src/server/routes/signIn.ts
@@ -239,6 +239,25 @@ router.get(
 	}),
 );
 
+router.get(
+	'/reauthenticate/password',
+	(req: Request, res: ResponseWithRequestState) => {
+		const state = res.locals;
+		const email =
+			state.queryParams.signInEmail || readEncryptedStateCookie(req)?.email;
+		const html = renderer('/reauthenticate/password', {
+			requestState: mergeRequestState(state, {
+				pageData: {
+					email,
+					focusPasswordField: !!email,
+				},
+			}),
+			pageTitle: 'Sign in',
+		});
+		return res.type('html').send(html);
+	},
+);
+
 router.post(
 	'/reauthenticate',
 	handleRecaptcha,
@@ -376,6 +395,7 @@ const oktaSignInController = async ({
 			await oktaIdxApiSignInController({
 				req,
 				res,
+				isReauthenticate,
 			});
 			// if successful, the user will be redirected
 			// so we need to check if the headers have been sent to prevent further processing

--- a/src/shared/model/Routes.ts
+++ b/src/shared/model/Routes.ts
@@ -29,6 +29,7 @@ export const ValidRoutePathsArray = [
 	'/oauth/authorization-code/delete-callback',
 	'/oauth/authorization-code/interaction-code-callback',
 	'/reauthenticate',
+	'/reauthenticate/password',
 	'/register',
 	'/register/code',
 	'/register/code/expired',


### PR DESCRIPTION
## What does this change?

We solved some reauthentication issues in https://github.com/guardian/gateway/pull/3095, however some issues remained when a user tried reauthenticating with a password.

Specifically the same issue occured, because the `/signin/password` page was on the `/signin` route, it would do a `POST` request to `/signin` when the user entered their email and password.

The `POST /signin` route also has the `redirectIfLoggedIn` middleware.

However in this example, unlike the PR above, we don't want to remove this middleware.

Instead what we've done is create a new page called `/reauthenticate/password`, which is the same as the `/signin/password` page, but with the `isReauthenticate` flag set to `true` so that it will `POST /reauthenticate` instead, which doesn't have the `redirectIfLoggedIn` middleware.

We also make sure to update the logic to show the correct page when it's reauthentication vs signin.

We've also added in a bunch of missing cypress tests for the reauthenitcation flow for both password and passcode reauthentication to hopefully catch any future bugs with this process!

<table>
<tr>
<th> Previous
<th> New
<tr>
<td>

https://github.com/user-attachments/assets/0993f2d2-4dde-465c-a9c5-ab6e76c42f70

<td>

https://github.com/user-attachments/assets/0f7712dc-8d1b-4cb5-babf-0551b6856bfb

</table>

## Tested

- [x] CODE