### PR TITLE
feat(jobs): Notify users that a Jobs account will be created after continuing

### DIFF
--- a/src/client/pages/SignedInAs.stories.tsx
+++ b/src/client/pages/SignedInAs.stories.tsx
@@ -31,6 +31,16 @@ export const FeastApp = () => (
 	/>
 );
 
+export const Jobs = () => (
+	<SignedInAs
+		email="test@example.com"
+		continueLink="#"
+		signOutLink="#"
+		appName="Guardian"
+		queryParams={{ clientId: 'jobs', returnUrl: '#' }}
+	/>
+);
+
 export const Error = () => (
 	<SignedInAs
 		email="test@example.com"

--- a/src/client/pages/SignedInAs.tsx
+++ b/src/client/pages/SignedInAs.tsx
@@ -49,6 +49,9 @@ const DetailedLoginRequiredError = ({
 	</>
 );
 
+const isJobsClient = (queryParams?: QueryParams): boolean =>
+	queryParams?.clientId === 'jobs';
+
 export const SignedInAs = ({
 	email,
 	continueLink,
@@ -72,12 +75,23 @@ export const SignedInAs = ({
 	return (
 		<MinimalLayout
 			shortRequestId={shortRequestId}
-			pageHeader={`Sign in to the ${appName ? `${appName} app` : 'Guardian'}`}
+			pageHeader={
+				isJobsClient(queryParams)
+					? 'Sign in with the Guardian'
+					: `Sign in to the ${appName ? `${appName} app` : 'Guardian'}`
+			}
 			errorOverride={pageError}
 			errorContext={errorContext}
 			leadText={
 				<MainBodyText>
-					You are signed in with <strong>{email}</strong>
+					You are signed in with <strong>{email}</strong>.
+					{isJobsClient(queryParams) && (
+						<p>
+							If this is your first time using Guardian Jobs, this email address
+							will be used to create your <strong>Guardian Jobs</strong>{' '}
+							account.
+						</p>
+					)}
 				</MainBodyText>
 			}
 		>


### PR DESCRIPTION
## What does this change?

Now that we're adding `?prompt=login` to Jobs users more of them will be seeing the "Signed in as" page when logging in. Add a message to this page to let them know that by continuing they'll create a Guardian Jobs account.



## How to test

Deployed to CODE and checked the Jobs login flow whilst signed in.

| Before | After |
|--------|--------|
| ![Screen Shot 2025-06-03 at 15 22 37](https://github.com/user-attachments/assets/f3f2a1e7-f664-4e44-9ded-5b7136e68e0e) | ![Screen Shot 2025-06-09 at 18 18 06](https://github.com/user-attachments/assets/382f61fc-18b5-475b-9f76-d2b3c449b26e) | 
