### PR TITLE
Add First Thing newsletter to US Newsletter Perk Page

### DIFF
--- a/playwright/tests/e2e/registration_newsletter.spec.ts
+++ b/playwright/tests/e2e/registration_newsletter.spec.ts
@@ -9,7 +9,7 @@ const RegistrationNewsletterDescriptions = {
 	auBundle:
 		"Get an exclusive, curated view of the week's best Guardian journalism from editor-in-chief Katharine Viner, and the local view from Guardian Australia's editors.",
 	usBundle:
-		"Get an exclusive, curated view of the week's best Guardian journalism from editor-in-chief Katharine Viner and more on the latest news from the US.",
+		'Start your day with the most important news from the US and around the world. On Saturdays, you’ll get an exclusive email from Katharine Viner, the Guardian’s editor-in-chief, highlighting the best journalism from our global newsroom',
 };
 
 // Geolocation codes
@@ -143,8 +143,10 @@ test.describe('Saturday Edition Geolocation', () => {
 			await route.continue({ headers });
 		});
 		await page.goto(`/register/email`);
-		await expect(page.getByText('Saturday Edition')).not.toBeVisible();
-		await expect(page.getByText('Weekend newsletters')).toBeVisible();
+		await expect(
+			page.getByText('First Thing and Saturday Edition newsletters'),
+		).toBeVisible();
+		await expect(page.getByText('Weekend newsletters')).not.toBeVisible();
 		await expect(
 			page.getByText(RegistrationNewsletterDescriptions.usBundle),
 		).toBeVisible();
@@ -162,8 +164,10 @@ test.describe('Saturday Edition Geolocation', () => {
 		await page.locator('input[name=password]').fill(finalPassword);
 		await page.locator('[data-cy="main-form-submit-button"]').click();
 		await expect(page).toHaveURL(/\/welcome\/google/);
-		await expect(page.getByText('Saturday Edition')).not.toBeVisible();
-		await expect(page.getByText('Weekend newsletters')).toBeVisible();
+		await expect(
+			page.getByText('First Thing and Saturday Edition newsletters'),
+		).toBeVisible();
+		await expect(page.getByText('Weekend newsletters')).not.toBeVisible();
 		await expect(
 			page.getByText(RegistrationNewsletterDescriptions.usBundle),
 		).toBeVisible();

--- a/src/shared/model/Newsletter.ts
+++ b/src/shared/model/Newsletter.ts
@@ -40,6 +40,7 @@ export const Newsletters = {
 	FEAST: '6002',
 	WEEKEND_MAIL_AU: '6043',
 	WEEKEND_US: '6044',
+	FIRST_THING: '4300',
 	// Registration newsletter bundles (parsed to individual newsletters in the backend)
 	AU_BUNDLE: 'auBundle',
 	US_BUNDLE: 'usBundle',
@@ -110,9 +111,9 @@ export const RegistrationNewslettersFormFieldsMap: Record<
 	},
 	usBundle: {
 		id: Newsletters.US_BUNDLE,
-		label: 'Weekend newsletters',
+		label: 'First Thing and Saturday Edition newsletters',
 		context:
-			"Get an exclusive, curated view of the week's best Guardian journalism from editor-in-chief Katharine Viner and more on the latest news from the US.",
+			'Start your day with the most important news from the US and around the world. On Saturdays, you’ll get an exclusive email from Katharine Viner, the Guardian’s editor-in-chief, highlighting the best journalism from our global newsroom.',
 	},
 };
 
@@ -121,7 +122,7 @@ export const newsletterBundleToIndividualNewsletters = (
 ): Literal<typeof Newsletters>[] => {
 	switch (bundleId) {
 		case Newsletters.US_BUNDLE:
-			return [Newsletters.SATURDAY_EDITION, Newsletters.WEEKEND_US];
+			return [Newsletters.SATURDAY_EDITION, Newsletters.FIRST_THING];
 		case Newsletters.AU_BUNDLE:
 			return [Newsletters.SATURDAY_EDITION, Newsletters.WEEKEND_MAIL_AU];
 		default:


### PR DESCRIPTION

<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
* Modifies copy of perks page in US sign in journey
* Replaces Weekend US with First Thing newsletter in the US bundle. Users will now receive Saturday Edition (6031) and First Thing (4300)

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## Deployed to CODE

<!-- For example, have you deployed your branch to `CODE` and tested certain functionality or is unit testing sufficent for this change? If you'd like help testing your changes as part of the PR review process then mention that explicitly here. -->

## Images

| Before | After |
|--------|-------|
|  <img width="1196" height="1028" alt="image" src="https://github.com/user-attachments/assets/88c70b7d-2d64-4294-bf69-8a20a8c5ac71" /> |  <img width="1184" height="1006" alt="image" src="https://github.com/user-attachments/assets/d603d338-701d-472c-aaf1-a745817f37b2" /> |
|  <img width="857" height="178" alt="image" src="https://github.com/user-attachments/assets/c57e1f90-2216-44e2-b4d2-7f2b16276437" />  | <img width="849" height="170" alt="image" src="https://github.com/user-attachments/assets/0b1c8bf8-d791-449a-b932-017c021faffd" /> |

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

