### PR TITLE
Bump @guardian/ophan-tracker-js to 4.0.2

### DIFF
--- a/.github/workflows/playwright-e2e.yml
+++ b/.github/workflows/playwright-e2e.yml
@@ -100,7 +100,6 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           name: build
-          github-token: ${{ github.token }}
       - name: Unzip build
         run: unzip -q build.zip
       - uses: pnpm/action-setup@v6

--- a/.github/workflows/playwright-e2e.yml
+++ b/.github/workflows/playwright-e2e.yml
@@ -100,6 +100,7 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           name: build
+          github-token: ${{ github.token }}
       - name: Unzip build
         run: unzip -q build.zip
       - uses: pnpm/action-setup@v6

--- a/.github/workflows/playwright-mocked.yml
+++ b/.github/workflows/playwright-mocked.yml
@@ -89,6 +89,7 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           name: build
+          github-token: ${{ github.token }}
       - name: Unzip build
         run: unzip -q build.zip
       - uses: pnpm/action-setup@v6

--- a/.github/workflows/playwright-mocked.yml
+++ b/.github/workflows/playwright-mocked.yml
@@ -89,7 +89,6 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           name: build
-          github-token: ${{ github.token }}
       - name: Unzip build
         run: unzip -q build.zip
       - uses: pnpm/action-setup@v6

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
 		"@faire/mjml-react": "4.0.1",
 		"@guardian/ab-core": "10.0.0",
 		"@guardian/libs": "32.0.0",
-		"@guardian/ophan-tracker-js": "4.0.2",
+		"@guardian/ophan-tracker-js": "5.0.0",
 		"@guardian/source": "12.2.1",
 		"@guardian/source-development-kitchen": "28.1.0",
 		"@okta/jwt-verifier": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
 		"@faire/mjml-react": "4.0.1",
 		"@guardian/ab-core": "10.0.0",
 		"@guardian/libs": "32.0.0",
-		"@guardian/ophan-tracker-js": "2.0.4",
+		"@guardian/ophan-tracker-js": "4.0.2",
 		"@guardian/source": "12.2.1",
 		"@guardian/source-development-kitchen": "28.1.0",
 		"@okta/jwt-verifier": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
 		"@faire/mjml-react": "4.0.1",
 		"@guardian/ab-core": "10.0.0",
 		"@guardian/libs": "32.0.0",
-		"@guardian/ophan-tracker-js": "5.0.0",
+		"@guardian/ophan-tracker-js": "4.0.2",
 		"@guardian/source": "12.2.1",
 		"@guardian/source-development-kitchen": "28.1.0",
 		"@okta/jwt-verifier": "4.0.2",

--- a/playwright/fixtures/e2e.ts
+++ b/playwright/fixtures/e2e.ts
@@ -1,0 +1,12 @@
+/* eslint-disable react-hooks/rules-of-hooks -- Playwright calls this fixture callback with a use function */
+import { test as base } from '@playwright/test';
+import { mockClientRecaptcha } from '../helpers/network/recaptcha';
+
+export * from '@playwright/test';
+
+export const test = base.extend({
+	page: async ({ page }, use) => {
+		await mockClientRecaptcha(page);
+		await use(page);
+	},
+});

--- a/playwright/fixtures/mockedApiRequest.ts
+++ b/playwright/fixtures/mockedApiRequest.ts
@@ -4,10 +4,14 @@ import {
 	test as base,
 	request as playwrightRequest,
 	APIRequestContext,
+	Page,
+	BrowserContext,
 } from '@playwright/test';
 
 type CustomFixtures = {
 	mockApi: APIRequestContext;
+	page: Page;
+	context: BrowserContext;
 };
 
 export const test = base.extend<CustomFixtures>({
@@ -17,5 +21,36 @@ export const test = base.extend<CustomFixtures>({
 		});
 		await use(mockApiContext);
 		await mockApiContext.dispose();
+	},
+	context: async ({ context }, use) => {
+		await context.route('**://ophan.theguardian.com/**', (route) =>
+			route.fulfill({
+				status: 204,
+				body: '',
+			}),
+		);
+		await use(context);
+	},
+	page: async ({ page, context }, use) => {
+		await context.route(
+			'**://ophan.theguardian.com/**',
+			(route) =>
+				route.fulfill({
+					status: 204,
+					body: '',
+				}),
+			// route.abort(),
+		);
+
+		await page.route(
+			'**://ophan.theguardian.com/**',
+			(route) =>
+				route.fulfill({
+					status: 204,
+					body: '',
+				}),
+			// route.abort(),
+		);
+		await use(page);
 	},
 });

--- a/playwright/fixtures/mockedApiRequest.ts
+++ b/playwright/fixtures/mockedApiRequest.ts
@@ -4,13 +4,11 @@ import {
 	test as base,
 	request as playwrightRequest,
 	APIRequestContext,
-	Page,
 	BrowserContext,
 } from '@playwright/test';
 
 type CustomFixtures = {
 	mockApi: APIRequestContext;
-	page: Page;
 	context: BrowserContext;
 };
 
@@ -30,27 +28,5 @@ export const test = base.extend<CustomFixtures>({
 			}),
 		);
 		await use(context);
-	},
-	page: async ({ page, context }, use) => {
-		await context.route(
-			'**://ophan.theguardian.com/**',
-			(route) =>
-				route.fulfill({
-					status: 204,
-					body: '',
-				}),
-			// route.abort(),
-		);
-
-		await page.route(
-			'**://ophan.theguardian.com/**',
-			(route) =>
-				route.fulfill({
-					status: 204,
-					body: '',
-				}),
-			// route.abort(),
-		);
-		await use(page);
 	},
 });

--- a/playwright/fixtures/mockedApiRequest.ts
+++ b/playwright/fixtures/mockedApiRequest.ts
@@ -6,6 +6,7 @@ import {
 	APIRequestContext,
 	BrowserContext,
 } from '@playwright/test';
+import { mockClientRecaptcha } from '../helpers/network/recaptcha';
 
 type CustomFixtures = {
 	mockApi: APIRequestContext;
@@ -28,5 +29,9 @@ export const test = base.extend<CustomFixtures>({
 			}),
 		);
 		await use(context);
+	},
+	page: async ({ page }, use) => {
+		await mockClientRecaptcha(page);
+		await use(page);
 	},
 });

--- a/playwright/helpers/accessibility.ts
+++ b/playwright/helpers/accessibility.ts
@@ -5,6 +5,7 @@ import { AxeBuilder } from '@axe-core/playwright';
  * Inject and check accessibility on the current page.
  */
 export async function injectAndCheckAxe(page: Page): Promise<void> {
+	await page.waitForLoadState('networkidle');
 	const results = await new AxeBuilder({ page })
 		.disableRules(['color-contrast'])
 		.analyze();

--- a/playwright/helpers/network/recaptcha.ts
+++ b/playwright/helpers/network/recaptcha.ts
@@ -3,6 +3,9 @@ import { Page } from '@playwright/test';
 
 interface WindowWIthGrecaptcha {
 	grecaptcha?: unknown;
+	_recaptchaCallback?: (token: string) => void;
+	_recaptchaErrorCallback?: () => void;
+	_mockRecaptchaShouldFail?: boolean;
 }
 
 export const mockClientRecaptcha = async (page: Page) => {
@@ -13,13 +16,14 @@ export const mockClientRecaptcha = async (page: Page) => {
 			ready: (callback: () => void) => callback(),
 			render: (
 				element: string | HTMLElement,
-				options: { callback?: (token: string) => void },
+				options: {
+					callback?: (token: string) => void;
+					'error-callback'?: () => void;
+				},
 			) => {
-				(
-					window as typeof window & {
-						_recaptchaCallback?: (token: string) => void;
-					}
-				)._recaptchaCallback = options.callback;
+				const mockWindow = window as WindowWIthGrecaptcha;
+				mockWindow._recaptchaCallback = options.callback;
+				mockWindow._recaptchaErrorCallback = options['error-callback'];
 
 				// Create the hidden input that Google reCAPTCHA normally creates
 				// This input is submitted with the form as 'g-recaptcha-response'
@@ -39,6 +43,12 @@ export const mockClientRecaptcha = async (page: Page) => {
 			},
 			reset: () => {},
 			execute: () => {
+				const mockWindow = window as WindowWIthGrecaptcha;
+				if (mockWindow._mockRecaptchaShouldFail) {
+					mockWindow._recaptchaErrorCallback?.();
+					return;
+				}
+
 				// Set the token value in the hidden input
 				const input = document.getElementById(
 					'g-recaptcha-response',
@@ -47,11 +57,7 @@ export const mockClientRecaptcha = async (page: Page) => {
 					input.value = FAKE_TOKEN;
 				}
 
-				const callback = (
-					window as typeof window & {
-						_recaptchaCallback?: (token: string) => void;
-					}
-				)._recaptchaCallback;
+				const callback = mockWindow._recaptchaCallback;
 				if (callback) {
 					callback(FAKE_TOKEN);
 				}
@@ -81,4 +87,13 @@ export const mockClientRecaptcha = async (page: Page) => {
 			});
 		},
 	);
+};
+
+export const setMockClientRecaptchaShouldFail = async (
+	page: Page,
+	shouldFail: boolean,
+) => {
+	await page.evaluate((value) => {
+		(window as WindowWIthGrecaptcha)._mockRecaptchaShouldFail = value;
+	}, shouldFail);
 };

--- a/playwright/helpers/network/recaptcha.ts
+++ b/playwright/helpers/network/recaptcha.ts
@@ -1,7 +1,7 @@
 /* eslint-disable functional/immutable-data --- only used for playwright test setup */
 import { Page } from '@playwright/test';
 
-interface WindowWIthGrecaptcha {
+interface WindowWithGrecaptcha {
 	grecaptcha?: unknown;
 	_recaptchaCallback?: (token: string) => void;
 	_recaptchaErrorCallback?: () => void;
@@ -12,7 +12,7 @@ export const mockClientRecaptcha = async (page: Page) => {
 	await page.addInitScript(() => {
 		const FAKE_TOKEN = 'fake-recaptcha-token';
 
-		(window as WindowWIthGrecaptcha).grecaptcha = {
+		(window as WindowWithGrecaptcha).grecaptcha = {
 			ready: (callback: () => void) => callback(),
 			render: (
 				element: string | HTMLElement,
@@ -21,7 +21,7 @@ export const mockClientRecaptcha = async (page: Page) => {
 					'error-callback'?: () => void;
 				},
 			) => {
-				const mockWindow = window as WindowWIthGrecaptcha;
+				const mockWindow = window as WindowWithGrecaptcha;
 				mockWindow._recaptchaCallback = options.callback;
 				mockWindow._recaptchaErrorCallback = options['error-callback'];
 
@@ -43,7 +43,7 @@ export const mockClientRecaptcha = async (page: Page) => {
 			},
 			reset: () => {},
 			execute: () => {
-				const mockWindow = window as WindowWIthGrecaptcha;
+				const mockWindow = window as WindowWithGrecaptcha;
 				if (mockWindow._mockRecaptchaShouldFail) {
 					mockWindow._recaptchaErrorCallback?.();
 					return;
@@ -94,6 +94,6 @@ export const setMockClientRecaptchaShouldFail = async (
 	shouldFail: boolean,
 ) => {
 	await page.evaluate((value) => {
-		(window as WindowWIthGrecaptcha)._mockRecaptchaShouldFail = value;
+		(window as WindowWithGrecaptcha)._mockRecaptchaShouldFail = value;
 	}, shouldFail);
 };

--- a/playwright/tests/e2e/change_email.spec.ts
+++ b/playwright/tests/e2e/change_email.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../../fixtures/e2e';
 import { randomMailosaurEmail } from '../../helpers/api/idapi';
 import { createTestUser, updateTestUser } from '../../helpers/api/idapi';
 import { checkForEmailAndGetDetails } from '../../helpers/api/mailosaur';

--- a/playwright/tests/e2e/consent_token.spec.ts
+++ b/playwright/tests/e2e/consent_token.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../../fixtures/e2e';
 import { createTestUser, sendConsentEmail } from '../../helpers/api/idapi';
 import { checkForEmailAndGetDetails } from '../../helpers/api/mailosaur';
 

--- a/playwright/tests/e2e/delete.spec.ts
+++ b/playwright/tests/e2e/delete.spec.ts
@@ -1,7 +1,6 @@
-import { test, expect, Page } from '@playwright/test';
+import { test, expect, Page } from '../../fixtures/e2e';
 import { randomPassword, createTestUser } from '../../helpers/api/idapi';
 import { checkForEmailAndGetDetails } from '../../helpers/api/mailosaur';
-import { mockClientRecaptcha } from '../../helpers/network/recaptcha';
 
 test.describe('Delete my account flow in Okta', () => {
 	const signInAndVisitDeletePage = async (
@@ -21,10 +20,6 @@ test.describe('Delete my account flow in Okta', () => {
 
 		await page.goto(`/delete`);
 	};
-
-	test.beforeEach(async ({ page }) => {
-		await mockClientRecaptcha(page);
-	});
 
 	test('successfully deletes a user account', async ({ request, page }) => {
 		const { emailAddress, finalPassword } = await createTestUser(request, {

--- a/playwright/tests/e2e/jobs_terms.spec.ts
+++ b/playwright/tests/e2e/jobs_terms.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../../fixtures/e2e';
 import { createTestUser } from '../../helpers/api/idapi';
 import {
 	getTestOktaUser,

--- a/playwright/tests/e2e/new_account_review.spec.ts
+++ b/playwright/tests/e2e/new_account_review.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../../fixtures/e2e';
 import { randomMailosaurEmail } from '../../helpers/api/idapi';
 import { checkForEmailAndGetDetails } from '../../helpers/api/mailosaur';
 import { JOBS_TOS_URI } from '@/shared/model/Configuration';

--- a/playwright/tests/e2e/reauthenticate.spec.ts
+++ b/playwright/tests/e2e/reauthenticate.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../../fixtures/e2e';
 import { createTestUser } from '../../helpers/api/idapi';
 import { checkForEmailAndGetDetails } from '../../helpers/api/mailosaur';
 import { getCurrentOktaSession } from '../../helpers/api/okta';

--- a/playwright/tests/e2e/registration_1.spec.ts
+++ b/playwright/tests/e2e/registration_1.spec.ts
@@ -62,7 +62,7 @@ test.describe('Registration flow - Split 1/4', () => {
 			 */
 			expect(oktaUser.profile.registrationPlatform).toBe('profile');
 
-			await expect(page).toHaveURL(/\/welcome\/review/, { timeout: 10000 });
+			await expect(page).toHaveURL(/\/welcome\/review/);
 		});
 
 		test('successfully registers using an email with no existing account using a passcode - using the combined signin/register flow', async ({

--- a/playwright/tests/e2e/registration_1.spec.ts
+++ b/playwright/tests/e2e/registration_1.spec.ts
@@ -1,11 +1,10 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../../fixtures/e2e';
 import { Status } from '../../../src/server/models/okta/User';
 import { randomMailosaurEmail, randomPassword } from '../../helpers/api/idapi';
 import { checkForEmailAndGetDetails } from '../../helpers/api/mailosaur';
 import { getTestOktaUser } from '../../helpers/api/okta';
 import { JOBS_TOS_URI } from '@/shared/model/Configuration';
 import { escapeRegExp, incrementPasscode } from '../../helpers/utils';
-import { mockClientRecaptcha } from '../../helpers/network/recaptcha';
 
 test.describe('Registration flow - Split 1/4', () => {
 	test.describe('Registering with Okta', () => {
@@ -139,9 +138,6 @@ test.describe('Registration flow - Split 1/4', () => {
 					await route.fulfill({ status: 200 });
 				},
 			);
-			// block recaptcha client script to prevent google from robot checking playwright
-			await mockClientRecaptcha(page);
-
 			const encodedReturnUrl =
 				'https%3A%2F%2Fm.code.dev-theguardian.com%2Ftravel%2F2019%2Fdec%2F18%2Ffood-culture-tour-bethlehem-palestine-east-jerusalem-photo-essay';
 			const unregisteredEmail = randomMailosaurEmail();

--- a/playwright/tests/e2e/registration_1.spec.ts
+++ b/playwright/tests/e2e/registration_1.spec.ts
@@ -62,7 +62,7 @@ test.describe('Registration flow - Split 1/4', () => {
 			 */
 			expect(oktaUser.profile.registrationPlatform).toBe('profile');
 
-			await expect(page).toHaveURL(/\/welcome\/review/);
+			await expect(page).toHaveURL(/\/welcome\/review/, { timeout: 10000 });
 		});
 
 		test('successfully registers using an email with no existing account using a passcode - using the combined signin/register flow', async ({

--- a/playwright/tests/e2e/registration_2.spec.ts
+++ b/playwright/tests/e2e/registration_2.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../../fixtures/e2e';
 import { Status } from '../../../src/server/models/okta/User';
 import {
 	randomMailosaurEmail,

--- a/playwright/tests/e2e/registration_3.spec.ts
+++ b/playwright/tests/e2e/registration_3.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../../fixtures/e2e';
 import { Status } from '../../../src/server/models/okta/User';
 import { randomMailosaurEmail, createTestUser } from '../../helpers/api/idapi';
 import { checkForEmailAndGetDetails } from '../../helpers/api/mailosaur';

--- a/playwright/tests/e2e/registration_4.spec.ts
+++ b/playwright/tests/e2e/registration_4.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../../fixtures/e2e';
 import { Status } from '../../../src/server/models/okta/User';
 import {
 	randomMailosaurEmail,
@@ -13,6 +13,7 @@ import {
 	suspendOktaUser,
 	getTestOktaUser,
 } from '../../helpers/api/okta';
+import { setMockClientRecaptchaShouldFail } from '../../helpers/network/recaptcha';
 import { escapeRegExp } from '../../helpers/utils';
 
 test.describe('Registration flow - Split 4/4', () => {
@@ -646,17 +647,6 @@ test.describe('Registration flow - Split 4/4', () => {
 			page,
 			request,
 		}) => {
-			// mechanism to block POST requests to recaptcha
-			// eslint-disable-next-line functional/no-let -- easiest way to control single recaptcha interception
-			let blockRecaptcha = false;
-			await page.route(/.*google\.com\/recaptcha\/api2\/.*/, async (route) => {
-				if (blockRecaptcha && route.request().method() === 'POST') {
-					await route.fulfill({ status: 500 });
-				} else {
-					await route.continue();
-				}
-			});
-
 			await page.context().addCookies([
 				{
 					name: 'playwright-mock-state',
@@ -687,7 +677,7 @@ test.describe('Registration flow - Split 4/4', () => {
 				timeRequestWasMadeInitialEmail,
 			);
 
-			blockRecaptcha = true;
+			await setMockClientRecaptchaShouldFail(page, true);
 
 			await page.waitForTimeout(1000); // wait for the send again button to be enabled
 			await page.getByText('send again').click();
@@ -701,7 +691,7 @@ test.describe('Registration flow - Split 4/4', () => {
 			const timeRequestWasMade = new Date();
 			await page.waitForTimeout(1000); // wait for the send again button to be enabled
 
-			blockRecaptcha = false;
+			await setMockClientRecaptchaShouldFail(page, false);
 
 			await page.getByText('send again').click();
 

--- a/playwright/tests/e2e/registration_newsletter.spec.ts
+++ b/playwright/tests/e2e/registration_newsletter.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../../fixtures/e2e';
 import { createTestUser } from '../../helpers/api/idapi';
 import { oktaGetApps } from '../../helpers/api/okta-apps';
 

--- a/playwright/tests/e2e/reset_password.spec.ts
+++ b/playwright/tests/e2e/reset_password.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, Request } from '@playwright/test';
+import { test, expect, Request } from '../../fixtures/e2e';
 import {
 	randomMailosaurEmail,
 	randomPassword,

--- a/playwright/tests/e2e/reset_password_passcode.spec.ts
+++ b/playwright/tests/e2e/reset_password_passcode.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../../fixtures/e2e';
 import { Status } from '../../../src/server/models/okta/User';
 import {
 	randomMailosaurEmail,

--- a/playwright/tests/e2e/reset_password_passcode_active_user.spec.ts
+++ b/playwright/tests/e2e/reset_password_passcode_active_user.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../../fixtures/e2e';
 import {
 	randomMailosaurEmail,
 	randomPassword,

--- a/playwright/tests/e2e/reset_password_passcode_remaining_users.spec.ts
+++ b/playwright/tests/e2e/reset_password_passcode_remaining_users.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../../fixtures/e2e';
 import { Status } from '../../../src/server/models/okta/User';
 import {
 	randomMailosaurEmail,

--- a/playwright/tests/e2e/reset_password_passcode_staged_provisioned_users.spec.ts
+++ b/playwright/tests/e2e/reset_password_passcode_staged_provisioned_users.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../../fixtures/e2e';
 import { Status } from '../../../src/server/models/okta/User';
 import {
 	randomMailosaurEmail,

--- a/playwright/tests/e2e/sign_in_1.spec.ts
+++ b/playwright/tests/e2e/sign_in_1.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../../fixtures/e2e';
 import {
 	randomMailosaurEmail,
 	randomPassword,
@@ -11,6 +11,7 @@ import {
 	addOktaUserToGroup,
 	findEmailValidatedOktaGroupId,
 } from '../../helpers/api/okta';
+import { setMockClientRecaptchaShouldFail } from '../../helpers/network/recaptcha';
 import { escapeRegExp } from '../../helpers/utils';
 
 const returnUrl =
@@ -583,17 +584,7 @@ test.describe('Sign in flow, Okta enabled - split 1', () => {
 			});
 			await page.goto('/signin?usePasswordSignIn=true');
 
-			// Intercept reCAPTCHA POST requests once to simulate failure
-			// eslint-disable-next-line functional/no-let -- easiest way to control single recaptcha interception
-			let recaptchaIntercepted = false;
-			await page.route('**/www.google.com/recaptcha/api2/**', async (route) => {
-				if (!recaptchaIntercepted && route.request().method() === 'POST') {
-					recaptchaIntercepted = true;
-					await route.fulfill({ status: 500 });
-				} else {
-					await route.continue();
-				}
-			});
+			await setMockClientRecaptchaShouldFail(page, true);
 
 			await page.locator('input[name=email]').fill(emailAddress);
 			await page.locator('input[name=password]').fill(finalPassword);
@@ -606,6 +597,7 @@ test.describe('Sign in flow, Okta enabled - split 1', () => {
 				page.getByText('If the problem persists please try the following:'),
 			).toBeVisible();
 
+			await setMockClientRecaptchaShouldFail(page, false);
 			await page.locator('[data-cy="main-form-submit-button"]').click();
 
 			await expect(

--- a/playwright/tests/e2e/sign_in_2.spec.ts
+++ b/playwright/tests/e2e/sign_in_2.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../../fixtures/e2e';
 import { createTestUser } from '../../helpers/api/idapi';
 import {
 	getTestOktaUser,

--- a/playwright/tests/e2e/sign_in_2.spec.ts
+++ b/playwright/tests/e2e/sign_in_2.spec.ts
@@ -5,12 +5,17 @@ import {
 	updateOktaTestUserProfile,
 	closeCurrentOktaSession,
 } from '../../helpers/api/okta';
+import { mockClientRecaptcha } from '../../helpers/network/recaptcha';
 import { JOBS_TOS_URI } from '@/shared/model/Configuration';
 
 const returnUrl =
 	'https://www.theguardian.com/world/2013/jun/09/edward-snowden-nsa-whistleblower-surveillance';
 
 test.describe('Sign in flow, Okta enabled - split 2', () => {
+	test.beforeEach(async ({ page }) => {
+		await mockClientRecaptcha(page);
+	});
+
 	test.describe('Social sign in', () => {
 		test('redirects correctly for social sign in', async ({ page }) => {
 			await page.goto(`/signin?returnUrl=${encodeURIComponent(returnUrl)}`);

--- a/playwright/tests/e2e/sign_in_2.spec.ts
+++ b/playwright/tests/e2e/sign_in_2.spec.ts
@@ -1,21 +1,16 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../../fixtures/e2e';
 import { createTestUser } from '../../helpers/api/idapi';
 import {
 	getTestOktaUser,
 	updateOktaTestUserProfile,
 	closeCurrentOktaSession,
 } from '../../helpers/api/okta';
-import { mockClientRecaptcha } from '../../helpers/network/recaptcha';
 import { JOBS_TOS_URI } from '@/shared/model/Configuration';
 
 const returnUrl =
 	'https://www.theguardian.com/world/2013/jun/09/edward-snowden-nsa-whistleblower-surveillance';
 
 test.describe('Sign in flow, Okta enabled - split 2', () => {
-	test.beforeEach(async ({ page }) => {
-		await mockClientRecaptcha(page);
-	});
-
 	test.describe('Social sign in', () => {
 		test('redirects correctly for social sign in', async ({ page }) => {
 			await page.goto(`/signin?returnUrl=${encodeURIComponent(returnUrl)}`);

--- a/playwright/tests/e2e/sign_in_passcode_active_user.spec.ts
+++ b/playwright/tests/e2e/sign_in_passcode_active_user.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../../fixtures/e2e';
 import {
 	randomMailosaurEmail,
 	randomPassword,
@@ -6,7 +6,6 @@ import {
 } from '../../helpers/api/idapi';
 import { checkForEmailAndGetDetails } from '../../helpers/api/mailosaur';
 import { getTestOktaUser } from '../../helpers/api/okta';
-import { mockClientRecaptcha } from '../../helpers/network/recaptcha';
 import { escapeRegExp, incrementPasscode } from '../../helpers/utils';
 
 test.describe('Sign In flow, with passcode', () => {
@@ -18,7 +17,6 @@ test.describe('Sign In flow, with passcode', () => {
 	const fromURI = '/oauth2/v1/authorize';
 
 	test.beforeEach(async ({ page }) => {
-		await mockClientRecaptcha(page);
 		// Intercept the external redirect pages.
 		// We just want to check that the redirect happens, not that the page loads.
 		await page.route('https://m.code.dev-theguardian.com/', async (route) => {

--- a/playwright/tests/e2e/sign_in_passcode_non_active_user.spec.ts
+++ b/playwright/tests/e2e/sign_in_passcode_non_active_user.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../../fixtures/e2e';
 import { Status } from '../../../src/server/models/okta/User';
 import { createTestUser } from '../../helpers/api/idapi';
 import {

--- a/playwright/tests/e2e/sign_out.spec.ts
+++ b/playwright/tests/e2e/sign_out.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../../fixtures/e2e';
 import { createTestUser } from '../../helpers/api/idapi';
 
 test.describe('Sign out flow', () => {

--- a/playwright/tests/e2e/subscription.spec.ts
+++ b/playwright/tests/e2e/subscription.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, Page } from '@playwright/test';
+import { test, expect, Page } from '../../fixtures/e2e';
 import crypto from 'crypto';
 import { createTestUser } from '../../helpers/api/idapi';
 

--- a/playwright/tests/mocked/register.spec.ts
+++ b/playwright/tests/mocked/register.spec.ts
@@ -1,6 +1,7 @@
 import { expect } from '@playwright/test';
 import { test } from '../../fixtures/mockedApiRequest';
 import { injectAndCheckAxe } from '../../helpers/accessibility';
+import { setMockClientRecaptchaShouldFail } from '../../helpers/network/recaptcha';
 
 test.describe('Registration flow', () => {
 	test.beforeEach(async ({ mockApi }) => {
@@ -39,13 +40,10 @@ test.describe('Registration flow', () => {
 		test('shows recaptcha error message when reCAPTCHA token request fails', async ({
 			page,
 		}) => {
-			await page.route(/.*google\.com\/recaptcha\/.*/, async (route) => {
-				await route.abort('failed');
-			});
-
 			await page.goto(
 				'/register/email?returnUrl=https%3A%2F%2Fwww.theguardian.com%2Fabout',
 			);
+			await setMockClientRecaptchaShouldFail(page, true);
 			await page.locator('input[name="email"]').fill('placeholder@example.com');
 			await page.locator('[data-cy=main-form-submit-button]').click();
 			await expect(

--- a/playwright/tests/mocked/reset_password.spec.ts
+++ b/playwright/tests/mocked/reset_password.spec.ts
@@ -1,5 +1,6 @@
 import { expect } from '@playwright/test';
 import { test } from '../../fixtures/mockedApiRequest';
+import { setMockClientRecaptchaShouldFail } from '../../helpers/network/recaptcha';
 import { injectAndCheckAxe } from '../../helpers/accessibility';
 
 const CONTENT = {
@@ -95,14 +96,12 @@ test.describe('Password reset flow', () => {
 		test('shows recaptcha error message when reCAPTCHA token request fails', async ({
 			page,
 		}) => {
-			await page.route(/.*google\.com\/recaptcha\/.*/, async (route) => {
-				await route.abort('failed');
-			});
 			/*
 			 * navigate again to /reset-password as the beforeEach block at the top of
 			 * this file would navigate and happen before the recaptcha network request intercept
 			 */
 			await page.goto('/reset-password');
+			await setMockClientRecaptchaShouldFail(page, true);
 
 			await page.locator('input[name="email"]').fill(emailNotRegistered);
 			await page.getByText('Request password reset').click();

--- a/playwright/tests/mocked/set_password.spec.ts
+++ b/playwright/tests/mocked/set_password.spec.ts
@@ -1,5 +1,6 @@
 import { expect } from '@playwright/test';
 import { test } from '../../fixtures/mockedApiRequest';
+import { setMockClientRecaptchaShouldFail } from '../../helpers/network/recaptcha';
 import { injectAndCheckAxe } from '../../helpers/accessibility';
 
 test.describe('Password set/create flow', () => {
@@ -134,10 +135,8 @@ test.describe('Password set/create flow', () => {
 					body: {},
 				},
 			});
-			await page.route(/.*google\.com\/recaptcha\/.*/, async (route) => {
-				await route.abort('failed');
-			});
 			await page.goto('/set-password/fake_token');
+			await setMockClientRecaptchaShouldFail(page, true);
 			await expect(page.getByText('This link has expired')).toBeVisible();
 			await page.locator('input[name="email"]').fill('some@email.com');
 			await page.locator('button[type="submit"]').click();

--- a/playwright/tests/mocked/sign_in.spec.ts
+++ b/playwright/tests/mocked/sign_in.spec.ts
@@ -1,6 +1,7 @@
 import { expect } from '@playwright/test';
 import { test } from '../../fixtures/mockedApiRequest';
 import { injectAndCheckAxe } from '../../helpers/accessibility';
+import { setMockClientRecaptchaShouldFail } from '../../helpers/network/recaptcha';
 
 test.describe('Sign in flow', () => {
 	test.beforeEach(async ({ mockApi }) => {
@@ -58,12 +59,10 @@ test.describe('Sign in flow', () => {
 					await route.fulfill({ status: 200 });
 				},
 			);
-			await page.route(/.*google.com\/recaptcha\/.*/, async (route) => {
-				await route.abort('failed');
-			});
 			await page.goto(
 				'/signin?returnUrl=https%3A%2F%2Fwww.theguardian.com%2Fabout&usePasswordSignIn=true',
 			);
+			await setMockClientRecaptchaShouldFail(page, true);
 			await page.locator('input[name="email"]').fill('placeholder@example.com');
 			await page
 				.locator('input[name="password"]')

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,16 +35,16 @@ importers:
         version: 10.0.0(tslib@2.8.1)(typescript@5.9.3)
       '@guardian/libs':
         specifier: 32.0.0
-        version: 32.0.0(@guardian/ophan-tracker-js@4.0.2)(tslib@2.8.1)(typescript@5.9.3)
+        version: 32.0.0(@guardian/ophan-tracker-js@5.0.0)(tslib@2.8.1)(typescript@5.9.3)
       '@guardian/ophan-tracker-js':
-        specifier: 4.0.2
-        version: 4.0.2
+        specifier: 5.0.0
+        version: 5.0.0
       '@guardian/source':
         specifier: 12.2.1
         version: 12.2.1(@emotion/react@11.14.0(@preact/compat@18.3.1(preact@10.29.4))(@types/react@19.2.17))(@preact/compat@18.3.1(preact@10.29.4))(@types/react@19.2.17)(tslib@2.8.1)(typescript@5.9.3)
       '@guardian/source-development-kitchen':
         specifier: 28.1.0
-        version: 28.1.0(@emotion/react@11.14.0(@preact/compat@18.3.1(preact@10.29.4))(@types/react@19.2.17))(@guardian/libs@32.0.0(@guardian/ophan-tracker-js@4.0.2)(tslib@2.8.1)(typescript@5.9.3))(@guardian/source@12.2.1(@emotion/react@11.14.0(@preact/compat@18.3.1(preact@10.29.4))(@types/react@19.2.17))(@preact/compat@18.3.1(preact@10.29.4))(@types/react@19.2.17)(tslib@2.8.1)(typescript@5.9.3))(@preact/compat@18.3.1(preact@10.29.4))(@types/react@19.2.17)(tslib@2.8.1)(typescript@5.9.3)
+        version: 28.1.0(@emotion/react@11.14.0(@preact/compat@18.3.1(preact@10.29.4))(@types/react@19.2.17))(@guardian/libs@32.0.0(@guardian/ophan-tracker-js@5.0.0)(tslib@2.8.1)(typescript@5.9.3))(@guardian/source@12.2.1(@emotion/react@11.14.0(@preact/compat@18.3.1(preact@10.29.4))(@types/react@19.2.17))(@preact/compat@18.3.1(preact@10.29.4))(@types/react@19.2.17)(tslib@2.8.1)(typescript@5.9.3))(@preact/compat@18.3.1(preact@10.29.4))(@types/react@19.2.17)(tslib@2.8.1)(typescript@5.9.3)
       '@okta/jwt-verifier':
         specifier: 4.0.2
         version: 4.0.2
@@ -978,8 +978,8 @@ packages:
       typescript:
         optional: true
 
-  '@guardian/ophan-tracker-js@4.0.2':
-    resolution: {integrity: sha512-sqgJG7G8zxHn9FlqcZGBF+gimu5lVa0CHAUs5fJicdf4xjjtnvpKuNfgKKpQaBFvhK686wtkur8zwhO+nm6BpQ==}
+  '@guardian/ophan-tracker-js@5.0.0':
+    resolution: {integrity: sha512-mUzRsr25A8K5pCaisNQctt3lFEAm7SC4KTbglbyu7FkCDVaTuiNMz3jgj9LcPpQw/csPMdEEe2nUpqCiqCZlHA==}
     engines: {node: '>=16'}
 
   '@guardian/prettier@11.0.0':
@@ -8352,14 +8352,14 @@ snapshots:
       - supports-color
       - typescript
 
-  '@guardian/libs@32.0.0(@guardian/ophan-tracker-js@4.0.2)(tslib@2.8.1)(typescript@5.9.3)':
+  '@guardian/libs@32.0.0(@guardian/ophan-tracker-js@5.0.0)(tslib@2.8.1)(typescript@5.9.3)':
     dependencies:
-      '@guardian/ophan-tracker-js': 4.0.2
+      '@guardian/ophan-tracker-js': 5.0.0
       tslib: 2.8.1
     optionalDependencies:
       typescript: 5.9.3
 
-  '@guardian/ophan-tracker-js@4.0.2':
+  '@guardian/ophan-tracker-js@5.0.0':
     dependencies:
       '@guardian/tsconfig': 1.0.1
 
@@ -8368,9 +8368,9 @@ snapshots:
       prettier: 3.9.4
       tslib: 2.8.1
 
-  '@guardian/source-development-kitchen@28.1.0(@emotion/react@11.14.0(@preact/compat@18.3.1(preact@10.29.4))(@types/react@19.2.17))(@guardian/libs@32.0.0(@guardian/ophan-tracker-js@4.0.2)(tslib@2.8.1)(typescript@5.9.3))(@guardian/source@12.2.1(@emotion/react@11.14.0(@preact/compat@18.3.1(preact@10.29.4))(@types/react@19.2.17))(@preact/compat@18.3.1(preact@10.29.4))(@types/react@19.2.17)(tslib@2.8.1)(typescript@5.9.3))(@preact/compat@18.3.1(preact@10.29.4))(@types/react@19.2.17)(tslib@2.8.1)(typescript@5.9.3)':
+  '@guardian/source-development-kitchen@28.1.0(@emotion/react@11.14.0(@preact/compat@18.3.1(preact@10.29.4))(@types/react@19.2.17))(@guardian/libs@32.0.0(@guardian/ophan-tracker-js@5.0.0)(tslib@2.8.1)(typescript@5.9.3))(@guardian/source@12.2.1(@emotion/react@11.14.0(@preact/compat@18.3.1(preact@10.29.4))(@types/react@19.2.17))(@preact/compat@18.3.1(preact@10.29.4))(@types/react@19.2.17)(tslib@2.8.1)(typescript@5.9.3))(@preact/compat@18.3.1(preact@10.29.4))(@types/react@19.2.17)(tslib@2.8.1)(typescript@5.9.3)':
     dependencies:
-      '@guardian/libs': 32.0.0(@guardian/ophan-tracker-js@4.0.2)(tslib@2.8.1)(typescript@5.9.3)
+      '@guardian/libs': 32.0.0(@guardian/ophan-tracker-js@5.0.0)(tslib@2.8.1)(typescript@5.9.3)
       '@guardian/source': 12.2.1(@emotion/react@11.14.0(@preact/compat@18.3.1(preact@10.29.4))(@types/react@19.2.17))(@preact/compat@18.3.1(preact@10.29.4))(@types/react@19.2.17)(tslib@2.8.1)(typescript@5.9.3)
       tslib: 2.8.1
     optionalDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,16 +35,16 @@ importers:
         version: 10.0.0(tslib@2.8.1)(typescript@5.9.3)
       '@guardian/libs':
         specifier: 32.0.0
-        version: 32.0.0(@guardian/ophan-tracker-js@2.0.4)(tslib@2.8.1)(typescript@5.9.3)
+        version: 32.0.0(@guardian/ophan-tracker-js@4.0.2)(tslib@2.8.1)(typescript@5.9.3)
       '@guardian/ophan-tracker-js':
-        specifier: 2.0.4
-        version: 2.0.4
+        specifier: 4.0.2
+        version: 4.0.2
       '@guardian/source':
         specifier: 12.2.1
         version: 12.2.1(@emotion/react@11.14.0(@preact/compat@18.3.1(preact@10.29.4))(@types/react@19.2.17))(@preact/compat@18.3.1(preact@10.29.4))(@types/react@19.2.17)(tslib@2.8.1)(typescript@5.9.3)
       '@guardian/source-development-kitchen':
         specifier: 28.1.0
-        version: 28.1.0(@emotion/react@11.14.0(@preact/compat@18.3.1(preact@10.29.4))(@types/react@19.2.17))(@guardian/libs@32.0.0(@guardian/ophan-tracker-js@2.0.4)(tslib@2.8.1)(typescript@5.9.3))(@guardian/source@12.2.1(@emotion/react@11.14.0(@preact/compat@18.3.1(preact@10.29.4))(@types/react@19.2.17))(@preact/compat@18.3.1(preact@10.29.4))(@types/react@19.2.17)(tslib@2.8.1)(typescript@5.9.3))(@preact/compat@18.3.1(preact@10.29.4))(@types/react@19.2.17)(tslib@2.8.1)(typescript@5.9.3)
+        version: 28.1.0(@emotion/react@11.14.0(@preact/compat@18.3.1(preact@10.29.4))(@types/react@19.2.17))(@guardian/libs@32.0.0(@guardian/ophan-tracker-js@4.0.2)(tslib@2.8.1)(typescript@5.9.3))(@guardian/source@12.2.1(@emotion/react@11.14.0(@preact/compat@18.3.1(preact@10.29.4))(@types/react@19.2.17))(@preact/compat@18.3.1(preact@10.29.4))(@types/react@19.2.17)(tslib@2.8.1)(typescript@5.9.3))(@preact/compat@18.3.1(preact@10.29.4))(@types/react@19.2.17)(tslib@2.8.1)(typescript@5.9.3)
       '@okta/jwt-verifier':
         specifier: 4.0.2
         version: 4.0.2
@@ -132,7 +132,7 @@ importers:
         version: 9.39.4
       '@guardian/eslint-config':
         specifier: 15.0.0
-        version: 15.0.0(@typescript-eslint/utils@8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+        version: 15.0.0(@typescript-eslint/utils@8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
       '@guardian/prettier':
         specifier: 11.0.0
         version: 11.0.0(prettier@3.9.4)(tslib@2.8.1)
@@ -978,8 +978,8 @@ packages:
       typescript:
         optional: true
 
-  '@guardian/ophan-tracker-js@2.0.4':
-    resolution: {integrity: sha512-kwUNUSfnL8SQwzTlVzInYh7a6VSMFy3zEq2A6Hm7cmKSbl8D7ed03y7ANqquViFuPffRZRQ0IrkJHSbMnsRmrA==}
+  '@guardian/ophan-tracker-js@4.0.2':
+    resolution: {integrity: sha512-sqgJG7G8zxHn9FlqcZGBF+gimu5lVa0CHAUs5fJicdf4xjjtnvpKuNfgKKpQaBFvhK686wtkur8zwhO+nm6BpQ==}
     engines: {node: '>=16'}
 
   '@guardian/prettier@11.0.0':
@@ -1025,6 +1025,9 @@ packages:
         optional: true
       typescript:
         optional: true
+
+  '@guardian/tsconfig@1.0.1':
+    resolution: {integrity: sha512-PB24nZ6WTBB8aZ9EyxJw1vC5FYkGqwMQ/O5Oogp6P5HCQU5MN0JpUXvpYci7kwV2oXD1Az06UBnLyyVXOVMadQ==}
 
   '@hapi/address@5.1.1':
     resolution: {integrity: sha512-A+po2d/dVoY7cYajycYI43ZbYMXukuopIsqCjh5QzsBCipDtdofHntljDlpccMjIfTy6UOkg+5KPriwYch2bXA==}
@@ -8327,14 +8330,14 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
-  '@guardian/eslint-config@15.0.0(@typescript-eslint/utils@8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)':
+  '@guardian/eslint-config@15.0.0(@typescript-eslint/utils@8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)':
     dependencies:
       '@eslint-community/eslint-plugin-eslint-comments': 4.7.1(eslint@9.39.4(jiti@2.7.0))
       '@eslint/js': 9.39.1
       '@stylistic/eslint-plugin': 5.10.0(eslint@9.39.4(jiti@2.7.0))
       eslint: 9.39.4(jiti@2.7.0)
       eslint-config-prettier: 10.1.8(eslint@9.39.4(jiti@2.7.0))
-      eslint-import-resolver-typescript: 4.4.4(eslint-plugin-import-x@4.16.1(@typescript-eslint/utils@8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@9.39.4(jiti@2.7.0)))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
+      eslint-import-resolver-typescript: 4.4.4(eslint-plugin-import-x@4.16.1(@typescript-eslint/utils@8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@9.39.4(jiti@2.7.0)))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-import-x: 4.16.1(@typescript-eslint/utils@8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.7.0))
@@ -8349,23 +8352,25 @@ snapshots:
       - supports-color
       - typescript
 
-  '@guardian/libs@32.0.0(@guardian/ophan-tracker-js@2.0.4)(tslib@2.8.1)(typescript@5.9.3)':
+  '@guardian/libs@32.0.0(@guardian/ophan-tracker-js@4.0.2)(tslib@2.8.1)(typescript@5.9.3)':
     dependencies:
-      '@guardian/ophan-tracker-js': 2.0.4
+      '@guardian/ophan-tracker-js': 4.0.2
       tslib: 2.8.1
     optionalDependencies:
       typescript: 5.9.3
 
-  '@guardian/ophan-tracker-js@2.0.4': {}
+  '@guardian/ophan-tracker-js@4.0.2':
+    dependencies:
+      '@guardian/tsconfig': 1.0.1
 
   '@guardian/prettier@11.0.0(prettier@3.9.4)(tslib@2.8.1)':
     dependencies:
       prettier: 3.9.4
       tslib: 2.8.1
 
-  '@guardian/source-development-kitchen@28.1.0(@emotion/react@11.14.0(@preact/compat@18.3.1(preact@10.29.4))(@types/react@19.2.17))(@guardian/libs@32.0.0(@guardian/ophan-tracker-js@2.0.4)(tslib@2.8.1)(typescript@5.9.3))(@guardian/source@12.2.1(@emotion/react@11.14.0(@preact/compat@18.3.1(preact@10.29.4))(@types/react@19.2.17))(@preact/compat@18.3.1(preact@10.29.4))(@types/react@19.2.17)(tslib@2.8.1)(typescript@5.9.3))(@preact/compat@18.3.1(preact@10.29.4))(@types/react@19.2.17)(tslib@2.8.1)(typescript@5.9.3)':
+  '@guardian/source-development-kitchen@28.1.0(@emotion/react@11.14.0(@preact/compat@18.3.1(preact@10.29.4))(@types/react@19.2.17))(@guardian/libs@32.0.0(@guardian/ophan-tracker-js@4.0.2)(tslib@2.8.1)(typescript@5.9.3))(@guardian/source@12.2.1(@emotion/react@11.14.0(@preact/compat@18.3.1(preact@10.29.4))(@types/react@19.2.17))(@preact/compat@18.3.1(preact@10.29.4))(@types/react@19.2.17)(tslib@2.8.1)(typescript@5.9.3))(@preact/compat@18.3.1(preact@10.29.4))(@types/react@19.2.17)(tslib@2.8.1)(typescript@5.9.3)':
     dependencies:
-      '@guardian/libs': 32.0.0(@guardian/ophan-tracker-js@2.0.4)(tslib@2.8.1)(typescript@5.9.3)
+      '@guardian/libs': 32.0.0(@guardian/ophan-tracker-js@4.0.2)(tslib@2.8.1)(typescript@5.9.3)
       '@guardian/source': 12.2.1(@emotion/react@11.14.0(@preact/compat@18.3.1(preact@10.29.4))(@types/react@19.2.17))(@preact/compat@18.3.1(preact@10.29.4))(@types/react@19.2.17)(tslib@2.8.1)(typescript@5.9.3)
       tslib: 2.8.1
     optionalDependencies:
@@ -8383,6 +8388,8 @@ snapshots:
       '@types/react': 19.2.17
       react: '@preact/compat@18.3.1(preact@10.29.4)'
       typescript: 5.9.3
+
+  '@guardian/tsconfig@1.0.1': {}
 
   '@hapi/address@5.1.1':
     dependencies:
@@ -11469,7 +11476,7 @@ snapshots:
       - supports-color
     optional: true
 
-  eslint-import-resolver-typescript@4.4.4(eslint-plugin-import-x@4.16.1(@typescript-eslint/utils@8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@9.39.4(jiti@2.7.0)))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)):
+  eslint-import-resolver-typescript@4.4.4(eslint-plugin-import-x@4.16.1(@typescript-eslint/utils@8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@9.39.4(jiti@2.7.0)))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       debug: 4.4.3(supports-color@5.5.0)
       eslint: 9.39.4(jiti@2.7.0)
@@ -11480,16 +11487,16 @@ snapshots:
       tinyglobby: 0.2.17
       unrs-resolver: 1.12.2
     optionalDependencies:
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-import-x: 4.16.1(@typescript-eslint/utils@8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@9.39.4(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.14.0(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@9.39.4(jiti@2.7.0)):
+  eslint-module-utils@2.14.0(@typescript-eslint/parser@8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
-      '@typescript-eslint/parser': 8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
       eslint: 9.39.4(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.9
     transitivePeerDependencies:
@@ -11528,7 +11535,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.29.1(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)):
+  eslint-plugin-import@2.29.1(@typescript-eslint/parser@8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       array-includes: 3.1.9
       array.prototype.findlastindex: 1.2.6
@@ -11538,7 +11545,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.4(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.14.0(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@9.39.4(jiti@2.7.0))
+      eslint-module-utils: 2.14.0(@typescript-eslint/parser@8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@9.39.4(jiti@2.7.0))
       hasown: 2.0.4
       is-core-module: 2.16.2
       is-glob: 4.0.3
@@ -11549,7 +11556,7 @@ snapshots:
       semver: 6.3.1
       tsconfig-paths: 3.15.0
     optionalDependencies:
-      '@typescript-eslint/parser': 8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,16 +35,16 @@ importers:
         version: 10.0.0(tslib@2.8.1)(typescript@5.9.3)
       '@guardian/libs':
         specifier: 32.0.0
-        version: 32.0.0(@guardian/ophan-tracker-js@5.0.0)(tslib@2.8.1)(typescript@5.9.3)
+        version: 32.0.0(@guardian/ophan-tracker-js@4.0.2)(tslib@2.8.1)(typescript@5.9.3)
       '@guardian/ophan-tracker-js':
-        specifier: 5.0.0
-        version: 5.0.0
+        specifier: 4.0.2
+        version: 4.0.2
       '@guardian/source':
         specifier: 12.2.1
         version: 12.2.1(@emotion/react@11.14.0(@preact/compat@18.3.1(preact@10.29.4))(@types/react@19.2.17))(@preact/compat@18.3.1(preact@10.29.4))(@types/react@19.2.17)(tslib@2.8.1)(typescript@5.9.3)
       '@guardian/source-development-kitchen':
         specifier: 28.1.0
-        version: 28.1.0(@emotion/react@11.14.0(@preact/compat@18.3.1(preact@10.29.4))(@types/react@19.2.17))(@guardian/libs@32.0.0(@guardian/ophan-tracker-js@5.0.0)(tslib@2.8.1)(typescript@5.9.3))(@guardian/source@12.2.1(@emotion/react@11.14.0(@preact/compat@18.3.1(preact@10.29.4))(@types/react@19.2.17))(@preact/compat@18.3.1(preact@10.29.4))(@types/react@19.2.17)(tslib@2.8.1)(typescript@5.9.3))(@preact/compat@18.3.1(preact@10.29.4))(@types/react@19.2.17)(tslib@2.8.1)(typescript@5.9.3)
+        version: 28.1.0(@emotion/react@11.14.0(@preact/compat@18.3.1(preact@10.29.4))(@types/react@19.2.17))(@guardian/libs@32.0.0(@guardian/ophan-tracker-js@4.0.2)(tslib@2.8.1)(typescript@5.9.3))(@guardian/source@12.2.1(@emotion/react@11.14.0(@preact/compat@18.3.1(preact@10.29.4))(@types/react@19.2.17))(@preact/compat@18.3.1(preact@10.29.4))(@types/react@19.2.17)(tslib@2.8.1)(typescript@5.9.3))(@preact/compat@18.3.1(preact@10.29.4))(@types/react@19.2.17)(tslib@2.8.1)(typescript@5.9.3)
       '@okta/jwt-verifier':
         specifier: 4.0.2
         version: 4.0.2
@@ -978,8 +978,8 @@ packages:
       typescript:
         optional: true
 
-  '@guardian/ophan-tracker-js@5.0.0':
-    resolution: {integrity: sha512-mUzRsr25A8K5pCaisNQctt3lFEAm7SC4KTbglbyu7FkCDVaTuiNMz3jgj9LcPpQw/csPMdEEe2nUpqCiqCZlHA==}
+  '@guardian/ophan-tracker-js@4.0.2':
+    resolution: {integrity: sha512-sqgJG7G8zxHn9FlqcZGBF+gimu5lVa0CHAUs5fJicdf4xjjtnvpKuNfgKKpQaBFvhK686wtkur8zwhO+nm6BpQ==}
     engines: {node: '>=16'}
 
   '@guardian/prettier@11.0.0':
@@ -8352,14 +8352,14 @@ snapshots:
       - supports-color
       - typescript
 
-  '@guardian/libs@32.0.0(@guardian/ophan-tracker-js@5.0.0)(tslib@2.8.1)(typescript@5.9.3)':
+  '@guardian/libs@32.0.0(@guardian/ophan-tracker-js@4.0.2)(tslib@2.8.1)(typescript@5.9.3)':
     dependencies:
-      '@guardian/ophan-tracker-js': 5.0.0
+      '@guardian/ophan-tracker-js': 4.0.2
       tslib: 2.8.1
     optionalDependencies:
       typescript: 5.9.3
 
-  '@guardian/ophan-tracker-js@5.0.0':
+  '@guardian/ophan-tracker-js@4.0.2':
     dependencies:
       '@guardian/tsconfig': 1.0.1
 
@@ -8368,9 +8368,9 @@ snapshots:
       prettier: 3.9.4
       tslib: 2.8.1
 
-  '@guardian/source-development-kitchen@28.1.0(@emotion/react@11.14.0(@preact/compat@18.3.1(preact@10.29.4))(@types/react@19.2.17))(@guardian/libs@32.0.0(@guardian/ophan-tracker-js@5.0.0)(tslib@2.8.1)(typescript@5.9.3))(@guardian/source@12.2.1(@emotion/react@11.14.0(@preact/compat@18.3.1(preact@10.29.4))(@types/react@19.2.17))(@preact/compat@18.3.1(preact@10.29.4))(@types/react@19.2.17)(tslib@2.8.1)(typescript@5.9.3))(@preact/compat@18.3.1(preact@10.29.4))(@types/react@19.2.17)(tslib@2.8.1)(typescript@5.9.3)':
+  '@guardian/source-development-kitchen@28.1.0(@emotion/react@11.14.0(@preact/compat@18.3.1(preact@10.29.4))(@types/react@19.2.17))(@guardian/libs@32.0.0(@guardian/ophan-tracker-js@4.0.2)(tslib@2.8.1)(typescript@5.9.3))(@guardian/source@12.2.1(@emotion/react@11.14.0(@preact/compat@18.3.1(preact@10.29.4))(@types/react@19.2.17))(@preact/compat@18.3.1(preact@10.29.4))(@types/react@19.2.17)(tslib@2.8.1)(typescript@5.9.3))(@preact/compat@18.3.1(preact@10.29.4))(@types/react@19.2.17)(tslib@2.8.1)(typescript@5.9.3)':
     dependencies:
-      '@guardian/libs': 32.0.0(@guardian/ophan-tracker-js@5.0.0)(tslib@2.8.1)(typescript@5.9.3)
+      '@guardian/libs': 32.0.0(@guardian/ophan-tracker-js@4.0.2)(tslib@2.8.1)(typescript@5.9.3)
       '@guardian/source': 12.2.1(@emotion/react@11.14.0(@preact/compat@18.3.1(preact@10.29.4))(@types/react@19.2.17))(@preact/compat@18.3.1(preact@10.29.4))(@types/react@19.2.17)(tslib@2.8.1)(typescript@5.9.3)
       tslib: 2.8.1
     optionalDependencies:

--- a/src/server/lib/__tests__/headers.test.ts
+++ b/src/server/lib/__tests__/headers.test.ts
@@ -83,7 +83,7 @@ describe('Content Security Policy headers', () => {
 			);
 			expect(splitCSPHeader).toContain('font-src assets.guim.co.uk');
 			expect(splitCSPHeader).toContain(
-				`connect-src 'self' consent-logs.${apiDomain} api.nextgen.guardianapps.co.uk https://api.pwnedpasswords.com localhost:1234 www.google.com`,
+				`connect-src 'self' consent-logs.${apiDomain} api.nextgen.guardianapps.co.uk https://api.pwnedpasswords.com localhost:1234 www.google.com ophan.theguardian.com`,
 			);
 			expect(splitCSPHeader).toContain("object-src 'none'");
 			expect(splitCSPHeader).toContain("script-src-attr 'none'");

--- a/src/server/lib/middleware/helmet.ts
+++ b/src/server/lib/middleware/helmet.ts
@@ -66,6 +66,7 @@ const helmetConfig: HelmetOptions = {
 				CSP_VALID_URI.HAVEIBEENPWNED,
 				idapiOrigin,
 				CSP_VALID_URI.GOOGLE_RECAPTCHA,
+				CSP_VALID_URI.OPHAN,
 			],
 			frameSrc: [CSP_VALID_URI.GOOGLE_RECAPTCHA],
 			formAction: null,

--- a/src/shared/model/ophan.ts
+++ b/src/shared/model/ophan.ts
@@ -1,5 +1,7 @@
-import { OphanABEvent, OphanComponentEvent } from '@guardian/libs';
-
+import {
+	ComponentEvent,
+	AbTestRegisterEntry,
+} from '@guardian/ophan-tracker-js';
 export interface OphanInteraction {
 	component: string;
 	value?: string;
@@ -8,8 +10,8 @@ export interface OphanInteraction {
 
 interface OphanBase {
 	experiences?: string;
-	abTestRegister?: Record<string, OphanABEvent>;
+	abTestRegister?: Record<string, AbTestRegisterEntry>;
 }
 
 export type OphanEvent =
-	OphanBase | OphanInteraction | { componentEvent: OphanComponentEvent };
+	OphanBase | OphanInteraction | { componentEvent: ComponentEvent };

--- a/src/shared/model/ophan.ts
+++ b/src/shared/model/ophan.ts
@@ -1,4 +1,4 @@
-import {
+import type {
 	ComponentEvent,
 	AbTestRegisterEntry,
 } from '@guardian/ophan-tracker-js';


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

- Bump @guardian/ophan-tracker-js to 4.0.2 and update shared Ophan event typing accordingly.
- Update Helmet CSP (and header tests) to allow ophan.theguardian.com in connect-src.
- Introduce shared Playwright helpers to mock client reCAPTCHA (and stub Ophan in mocked tests), refactoring tests to use them.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How has this change been tested?
Tested locally and deployed to CODE.
<!-- For example, have you deployed your branch to `CODE` and tested certain functionality or is unit testing sufficent for this change? If you'd like help testing your changes as part of the PR review process then mention that explicitly here. -->


