### PR TITLE
fix(jobs): Show `/accept/GRS` on Jobs registration

### DIFF
--- a/src/server/lib/welcome.ts
+++ b/src/server/lib/welcome.ts
@@ -19,8 +19,13 @@ export const getNextWelcomeFlowPage = ({
 	returnUrl: string;
 	queryParams: QueryParams;
 }): string => {
+	// Jobs users need to accept additional Jobs terms and conditions
+	// and submit their first and last name.
+	if (queryParams.clientId === 'jobs') {
+		return addQueryParamsToPath('/agree/GRS', queryParams);
+	}
+
 	// if there is a fromURI, we need to complete the oauth flow by redirecting to it
-	// fromURIs are only set in apps.
 	if (fromURI) {
 		return fromURI;
 	}


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

After registering on the Guardian jobs flow we need to ask the user for their first name and last name and whether they consent to the Guardian Jobs terms and conditions. This PR adds a redirect after the user confirms their account settings to show the Guardian Jobs onboarding page.

The `/agree/GRS` route checks if the user has a Jobs account and redirects them to fromURI if they do, or prompts for further information if they don't.

## How to test

Deployed to CODE, registered for a new account via the Guardian Jobs client ID


https://github.com/user-attachments/assets/0dc452af-2391-44df-9c79-cb6005c10c23


