### PR TITLE
Add new onboarding flow empty

### DIFF
--- a/src/client/pages/Onboarding.tsx
+++ b/src/client/pages/Onboarding.tsx
@@ -1,0 +1,12 @@
+import { MinimalLayout } from '@/client/layouts/MinimalLayout';
+
+export interface OnboardingProps {
+	shortRequestId?: string;
+}
+
+export const Onboarding = ({ shortRequestId }: OnboardingProps) => (
+	<MinimalLayout
+		shortRequestId={shortRequestId}
+		pageHeader="Welcome to the Guardian"
+	/>
+);

--- a/src/client/pages/OnboardingPage.tsx
+++ b/src/client/pages/OnboardingPage.tsx
@@ -1,0 +1,7 @@
+import useClientState from '@/client/lib/hooks/useClientState';
+import { Onboarding } from '@/client/pages/Onboarding';
+
+export const OnboardingPage = () => {
+	const { shortRequestId } = useClientState();
+	return <Onboarding shortRequestId={shortRequestId} />;
+};

--- a/src/client/routes.tsx
+++ b/src/client/routes.tsx
@@ -41,6 +41,7 @@ import { SubscriptionSuccessPage } from '@/client/pages/SubscriptionSuccessPage'
 import { UnexpectedErrorPage } from '@/client/pages/UnexpectedErrorPage';
 import { UnvalidatedEmailEmailSentPage } from '@/client/pages/UnvalidatedEmailEmailSentPage';
 import { VerifyEmailResetPasswordPage } from '@/client/pages/VerifyEmailResetPasswordPage';
+import { OnboardingPage } from '@/client/pages/OnboardingPage';
 import { WelcomeExistingPage } from '@/client/pages/WelcomeExistingPage';
 import { WelcomePage } from '@/client/pages/WelcomePage';
 import { WelcomePasswordAlreadySetPage } from '@/client/pages/WelcomePasswordAlreadySetPage';
@@ -225,6 +226,10 @@ const routes: Array<{
 	{
 		path: '/welcome/newsletters',
 		element: <NewAccountNewslettersPage />,
+	},
+	{
+		path: '/welcome/onboarding',
+		element: <OnboardingPage />,
 	},
 	{
 		path: '/welcome/:token',

--- a/src/server/lib/__tests__/queryParams.test.ts
+++ b/src/server/lib/__tests__/queryParams.test.ts
@@ -150,6 +150,35 @@ describe('parseExpressQueryParams', () => {
 			expect(output.fromURI).toEqual(undefined);
 		});
 	});
+
+	describe('newOnboardingFlow', () => {
+		test('it should parse a true string to boolean true', () => {
+			const input = {
+				newOnboardingFlow: 'true',
+			};
+
+			const output = parseExpressQueryParams('GET', input);
+			expect(output.newOnboardingFlow).toEqual(true);
+		});
+
+		test('it should parse a false string to boolean false', () => {
+			const input = {
+				newOnboardingFlow: 'false',
+			};
+
+			const output = parseExpressQueryParams('GET', input);
+			expect(output.newOnboardingFlow).toEqual(false);
+		});
+
+		test('it should parse non-true values to boolean false', () => {
+			const input = {
+				newOnboardingFlow: 'not-boolean',
+			};
+
+			const output = parseExpressQueryParams('GET', input);
+			expect(output.newOnboardingFlow).toEqual(false);
+		});
+	});
 });
 
 describe('addReturnUrlToPath', () => {

--- a/src/server/lib/queryParams.ts
+++ b/src/server/lib/queryParams.ts
@@ -54,6 +54,7 @@ export const parseExpressQueryParams = (
 		useOktaClassic,
 		usePasswordSignIn,
 		useSetPassword,
+		newOnboardingFlow,
 		signInEmail,
 	}: Record<keyof QueryParams, string | undefined>, // parameters from req.query
 	// some parameters may be manually passed in req.body too,
@@ -81,6 +82,7 @@ export const parseExpressQueryParams = (
 		useOktaClassic: isStringBoolean(useOktaClassic),
 		usePasswordSignIn: isStringBoolean(usePasswordSignIn),
 		useSetPassword: isStringBoolean(useSetPassword),
+		newOnboardingFlow: isStringBoolean(newOnboardingFlow),
 		signInEmail,
 	};
 };

--- a/src/server/routes/__tests__/welcome.test.ts
+++ b/src/server/routes/__tests__/welcome.test.ts
@@ -1,0 +1,175 @@
+import express, { NextFunction, Request, Response } from 'express';
+import request from 'supertest';
+
+const mockBodyFormFieldsToRegistrationConsents = jest.fn();
+
+jest.mock('@/server/lib/getConfiguration', () => ({
+	getConfiguration: () => ({
+		baseUri: 'http://localhost',
+		googleRecaptcha: { secretKey: '' },
+		passcodesEnabled: false,
+		signInPageUrl: '/signin',
+	}),
+}));
+
+jest.mock('@/server/controllers/checkPasswordToken', () => ({
+	checkPasswordTokenController: jest.fn(
+		() => (_req: unknown, _res: unknown, next: () => void) => next(),
+	),
+}));
+
+jest.mock('@/server/controllers/changePassword', () => ({
+	setPasswordController: jest.fn(
+		() => (_req: unknown, _res: unknown, next: () => void) => next(),
+	),
+}));
+
+jest.mock('@/server/lib/middleware/rateLimit', () => ({
+	rateLimiterMiddleware: (_req: unknown, _res: unknown, next: () => void) =>
+		next(),
+}));
+
+jest.mock('@/server/lib/middleware/login', () => ({
+	loginMiddlewareOAuth: (req: Request, res: Response, next: NextFunction) => {
+		const parseBooleanQuery = (value: unknown): boolean | undefined => {
+			if (value === 'true') {
+				return true;
+			}
+			if (value === 'false') {
+				return false;
+			}
+			return undefined;
+		};
+
+		/* eslint-disable-next-line functional/immutable-data -- test-only middleware setup */
+		res.locals.queryParams = {
+			returnUrl:
+				typeof req.query.returnUrl === 'string'
+					? req.query.returnUrl
+					: 'https://www.theguardian.com',
+			clientId:
+				typeof req.query.clientId === 'string' ? req.query.clientId : undefined,
+			newOnboardingFlow: parseBooleanQuery(req.query.newOnboardingFlow),
+		};
+
+		next();
+	},
+}));
+
+jest.mock('@/server/lib/registrationConsents', () => ({
+	bodyFormFieldsToRegistrationConsents: (...args: unknown[]) =>
+		mockBodyFormFieldsToRegistrationConsents(...args),
+}));
+
+jest.mock('@/server/lib/serverSideLogger', () => ({
+	logger: {
+		error: jest.fn(),
+		warn: jest.fn(),
+		info: jest.fn(),
+	},
+}));
+
+jest.mock('@/server/lib/renderer', () => ({
+	renderer: jest.fn(() => '<html lang="en"></html>'),
+}));
+
+jest.mock('@/server/routes/register', () => ({
+	oktaRegistrationOrSignin: jest.fn(),
+	setEncryptedStateCookieForOktaRegistration: jest.fn(),
+}));
+
+import welcomeRouter from '@/server/routes/welcome';
+
+const getRedirectPathname = (location: string): string =>
+	new URL(location, 'http://localhost').pathname;
+
+const getRedirectSearchParams = (location: string): URLSearchParams =>
+	new URL(location, 'http://localhost').searchParams;
+
+const getApp = () => {
+	const app = express();
+	app.use(express.urlencoded({ extended: false }));
+	app.use(express.json());
+	app.use(welcomeRouter);
+	return app;
+};
+
+describe('POST /welcome/complete-account', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+		mockBodyFormFieldsToRegistrationConsents.mockReturnValue({});
+	});
+
+	test('redirects jobs users to jobs terms path', async () => {
+		const response = await request(getApp())
+			.post('/welcome/complete-account')
+			.query({
+				clientId: 'jobs',
+				newOnboardingFlow: 'true',
+				returnUrl: 'https://www.theguardian.com',
+			})
+			.send({});
+
+		expect(response.status).toBe(303);
+		expect(getRedirectPathname(response.headers.location)).toBe('/agree/GRS');
+
+		const queryParams = getRedirectSearchParams(response.headers.location);
+		expect(queryParams.get('clientId')).toBe('jobs');
+		expect(queryParams.get('newOnboardingFlow')).toBe('true');
+		expect(queryParams.get('returnUrl')).toBe('https://www.theguardian.com');
+	});
+
+	test('redirects to onboarding when newOnboardingFlow is true', async () => {
+		const response = await request(getApp())
+			.post('/welcome/complete-account')
+			.query({
+				newOnboardingFlow: 'true',
+				returnUrl: 'https://www.theguardian.com',
+			})
+			.send({});
+
+		expect(response.status).toBe(303);
+		expect(getRedirectPathname(response.headers.location)).toBe(
+			'/welcome/onboarding',
+		);
+
+		const queryParams = getRedirectSearchParams(response.headers.location);
+		expect(queryParams.get('newOnboardingFlow')).toBe('true');
+		expect(queryParams.get('returnUrl')).toBe('https://www.theguardian.com');
+	});
+
+	test('redirects to review when newOnboardingFlow is not enabled', async () => {
+		const response = await request(getApp())
+			.post('/welcome/complete-account')
+			.query({
+				returnUrl: 'https://www.theguardian.com',
+			})
+			.send({});
+
+		expect(response.status).toBe(303);
+		expect(getRedirectPathname(response.headers.location)).toBe(
+			'/welcome/review',
+		);
+	});
+
+	test('still redirects in finally when registration consents parsing throws', async () => {
+		mockBodyFormFieldsToRegistrationConsents.mockImplementationOnce(() => {
+			throw new Error('consent parse failed');
+		});
+
+		const response = await request(getApp())
+			.post('/welcome/complete-account')
+			.query({
+				newOnboardingFlow: 'true',
+				returnUrl: 'https://www.theguardian.com',
+			})
+			.send({});
+
+		expect(response.status).toBe(303);
+		expect(getRedirectPathname(response.headers.location)).toBe(
+			'/welcome/onboarding',
+		);
+		const mockedLogger = jest.requireMock('@/server/lib/serverSideLogger');
+		expect(mockedLogger.logger.error).toHaveBeenCalled();
+	});
+});

--- a/src/server/routes/__tests__/welcome.test.ts
+++ b/src/server/routes/__tests__/welcome.test.ts
@@ -169,7 +169,5 @@ describe('POST /welcome/complete-account', () => {
 		expect(getRedirectPathname(response.headers.location)).toBe(
 			'/welcome/onboarding',
 		);
-		const mockedLogger = jest.requireMock('@/server/lib/serverSideLogger');
-		expect(mockedLogger.logger.error).toHaveBeenCalled();
 	});
 });

--- a/src/server/routes/dev.ts
+++ b/src/server/routes/dev.ts
@@ -76,6 +76,7 @@ router.get('/', async (req: Request, res: ResponseWithRequestState) => {
 					<li><a href="/signout">Sign Out</a></li>
 					<li><a href="/delete">Delete Account</a></li>
 					<li><a href="/maintenance">Maintenance</a></li>
+					<li><a href="/signin?newOnboardingFlow=true">New Onboarding Flow</a>&nbsp&nbsp&nbsp&nbsp&nbsp&nbsp<a href="/signin">Old Onboarding Flow</a></li>
 				</ul>
 			</body>
 		</html>

--- a/src/server/routes/welcome.ts
+++ b/src/server/routes/welcome.ts
@@ -45,6 +45,8 @@ import { requestStateHasOAuthTokens } from '../lib/middleware/requestState';
 import { readEncryptedStateCookie } from '../lib/encryptedStateCookie';
 import { RegistrationConsents } from '@/shared/model/RegistrationConsents';
 import { JOBS_TOS_URI } from '@/shared/model/Configuration';
+import { QueryParams } from '@/shared/model/QueryParams';
+import { RoutePaths } from '@/shared/model/Routes';
 
 const { passcodesEnabled: passcodesEnabled, signInPageUrl } =
 	getConfiguration();
@@ -260,10 +262,7 @@ router.post(
 			// we don't want to block the user at this point, so we'll just log the error, and go to the finally block
 			logger.error(`${req.method} ${req.originalUrl}  Error`, error);
 		} finally {
-			const redirectPath =
-				state.queryParams.clientId === 'jobs'
-					? JOBS_TOS_URI
-					: '/welcome/review';
+			const redirectPath = getPostRegistrationRedirectPath(state.queryParams);
 			// eslint-disable-next-line no-unsafe-finally -- we want to redirect and return regardless of any throws
 			return res.redirect(
 				303,
@@ -323,6 +322,28 @@ router.get(
 
 		return res.type('html').send(html);
 	}),
+);
+
+router.get(
+	'/welcome/onboarding',
+	loginMiddlewareOAuth,
+	(_: Request, res: ResponseWithRequestState) => {
+		const state = res.locals;
+
+		if (!requestStateHasOAuthTokens(state)) {
+			return res.redirect(
+				303,
+				addQueryParamsToUntypedPath(signInPageUrl, state.queryParams),
+			);
+		}
+
+		const html = renderer('/welcome/onboarding', {
+			pageTitle: 'Onboarding',
+			requestState: state,
+		});
+
+		return res.type('html').send(html);
+	},
 );
 
 router.get(
@@ -476,6 +497,21 @@ router.post(
 	'/welcome/:token',
 	setPasswordController('/welcome', 'Welcome', '/welcome/review'),
 );
+
+const getPostRegistrationRedirectPath = ({
+	clientId,
+	newOnboardingFlow,
+}: Pick<QueryParams, 'clientId' | 'newOnboardingFlow'>): RoutePaths => {
+	if (clientId === 'jobs') {
+		return JOBS_TOS_URI;
+	}
+
+	if (newOnboardingFlow) {
+		return '/welcome/onboarding';
+	}
+
+	return '/welcome/review';
+};
 
 const OktaResendEmail = async (req: Request, res: ResponseWithRequestState) => {
 	const state = res.locals;

--- a/src/shared/__tests__/queryParams.test.ts
+++ b/src/shared/__tests__/queryParams.test.ts
@@ -23,6 +23,7 @@ describe('getPersistableQueryParams', () => {
 			componentEventParams: 'componentEventParams',
 			fromURI: 'fromURI',
 			appClientId: 'appClientId',
+			newOnboardingFlow: true,
 		};
 
 		const output = getPersistableQueryParams(input);
@@ -39,6 +40,7 @@ describe('getPersistableQueryParams', () => {
 			listName: undefined,
 			usePasswordSignIn: undefined,
 			useSetPassword: undefined,
+			newOnboardingFlow: true,
 		};
 
 		expect(output).toStrictEqual(expected);
@@ -58,12 +60,13 @@ describe('addQueryParamsToPath', () => {
 			ref: 'ref',
 			refViewId: 'refViewId',
 			componentEventParams: 'componentEventParams',
+			newOnboardingFlow: true,
 		};
 
 		const output = addQueryParamsToPath('/consents', input);
 
 		expect(output).toEqual(
-			'/consents?clientId=jobs&componentEventParams=componentEventParams&ref=ref&refViewId=refViewId&returnUrl=returnUrl',
+			'/consents?clientId=jobs&componentEventParams=componentEventParams&newOnboardingFlow=true&ref=ref&refViewId=refViewId&returnUrl=returnUrl',
 		);
 	});
 
@@ -112,6 +115,19 @@ describe('addQueryParamsToPath', () => {
 
 		expect(output).toEqual(
 			'/consents?clientId=jobs&componentEventParams=componentEventParams&returnUrl=returnUrl',
+		);
+	});
+
+	it('preserves newOnboardingFlow=true in welcome redirect URLs', () => {
+		const input: QueryParams = {
+			returnUrl: 'https://www.theguardian.com',
+			newOnboardingFlow: true,
+		};
+
+		const output = addQueryParamsToPath('/welcome/onboarding', input);
+
+		expect(output).toEqual(
+			'/welcome/onboarding?newOnboardingFlow=true&returnUrl=https%3A%2F%2Fwww.theguardian.com',
 		);
 	});
 });

--- a/src/shared/lib/queryParams.ts
+++ b/src/shared/lib/queryParams.ts
@@ -44,6 +44,7 @@ export const getPersistableQueryParams = (
 	useOktaClassic: params.useOktaClassic,
 	usePasswordSignIn: params.usePasswordSignIn,
 	useSetPassword: params.useSetPassword,
+	newOnboardingFlow: params.newOnboardingFlow,
 });
 
 /**

--- a/src/shared/model/QueryParams.ts
+++ b/src/shared/model/QueryParams.ts
@@ -50,6 +50,8 @@ export interface PersistableQueryParams
 	usePasswordSignIn?: boolean;
 	// Flag to force the create account flow to force the user to set a password, useful for testing/using previous behaviour
 	useSetPassword?: boolean;
+	// Flag to opt users into the new onboarding flow
+	newOnboardingFlow?: boolean;
 }
 
 /**

--- a/src/shared/model/Routes.ts
+++ b/src/shared/model/Routes.ts
@@ -102,6 +102,7 @@ export const ValidRoutePathsArray = [
 	'/welcome/complete-account',
 	'/welcome/review',
 	'/welcome/newsletters',
+	'/welcome/onboarding',
 	'/welcome/password',
 ] as const;
 


### PR DESCRIPTION
## What does this change?

It includes a new empty Onboarding page - header only atm - but which will be used in the future to add the new sections in the new onboarding flow.

It also adds a new flag `newOnboardingFlow` and navigates to the `/welcome/onboarding` page from the `/welcome/complete-account` page when the flag is true.

## How has this change been tested?

Unit tests were written + tested locally pointing to CODE that both of the flows are behaving as expected.

Also tested in CODE.

## How can we measure success?

Shouldn't have impact on errors, as it's a new flow. 

## Have we considered potential risks?

Only risk I can think of is the new rule having some unforeseen bug, but unit tests should mitigate that risk. 

It doesn't affect the existing website otherwise.

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
