### PR TITLE
Fix undefined Ophan value for identity-onboarding-newsletter component

### DIFF
--- a/src/server/lib/__tests__/idapi/newsletters.test.ts
+++ b/src/server/lib/__tests__/idapi/newsletters.test.ts
@@ -34,7 +34,7 @@ describe('idapi newsletters calls', () => {
 		it('maps listId to newsletter id', async () => {
 			mockIdapiFetch.mockResolvedValue([
 				{
-					id: 'morning-briefing-uk',
+					identityName: 'morning-briefing-uk',
 					name: 'Morning Briefing',
 					theme: 'news',
 					frequency: 'Every weekday',
@@ -107,7 +107,7 @@ describe('idapi newsletters calls', () => {
 		it('maps all fields correctly', async () => {
 			mockIdapiFetch.mockResolvedValue([
 				{
-					id: 'morning-briefing-uk',
+					identityName: 'morning-briefing-uk',
 					name: 'Morning Briefing',
 					theme: 'news',
 					frequency: 'Every weekday',

--- a/src/server/lib/idapi/newsletters.ts
+++ b/src/server/lib/idapi/newsletters.ts
@@ -12,7 +12,7 @@ import { IdapiError } from '@/server/models/Error';
 import { NewsletterPatch } from '@/shared/model/NewsletterPatch';
 
 interface NewsletterAPIResponse {
-	id: string;
+	identityName: string;
 	theme: string;
 	name: string;
 	signUpDescription?: string | null;
@@ -32,14 +32,14 @@ const responseToEntity = (newsletter: NewsletterAPIResponse): NewsLetter => {
 		signUpEmbedDescription,
 		frequency,
 		listId,
-		id,
+		identityName,
 	} = newsletter;
 	return {
 		id: listId.toString(),
 		description: signUpDescription ?? signUpEmbedDescription ?? '',
 		name,
 		frequency,
-		nameId: id,
+		nameId: identityName,
 	};
 };
 


### PR DESCRIPTION

<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Reads from identity API identityName instead of id field. id doesn't exist and nameId ends up undefined.

## Why?
Fixes an issue where if the user selects at least one newsletter in the onboarding newsletters page we send undefined value to ophan.

## Images

| Before | After |
|--------|-------|
| <img width="1000" alt="image" src="https://github.com/user-attachments/assets/829e79b1-bafc-484d-a282-778365c21dec" /> |  <img width="1000" alt="image" src="https://github.com/user-attachments/assets/43e62052-0709-4bc5-8e57-8b7ebacf6e73" />     |

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
