### PR TITLE
fix: Correctly announce "Show password" interactions with screen reader

### DIFF
--- a/src/client/components/PasswordInput.tsx
+++ b/src/client/components/PasswordInput.tsx
@@ -109,9 +109,10 @@ const EyeSymbol = ({
 			type="button"
 			css={buttonStyles}
 			onClick={onClick}
-			title="show or hide password text"
 			data-cy="password-input-eye-button"
-			aria-label="Show password"
+			title={isOpen ? 'Hide password' : 'Show password'}
+			aria-label={isOpen ? 'Hide password' : 'Show password'}
+			aria-pressed={isOpen}
 			onFocus={() => setPasswordButtonIsFocused(true)}
 			onBlur={() => setPasswordButtonIsFocused(false)}
 		>


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Update the "Show password" button to announce its state to screen readers by modifying its `aria-label` and `aria-pressed` state whenever pressed.

## How has this change been tested?

Ran locally.


https://github.com/user-attachments/assets/255a34ba-0137-42da-bd58-a112a1ef6e69

