### PR TITLE
Wording adjustment in passcode page

### DIFF
--- a/src/client/pages/IframedPasscodeEmailSent.tsx
+++ b/src/client/pages/IframedPasscodeEmailSent.tsx
@@ -38,7 +38,7 @@ const text: Text = {
 	title: 'Enter your code',
 	sentTextWithEmail: 'We’ve sent a temporary verification code to',
 	sentTextWithoutEmail:
-		'We’ve sent you a temporary verification code. Please check your inbox.',
+		'We’ve sent you a temporary verification code. Please check your inbox in a separate window.',
 	securityText:
 		'For your security, the verification code will expire in 30 minutes.',
 	passcodeInputLabel: 'Verification code',
@@ -193,7 +193,7 @@ export const IframedPasscodeEmailSent = ({
 			{email ? (
 				<MainBodyText>
 					{text.sentTextWithEmail} <strong>{email}</strong>. Please check your
-					inbox.
+					inbox in a separate window.
 				</MainBodyText>
 			) : (
 				<MainBodyText>{text.sentTextWithoutEmail}</MainBodyText>

--- a/src/client/pages/PasscodeEmailSent.tsx
+++ b/src/client/pages/PasscodeEmailSent.tsx
@@ -44,7 +44,7 @@ const getText = (textType: TextType): Text => {
 				successOverride: 'Email with verification code sent',
 				sentTextWithEmail: 'We’ve sent a temporary verification code to',
 				sentTextWithoutEmail:
-					'We’ve sent you a temporary verification code. Please check your inbox.',
+					'We’ve sent you a temporary verification code. Please check your inbox in a separate window.',
 				securityText:
 					'For your security, the verification code will expire in 30 minutes.',
 				passcodeInputLabel: 'Verification code',
@@ -57,7 +57,7 @@ const getText = (textType: TextType): Text => {
 				sentTextWithEmail:
 					'For security reasons we need you to change your password. We’ve sent a 6-digit verification code to',
 				sentTextWithoutEmail:
-					'For security reasons we need you to change your password. We’ve sent you a 6-digit verification code. Please check your inbox.',
+					'For security reasons we need you to change your password. We’ve sent you a 6-digit verification code. Please check your inbox in a separate window.',
 				securityText: 'For your security, the code will expire in 30 minutes.',
 				passcodeInputLabel: 'Verification code',
 				submitButtonText: 'Submit verification code',
@@ -69,7 +69,7 @@ const getText = (textType: TextType): Text => {
 				successOverride: 'Email with one time code sent',
 				sentTextWithEmail: 'We’ve sent a 6-digit code to',
 				sentTextWithoutEmail:
-					'We’ve sent you a 6-digit code. Please check your inbox.',
+					'We’ve sent you a 6-digit code. Please check your inbox in a separate window.',
 				securityText: 'For your security, the code will expire in 30 minutes.',
 				passcodeInputLabel: 'One-time code',
 				submitButtonText: 'Submit one-time code',


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How has this change been tested?

<!-- For example, have you deployed your branch to `CODE` and tested certain functionality or is unit testing sufficent for this change? If you'd like help testing your changes as part of the PR review process then mention that explicitly here. -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
