### PR TITLE
Turn on some ESLint rules we previously turned off

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -109,7 +109,6 @@ const config = tseslint.config(
 			'@typescript-eslint/no-unsafe-return': 'off',
 			'import/no-named-as-default': 'off',
 			'@typescript-eslint/no-unsafe-enum-comparison': 'off',
-			'import/no-named-as-default-member': 'off',
 		},
 	},
 	{

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -110,7 +110,6 @@ const config = tseslint.config(
 			'import/no-named-as-default': 'off',
 			'@typescript-eslint/no-unsafe-enum-comparison': 'off',
 			'import/no-named-as-default-member': 'off',
-			'import/no-cycle': 'off',
 		},
 	},
 	{

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -107,7 +107,6 @@ const config = tseslint.config(
 			'@typescript-eslint/prefer-nullish-coalescing': 'off',
 			'@typescript-eslint/no-unsafe-call': 'off',
 			'@typescript-eslint/no-unsafe-return': 'off',
-			'import/no-named-as-default': 'off',
 		},
 	},
 	{

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -108,7 +108,6 @@ const config = tseslint.config(
 			'@typescript-eslint/no-unsafe-call': 'off',
 			'@typescript-eslint/no-unsafe-return': 'off',
 			'import/no-named-as-default': 'off',
-			'@typescript-eslint/no-unsafe-enum-comparison': 'off',
 		},
 	},
 	{

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -111,7 +111,6 @@ const config = tseslint.config(
 			'@typescript-eslint/no-unsafe-enum-comparison': 'off',
 			'import/no-named-as-default-member': 'off',
 			'import/no-cycle': 'off',
-			'@typescript-eslint/only-throw-error': 'off',
 		},
 	},
 	{

--- a/src/server/lib/IDAPIFetch.ts
+++ b/src/server/lib/IDAPIFetch.ts
@@ -37,7 +37,7 @@ const handleResponseFailure = async (
 	} catch (_) {
 		err = raw;
 	}
-	throw { error: err, status: response.status };
+	throw new Error(raw, { cause: { error: err, status: response.status } });
 };
 
 const handleResponseSuccess = async (response: Response) => {

--- a/src/server/lib/validateUrl.ts
+++ b/src/server/lib/validateUrl.ts
@@ -23,12 +23,12 @@ export const validateReturnUrl = (returnUrl = ''): string => {
 
 		//This guards against invalid protocol, including app ones
 		if (url.protocol !== 'https:') {
-			throw 'Invalid protocol';
+			throw new Error('Invalid protocol');
 		}
 
 		// check the hostname is valid
 		if (!validHostnames.some((hostname) => url.hostname.endsWith(hostname))) {
-			throw 'Invalid hostname';
+			throw new Error('Invalid hostname');
 		}
 
 		// if valid subdomains are present, we can return the url with the query params
@@ -40,7 +40,7 @@ export const validateReturnUrl = (returnUrl = ''): string => {
 				url.hostname.startsWith('profile.') &&
 				invalidPaths.some((path) => url.pathname.startsWith(path))
 			) {
-				throw 'Invalid path';
+				throw new Error('Invalid path');
 			}
 
 			return url.href;
@@ -61,7 +61,7 @@ export const validateRefUrl = (ref = ''): string | undefined => {
 
 		// check the hostname is valid
 		if (!validHostnames.some((hostname) => url.hostname.endsWith(hostname))) {
-			throw 'Invalid hostname';
+			throw new Error('Invalid hostname');
 		}
 
 		return `https://${url.hostname}${url.pathname}`;


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Wayyyy back in 2024 [I migrated us to the standard Guardian eslint config ](https://github.com/guardian/gateway/pull/2827), at the time we had thousands of linting errors from doing this so I switched off many of the rules that weren't easy to comply with under the expectation that some day I'd get around to fixing the errors, well today is that day (sort of - i only had time to fix some of them!)

## How has this change been tested?

Deployed to CODE.