### PR TITLE
Passcode sent wording change

### DIFF
--- a/src/client/pages/IframedPasscodeEmailSent.tsx
+++ b/src/client/pages/IframedPasscodeEmailSent.tsx
@@ -38,7 +38,7 @@ const text: Text = {
 	title: 'Enter your code',
 	sentTextWithEmail: 'We’ve sent a temporary verification code to',
 	sentTextWithoutEmail:
-		'We’ve sent you a temporary verification code. Please check your inbox.',
+		'We’ve sent you a temporary verification code. Please check your inbox in a separate window.',
 	securityText:
 		'For your security, the verification code will expire in 30 minutes.',
 	passcodeInputLabel: 'Verification code',
@@ -193,7 +193,7 @@ export const IframedPasscodeEmailSent = ({
 			{email ? (
 				<MainBodyText>
 					{text.sentTextWithEmail} <strong>{email}</strong>. Please check your
-					inbox.
+					inbox in a separate window.
 				</MainBodyText>
 			) : (
 				<MainBodyText>{text.sentTextWithoutEmail}</MainBodyText>

--- a/src/client/pages/PasscodeEmailSent.stories.tsx
+++ b/src/client/pages/PasscodeEmailSent.stories.tsx
@@ -453,3 +453,16 @@ export const WithSignInWithPasswordOption = () => (
 WithSignInWithPasswordOption.story = {
 	name: 'with sign in with password option - signin',
 };
+
+export const WithRequestComingFromApp = () => (
+	<PasscodeEmailSent
+		passcodeAction="#"
+		expiredPage="#"
+		changeEmailPage="#"
+		email="example@theguardian.com"
+		appName="ios_live_app"
+	/>
+);
+WithRequestComingFromApp.story = {
+	name: 'with request coming from app',
+};

--- a/src/client/pages/PasscodeEmailSent.tsx
+++ b/src/client/pages/PasscodeEmailSent.tsx
@@ -21,6 +21,7 @@ type Props = {
 	textType?: TextType;
 	showSignInWithPasswordOption?: boolean;
 	sendAgainTimerInSeconds?: number;
+	appName?: string;
 };
 
 type PasscodeEmailSentProps = EmailSentProps & Props;
@@ -35,7 +36,7 @@ type Text = {
 	submitButtonText: string;
 };
 
-const getText = (textType: TextType): Text => {
+const getText = (textType: TextType, isWeb: boolean): Text => {
 	switch (textType) {
 		case 'verification':
 		case 'signin':
@@ -43,8 +44,7 @@ const getText = (textType: TextType): Text => {
 				title: 'Enter your one-time code',
 				successOverride: 'Email with verification code sent',
 				sentTextWithEmail: 'We’ve sent a temporary verification code to',
-				sentTextWithoutEmail:
-					'We’ve sent you a temporary verification code. Please check your inbox.',
+				sentTextWithoutEmail: `We’ve sent you a temporary verification code. Please check your inbox${isWeb ? ' in a separate window' : ''}.`,
 				securityText:
 					'For your security, the verification code will expire in 30 minutes.',
 				passcodeInputLabel: 'Verification code',
@@ -56,8 +56,7 @@ const getText = (textType: TextType): Text => {
 				successOverride: 'Email with verification code sent',
 				sentTextWithEmail:
 					'For security reasons we need you to change your password. We’ve sent a 6-digit verification code to',
-				sentTextWithoutEmail:
-					'For security reasons we need you to change your password. We’ve sent you a 6-digit verification code. Please check your inbox.',
+				sentTextWithoutEmail: `For security reasons we need you to change your password. We’ve sent you a 6-digit verification code. Please check your inbox${isWeb ? ' in a separate window' : ''}.`,
 				securityText: 'For your security, the code will expire in 30 minutes.',
 				passcodeInputLabel: 'Verification code',
 				submitButtonText: 'Submit verification code',
@@ -68,8 +67,7 @@ const getText = (textType: TextType): Text => {
 				title: 'Enter your one-time code',
 				successOverride: 'Email with one time code sent',
 				sentTextWithEmail: 'We’ve sent a 6-digit code to',
-				sentTextWithoutEmail:
-					'We’ve sent you a 6-digit code. Please check your inbox.',
+				sentTextWithoutEmail: `We’ve sent you a 6-digit code. Please check your inbox${isWeb ? ' in a separate window' : ''}.`,
 				securityText: 'For your security, the code will expire in 30 minutes.',
 				passcodeInputLabel: 'One-time code',
 				submitButtonText: 'Submit one-time code',
@@ -96,13 +94,15 @@ export const PasscodeEmailSent = ({
 	textType = 'generic',
 	showSignInWithPasswordOption,
 	sendAgainTimerInSeconds,
+	appName,
 }: PasscodeEmailSentProps) => {
 	const [recaptchaErrorMessage, setRecaptchaErrorMessage] = useState('');
 	const [recaptchaErrorContext, setRecaptchaErrorContext] =
 		useState<ReactNode>(null);
 	const formRef = useRef<HTMLFormElement>(null);
 
-	const text = getText(textType);
+	const isWebReq = appName === undefined;
+	const text = getText(textType, isWebReq);
 
 	useEffect(() => {
 		// we only want this to run in the browser as window is not
@@ -149,7 +149,7 @@ export const PasscodeEmailSent = ({
 			{email ? (
 				<MainBodyText>
 					{text.sentTextWithEmail} <strong>{email}</strong>. Please check your
-					inbox.
+					inbox{isWebReq ? ' in a separate window' : ''}.
 				</MainBodyText>
 			) : (
 				<MainBodyText>{text.sentTextWithoutEmail}</MainBodyText>

--- a/src/client/pages/PasscodeEmailSentPage.tsx
+++ b/src/client/pages/PasscodeEmailSentPage.tsx
@@ -13,7 +13,8 @@ export const PasscodeEmailSentPage = () => {
 		recaptchaConfig,
 		shortRequestId,
 	} = clientState;
-	const { email, fieldErrors, token, passcodeSendAgainTimer } = pageData;
+	const { email, fieldErrors, token, passcodeSendAgainTimer, appName } =
+		pageData;
 	const { emailSentSuccess } = queryParams;
 	const { error } = globalMessage;
 	const { recaptchaSiteKey } = recaptchaConfig;
@@ -39,6 +40,7 @@ export const PasscodeEmailSentPage = () => {
 			textType="verification"
 			sendAgainTimerInSeconds={passcodeSendAgainTimer}
 			showSignInWithPasswordOption
+			appName={appName}
 		/>
 	);
 };

--- a/src/client/pages/ResetPasswordEmailSentPage.tsx
+++ b/src/client/pages/ResetPasswordEmailSentPage.tsx
@@ -41,6 +41,7 @@ export const ResetPasswordEmailSentPage = () => {
 	const { emailSentSuccess } = queryParams;
 	const { error } = globalMessage;
 	const { recaptchaSiteKey } = recaptchaConfig;
+	const { appName } = pageData;
 
 	const queryString = buildQueryParamsString(queryParams, {
 		emailSentSuccess: true,
@@ -68,6 +69,7 @@ export const ResetPasswordEmailSentPage = () => {
 				noAccountInfo
 				textType="generic"
 				sendAgainTimerInSeconds={passcodeSendAgainTimer}
+				appName={appName}
 			/>
 		);
 	}

--- a/src/server/lib/getAppNameFromRegistrationPlatform.ts
+++ b/src/server/lib/getAppNameFromRegistrationPlatform.ts
@@ -1,0 +1,11 @@
+import { getRegistrationPlatform } from '@/server/lib/registrationPlatform';
+import { getAppName, isAppLabel } from '@/shared/lib/appNameUtils';
+
+export const getAppNameFromRegistrationPlatform = async (
+	appClientId: string | undefined,
+) => {
+	const registrationPlatform = await getRegistrationPlatform(appClientId);
+	return isAppLabel(registrationPlatform)
+		? getAppName(registrationPlatform)
+		: undefined;
+};

--- a/src/server/routes/passcode.ts
+++ b/src/server/routes/passcode.ts
@@ -17,8 +17,9 @@ import { getErrorMessageFromQueryParams } from './signIn';
 import { registerPasscodeHandler } from './register';
 import handleRecaptcha from '../lib/recaptcha';
 import { JOBS_TOS_URI } from '@/shared/model/Configuration';
+import { getAppNameFromRegistrationPlatform } from '@/server/lib/getAppNameFromRegistrationPlatform';
 
-router.get('/passcode', (req: Request, res: ResponseWithRequestState) => {
+router.get('/passcode', async (req: Request, res: ResponseWithRequestState) => {
 	res.set('Cache-Control', 'no-store');
 	const state = res.locals;
 	const encrypedCookieState = readEncryptedStateCookie(req);
@@ -108,6 +109,10 @@ router.get('/passcode', (req: Request, res: ResponseWithRequestState) => {
 		}
 
 		if (!encrypedCookieState.passcodeUsed) {
+			const appName = await getAppNameFromRegistrationPlatform(
+				res.locals.queryParams.appClientId,
+			);
+
 			const html = renderer('/passcode', {
 				requestState: mergeRequestState(state, {
 					pageData: {
@@ -115,6 +120,7 @@ router.get('/passcode', (req: Request, res: ResponseWithRequestState) => {
 						timeUntilTokenExpiry: convertExpiresAtToExpiryTimeInMs(
 							encrypedCookieState.stateHandleExpiresAt,
 						),
+						appName,
 					},
 					queryParams: {
 						...res.locals.queryParams,

--- a/src/server/routes/resetPassword.ts
+++ b/src/server/routes/resetPassword.ts
@@ -27,6 +27,7 @@ import { forgotPassword } from '@/server/lib/okta/api/users';
 import { buildUrlWithQueryParams } from '@/shared/lib/routeUtils';
 import { GenericErrors, PasscodeErrors } from '@/shared/model/Errors';
 import { logger } from '@/server/lib/serverSideLogger';
+import { getAppNameFromRegistrationPlatform } from '@/server/lib/getAppNameFromRegistrationPlatform';
 
 /**
  * Helper method to determine if a global error should show on the reset password page
@@ -83,11 +84,16 @@ router.post(
 // reset password email sent page
 router.get(
 	'/reset-password/email-sent',
-	(req: Request, res: ResponseWithRequestState) => {
+	async (req: Request, res: ResponseWithRequestState) => {
+		const appName = await getAppNameFromRegistrationPlatform(
+			res.locals.queryParams.appClientId,
+		);
+
 		const html = renderer('/reset-password/email-sent', {
 			pageTitle: 'Check Your Inbox',
 			requestState: mergeRequestState(res.locals, {
 				pageData: {
+					appName,
 					email: readEmailCookie(req),
 					resendEmailAction: '/reset-password',
 					changeEmailPage: '/reset-password',

--- a/src/shared/model/QueryParams.ts
+++ b/src/shared/model/QueryParams.ts
@@ -38,7 +38,7 @@ export interface PersistableQueryParams
 	extends TrackingQueryParams, StringifiableRecord {
 	returnUrl: string;
 	clientId?: ValidClientId;
-	// This is the fromURI query parameter from Otka authorization code flow
+	// This is the fromURI query parameter from Okta authorization code flow
 	// that we intercept in fastly. We can send a user back to this uri
 	// to complete the authorization code flow for that application
 	fromURI?: string;


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
Changes the copy of the passcode sent page to "Please check your inbox in a separate window" when user triggers this flow on the web. 

## Why?
Our less tech-savvy users sometimes try to retrieve their passcode by going to their email in the same window as the passcode page, and lose the page and repeat the flow.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## Testing

|                     | Before | After |
|---------------------|--------|-------|
| Sign In             | <img width="454" height="346" alt="image" src="https://github.com/user-attachments/assets/9ab855b1-d097-43f3-a567-009cd88ef160" /> | <img width="513" height="393" alt="image" src="https://github.com/user-attachments/assets/e1dbae3e-6fba-49d0-b584-523ce1a4b6ab" /> |
| Reset password      | <img width="435" height="280" alt="image" src="https://github.com/user-attachments/assets/847f0dc7-73d4-48b0-bac8-bbe7d29f0898" /> | <img width="493" height="315" alt="image" src="https://github.com/user-attachments/assets/dee0ef52-cf5e-468c-a0f5-617f1f3f7b47" /> |
| Send passcode again | <img width="454" height="346" alt="image" src="https://github.com/user-attachments/assets/9ab855b1-d097-43f3-a567-009cd88ef160" /> | <img width="494" height="389" alt="image" src="https://github.com/user-attachments/assets/d794ee09-2c7e-49d9-bd52-c5c77ebdd827" /> |


<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

