### PR TITLE
Update the comment for the ad free cookie expiry in user-features

### DIFF
--- a/src/server/lib/user-features.ts
+++ b/src/server/lib/user-features.ts
@@ -109,7 +109,7 @@ const persistUserBenefitsCookies = ({
 		createCookie({ name: ALLOW_REJECT_ALL_COOKIE, res, daysTillExpiry: 1 });
 	}
 	// Ad free user cookie is set for 2 days
-	// https://github.com/guardian/frontend/blob/f17fe93c542fbd448392a0687d0b92f35796097a/static/src/javascripts/projects/common/modules/commercial/user-features.ts#L128
+	// https://github.com/guardian/dotcom-rendering/blob/d629dfc882b72b32114209345ccfa3e995397eb2/dotcom-rendering/src/client/userFeatures/user-features.ts#L59
 	if (userBenefits?.benefits?.includes('adFree')) {
 		createCookie({ name: AD_FREE_USER_COOKIE, res, daysTillExpiry: 2 });
 	}


### PR DESCRIPTION
## What does this change?

Updates the comment referencing the two day expiry for the ad free cookie in user features

It used to point to the client-side code in `frontend` as this is where it was copied from. 
It now references the `dotcom-rendering` code since this is the code most likely to be running in the browser.

## Why

We don't use `frontend` to render our pages much any more and as such, we rarely run the client-side code.

To help future developers understand what the code is doing in various places in the codebase, it is more helpful to direct them to the code that is most likely to be running on users' machines (ie the better source of truth) rather than the reference of where the code originally came from.
