### PR TITLE
fix: Set correct evaluation periods and thresholds for alarms to make them actually what they say they are.

### DIFF
--- a/cdk/lib/__snapshots__/identity-gateway.test.ts.snap
+++ b/cdk/lib/__snapshots__/identity-gateway.test.ts.snap
@@ -1550,7 +1550,7 @@ exports[`The IdentityGateway stack matches the snapshot 1`] = `
         "AlarmDescription": "No one has successfully registered in the last hour.",
         "AlarmName": "CRITICAL Respond Immediately - identity-gateway TEST has had no new registrations in the last hour - CDK",
         "ComparisonOperator": "LessThanThreshold",
-        "EvaluationPeriods": 1,
+        "EvaluationPeriods": 12,
         "InsufficientDataActions": [
           {
             "Ref": "IdentityGatewayAlarmTopicEEA18544",
@@ -1627,7 +1627,7 @@ exports[`The IdentityGateway stack matches the snapshot 1`] = `
             "Value": "TEST",
           },
         ],
-        "Threshold": 1,
+        "Threshold": 12,
       },
       "Type": "AWS::CloudWatch::Alarm",
     },
@@ -1876,7 +1876,7 @@ exports[`The IdentityGateway stack matches the snapshot 1`] = `
         "AlarmDescription": "No one has successfully signed ins in the last 20 minutes.",
         "AlarmName": "CRITICAL Respond Immediately - identity-gateway TEST has had no new sign-ins in the last 20 minutes - CDK",
         "ComparisonOperator": "LessThanThreshold",
-        "EvaluationPeriods": 1,
+        "EvaluationPeriods": 4,
         "InsufficientDataActions": [
           {
             "Ref": "IdentityGatewayAlarmTopicEEA18544",
@@ -1953,7 +1953,7 @@ exports[`The IdentityGateway stack matches the snapshot 1`] = `
             "Value": "TEST",
           },
         ],
-        "Threshold": 1,
+        "Threshold": 4,
       },
       "Type": "AWS::CloudWatch::Alarm",
     },

--- a/cdk/lib/identity-gateway.ts
+++ b/cdk/lib/identity-gateway.ts
@@ -365,6 +365,7 @@ systemctl start ${app}
 			alarmDescription: 'No one has successfully signed ins in the last 20 minutes.',
 			metric: new MathExpression({
 				expression: 'oktaSignInCount + oktaIdxSignInCount',
+				period: Duration.minutes(5),
 				usingMetrics: {
 					'oktaSignInCount': new Metric({
 						namespace: 'Gateway',
@@ -373,7 +374,6 @@ systemctl start ${app}
 							Stage: stage,
 							ApiMode: app
 						},
-						period: Duration.minutes(20),
 						statistic: 'Sum',
 						unit: Unit.COUNT
 					}),
@@ -384,15 +384,14 @@ systemctl start ${app}
 							Stage: stage,
 							ApiMode: app
 						},
-						period: Duration.minutes(20),
 						statistic: 'Sum',
 						unit: Unit.COUNT
 					})
 				}
 			}),
 			comparisonOperator: ComparisonOperator.LESS_THAN_THRESHOLD,
-			threshold: 1,
-			evaluationPeriods: 1,
+			threshold: 4,
+			evaluationPeriods: 4,
 			app,
 			actionsEnabled: stage === 'PROD'
 		});
@@ -404,6 +403,7 @@ systemctl start ${app}
 			alarmDescription: 'No one has successfully registered in the last hour.',
 			metric: new MathExpression({
 				expression: 'oktaIdxRegistrationCount + oktaRegistrationCount',
+				period: Duration.minutes(5),
 				usingMetrics: {
 					'oktaRegistrationCount': new Metric({
 						namespace: 'Gateway',
@@ -412,7 +412,6 @@ systemctl start ${app}
 							Stage: stage,
 							ApiMode: app
 						},
-						period: Duration.hours(1),
 						statistic: 'Sum',
 						unit: Unit.COUNT
 					}),
@@ -423,15 +422,14 @@ systemctl start ${app}
 							Stage: stage,
 							ApiMode: app
 						},
-						period: Duration.hours(1),
 						statistic: 'Sum',
 						unit: Unit.COUNT
 					})
 				}
 			}),
 			comparisonOperator: ComparisonOperator.LESS_THAN_THRESHOLD,
-			threshold: 1,
-			evaluationPeriods: 1,
+			threshold: 12,
+			evaluationPeriods: 12,
 			app,
 			actionsEnabled: stage === 'PROD'
 		});


### PR DESCRIPTION
## What does this change?

When we migrated to CDK we used the `MathExpression` construct, [which seemingly overrides the Alarm periods to a default value of 5m if not specified](https://docs.aws.amazon.com/cdk/api/v2/python/aws_cdk.aws_cloudwatch/MathExpression.html).

This has caused our long alarms like the registration alarm, which is meant to alert us if theres been no registrations for an hour, to actually only consider 5 minutes instead.

To fix this, we've increased the evaluation periods, rather than the metric period, to match the previous pre-cdk periods. We decided to use evaluation periods, rather than the metric period, to make the alarm more responsive as we might otherwise be waiting longer than an hour depending on when the alarm polls the metrics.

## How has this change been tested?

Deployed to CODE and checked the alarms, the periods and datapoints look good, but obviously hard to tell if it will work in the CODE environment.