### PR TITLE
feat: Support merge queues in Gateway

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -7,13 +7,14 @@ on:
       - main
   pull_request:
     types: ['review_requested', 'labeled']
+  merge_group:
 
 # List of jobs
 jobs:
   chromatic-deployment:
     # Operating System
     runs-on: ubuntu-latest
-    if: contains(github.event.pull_request.labels.*.name, 'run_tests')  ||  github.ref == 'refs/heads/main'
+    if: contains(github.event.pull_request.labels.*.name, 'run_tests')  ||  github.ref == 'refs/heads/main' || github.event_name == 'merge_group'
     # Job steps
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,7 @@
 name: CI
-on: push
+on:
+  push:
+  merge_group:
 jobs:
   CI:
     name: Continuous Integration

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -10,11 +10,12 @@ on:
   pull_request:
     types: ['review_requested', 'labeled']
   workflow_dispatch:
+  merge_group:
 jobs:
   build:
     name: Build Gateway
     runs-on: ubuntu-latest
-    if: contains(github.event.pull_request.labels.*.name, 'run_tests')  ||  github.ref == 'refs/heads/main'
+    if: contains(github.event.pull_request.labels.*.name, 'run_tests')  ||  github.ref == 'refs/heads/main' || github.event_name == 'merge_group'
     steps:
       - name: Checkout
         uses: actions/checkout@v5


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Add support to our CI pipelines for [Merge Queues](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue).

This is based on discussions in the Engineering channels about preferring "Merge Queues" over "Auto merge".

Frequently I will find that a PR is out of date from the mainline branch after its been approved, usually in this scenario I will hit the "Update" button and then "Auto-merge" so that the PR will be merged once checks have finished running on the now updated PR.

Ocassionally, more than one person might be working on a repo, and between the time that I've hit the "Update" button and CI completing, someone else might merge another change in which puts my PR out of date again, requiring me to update the PR again and start my CI from scratch.

Merge queues fixes this issue by basically managing the process of updating your PR and running CI automatically, so if `main` is updated after you've hit the merge button on your PR the merge queue will take care of updating your branch and making sure CI still works.

"Auto-merge" also has the unfortunate effect that sometimes it will be enabled before a PR is approved, this goes against the way we usually treat reviews at The Guardian, where the PR creator is usually responsible for supervising its deployment, "Auto-merge" flips this on its head and makes the approver potentially responsible for the merge. We do run a "no blame" culture, so its not like the approver has done anything wrong, but it can be a barrier to approving a PR when you know that you'll potentially have to be the one monitoring it.

After merging this PR we can remove the check for a branch to be up to date before merging and then enable merge queues in our branch protection rules.