### PR TITLE
Log authentication metrics

### DIFF
--- a/src/server/controllers/sendChangePasswordEmail.ts
+++ b/src/server/controllers/sendChangePasswordEmail.ts
@@ -123,6 +123,10 @@ export const changePasswordEmailIdx = async ({
 				confirmationPagePath: user.credentials.password
 					? '/reset-password/complete'
 					: '/set-password/complete',
+				extraData: {
+					flow: 'account-recovery',
+					appLabel: res.locals.appLabel,
+				},
 			},
 		});
 

--- a/src/server/controllers/signInControllers.ts
+++ b/src/server/controllers/signInControllers.ts
@@ -243,6 +243,10 @@ export const oktaIdxApiSignInPasscodeController = async ({
 					res,
 					authorizationCodeFlowOptions: {
 						confirmationPagePath,
+						extraData: {
+							flow: 'sign-in-passcode',
+							appLabel: res.locals.appLabel,
+						},
 					},
 				});
 
@@ -446,6 +450,12 @@ export const oktaIdxApiSignInController = async ({
 			email,
 			req,
 			res,
+			authorizationCodeFlowOptions: {
+				extraData: {
+					flow: 'sign-in-password',
+					appLabel: res.locals.appLabel,
+				},
+			},
 		});
 
 		// check for the "password" authenticator, we can only authenticate with a password

--- a/src/server/lib/middleware/requestState.ts
+++ b/src/server/lib/middleware/requestState.ts
@@ -68,10 +68,15 @@ const getRequestState = async (
 	// eslint-disable-next-line functional/no-let -- need to assign value based on logic
 	let appName: AppName | undefined;
 
+	// the app label as it is returned from the api
+	// eslint-disable-next-line functional/no-let -- need to assign value based on logic
+	let appLabel: string | undefined;
+
 	try {
 		if (queryParams.appClientId) {
 			const app = await getApp(queryParams.appClientId);
 			const label = app.label.toLowerCase();
+			appLabel = label;
 
 			if (isAppLabel(label)) {
 				if (label.startsWith('android_')) {
@@ -127,6 +132,7 @@ const getRequestState = async (
 		},
 		browser: browser.getBrowser(),
 		requestId: req.get('x-request-id'),
+		appLabel,
 	};
 };
 

--- a/src/server/lib/okta/idx/interact.ts
+++ b/src/server/lib/okta/idx/interact.ts
@@ -93,6 +93,8 @@ export const interact = async (
 				appPrefix: extraData?.appPrefix,
 				encryptedRegistrationConsents: extraData?.encryptedRegistrationConsents,
 				codeVerifier,
+				flow: extraData?.flow,
+				appLabel: extraData?.appLabel,
 			},
 		);
 		setAuthorizationStateCookie(authState, res);

--- a/src/server/lib/okta/openid-connect.ts
+++ b/src/server/lib/okta/openid-connect.ts
@@ -11,6 +11,14 @@ import { RoutePaths } from '@/shared/model/Routes';
 import { SocialProvider } from '@/shared/model/Social';
 import type { OutgoingHttpHeaders } from 'http';
 
+export type UserFlow =
+	| 'sign-in-passcode'
+	| 'sign-in-password'
+	| 'social-registration'
+	| 'social-sign-in'
+	| 'social-authentication'
+	| 'create-account'
+	| 'account-recovery';
 /**
  * @interface AuthorizationState
  * An object to hold the state the user was in while performing the
@@ -39,12 +47,7 @@ export interface AuthorizationState {
 		codeVerifier?: string; // used to track the code verifier used in the PKCE flow
 		stateToken?: string; // state handle from Okta IDX /introspect response but only everything before the first tilde (`stateHandle.split('~')[0]`), used to redirect user to login redirect endpoint to set global session (`/login/token/redirect?stateToken=${stateToken}`)
 		// used to track the flow the user is in for basic metrics/analytics
-		flow?:
-			| 'sign-in-passcode'
-			| 'sign-in-password'
-			| 'social-authentication'
-			| 'create-account'
-			| 'account-recovery'; // password reset, and email verification flows outside of create account
+		flow?: UserFlow; // password reset, and email verification flows outside of create account
 		appLabel?: string; // used to track the app used to start the flow
 	};
 }

--- a/src/server/lib/okta/openid-connect.ts
+++ b/src/server/lib/okta/openid-connect.ts
@@ -38,6 +38,14 @@ export interface AuthorizationState {
 		appPrefix?: string; // used to track if the recovery token has a native app prefix
 		codeVerifier?: string; // used to track the code verifier used in the PKCE flow
 		stateToken?: string; // state handle from Okta IDX /introspect response but only everything before the first tilde (`stateHandle.split('~')[0]`), used to redirect user to login redirect endpoint to set global session (`/login/token/redirect?stateToken=${stateToken}`)
+		// used to track the flow the user is in for basic metrics/analytics
+		flow?:
+			| 'sign-in-passcode'
+			| 'sign-in-password'
+			| 'social-authentication'
+			| 'create-account'
+			| 'account-recovery'; // password reset, and email verification flows outside of create account
+		appLabel?: string; // used to track the app used to start the flow
 	};
 }
 

--- a/src/server/models/Express.ts
+++ b/src/server/models/Express.ts
@@ -43,6 +43,7 @@ export interface RequestState {
 	browser: Bowser.Parser.Details;
 	oauthState?: OAuthState;
 	requestId?: string;
+	appLabel?: string;
 }
 
 export type ResponseWithRequestState = Response<unknown, RequestState>;

--- a/src/server/models/Metrics.ts
+++ b/src/server/models/Metrics.ts
@@ -5,6 +5,7 @@ import { PasswordRoutePath } from '@/shared/model/Routes';
 import { IDXPath } from '@/server/lib/okta/idx/shared/paths';
 import { Status } from './okta/User';
 import { Literal } from '@/shared/types';
+import { UserFlow } from '../lib/okta/openid-connect';
 
 // Specific emails to track
 type EmailMetrics =
@@ -93,7 +94,8 @@ type UnconditionalMetrics =
 			| 'WeakPassword'
 			| 'StrongPassword'}`
 	| `PasscodePasswordNotCompleteRemediation-${'ResetPassword' | 'Register'}-${'STAGED' | 'PROVISIONED'}-${'Start' | 'Complete'}`
-	| `ExistingUserInCreateAccountFlow`;
+	| `ExistingUserInCreateAccountFlow`
+	| `UserFlow-${UserFlow}-${string}`;
 
 // Combine all the metrics above together into a type
 export type Metrics =

--- a/src/server/routes/oauth.ts
+++ b/src/server/routes/oauth.ts
@@ -423,6 +423,7 @@ const authenticationHandler = async (
 						idp,
 						appLabel,
 					});
+					trackMetric(`UserFlow-social-registration-${idp}-${appLabel}`);
 				} else {
 					// if the user is an existing social user, we want to log the flow as social sign in
 					logger.info('OAuth Authentication via Gateway flow', undefined, {
@@ -430,6 +431,7 @@ const authenticationHandler = async (
 						idp,
 						appLabel,
 					});
+					trackMetric(`UserFlow-social-sign-in-${idp}-${appLabel}`);
 				}
 			} else {
 				// otherwise log the flow as is
@@ -437,6 +439,7 @@ const authenticationHandler = async (
 					flow: authState.data.flow,
 					appLabel,
 				});
+				trackMetric(`UserFlow-${authState.data.flow}-${appLabel}`);
 			}
 		} else {
 			// users would hit this if they complete oauth authentication without a flow

--- a/src/server/routes/register.ts
+++ b/src/server/routes/register.ts
@@ -469,6 +469,10 @@ const oktaIdxCreateAccount = async (
 			res,
 			authorizationCodeFlowOptions: {
 				confirmationPagePath: '/welcome/review',
+				extraData: {
+					flow: 'create-account',
+					appLabel: res.locals.appLabel,
+				},
 			},
 			consents,
 		});

--- a/src/server/routes/signIn.ts
+++ b/src/server/routes/signIn.ts
@@ -609,6 +609,10 @@ router.get(
 		try {
 			const [{ interaction_handle }, authState] = await interact(req, res, {
 				closeExistingSession: true,
+				extraData: {
+					flow: 'social-authentication',
+					appLabel: res.locals.appLabel,
+				},
 			});
 
 			const introspectResponse = await introspect(


### PR DESCRIPTION
## What does this change?

Currently it's difficult for us to know exactly which flow and app a user used to authenticate with the Guardian.

To remediate this problem, this PR adds a new log line in the OAuth Authentication Callback so we can track this. using the `extraData` object we can pass to the server side logger, and thus kibana.

However we first need to be able to know which flows we're using. We can do this by adding additional information to the Authorization Code Flow state cookie when a user comes to Gateway. In the `AuthorizationState` we add the `flow` and `appLabel` parameter, which allow us to track the flow the user is authenticating with, and also which app they're authenticating from.

We then make sure that the authorization state in the IDX API `interact` call takes into account these two new parameters and persists them. From there we make sure that at the start of each flow this information is available, i.e at the start of the sign in flow (with passcode and password), social authentication, create account, and reset password (account recovery).

Finally just before we redirect the user in the OAuth Authentication Callback, we add the log messaging in.

`OAuth Authentication via Gateway flow` - is the message used when we know the user authenticated via one of the gateway flows, this will include the `flow` and `appLabel` if available.

`OAuth Authentication without Gateway flow` - is authentication flows that didn't require the user to reauthenticate, e.g. sign in refresh flows, token refreshes etc.

When successful, the event will look like the following in the local gateway logs

```
{"appLabel":"<appLabel>","flow":"sign-in-passcode","ip":"<ip>","level":"info","message":"OAuth Authentication via Gateway flow","requestId":"<requestId>"}
```

You can then query it in Grafana too, with an example lucene query being:

```
app.keyword:identity-gateway AND stage:$stage AND message:"OAuth Authentication via Gateway flow" AND flow:"<flow>" AND appLabel:<appLabel>
```

Possible flows include

```js
'sign-in-passcode'
'sign-in-password'
'social-registration' // the idp parameter can be used to differentiate google/apple
'social-signin' // the idp parameter can be used to differentiate google/apple
'create-account'
'account-recovery' // password reset, and email verification flows outside of create account
```

We also added new metrics with the following structure, so we can have a longer term view of the data (as logs are only available for 12 days). While these metrics will cost a little extra, it won't be as many as if we were to add the app to every metric.

```
`UserFlow-${flow}-${app}`
e.g.
`UserFlow-sign-in-passcode-android_live_app`
`UserFlow-social-registration-apple-ios_feast_app`
```

## Tested

- [x] CODE - `sign-in-passcode`
- [x] CODE - `sign-in-password`
- [x] CODE - `social-registration`
- [x] CODE - `social-sign-in`
- [x] CODE - `create-account`
- [x] CODE - `account-recovery`

<img width="1513" alt="Screenshot 2025-05-02 at 16 07 21" src="https://github.com/user-attachments/assets/58381665-8885-481d-aa74-24f7688ad814" />
