### PR TITLE
feat: Allow setting `appClientId` to `maj` to indicate secondary user flow

### DIFF
--- a/src/client/layouts/MinimalLayout.tsx
+++ b/src/client/layouts/MinimalLayout.tsx
@@ -30,7 +30,7 @@ import { GatewayErrorSummary } from '@/client/components/GatewayErrorSummary';
 interface MinimalLayoutProps {
 	children?: React.ReactNode;
 	wide?: boolean;
-	pageHeader: string;
+	pageHeader?: string;
 	leadText?: React.ReactNode;
 	imageId?: DecorativeImageId;
 	successOverride?: string;

--- a/src/client/pages/IframedRegisterWithEmail.stories.tsx
+++ b/src/client/pages/IframedRegisterWithEmail.stories.tsx
@@ -25,11 +25,17 @@ Default.story = {
 	name: 'with defaults',
 };
 
-export const Email = (args: RegistrationProps) => (
-	<IframedRegisterWithEmail {...args} email="someone@theguardian.com" />
+export const MultipleAccountJourney = (args: RegistrationProps) => (
+	<IframedRegisterWithEmail
+		{...args}
+		queryParams={{
+			returnUrl: 'https://www.theguardian.com/uk',
+			appClientId: 'maj',
+		}}
+	/>
 );
-Email.story = {
-	name: 'with email',
+MultipleAccountJourney.story = {
+	name: 'with multiple account journey',
 };
 
 export const InvalidRecaptcha = (args: RegistrationProps) => (

--- a/src/client/pages/IframedRegisterWithEmail.tsx
+++ b/src/client/pages/IframedRegisterWithEmail.tsx
@@ -12,6 +12,7 @@ import { SUPPORT_EMAIL } from '@/shared/model/Configuration';
 import { PasscodeErrors } from '@/shared/model/Errors';
 import IframeThemedEmailInput from '../components/IframeThemedEmailInput';
 import { disableAutofillBackground } from '../styles/Shared';
+import { RegistrationConsents } from '../components/RegistrationConsents';
 
 type RegisterWithEmailProps = RegistrationProps & {
 	shortRequestId?: string;
@@ -47,14 +48,19 @@ export const IframedRegisterWithEmail = ({
 	shortRequestId,
 	pageError,
 }: RegisterWithEmailProps) => {
+	const isMultipleAccountFlow = queryParams.appClientId === 'maj';
 	const formTrackingName = 'register-iframed';
 
 	usePageLoadOphanInteraction(formTrackingName);
 
 	return (
 		<MinimalLayout
-			pageHeader="Create your account"
-			leadText="Unlock your premium experience, online and in the app."
+			pageHeader={isMultipleAccountFlow ? undefined : 'Create your account'}
+			leadText={
+				isMultipleAccountFlow
+					? undefined
+					: 'Unlock your premium experience, online and in the app.'
+			}
 			shortRequestId={shortRequestId}
 			errorContext={getErrorContext(pageError)}
 			errorOverride={pageError}
@@ -94,6 +100,7 @@ export const IframedRegisterWithEmail = ({
 						autoComplete="off"
 					/>
 				)}
+				{isMultipleAccountFlow && <RegistrationConsents />}
 			</MainForm>
 		</MinimalLayout>
 	);

--- a/src/client/pages/IframedRegisterWithEmail.tsx
+++ b/src/client/pages/IframedRegisterWithEmail.tsx
@@ -55,10 +55,10 @@ export const IframedRegisterWithEmail = ({
 
 	return (
 		<MinimalLayout
-			pageHeader={isMultipleAccountFlow ? undefined : 'Create your account'}
+			pageHeader="Create your account"
 			leadText={
 				isMultipleAccountFlow
-					? undefined
+					? 'Redeem your invitation and start exploring your full Guardian access.'
 					: 'Unlock your premium experience, online and in the app.'
 			}
 			shortRequestId={shortRequestId}

--- a/src/client/pages/IframedSignIn.stories.tsx
+++ b/src/client/pages/IframedSignIn.stories.tsx
@@ -159,3 +159,17 @@ export const NoSocialButtonsEmail = (args: IframedSignInProps) => (
 NoSocialButtonsEmail.story = {
 	name: 'no social buttons with email',
 };
+
+export const MultipleAccountJourney = (args: IframedSignInProps) => (
+	<IframedSignIn
+		{...args}
+		hideSocialButtons={true}
+		queryParams={{
+			returnUrl: 'https://www.theguardian.com/uk',
+			appClientId: 'maj',
+		}}
+	/>
+);
+MultipleAccountJourney.story = {
+	name: 'multiple account journey',
+};

--- a/src/client/pages/IframedSignIn.tsx
+++ b/src/client/pages/IframedSignIn.tsx
@@ -139,6 +139,7 @@ export const IframedSignIn = ({
 	shortRequestId,
 	hideSocialButtons = false,
 }: IframedSignInProps) => {
+	const isMultipleAccountFlow = queryParams.appClientId === 'maj';
 	const formTrackingName = 'sign-in';
 
 	// The page level error is equivalent to this enum if social signin has been blocked.
@@ -151,8 +152,12 @@ export const IframedSignIn = ({
 		<MinimalLayout
 			errorContext={getErrorContext(pageError, queryParams)}
 			errorOverride={pageError}
-			pageHeader="Sign in to your account"
-			leadText="This unlocks your premium experience, online and in the app."
+			pageHeader={isMultipleAccountFlow ? undefined : 'Sign in to your account'}
+			leadText={
+				isMultipleAccountFlow
+					? undefined
+					: 'This unlocks your premium experience, online and in the app.'
+			}
 			shortRequestId={shortRequestId}
 			overrideTheme="iframe-light"
 		>

--- a/src/client/pages/IframedSignIn.tsx
+++ b/src/client/pages/IframedSignIn.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {
 	extractMessage,
 	GatewayError,
@@ -152,10 +151,10 @@ export const IframedSignIn = ({
 		<MinimalLayout
 			errorContext={getErrorContext(pageError, queryParams)}
 			errorOverride={pageError}
-			pageHeader={isMultipleAccountFlow ? undefined : 'Sign in to your account'}
+			pageHeader="Sign in to your account"
 			leadText={
 				isMultipleAccountFlow
-					? undefined
+					? 'To redeem your invitation and unlock your premium experience, online and in the app.'
 					: 'This unlocks your premium experience, online and in the app.'
 			}
 			shortRequestId={shortRequestId}

--- a/src/server/lib/middleware/helmet.ts
+++ b/src/server/lib/middleware/helmet.ts
@@ -29,7 +29,7 @@ const idapiOrigin = idapiBaseUrl.replace(/https?:\/\/|\/identity-api/g, '');
 const frameAncestors = [
 	stage === 'PROD' && 'https://support.theguardian.com',
 	stage === 'CODE' &&
-		'https://support.code.dev-theguardian.com support.thegulocal.com',
+		'https://support.code.dev-theguardian.com support.thegulocal.com https://support.thegulocal.com',
 	stage === 'DEV' && 'support.thegulocal.com',
 ].filter((element) => !!element) as string[];
 

--- a/src/server/lib/middleware/helmet.ts
+++ b/src/server/lib/middleware/helmet.ts
@@ -29,7 +29,7 @@ const idapiOrigin = idapiBaseUrl.replace(/https?:\/\/|\/identity-api/g, '');
 const frameAncestors = [
 	stage === 'PROD' && 'https://support.theguardian.com',
 	stage === 'CODE' &&
-		'https://support.code.dev-theguardian.com support.thegulocal.com https://support.thegulocal.com',
+		'https://support.code.dev-theguardian.com support.thegulocal.com',
 	stage === 'DEV' && 'support.thegulocal.com',
 ].filter((element) => !!element) as string[];
 
@@ -74,6 +74,7 @@ const helmetConfig: HelmetOptions = {
 		},
 	},
 	crossOriginEmbedderPolicy: false,
+	xFrameOptions: false, // Use CSP frame-ancestors instead of X-Frame-Options
 };
 
 export const helmetMiddleware = helmet(helmetConfig);

--- a/src/server/lib/middleware/helmet.ts
+++ b/src/server/lib/middleware/helmet.ts
@@ -28,8 +28,7 @@ const idapiOrigin = idapiBaseUrl.replace(/https?:\/\/|\/identity-api/g, '');
 // Filter removes any falsey values
 const frameAncestors = [
 	stage === 'PROD' && 'https://support.theguardian.com',
-	stage === 'CODE' &&
-		'https://support.code.dev-theguardian.com support.thegulocal.com',
+	stage === 'CODE' && 'https://support.code.dev-theguardian.com',
 	stage === 'DEV' && 'support.thegulocal.com',
 ].filter((element) => !!element) as string[];
 
@@ -74,7 +73,6 @@ const helmetConfig: HelmetOptions = {
 		},
 	},
 	crossOriginEmbedderPolicy: false,
-	xFrameOptions: false, // Use CSP frame-ancestors instead of X-Frame-Options
 };
 
 export const helmetMiddleware = helmet(helmetConfig);

--- a/src/server/lib/middleware/helmet.ts
+++ b/src/server/lib/middleware/helmet.ts
@@ -28,7 +28,8 @@ const idapiOrigin = idapiBaseUrl.replace(/https?:\/\/|\/identity-api/g, '');
 // Filter removes any falsey values
 const frameAncestors = [
 	stage === 'PROD' && 'https://support.theguardian.com',
-	stage === 'CODE' && 'https://support.code.dev-theguardian.com',
+	stage === 'CODE' &&
+		'https://support.code.dev-theguardian.com support.thegulocal.com',
 	stage === 'DEV' && 'support.thegulocal.com',
 ].filter((element) => !!element) as string[];
 

--- a/src/server/routes/dev.ts
+++ b/src/server/routes/dev.ts
@@ -76,6 +76,8 @@ router.get('/', async (req: Request, res: ResponseWithRequestState) => {
 					<li><a href="/signout">Sign Out</a></li>
 					<li><a href="/delete">Delete Account</a></li>
 					<li><a href="/maintenance">Maintenance</a></li>
+					<li><a href="/iframed/signin">Iframed Sign-in</a> | <a href="/iframed/signin?appClientId=maj">Iframed Sign-in (Multiple Account)</a></li>
+					<li><a href="/iframed/register/email">Iframed Register</a> | <a href="/iframed/register/email?appClientId=maj">Iframed Register (Multiple Account)</a></li>
 				</ul>
 			</body>
 		</html>


### PR DESCRIPTION
## What does this change?

Implements the Sign-In and Sign-In with email flows on the iframe, for use by the support front-end. 

## How has this change been tested?

Tested locally pointing to CODE.

## How can we measure success?

The support front-end can successfully connect to the iframe and get control back when registration is successful.

## Have we considered potential risks?

Nothing comes to mind.

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
