### PR TITLE
feat: Add alarms for newsletter email signup inactivity

### DIFF
--- a/cdk/lib/__snapshots__/identity-gateway.test.ts.snap
+++ b/cdk/lib/__snapshots__/identity-gateway.test.ts.snap
@@ -46,6 +46,7 @@ exports[`The IdentityGateway stack matches the snapshot 1`] = `
       "GuAlarm",
       "GuAlarm",
       "GuAlarm",
+      "GuAlarm",
       "GuRole",
     ],
     "gu:cdk:version": "TEST",
@@ -1212,6 +1213,75 @@ exports[`The IdentityGateway stack matches the snapshot 1`] = `
         "ToPort": 9233,
       },
       "Type": "AWS::EC2::SecurityGroupEgress",
+    },
+    "NewsletterSignupInactivityAlarm79FF2B1A": {
+      "Properties": {
+        "ActionsEnabled": false,
+        "AlarmActions": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:aws:sns:eu-west-1:",
+                {
+                  "Ref": "AWS::AccountId",
+                },
+                ":",
+                {
+                  "Fn::GetAtt": [
+                    "IdentityGatewayAlarmTopicEEA18544",
+                    "TopicName",
+                  ],
+                },
+              ],
+            ],
+          },
+        ],
+        "AlarmDescription": "No one has successfully signed up a newsletter in the last 6 hours.",
+        "AlarmName": "URGENT 9-5 - identity-gateway TEST has had no successful newsletter signups in the last 6 hours - CDK",
+        "ComparisonOperator": "LessThanThreshold",
+        "Dimensions": [
+          {
+            "Name": "ApiMode",
+            "Value": "identity-gateway",
+          },
+          {
+            "Name": "Stage",
+            "Value": "TEST",
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "InsufficientDataActions": [
+          {
+            "Ref": "IdentityGatewayAlarmTopicEEA18544",
+          },
+        ],
+        "MetricName": "ConsentToken::Success",
+        "Namespace": "Gateway",
+        "Period": 21600,
+        "Statistic": "Sum",
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/gateway",
+          },
+          {
+            "Key": "Stack",
+            "Value": "identity",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+        "Threshold": 1,
+        "Unit": "Count",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
     },
     "OAuthApplicationCallbackInactivityAlarm00589919": {
       "Properties": {

--- a/cdk/lib/identity-gateway.ts
+++ b/cdk/lib/identity-gateway.ts
@@ -529,6 +529,30 @@ systemctl start ${app}
 		});
 		unsubscribeAllInactivityAlarm.addInsufficientDataAction(new SnsAction(alarmTopic));
 
+
+		const newsletterSignupInactivityAlarm = new GuAlarm(this, 'NewsletterSignupInactivityAlarm', {
+			snsTopicName: alarmTopic.topicName,
+			alarmName: `${alarmPriorities.P2} - ${app} ${stage} has had no successful newsletter signups in the last 6 hours - CDK`,
+			alarmDescription: 'No one has successfully signed up a newsletter in the last 6 hours.',
+			metric: new Metric({
+				namespace: 'Gateway',
+				metricName: 'ConsentToken::Success',
+				dimensionsMap: {
+					Stage: stage,
+					ApiMode: app
+				},
+				period: Duration.hours(6),
+				statistic: 'Sum',
+				unit: Unit.COUNT
+			}),
+			comparisonOperator: ComparisonOperator.LESS_THAN_THRESHOLD,
+			threshold: 1,
+			evaluationPeriods: 1,
+			app,
+			actionsEnabled: stage === 'PROD'
+		});
+		newsletterSignupInactivityAlarm.addInsufficientDataAction(new SnsAction(alarmTopic));
+
 		// Allow Github Actions to send use SES to send emails from Playwright
 		if (['TEST', 'CODE'].includes(stage)) {
 			new GuRole(this, 'GithubSESSendEmailRole', {


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Adds an inactivity alarm for our newsletter token signup route. This is the route that is used whenever a user is sent an email to verify their newsletter subscription, and then clicks the link to confirm their subscription.

Last week we had an incident where users were seeing a "Link Expired" error due to a bug in Identity API that went amiss as it did not trigger any alarms.

I've picked a window of 6 hours, looking at the incident period this would definitely have triggered the alarm. Unfortunately this route does not get much traffic, and is a bit sporadic, so its somewhat hard to have a more precisce window.

## How has this change been tested?

Deployed to CODE