### PR TITLE
Fix  | `registrationLocationState` | Allow empty string as valid value

### DIFF
--- a/src/shared/model/RegistrationLocation.ts
+++ b/src/shared/model/RegistrationLocation.ts
@@ -96,6 +96,7 @@ export const RegistrationLocationStateSchema = z.enum([
 	// General
 	'Other', // Other
 	'Prefer not to say', // Prefer not to say
+	'', // Empty string - for when the user has manually changed their location from AU or US to something else, where we need to set it to empty
 ]);
 
 export type RegistrationLocationState = z.infer<


### PR DESCRIPTION
## What does this change?

Update the zod parsing for the user object to allow an empty string value (`""`) for the `registrationLocationState`.

This will happen for users who previously had a `registrationLocationState` set, but changed their `registrationLocation` from Australia or the United States to something else, where we update the state to be empty.

Otherwise we get a error and we cannot read the user object:

```
...
"message":"GET /delete  Error - Could not parse Okta user response - OktaError: Could not parse Okta user response\n    at pg (/etc/gu/server.js:832:16072)\n
...
``` 

## Tested

- [x] CODE