### PR TITLE
chore: Update copy on Guardian Jobs GRS page

### DIFF
--- a/playwright/tests/e2e/new_account_review.spec.ts
+++ b/playwright/tests/e2e/new_account_review.spec.ts
@@ -108,9 +108,7 @@ test.describe('New account newsletters page', () => {
 		// jobs T&C page
 		await expect(page).toHaveURL(new RegExp(escapeRegExp(JOBS_TOS_URI)));
 		await expect(
-			page.getByText(
-				'Click ‘continue’ to automatically use your existing Guardian account to sign in with Guardian Jobs',
-			),
+			page.getByText('By activating your guardian jobs account'),
 		).toBeVisible();
 
 		await page.locator('input[name=firstName]').fill(id);

--- a/playwright/tests/e2e/registration_1.spec.ts
+++ b/playwright/tests/e2e/registration_1.spec.ts
@@ -190,9 +190,7 @@ test.describe('Registration flow - Split 1/4', () => {
 			// jobs T&C page
 			await expect(page).toHaveURL(new RegExp(escapeRegExp(JOBS_TOS_URI)));
 			await expect(
-				page.getByText(
-					'Click ‘continue’ to automatically use your existing Guardian account to sign in with Guardian Jobs',
-				),
+				page.getByText('By activating your guardian jobs account'),
 			).toBeVisible();
 
 			await page.locator('input[name=firstName]').fill(id);

--- a/src/client/pages/JobsTermsAccept.tsx
+++ b/src/client/pages/JobsTermsAccept.tsx
@@ -6,7 +6,6 @@ import {
 	neutral,
 	remSpace,
 	textSans15,
-	textSansBold15,
 	until,
 } from '@guardian/source/foundations';
 import ThemedLink from '@/client/components/ThemedLink';
@@ -44,10 +43,6 @@ const text = css`
 	margin: 0;
 	${textSans15}
 	color: var(--color-text);
-`;
-
-const leadText = css`
-	${textSansBold15}
 `;
 
 const textSpacing = css`
@@ -142,26 +137,6 @@ export const JobsTermsAccept: React.FC<JobsTermsAcceptProps> = ({
 				</>
 			) : (
 				<>
-					<MainBodyText cssOverrides={leadText}>
-						Click &lsquo;continue&rsquo; to automatically use your existing
-						Guardian account to sign in with Guardian&nbsp;Jobs.
-					</MainBodyText>
-					<MainBodyText>
-						By activating your Guardian&nbsp;Jobs account you will receive a
-						welcome email detailing the range of career-enhancing features that
-						can be set up on our jobs site. These include:
-					</MainBodyText>
-					<ul css={[text, listBullets]}>
-						<li>
-							Creating a job alert and receiving relevant jobs straight to your
-							inbox
-						</li>
-						<li>
-							Shortlisting jobs that interest you so you can access them later
-							on different devices
-						</li>
-						<li>Uploading your CV and let employers find you</li>
-					</ul>
 					<MainForm
 						submitButtonText="Continue"
 						hasJobsTerms={true}
@@ -176,6 +151,16 @@ export const JobsTermsAccept: React.FC<JobsTermsAcceptProps> = ({
 							firstName={firstName}
 							secondName={secondName}
 						/>
+						<MainBodyText>
+							By activating your Guardian&nbsp;Jobs account you will receive a
+							welcome email detailing the range of career-enhancing features
+							that can be set up on our jobs site. These include:
+						</MainBodyText>
+						<ul css={[text, listBullets]}>
+							<li>Getting job alerts straight to your inbox</li>
+							<li>Shortlisting jobs that interest you</li>
+							<li>Uploading your CV and letting employers find you</li>
+						</ul>
 					</MainForm>
 					<MainBodyText>
 						Or <ThemedLink href={'/signout'}>sign out and continue</ThemedLink>


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Updates the copy on the Guardian Jobs T&Cs page.

| Before | After |
|--------|--------|
| <img width="1908" height="2271" alt="Screen Shot 2026-05-21 at 10 11 21" src="https://github.com/user-attachments/assets/102bcdf3-3abd-49f2-a797-8c13dc0dacbe" /> | <img width="1908" height="2271" alt="Screen Shot 2026-05-21 at 10 10 49" src="https://github.com/user-attachments/assets/01c2e7a2-40e5-4b99-af8c-54abc130f172" /> | 



## How has this change been tested?

Ran locally and created a new Guardian Jobs account.