### PR TITLE
chore: Surpress various Gateway errors

### DIFF
--- a/src/server/controllers/changePassword.ts
+++ b/src/server/controllers/changePassword.ts
@@ -64,7 +64,7 @@ const oktaIdxApiPasswordHandler = async ({
 	password,
 	path,
 }: {
-	req: Request<{ token: string }>;
+	req: Request<{ token?: string }>;
 	res: ResponseWithRequestState;
 	pageTitle: PasswordPageTitle;
 	password: string;
@@ -131,7 +131,7 @@ export const setPasswordController = (
 	successRedirectPath: RoutePaths,
 ) =>
 	handleAsyncErrors(
-		async (req: Request<{ token: string }>, res: ResponseWithRequestState) => {
+		async (req: Request<{ token?: string }>, res: ResponseWithRequestState) => {
 			const { token: encryptedRecoveryToken } = req.params;
 			const { password, firstName, secondName } = req.body;
 			const { clientId, useOktaClassic } = res.locals.queryParams;

--- a/src/server/controllers/checkPasswordToken.ts
+++ b/src/server/controllers/checkPasswordToken.ts
@@ -31,6 +31,7 @@ import {
 } from '@/server/lib/okta/idx/introspect';
 import { convertExpiresAtToExpiryTimeInMs } from '@/server/lib/okta/idx/shared/convertExpiresAtToExpiryTimeInMs';
 import { Literal } from '@/shared/types';
+import { fourZeroZeroMiddleware } from '../lib/middleware/400';
 
 const { defaultReturnUri, passcodesEnabled } = getConfiguration();
 
@@ -134,7 +135,7 @@ const oktaIdxApiCheckHandler = async ({
 }: {
 	path: PasswordRoutePath;
 	pageTitle: PasswordPageTitle;
-	req: Request<{ token: string }>;
+	req: Request<{ token?: string }>;
 	res: ResponseWithRequestState;
 	error?: Literal<typeof ChangePasswordErrors>;
 	fieldErrors?: FieldError[];
@@ -198,13 +199,18 @@ const oktaIdxApiCheckHandler = async ({
 export const checkTokenInOkta = async (
 	path: PasswordRoutePath,
 	pageTitle: PasswordPageTitle,
-	req: Request<{ token: string }>,
+	req: Request<{ token?: string }>,
 	res: ResponseWithRequestState,
 	error?: Literal<typeof ChangePasswordErrors>,
 	fieldErrors?: FieldError[],
 ) => {
 	const state = res.locals;
 	const { token } = req.params;
+
+	if (token === undefined) {
+		logger.warn('No token provided in URL parameters');
+		return fourZeroZeroMiddleware(req, res);
+	}
 
 	// OKTA IDX API FLOW
 	// If the user is using the passcode flow for registration/reset password,
@@ -346,7 +352,7 @@ export const checkPasswordTokenController = (
 	pageTitle: PasswordPageTitle,
 ) =>
 	handleAsyncErrors(
-		async (req: Request<{ token: string }>, res: ResponseWithRequestState) => {
+		async (req: Request<{ token?: string }>, res: ResponseWithRequestState) => {
 			await checkTokenInOkta(path, pageTitle, req, res);
 		},
 	);

--- a/src/server/lib/httpErrors.ts
+++ b/src/server/lib/httpErrors.ts
@@ -1,0 +1,5 @@
+export const isHttpErrorWithStatus = (
+	error: unknown,
+	status: number,
+): boolean =>
+	error instanceof Object && 'status' in error && error.status === status;

--- a/src/server/lib/idapi/consents.ts
+++ b/src/server/lib/idapi/consents.ts
@@ -53,7 +53,13 @@ const read = async ({
 			})) as ConsentAPIResponse[]
 		).map(responseToEntity);
 	} catch (error) {
-		logger.error(`IDAPI Error consents read '/consents'`, error);
+		const isWarning =
+			error instanceof Object && 'status' in error && error.status === 400;
+		logger.log(
+			isWarning ? 'warn' : 'error',
+			`IDAPI Error consents read '/consents'`,
+			error,
+		);
 		return handleError();
 	}
 };
@@ -70,7 +76,13 @@ const readUserConsents = async ({
 			options,
 		})) as UserConsent[];
 	} catch (error) {
-		logger.error(`IDAPI Error consents read '/users/me/consents'`, error);
+		const isWarning =
+			error instanceof Object && 'status' in error && error.status === 400;
+		logger.log(
+			isWarning ? 'warn' : 'error',
+			`IDAPI Error consents read '/users/me/consents'`,
+			error,
+		);
 		return handleError();
 	}
 };
@@ -97,7 +109,13 @@ export const update = async ({
 		});
 		return;
 	} catch (error) {
-		logger.error(`IDAPI Error consents update  '/users/me/consents'`, error);
+		const isWarning =
+			error instanceof Object && 'status' in error && error.status === 400;
+		logger.log(
+			isWarning ? 'warn' : 'error',
+			`IDAPI Error consents update  '/users/me/consents'`,
+			error,
+		);
 		return handleError();
 	}
 };

--- a/src/server/lib/idapi/consents.ts
+++ b/src/server/lib/idapi/consents.ts
@@ -14,6 +14,7 @@ import {
 } from './invertOptOutConsents';
 import { IdApiQueryParams } from '@/shared/model/IdapiQueryParams';
 import { UserConsent } from '@/shared/model/UserConsents';
+import { isHttpErrorWithStatus } from '@/server/lib/httpErrors';
 
 const handleError = (): never => {
 	throw new IdapiError({ message: ConsentsErrors.GENERIC, status: 500 });
@@ -53,10 +54,8 @@ const read = async ({
 			})) as ConsentAPIResponse[]
 		).map(responseToEntity);
 	} catch (error) {
-		const isWarning =
-			error instanceof Object && 'status' in error && error.status === 400;
 		logger.log(
-			isWarning ? 'warn' : 'error',
+			isHttpErrorWithStatus(error, 400) ? 'warn' : 'error',
 			`IDAPI Error consents read '/consents'`,
 			error,
 		);
@@ -76,10 +75,8 @@ const readUserConsents = async ({
 			options,
 		})) as UserConsent[];
 	} catch (error) {
-		const isWarning =
-			error instanceof Object && 'status' in error && error.status === 400;
 		logger.log(
-			isWarning ? 'warn' : 'error',
+			isHttpErrorWithStatus(error, 400) ? 'warn' : 'error',
 			`IDAPI Error consents read '/users/me/consents'`,
 			error,
 		);
@@ -109,10 +106,8 @@ export const update = async ({
 		});
 		return;
 	} catch (error) {
-		const isWarning =
-			error instanceof Object && 'status' in error && error.status === 400;
 		logger.log(
-			isWarning ? 'warn' : 'error',
+			isHttpErrorWithStatus(error, 400) ? 'warn' : 'error',
 			`IDAPI Error consents update  '/users/me/consents'`,
 			error,
 		);

--- a/src/server/lib/middleware/400.ts
+++ b/src/server/lib/middleware/400.ts
@@ -1,0 +1,17 @@
+import { Request } from 'express';
+import { renderer } from '@/server/lib/renderer';
+import { ResponseWithRequestState } from '@/server/models/Express';
+
+const fourZeroZeroRenderer = (res: ResponseWithRequestState) =>
+	renderer('/error', {
+		pageTitle: 'Unexpected Error',
+		requestState: res.locals,
+	});
+
+export const fourZeroZeroMiddleware = (
+	_: Request,
+	res: ResponseWithRequestState,
+) => {
+	const html = fourZeroZeroRenderer(res);
+	res.type('html').status(400).send(html);
+};

--- a/src/server/lib/middleware/errorHandler.ts
+++ b/src/server/lib/middleware/errorHandler.ts
@@ -21,7 +21,7 @@ export const routeErrorHandler = (
 		// we attempt to redirect to res.locals.csrf.pageUrl provided by a hidden form field falling back to req.url
 		// we use res.locals.csrf.pageUrl since the URL might not be GET-able if the request was a POST
 		// we also have to manually build the query params object, as it may not be defined in an unexpected csrf error
-		logger.error('csrf error', err);
+		logger.warn('csrf error', err);
 		res.redirect(
 			303,
 			addQueryParamsToUntypedPath(
@@ -35,7 +35,7 @@ export const routeErrorHandler = (
 		return next(err);
 	} else if (err.code === 'EBADRECAPTCHA') {
 		trackMetric('RecaptchaMiddleware::Failure');
-		logger.error('recaptcha error', err);
+		logger.warn('recaptcha error', err);
 		res.redirect(
 			303,
 			addQueryParamsToUntypedPath(

--- a/src/server/lib/okta/idx/shared/idxFetch.ts
+++ b/src/server/lib/okta/idx/shared/idxFetch.ts
@@ -28,7 +28,13 @@ const IGNORED_ERRORS = [
 	 */
 	'registration.error.notUniqueWithinOrg',
 	/**
-	 * User Error when a user enters an invalid passcode during the authentication process.
+	 * User error.
+	 * This error is thrown when a user enters an email in an invalid format.
+	 */
+	'registration.error.doesNotMatchPattern',
+	/**
+	 * User error.
+	 * This error is thrown when a user enters an invalid passcode during the authentication process.
 	 */
 	'api.authn.error.PASSCODE_INVALID',
 ];

--- a/src/server/lib/okta/idx/shared/idxFetch.ts
+++ b/src/server/lib/okta/idx/shared/idxFetch.ts
@@ -12,6 +12,27 @@ import { IDXPath } from '@/server/lib/okta/idx/shared/paths';
 
 const { okta } = getConfiguration();
 
+/**
+ * List of error messages that we want to ignore and not track in our monitoring
+ * These are errors that we expect to happen during the normal authentication process,
+ * and don't indicate a problem with our integration or the IDX API.
+ *
+ * We will still throw these errors and handle them in the same way as other errors,
+ * but we won't track them in our monitoring to avoid noise.
+ */
+const IGNORED_ERRORS = [
+	/**
+	 * This error is thrown when a user enters an existing email during registration.
+	 * Since the registration and sign in flows are combined, its expected that users
+	 * will enter an existing email during registration.
+	 */
+	'registration.error.notUniqueWithinOrg',
+	/**
+	 * User Error when a user enters an invalid passcode during the authentication process.
+	 */
+	'api.authn.error.PASSCODE_INVALID',
+];
+
 // Schema for when the authentication process is completed, and we return a base user object
 export const completeLoginResponseSchema = idxBaseResponseSchema.merge(
 	z.object({
@@ -111,8 +132,11 @@ export const idxFetch = async <ResponseType, BodyType>({
 
 		return parsed;
 	} catch (error) {
-		trackMetric(`OktaIDX::${path}::Failure`);
-		logger.error(`Okta IDX ${path}`, error);
+		if (!(error instanceof OAuthError && IGNORED_ERRORS.includes(error.name))) {
+			trackMetric(`OktaIDX::${path}::Failure`);
+			logger.error(`Okta IDX ${path}`, error);
+		}
+
 		throw error;
 	}
 };

--- a/src/server/lib/recaptcha.ts
+++ b/src/server/lib/recaptcha.ts
@@ -62,10 +62,13 @@ const handleRecaptcha = async (
 		const recaptchaResponseJson =
 			(await recaptchaResponse.json()) as RecaptchaAPIResponse;
 		if (!recaptchaResponseJson.success) {
+			// https://developers.google.com/recaptcha/docs/verify#error_code_reference
 			const formattedErrorCodes = recaptchaResponseJson['error-codes']?.length
 				? recaptchaResponseJson['error-codes']?.join(', ')
 				: 'unknown';
-			logger.error(
+			const isWarning = formattedErrorCodes === 'timeout-or-duplicate';
+			logger.log(
+				isWarning ? 'warn' : 'error',
 				'Problem verifying reCAPTCHA, error response',
 				formattedErrorCodes,
 			);

--- a/src/server/routes/oauth.ts
+++ b/src/server/routes/oauth.ts
@@ -766,7 +766,7 @@ router.get(
 			// b) someone is trying to attack the oauth flow
 			// for example with an invalid state cookie, or without the state cookie
 			// the state cookie is used to prevent CSRF attacks
-			logger.error('Missing auth state cookie on OAuth Callback!', undefined);
+			logger.warn('Missing auth state cookie on OAuth Callback!', undefined);
 			trackMetric('OAuthAuthorization::Failure');
 			return redirectForGenericError(req, res);
 		}

--- a/src/server/routes/subscriptions.ts
+++ b/src/server/routes/subscriptions.ts
@@ -183,7 +183,13 @@ router.post(
 
 			return res.status(200).send();
 		} catch (error) {
-			logger.error(`${req.method} ${req.originalUrl}  Error`, error);
+			const isWarning =
+				error instanceof Object && 'status' in error && error.status === 400;
+			logger.log(
+				isWarning ? 'warn' : 'error',
+				`${req.method} ${req.originalUrl}  Error`,
+				error,
+			);
 
 			trackMetric(`UnsubscribeAll::Failure`);
 

--- a/src/server/routes/subscriptions.ts
+++ b/src/server/routes/subscriptions.ts
@@ -20,6 +20,7 @@ import {
 	subscriptionActionName,
 } from '@/shared/lib/subscriptions';
 import { read as getNewsletters } from '@/server/lib/idapi/newsletters';
+import { isHttpErrorWithStatus } from '@/server/lib/httpErrors';
 
 const { accountManagementUrl } = getConfiguration();
 
@@ -183,10 +184,8 @@ router.post(
 
 			return res.status(200).send();
 		} catch (error) {
-			const isWarning =
-				error instanceof Object && 'status' in error && error.status === 400;
 			logger.log(
-				isWarning ? 'warn' : 'error',
+				isHttpErrorWithStatus(error, 400) ? 'warn' : 'error',
 				`${req.method} ${req.originalUrl}  Error`,
 				error,
 			);


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

We got a critical alarm trigger last night about not getting any registrations for 5 minutes, I don't think it was anything particularly concerning, but trying to investigate the cause was incredibly difficult due to the sheer number of errors in the Gateway logs.

Most Gateway errors that are being logged are completely normal parts of the registration/sign-in flow, or user error, and should either be logged as warnings or not logged at all, this PR cleans up various areas where we log these errors to hopefully reduce the number of errors we see in Gateway and make it easier to diagnose alarms.

This pull request improves error handling and logging throughout the codebase, especially for user errors.

<!--
- **Existing Email Errors**: When a user signs in we initially send them down to the registration flow as we've combined the two flows together, since the user already has an account a "notUniqueWithinOrg" error which is handled later in the flow but not after it gets logged.
- **Invalid Passcodes or Email addresses**
- **ReCAPTCHA or CSRF errors**
- **IDAPI Errors**: For various reasons IDAPI throws a 400 error which is logged as an error in Gateway, my assumption here is that this is stuff like consent tokens being expired by the time the user uses them. I've changed logging here to only log an error when its not a 400 status code.
- **Missing Query Parameters & Cookies**: Sometimes a request is missing a crucial cookie or query parameter, in these scenarios Gateway previously blew up with an error. My assumption here is either user error, where the user has a browser thats has cookies switched off, or potentially vulnerability scanning tools probing our endpoints with invalid query parameters. In theory we have alarms setup to alert us if theres an issue in sign-ins or registrations so if there is a Gateway issue that causes these cookies or query parameters to be set we should get alerted and be able to check the warn logs if theres nothing in the error logs.
- -->

## How has this change been tested?

Deployed to CODE.
