### PR TITLE
Ash/metric bucket capacity

### DIFF
--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -17,5 +17,5 @@ if (
 	typeof redisClient !== 'undefined' &&
 	rateLimiter.settings?.trackBucketCapacity === true
 ) {
-	startGlobalBucketCapacityLogger(redisClient, 5000);
+	startGlobalBucketCapacityLogger(redisClient, 60000);
 }

--- a/src/server/lib/rate-limit/logger.ts
+++ b/src/server/lib/rate-limit/logger.ts
@@ -1,6 +1,7 @@
 import Redis from 'ioredis';
 import { logger } from '@/server/lib/serverSideLogger';
 import { LogLevel } from '@/shared/model/Logger';
+import { trackMetric } from '../trackMetric';
 
 /**
  * Starts a timer to keep track of global bucket capacity
@@ -39,7 +40,8 @@ const logValues = (keys: string[], values: Array<string | null>) => {
 	keys.forEach((key, index) => {
 		const value = values[index];
 		if (value) {
-			const tokensLeft = JSON.parse(value)?.tokens;
+			const tokensLeft: number = JSON.parse(value)?.tokens;
+			trackMetric('RateLimitBucketCapacity', { bucket: key }, tokensLeft);
 			logger.log(LogLevel.INFO, `Bucket(${key})`, undefined, {
 				bucket_capacity: tokensLeft,
 			});

--- a/src/server/lib/trackMetric.ts
+++ b/src/server/lib/trackMetric.ts
@@ -24,6 +24,7 @@ const defaultDimensions = {
 export const trackMetric = (
 	metricName: Metrics,
 	dimensions?: MetricDimensions,
+	value: number = 1,
 ): void => {
 	if (process.env.RUNNING_IN_PLAYWRIGHT === 'true') {
 		// return void in playwright
@@ -49,7 +50,7 @@ export const trackMetric = (
 								Value,
 							}),
 						),
-						Value: 1,
+						Value: value,
 						Unit: 'Count',
 					},
 				],

--- a/src/server/models/Metrics.ts
+++ b/src/server/models/Metrics.ts
@@ -95,7 +95,8 @@ type UnconditionalMetrics =
 			| 'StrongPassword'}`
 	| `PasscodePasswordNotCompleteRemediation-${'ResetPassword' | 'Register'}-${'STAGED' | 'PROVISIONED'}-${'Start' | 'Complete'}`
 	| `ExistingUserInCreateAccountFlow`
-	| `UserFlow-${UserFlow}-${string}`;
+	| `UserFlow-${UserFlow}-${string}`
+	| 'RateLimitBucketCapacity';
 
 // Combine all the metrics above together into a type
 export type Metrics =


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How has this change been tested?

<!-- For example, have you deployed your branch to `CODE` and tested certain functionality or is unit testing sufficent for this change? If you'd like help testing your changes as part of the PR review process then mention that explicitly here. -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
