### PR TITLE
chore: Turn off dependabot updates for NPM dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,33 +1,5 @@
 version: 2
 updates:
-  - package-ecosystem: 'npm'
-    directory: '/'
-    schedule:
-      interval: 'weekly'
-      day: monday
-      time: '07:00'
-    labels:
-      - 'dependencies'
-    groups:
-      dependencies:
-        dependency-type: 'production'
-        update-types: ['minor', 'patch']
-      devDependencies:
-        dependency-type: 'development'
-        update-types: ['minor', 'patch']
-  - package-ecosystem: 'npm'
-    directory: '/cdk'
-    schedule:
-      interval: 'weekly'
-      day: monday
-      time: '07:30'
-    labels:
-      - 'dependencies'
-    groups:
-      cdk:
-        update-types:
-          - 'minor'
-          - 'patch'
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Turn off Dependabot updates for NPM dependencies. Our designated rota engineer updates all of our NPM dependencies every week via the `make upgrade` script instead of using Dependabot.

Dependabot PRs constantly get updated every time a new commit is merged into the main branch which uses up our Mailosaur and Okta rate limits unecessarily, it also creates a bunch of PRs that show up in our Dependabot thread which just add to spam.
