### PR TITLE
chore(okta): Specify hosted login page JS hash

### DIFF
--- a/scripts/okta/okta-login.html
+++ b/scripts/okta/okta-login.html
@@ -60,6 +60,9 @@
 		</noscript>
 		<div id="okta-login-container"></div>
 		{{{OktaUtil}}}
-		<script src="https://cdn.jsdelivr.net/gh/guardian/gateway@main/scripts/okta/okta-login.min.js"></script>
+		<!-- Temporarily set to https://github.com/guardian/gateway/commit/0d2d9f14ec39ad9d1a442b0ccbe6241634058fdb -->
+		<!-- Which is the latest commit on main at time of writting. -->
+		<!-- This allows us to bust the cache on the following JS and avoid redirect loops -->
+		<script src="https://cdn.jsdelivr.net/gh/guardian/gateway@0d2d9f14ec39ad9d1a442b0ccbe6241634058fdb/scripts/okta/okta-login.min.js"></script>
 	</body>
 </html>


### PR DESCRIPTION
We use jsdelivr to host the JS bundle thats used on the Okta hosted login page, the way this service works is that it directly serves the contents of this repository to the end user.

The way jsdelivr is currently setup is to serve the latest code on the `main` branch, this is great for simplicity but because we don't use a version string it means it can take up to 7 days for an update to be reflected on end user devices due to caching.

When we merge https://github.com/guardian/identity-platform/pull/824 any users running outdated JS will end up stuck in a login loop when logging into the Jobs application. To avoid this lets point jsdelivr to the latest commit on main, instead of main itself, this should bust the cache.

Its worth noting that it is possible to purge the CDN cache on jsdelivr via https://www.jsdelivr.com/tools/purge but this does not clear the local browser cache.
## How to test

Tested in CODE.

<img width="810" alt="image" src="https://github.com/user-attachments/assets/566d31af-faba-4b94-a7f7-4b7f4c22ff05" />

