### PR TITLE
Add regionalised newsletters page in News App sign in flow

### DIFF
--- a/src/client/pages/NewAccountReviewPage.tsx
+++ b/src/client/pages/NewAccountReviewPage.tsx
@@ -9,7 +9,6 @@ export const NewAccountReviewPage = () => {
 
 	const nextPage = getNextWelcomeFlowPage({
 		geolocation: pageData.geolocation,
-		fromURI: queryParams.fromURI,
 		returnUrl: queryParams.returnUrl,
 		queryParams,
 	});

--- a/src/client/pages/NewAccountReviewPage.tsx
+++ b/src/client/pages/NewAccountReviewPage.tsx
@@ -6,11 +6,14 @@ import { getNextWelcomeFlowPage } from '@/shared/lib/welcome';
 export const NewAccountReviewPage = () => {
 	const clientState = useClientState();
 	const { pageData = {}, queryParams, shortRequestId } = clientState;
+	const { appName } = pageData;
 
 	const nextPage = getNextWelcomeFlowPage({
 		geolocation: pageData.geolocation,
+		fromURI: queryParams.fromURI,
 		returnUrl: queryParams.returnUrl,
 		queryParams,
+		appName,
 	});
 
 	return (

--- a/src/server/routes/welcome.ts
+++ b/src/server/routes/welcome.ts
@@ -371,7 +371,7 @@ router.post(
 				addQueryParamsToUntypedPath(signInPageUrl, state.queryParams),
 			);
 		}
-		const { returnUrl } = state.queryParams;
+		const { returnUrl, fromURI } = state.queryParams;
 
 		try {
 			const userNewsletterSubscriptions = await getUserNewsletterSubscriptions({
@@ -421,7 +421,7 @@ router.post(
 			trackMetric('NewAccountNewslettersSubmit::Failure');
 		} finally {
 			// eslint-disable-next-line no-unsafe-finally -- we want to redirect and return regardless of any throws
-			return res.redirect(303, returnUrl);
+			return res.redirect(303, fromURI ?? returnUrl);
 		}
 	},
 );

--- a/src/server/routes/welcome.ts
+++ b/src/server/routes/welcome.ts
@@ -372,6 +372,7 @@ router.post(
 			);
 		}
 		const { returnUrl, fromURI } = state.queryParams;
+		const { appName } = state.pageData;
 
 		try {
 			const userNewsletterSubscriptions = await getUserNewsletterSubscriptions({
@@ -420,8 +421,11 @@ router.post(
 			logger.error(`${req.method} ${req.originalUrl}  Error`, error);
 			trackMetric('NewAccountNewslettersSubmit::Failure');
 		} finally {
+			const redirectUrl =
+				fromURI && appName === 'Guardian' ? fromURI : returnUrl;
+
 			// eslint-disable-next-line no-unsafe-finally -- we want to redirect and return regardless of any throws
-			return res.redirect(303, fromURI ?? returnUrl);
+			return res.redirect(303, redirectUrl);
 		}
 	},
 );

--- a/src/shared/lib/welcome.ts
+++ b/src/shared/lib/welcome.ts
@@ -2,6 +2,7 @@ import { addQueryParamsToPath } from '@/shared/lib/queryParams';
 import { GeoLocation } from '@/shared/model/Geolocation';
 import { QueryParams } from '@/shared/model/QueryParams';
 import { JOBS_TOS_URI } from '../model/Configuration';
+import { AppName } from '@/shared/lib/appNameUtils';
 
 /**
  * Returns the next page in the welcome flow based on the user's geolocation
@@ -11,17 +12,25 @@ import { JOBS_TOS_URI } from '../model/Configuration';
  */
 export const getNextWelcomeFlowPage = ({
 	geolocation,
+	fromURI,
 	returnUrl,
 	queryParams,
+	appName,
 }: {
 	geolocation?: GeoLocation;
+	fromURI?: string;
 	returnUrl: string;
 	queryParams: QueryParams;
+	appName?: AppName;
 }): string => {
 	// Jobs users need to accept additional Jobs terms and conditions
 	// and submit their first and last name.
 	if (queryParams.clientId === 'jobs') {
 		return addQueryParamsToPath(JOBS_TOS_URI, queryParams);
+	}
+
+	if (fromURI && appName !== 'Guardian') {
+		return fromURI;
 	}
 
 	return geolocation

--- a/src/shared/lib/welcome.ts
+++ b/src/shared/lib/welcome.ts
@@ -11,12 +11,10 @@ import { JOBS_TOS_URI } from '../model/Configuration';
  */
 export const getNextWelcomeFlowPage = ({
 	geolocation,
-	fromURI,
 	returnUrl,
 	queryParams,
 }: {
 	geolocation?: GeoLocation;
-	fromURI?: string;
 	returnUrl: string;
 	queryParams: QueryParams;
 }): string => {
@@ -26,20 +24,7 @@ export const getNextWelcomeFlowPage = ({
 		return addQueryParamsToPath(JOBS_TOS_URI, queryParams);
 	}
 
-	// if there is a fromURI, we need to complete the oauth flow by redirecting to it
-	if (fromURI) {
-		return fromURI;
-	}
-
-	// Otherwise (web), we select based on geolocation.
-	switch (geolocation) {
-		case 'US':
-		case 'AU':
-		case 'GB':
-		case 'ROW':
-		case 'EU':
-			return addQueryParamsToPath('/welcome/newsletters', queryParams);
-		default:
-			return returnUrl;
-	}
+	return geolocation
+		? addQueryParamsToPath('/welcome/newsletters', queryParams)
+		: returnUrl;
 };


### PR DESCRIPTION
## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Adds the regionalised newsletters page to News App create account flow. We now see the newsletters page after the account has been created successfully.

## How has this change been tested?

Tested in CODE using the debug build of the Android app.

## Images

### News App

| Before | <img width="527" height="1188" alt="image" src="https://github.com/user-attachments/assets/1180987b-92ce-4ceb-8fde-6d58b1fee61c" /> |  |
|--------|---|---|
| After  | <img width="527" height="1188" alt="image" src="https://github.com/user-attachments/assets/a5d58839-b4c9-4e4d-aa0d-49b35bde1903" /> | <img width="527" height="1191" alt="image" src="https://github.com/user-attachments/assets/5682a69d-37c2-48c4-8292-2f2cbd378df9" /> |


### Feast App

No regionalised newsletters page is added

| Before | <img width="300" alt="image" src="https://github.com/user-attachments/assets/412c41e8-ffd6-4323-b198-d84b467bcb95" /> 
|--------|---|
| After  | <img width="300" alt="image" src="https://github.com/user-attachments/assets/fc562c7e-2dba-4204-a2ac-da5a902697c1" /> 


