### PR TITLE
Remove recaptcha from SOI page

### DIFF
--- a/src/client/pages/NewAccountConsents.tsx
+++ b/src/client/pages/NewAccountConsents.tsx
@@ -46,7 +46,6 @@ const getErrorContext = (pageError?: string) => {
 
 export const NewAccountConsents = ({
 	email,
-	recaptchaSiteKey,
 	queryParams,
 	formError,
 	geolocation,
@@ -81,7 +80,6 @@ export const NewAccountConsents = ({
 					queryParams,
 				)}
 				submitButtonText="Next"
-				recaptchaSiteKey={recaptchaSiteKey}
 				formTrackingName={formTrackingName}
 				disableOnSubmit
 				formErrorMessageFromParent={formError}

--- a/src/client/pages/NewAccountConsentsPage.tsx
+++ b/src/client/pages/NewAccountConsentsPage.tsx
@@ -6,20 +6,17 @@ export const NewAccountConsentsPage = () => {
 	const clientState = useClientState();
 	const {
 		pageData = {},
-		recaptchaConfig,
 		queryParams,
 		shortRequestId,
 		globalMessage = {},
 	} = clientState;
 	const { email, formError, signInOrRegister } = pageData;
-	const { recaptchaSiteKey } = recaptchaConfig;
 	const { error: pageError } = globalMessage;
 
 	return (
 		<NewAccountConsents
 			formError={formError}
 			email={email}
-			recaptchaSiteKey={recaptchaSiteKey}
 			queryParams={queryParams}
 			geolocation={pageData.geolocation}
 			appName={pageData.appName}


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## Why?
We do not require Recaptcha on this page as by this point in the journey, the user has validated they own the email address they have provided.

This is most likely to hit privacy centric users, and users who are using ad-blockers/VPN settings without realising.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How has this change been tested?

Deployed to CODE and checked network tab to make sure there are no recaptcha requests in the SOI page.

## Images

| Before | After |
|--------|-------|
| <img width="2397" height="1048" alt="image" src="https://github.com/user-attachments/assets/59af1777-14b1-4234-9fef-aed3a90c76a0" /> | <img width="2305" height="888" alt="image" src="https://github.com/user-attachments/assets/383bd4cc-f1b9-4cb5-a4ae-57644782c328" /> |


