### PR TITLE
Use mainBodyTextStyles to ensure text on NewAccountReview is visible in dark mode

### DIFF
--- a/scripts/nginx.conf
+++ b/scripts/nginx.conf
@@ -21,6 +21,7 @@ http {
     proxy_buffer_size   128k;
     proxy_buffers   4 256k;
     proxy_busy_buffers_size   256k;
+    large_client_header_buffers 4 9K;
 
     server {
         listen       8080;

--- a/src/client/components/MainBodyText.tsx
+++ b/src/client/components/MainBodyText.tsx
@@ -6,7 +6,7 @@ interface Props {
 	cssOverrides?: SerializedStyles;
 }
 
-const mainBodyTextStyles = css`
+export const mainBodyTextStyles = css`
 	${textSans15};
 	color: var(--color-text);
 	margin: 0;

--- a/src/client/pages/NewAccountReview.tsx
+++ b/src/client/pages/NewAccountReview.tsx
@@ -1,5 +1,8 @@
 import React from 'react';
-import { MainBodyText } from '@/client/components/MainBodyText';
+import {
+	MainBodyText,
+	mainBodyTextStyles,
+} from '@/client/components/MainBodyText';
 import { Consent } from '@/shared/model/Consent';
 import { ToggleSwitchInput } from '@/client/components/ToggleSwitchInput';
 import {
@@ -8,11 +11,7 @@ import {
 } from '@/client/components/InformationBox';
 import { ExternalLink } from '@/client/components/ExternalLink';
 import locations from '@/shared/lib/locations';
-import {
-	remSpace,
-	textSans15,
-	textSansBold17,
-} from '@guardian/source/foundations';
+import { remSpace, textSansBold17 } from '@guardian/source/foundations';
 import { css } from '@emotion/react';
 import { buildUrlWithQueryParams } from '@/shared/lib/routeUtils';
 import { QueryParams } from '@/shared/model/QueryParams';
@@ -25,10 +24,6 @@ import { MainForm } from '@/client/components/MainForm';
 
 const subheadingStyles = css`
 	${textSansBold17};
-`;
-
-const listContainerStyles = css`
-	${textSans15};
 `;
 
 const listStyles = css`
@@ -117,7 +112,7 @@ export const NewAccountReview = ({
 							Personalised advertising
 						</MainBodyText>
 						<MainBodyText>We do this by:</MainBodyText>
-						<div css={listContainerStyles}>
+						<div css={mainBodyTextStyles}>
 							<ul css={listStyles}>
 								<li>
 									Checking if you are already a customer of other trusted
@@ -141,7 +136,7 @@ export const NewAccountReview = ({
 				<MainBodyText>
 					Information you provide when you create an account with us e.g.
 				</MainBodyText>
-				<div css={listContainerStyles}>
+				<div css={mainBodyTextStyles}>
 					<ul css={listStyles}>
 						<li>First name and last name</li>
 						<li>Email address</li>


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
This PR uses the mainBodyTextStyles to fix the ul element which doesn't change colour in dark mode.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test
Checked locally and in CODE
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->


## Images

Before
<img width="474" alt="image (1)" src="https://github.com/user-attachments/assets/5f32289f-fb7c-4bb4-8b48-8c8e3664a209" />

After
<img width="1500" alt="Screenshot 2025-07-03 at 16 26 20" src="https://github.com/user-attachments/assets/97b48128-31be-4afe-ad3e-28ab614a7448" />

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

