### PR TITLE
Change FromEmailAddress to no-reply

### DIFF
--- a/src/email/lib/send.ts
+++ b/src/email/lib/send.ts
@@ -52,7 +52,7 @@ export const send = async ({
 		Destination: {
 			ToAddresses: [to],
 		},
-		FromEmailAddress: 'The Guardian <registration-reply@theguardian.com>',
+		FromEmailAddress: 'The Guardian <no-reply@profile.theguardian.com>',
 	};
 
 	const result = await ses.send(new SendEmailCommand(params));


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
This PR migrates the Okta Classic flow email to use the new `no-reply@profile.theguardian.com` instead of the old `registraiton-reply@theguardian.com`

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How has this change been tested?
Tested by deploying to CODE and registering an email with `?useOktaClassic=true` appended.

