### PR TITLE
Set the toggle to true on New Account Review

### DIFF
--- a/cypress/integration/ete/new_account_review.3.cy.ts
+++ b/cypress/integration/ete/new_account_review.3.cy.ts
@@ -61,9 +61,7 @@ describe('New account review page', () => {
 				);
 				cy.contains('Advertising is a crucial source of our funding');
 
-				// Flip the switches so personalised advertising is on
-				// and profiling is off
-				cy.get(`label#${Consents.ADVERTISING}_description`).click();
+				// Flip profiling_optout toggle switch
 				cy.get(`label#${Consents.PROFILING}_description`).click();
 				cy.get('button[type="submit"]').click();
 

--- a/src/client/pages/NewAccountReview.tsx
+++ b/src/client/pages/NewAccountReview.tsx
@@ -92,14 +92,14 @@ export const NewAccountReview = ({
 						<ToggleSwitchInput
 							id={advertising.id}
 							description="Allow personalised advertising with my signed-in data"
-							defaultChecked={advertising.consented ?? true} // should opt in by default
+							defaultChecked // should opt in by default
 						/>
 					)}
 					{!!profiling && (
 						<ToggleSwitchInput
 							id={profiling.id}
 							description="Allow the Guardian to analyse my signed-in data to improve marketing content"
-							defaultChecked={profiling.consented ?? true} // legitimate interests so defaults to true
+							defaultChecked // legitimate interests so defaults to true
 						/>
 					)}
 				</ToggleSwitchList>


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
Shows the advertisng and profiling sections by default for non ad-free users.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

Tested in CODE.
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
