### PR TITLE
chore(design): Remove "welcome" image and center pages vertically.

### DIFF
--- a/src/client/layouts/MinimalLayout.tsx
+++ b/src/client/layouts/MinimalLayout.tsx
@@ -27,6 +27,7 @@ interface MinimalLayoutProps {
 	pageHeader: string;
 	leadText?: React.ReactNode;
 	imageId?: DecorativeImageId;
+	centered?: boolean;
 	successOverride?: string;
 	errorOverride?: string;
 	errorContext?: React.ReactNode;
@@ -34,11 +35,11 @@ interface MinimalLayoutProps {
 	shortRequestId?: string;
 }
 
-const mainStyles = (wide: boolean) => css`
+const mainStyles = (wide: boolean, centered?: boolean) => css`
 	padding: ${remSpace[3]} ${remSpace[4]} ${remSpace[4]} ${remSpace[4]};
 	max-width: ${wide ? LAYOUT_WIDTH_WIDE : LAYOUT_WIDTH_NARROW}px;
 	width: 100%;
-	margin: 0 auto;
+	margin: ${!centered && '0'} auto;
 	display: flex;
 	flex-direction: column;
 	gap: ${CONTAINER_GAP};
@@ -59,6 +60,7 @@ export const MinimalLayout = ({
 	pageHeader,
 	leadText,
 	imageId,
+	centered,
 	successOverride,
 	errorOverride,
 	errorContext,
@@ -75,7 +77,7 @@ export const MinimalLayout = ({
 		<>
 			<Theme />
 			<MinimalHeader />
-			<main css={mainStyles(wide)}>
+			<main css={mainStyles(wide, centered)}>
 				{imageId && <MinimalLayoutImage id={imageId} />}
 				{pageHeader && (
 					<header>

--- a/src/client/pages/NewAccountReview.tsx
+++ b/src/client/pages/NewAccountReview.tsx
@@ -50,7 +50,7 @@ export const NewAccountReview = ({
 			<MinimalLayout
 				shortRequestId={shortRequestId}
 				pageHeader="You're signed in! Welcome to the Guardian."
-				imageId="welcome"
+				centered={true}
 			>
 				<MainForm
 					shortRequestId={shortRequestId}
@@ -68,11 +68,11 @@ export const NewAccountReview = ({
 		<MinimalLayout
 			shortRequestId={shortRequestId}
 			pageHeader="You're signed in! Welcome to the Guardian."
-			imageId="welcome"
 			leadText="
 				Before you start, confirm how you’d like the Guardian to use your
 				signed-in data.
 			"
+			centered={true}
 		>
 			<MainForm
 				formAction={buildUrlWithQueryParams('/welcome/review', {}, queryParams)}

--- a/src/client/pages/WelcomeExisting.tsx
+++ b/src/client/pages/WelcomeExisting.tsx
@@ -20,10 +20,7 @@ export const WelcomeExisting = ({
 	accountManagementUrl = 'https://manage.theguardian.com',
 }: WelcomeExistingProps) => {
 	return (
-		<MinimalLayout
-			pageHeader="Welcome back. You're signed in!"
-			imageId="welcome"
-		>
+		<MinimalLayout pageHeader="Welcome back. You're signed in!" centered={true}>
 			<MainBodyText>
 				We noticed you already have a Guardian account
 				{email && (


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

![image](https://github.com/user-attachments/assets/227dbc43-eb08-4fb6-9916-5fe4ceceac46)

We've been requested to remove the "slender man" image from the Welcome and New Account page. This PR does that and centers those pages vertically now to make use of the extra white space available on the page and avoid changing the layout too much.

## Images



| Before | After |
|--------|--------|
| ![Screen Shot 2025-05-27 at 16 08 57](https://github.com/user-attachments/assets/7424151e-5a0a-41d5-86bc-72ace278b34d) | ![Screen Shot 2025-05-27 at 16 07 00](https://github.com/user-attachments/assets/28ffc57d-cf94-49bf-aa7c-99f0f435a055) |
| ![Screen Shot 2025-05-27 at 16 08 44](https://github.com/user-attachments/assets/84ce9799-cf4f-4dc4-be52-a79577647324) | ![Screen Shot 2025-05-27 at 16 06 38](https://github.com/user-attachments/assets/64ae885d-8d61-492e-b3ff-e7decf947944) |