### PR TITLE
Override path-to-regexp to 8.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -147,7 +147,8 @@
 			"serialize-javascript@6.0.2": "7.0.3",
 			"fast-xml-parser@5.4.1": "5.5.6",
 			"playwright-core": "1.57.0",
-			"picomatch@4.0.3": "4.0.4"
+			"picomatch@4.0.3": "4.0.4",
+			"path-to-regexp@8.3.0": "8.4.0"
 		},
 		"onlyBuiltDependencies": [
 			"@playwright/test",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,7 @@ overrides:
   fast-xml-parser@5.4.1: 5.5.6
   playwright-core: 1.57.0
   picomatch@4.0.3: 4.0.4
+  path-to-regexp@8.3.0: 8.4.0
 
 importers:
 
@@ -5756,8 +5757,8 @@ packages:
     resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
     engines: {node: '>=16 || 14 >=14.18'}
 
-  path-to-regexp@8.3.0:
-    resolution: {integrity: sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==}
+  path-to-regexp@8.4.0:
+    resolution: {integrity: sha512-PuseHIvAnz3bjrM2rGJtSgo1zjgxapTLZ7x2pjhzWwlp4SJQgK3f3iZIQwkpEnBaKz6seKBADpM4B4ySkuYypg==}
 
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
@@ -13546,7 +13547,7 @@ snapshots:
       lru-cache: 10.4.3
       minipass: 7.1.2
 
-  path-to-regexp@8.3.0: {}
+  path-to-regexp@8.4.0: {}
 
   path-type@4.0.0: {}
 
@@ -13887,7 +13888,7 @@ snapshots:
       depd: 2.0.0
       is-promise: 4.0.0
       parseurl: 1.3.3
-      path-to-regexp: 8.3.0
+      path-to-regexp: 8.4.0
     transitivePeerDependencies:
       - supports-color
 


### PR DESCRIPTION
<!--

-->

## What does this change?
Override path-to-regexp to  8.4.0
## Why?
Keep packages up to date.
