### PR TITLE
feat: Allow specifying first and last name during registration/signin

### DIFF
--- a/playwright/tests/e2e/sign_in_passcode_active_user.spec.ts
+++ b/playwright/tests/e2e/sign_in_passcode_active_user.spec.ts
@@ -134,7 +134,7 @@ test.describe('Sign In flow, with passcode', () => {
 			expect(updatedUser.profile.emailValidated).toBe(true);
 		});
 
-		test('should sign in with passcode - preserve lastName & firstName', async ({
+		test('should sign in with passcode - preserve firstName & lastName', async ({
 			request,
 			page,
 		}) => {
@@ -161,7 +161,7 @@ test.describe('Sign In flow, with passcode', () => {
 
 			await page.locator('input[name=email]').fill(emailAddress);
 
-			const timeRequestWasMade = new Date();
+			const passcodeRequestTime = new Date();
 			await page.locator('[data-cy="main-form-submit-button"]').click();
 
 			await expect(page).toHaveURL(/\/passcode/);
@@ -169,7 +169,7 @@ test.describe('Sign In flow, with passcode', () => {
 
 			const { codes } = await checkForEmailAndGetDetails(
 				emailAddress,
-				timeRequestWasMade,
+				passcodeRequestTime,
 			);
 
 			const code = codes?.[0].value;

--- a/playwright/tests/e2e/sign_in_passcode_active_user.spec.ts
+++ b/playwright/tests/e2e/sign_in_passcode_active_user.spec.ts
@@ -134,6 +134,54 @@ test.describe('Sign In flow, with passcode', () => {
 			expect(updatedUser.profile.emailValidated).toBe(true);
 		});
 
+		test('should sign in with passcode - preserve lastName & firstName', async ({
+			request,
+			page,
+		}) => {
+			const { emailAddress } = await createTestUser(request, {
+				isUserEmailValidated: true,
+			});
+
+			await page.goto(`/signin?appClientId=${appClientId}`);
+			const element = await page.locator('input[name=email]').elementHandle();
+
+			// TODO: Use real form elements once implemented.
+			await element?.evaluate((element) => {
+				/* eslint-disable functional/immutable-data */
+				const firstNameInput = document.createElement('input');
+				firstNameInput.name = 'firstName';
+				firstNameInput.value = 'TestFirstName';
+				element.append(firstNameInput);
+				const secondNameInput = document.createElement('input');
+				secondNameInput.name = 'secondName';
+				secondNameInput.value = 'TestLastName';
+				element.append(secondNameInput);
+				/* eslint-enable functional/immutable-data */
+			});
+
+			await page.locator('input[name=email]').fill(emailAddress);
+
+			const timeRequestWasMade = new Date();
+			await page.locator('[data-cy="main-form-submit-button"]').click();
+
+			await expect(page).toHaveURL(/\/passcode/);
+			await expect(page.getByText('Enter your one-time code')).toBeVisible();
+
+			const { codes } = await checkForEmailAndGetDetails(
+				emailAddress,
+				timeRequestWasMade,
+			);
+
+			const code = codes?.[0].value;
+			await page.locator('input[name=code]').fill(code!);
+
+			await expect(page).toHaveURL(/\/welcome\/existing/);
+
+			const updatedUser = await getTestOktaUser(request, emailAddress);
+			expect(updatedUser.profile.firstName).toBe('TestFirstName');
+			expect(updatedUser.profile.lastName).toBe('TestLastName');
+		});
+
 		test('selects password option to sign in from initial sign in page', async ({
 			request,
 			page,

--- a/src/server/controllers/signInControllers.ts
+++ b/src/server/controllers/signInControllers.ts
@@ -201,7 +201,7 @@ export const oktaIdxApiSignInPasscodeController = async ({
 	loopDetectionFlag?: boolean;
 	confirmationPagePath?: StartIdxFlowParams['authorizationCodeFlowOptions']['confirmationPagePath'];
 }): Promise<void> => {
-	const { email = '' } = req.body;
+	const { email = '', firstName, secondName } = req.body;
 	const referrerUrl = new URL(req.body.ref);
 	const referrerPath = referrerUrl.pathname;
 	const emailSentPage = referrerPath.includes('/iframed')
@@ -249,6 +249,8 @@ export const oktaIdxApiSignInPasscodeController = async ({
 						extraData: {
 							flow: 'sign-in-passcode',
 							appLabel: res.locals.appLabel,
+							firstName,
+							lastName: secondName,
 						},
 					},
 				});

--- a/src/server/lib/okta/idx/interact.ts
+++ b/src/server/lib/okta/idx/interact.ts
@@ -95,6 +95,8 @@ export const interact = async (
 				codeVerifier,
 				flow: extraData?.flow,
 				appLabel: extraData?.appLabel,
+				firstName: extraData?.firstName,
+				lastName: extraData?.lastName,
 			},
 		);
 		setAuthorizationStateCookie(authState, res);

--- a/src/server/lib/okta/openid-connect.ts
+++ b/src/server/lib/okta/openid-connect.ts
@@ -50,6 +50,8 @@ export interface AuthorizationState {
 		// used to track the flow the user is in for basic metrics/analytics
 		flow?: UserFlow; // password reset, and email verification flows outside of create account
 		appLabel?: string; // used to track the app used to start the flow
+		firstName?: string; // used to persist the first name during the signin flow, so that we can set it after login
+		lastName?: string; // used to persist the last name during the signin flow, so that we can set it after login
 	};
 }
 

--- a/src/server/routes/oauth.ts
+++ b/src/server/routes/oauth.ts
@@ -426,6 +426,16 @@ const authenticationHandler = async (
 			}
 		}
 
+		// Update the users first and last name if they exist in the authState
+		if (authState.data?.firstName || authState.data?.lastName) {
+			await updateUser(sub, {
+				profile: {
+					firstName: authState.data.firstName,
+					lastName: authState.data.lastName,
+				},
+			});
+		}
+
 		// clear any existing oauth application cookies if they exist
 		checkAndDeleteOAuthTokenCookies(req, res);
 

--- a/src/server/routes/oauth.ts
+++ b/src/server/routes/oauth.ts
@@ -428,12 +428,16 @@ const authenticationHandler = async (
 
 		// Update the users first and last name if they exist in the authState
 		if (authState.data?.firstName || authState.data?.lastName) {
-			await updateUser(sub, {
-				profile: {
-					firstName: authState.data.firstName,
-					lastName: authState.data.lastName,
-				},
-			});
+			try {
+				await updateUser(sub, {
+					profile: {
+						firstName: authState.data.firstName,
+						lastName: authState.data.lastName,
+					},
+				});
+			} catch (error) {
+				logger.error('OAuth authentication: failed to update user name', error);
+			}
 		}
 
 		// clear any existing oauth application cookies if they exist

--- a/src/server/routes/register.ts
+++ b/src/server/routes/register.ts
@@ -368,7 +368,12 @@ const oktaIdxCreateAccountOrSignIn = async (
 	req: Request,
 	res: ResponseWithRequestState,
 ) => {
-	const { email = '', isCombinedSigninAndRegisterFlow = false } = req.body;
+	const {
+		email = '',
+		firstName,
+		secondName,
+		isCombinedSigninAndRegisterFlow = false,
+	} = req.body;
 
 	const {
 		queryParams: { appClientId, clientId },
@@ -406,6 +411,8 @@ const oktaIdxCreateAccountOrSignIn = async (
 				extraData: {
 					flow: 'create-account',
 					appLabel: res.locals.appLabel,
+					firstName,
+					lastName: secondName,
 				},
 			},
 			consents,


### PR DESCRIPTION
## What does this change?

Adds 2 fields to the sign-in forms which accept a string value for the users `firstName` and `lastName` properties. At the end of the authorization flow these are then used to update the users Okta profile to set their `firstName` and `lastName` properties.

Note that this is a backend change at the moment, none of our login forms actually include fields for entering these details yet. Eventually we'd like to update the IFramed Sign-in flow to let guest users submit their name when finishing their Guardian account.

## Flow

1. Read the `firstName` and `lastName` fields from the sign-in/registration request.
2. Set `firstName` and `lastName` in the Authorization state cookie.
3. After the user enters their passcode, during the end of the Authorization flow, read the `firstName` and `lastName` cookies from the Authorization state cookie and update the users Okta profile.

Alternatively we could simply set the users first and last name in their Okta profile the moment they submit the login form, however that could potentially allow malicious actors to modify a users first and last name without verifying that they own the account. By pushing it to the end of the authorization flow we can ensure that the user legitimately owns the account.

## How has this change been tested?

Ran locally and modified the HTML of the sign in form to have 2 extra fields for firstName and lastName
