### PR TITLE
Openid v6 2ndattempt

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -19,15 +19,16 @@ module.exports = {
 		'cdk',
 	],
 	transformIgnorePatterns: [
-		// Don't try to transform any node_modules except Preact and @testing-library/preact
+		// Don't try to transform any node_modules except the packages we know ship ESM
+		// and are imported by our test graph.
 		// Since updating to Jest 30 trying to import these dependencies has resulted in
 		// unsupported ESM getting imported instead of CJS. Possibly because due to
 		// some siginificant changes in how Jest handles ESM under the hood?
 		// See:  https://jestjs.io/docs/upgrading-to-jest30#esm-module-support-and-internal-restructuring
-		'/node_modules/.pnpm/(?!(preact|@testing-library))',
+		'/node_modules/.pnpm/(?!(preact|@testing-library|openid-client|oauth4webapi|jose))',
 	],
 	transform: {
-		'^.+\\.(ts|tsx|jsx|mjs|module.js)?$': [
+		'^.+\\.(ts|tsx|js|jsx|mjs)$': [
 			'@swc/jest',
 			{
 				...config.options,

--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
 		"mjml": "5.4.0",
 		"mjml-browser": "5.4.0",
 		"ms": "2.1.3",
-		"openid-client": "5.7.1",
+		"openid-client": "6.8.4",
 		"preact": "10.29.8",
 		"preact-render-to-string": "6.7.0",
 		"react": "npm:@preact/compat",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -94,8 +94,8 @@ importers:
         specifier: 2.1.3
         version: 2.1.3
       openid-client:
-        specifier: 5.7.1
-        version: 5.7.1
+        specifier: 6.8.4
+        version: 6.8.4
       preact:
         specifier: 10.29.8
         version: 10.29.8(preact-render-to-string@6.7.0)
@@ -5257,6 +5257,9 @@ packages:
   jose@4.15.9:
     resolution: {integrity: sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA==}
 
+  jose@6.2.4:
+    resolution: {integrity: sha512-N8acGzVsQy6M/fjFcxtysNc4Q379TcM5dM/qKkNtsHFji88yANnXTr7BLeP75iPnFwBfQzM/jg2BZ9+HZrHCZA==}
+
   js-beautify@1.15.4:
     resolution: {integrity: sha512-9/KXeZUKKJwqCXUdBxFJ3vPh467OCckSBmYDwSK/EtV090K+iMJ7zx2S3HLVDIWFQdqMIsZWbnaGiba18aWhaA==}
     engines: {node: '>=14'}
@@ -5500,10 +5503,6 @@ packages:
 
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
-
-  lru-cache@11.5.0:
-    resolution: {integrity: sha512-5YgH9UJd7wVb9hIouI2adWpgqrrICkt070Dnj8EUY1+B4B2P9eRLPAkAAo6NICA7CEhOIeBHl46u9zSNpNu7zA==}
-    engines: {node: 20 || >=22}
 
   lru-cache@11.5.1:
     resolution: {integrity: sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==}
@@ -5899,13 +5898,12 @@ packages:
   nwsapi@2.2.23:
     resolution: {integrity: sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==}
 
+  oauth4webapi@3.8.6:
+    resolution: {integrity: sha512-iwemM91xz8nryHti2yTmg5fhyEMVOkOXwHNqbvcATjyajb5oQxCQzrNOA6uElRHuMhQQTKUyFKV9y/CNyg25BQ==}
+
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
-
-  object-hash@2.2.0:
-    resolution: {integrity: sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==}
-    engines: {node: '>= 6'}
 
   object-inspect@1.13.4:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
@@ -5943,10 +5941,6 @@ packages:
     resolution: {integrity: sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==}
     engines: {node: '>= 0.4'}
 
-  oidc-token-hash@5.1.0:
-    resolution: {integrity: sha512-y0W+X7Ppo7oZX6eovsRkuzcSM40Bicg2JEJkDJ4irIt1wsYAP5MLSNv+QAogO8xivMffw/9OvV3um1pxXgt1uA==}
-    engines: {node: ^10.13.0 || >=12.0.0}
-
   on-finished@2.4.1:
     resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
     engines: {node: '>= 0.8'}
@@ -5973,8 +5967,8 @@ packages:
     resolution: {integrity: sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==}
     hasBin: true
 
-  openid-client@5.7.1:
-    resolution: {integrity: sha512-jDBPgSVfTnkIh71Hg9pRvtJc6wTwqjRkN88+gCFtYWrlP4Yx2Dsrow8uPi3qLr/aeymPF3o2+dS+wOpglK04ew==}
+  openid-client@6.8.4:
+    resolution: {integrity: sha512-QSw0BA08piujetEwfZsHoTrDpMEha7GDZDicQqVwX4u0ChCjefvjDB++TZ8BTg76UpwhzIQgdvvfgfl3HpCSAw==}
 
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
@@ -12178,7 +12172,7 @@ snapshots:
 
   hosted-git-info@9.0.3:
     dependencies:
-      lru-cache: 11.5.0
+      lru-cache: 11.5.1
 
   html-encoding-sniffer@4.0.0:
     dependencies:
@@ -13028,6 +13022,8 @@ snapshots:
 
   jose@4.15.9: {}
 
+  jose@6.2.4: {}
+
   js-beautify@1.15.4:
     dependencies:
       config-chain: 1.1.13
@@ -13276,8 +13272,6 @@ snapshots:
       tslib: 2.8.1
 
   lru-cache@10.4.3: {}
-
-  lru-cache@11.5.0: {}
 
   lru-cache@11.5.1: {}
 
@@ -13979,9 +13973,9 @@ snapshots:
 
   nwsapi@2.2.23: {}
 
-  object-assign@4.1.1: {}
+  oauth4webapi@3.8.6: {}
 
-  object-hash@2.2.0: {}
+  object-assign@4.1.1: {}
 
   object-inspect@1.13.4: {}
 
@@ -14036,8 +14030,6 @@ snapshots:
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
 
-  oidc-token-hash@5.1.0: {}
-
   on-finished@2.4.1:
     dependencies:
       ee-first: 1.1.1
@@ -14065,12 +14057,10 @@ snapshots:
 
   opener@1.5.2: {}
 
-  openid-client@5.7.1:
+  openid-client@6.8.4:
     dependencies:
-      jose: 4.15.9
-      lru-cache: 6.0.0
-      object-hash: 2.2.0
-      oidc-token-hash: 5.1.0
+      jose: 6.2.4
+      oauth4webapi: 3.8.6
 
   optionator@0.9.4:
     dependencies:

--- a/src/server/lib/__tests__/okta/openid-connect.test.ts
+++ b/src/server/lib/__tests__/okta/openid-connect.test.ts
@@ -1,0 +1,368 @@
+import { Request } from 'express';
+import { getOpenIdClient } from '@/server/lib/okta/openid-connect';
+import {
+	authorizationCodeGrant,
+	buildAuthorizationUrl,
+	customFetch,
+	refreshTokenGrant,
+	allowInsecureRequests,
+} from 'openid-client';
+
+jest.mock('@/server/lib/getConfiguration', () => ({
+	getConfiguration: () => ({
+		okta: {
+			orgUrl: 'https://example.okta.com',
+			authServerId: 'default',
+			clientId: 'gateway-client-id',
+			clientSecret: 'gateway-client-secret',
+		},
+		baseUri: 'profile.theguardian.com',
+		stage: 'CODE',
+	}),
+}));
+
+jest.mock('@/server/lib/getProfileUrl', () => ({
+	getProfileUrl: () => 'https://profile.theguardian.com',
+}));
+
+jest.mock('openid-client', () => {
+	const customFetchSymbol = Symbol('customFetch');
+
+	return {
+		customFetch: customFetchSymbol,
+		allowInsecureRequests: jest.fn(),
+		Configuration: class {
+			serverMetadata: unknown;
+			clientId: string;
+			metadata: unknown;
+			[customFetchSymbol]?: (
+				url: URL | string,
+				options?: RequestInit,
+			) => Promise<Response>;
+
+			constructor(
+				serverMetadata: unknown,
+				clientId: string,
+				metadata: unknown,
+			) {
+				this.serverMetadata = serverMetadata;
+				this.clientId = clientId;
+				this.metadata = metadata;
+			}
+		},
+		buildAuthorizationUrl: jest.fn(
+			(_: unknown, params: URLSearchParams) =>
+				new URL(
+					`https://example.okta.com/oauth2/v1/authorize?${params.toString()}`,
+				),
+		),
+		authorizationCodeGrant: jest.fn(),
+		refreshTokenGrant: jest.fn(),
+	};
+});
+
+describe('okta openid-connect v6 compatibility layer', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	test('authorizationUrl filters undefined values before calling openid-client', () => {
+		const req = {
+			ip: '127.0.0.1',
+			get: () => undefined,
+		} as unknown as Request;
+		const openIdClient = getOpenIdClient(req);
+
+		const url = openIdClient.authorizationUrl({
+			state: 'abc123',
+			sessionToken: undefined,
+			scope: 'openid profile',
+		});
+
+		expect(buildAuthorizationUrl).toHaveBeenCalledTimes(1);
+		const [, params] = (buildAuthorizationUrl as jest.Mock).mock.calls[0] as [
+			unknown,
+			URLSearchParams,
+		];
+
+		expect(params.get('state')).toBe('abc123');
+		expect(params.get('scope')).toBe('openid profile');
+		expect(params.has('sessionToken')).toBe(false);
+		expect(url).toContain('state=abc123');
+	});
+
+	test('callbackParams keeps only string query values', () => {
+		const req = {
+			ip: '127.0.0.1',
+			get: () => undefined,
+			query: {
+				code: 'auth-code',
+				state: ['state-value', 'secondary-state'],
+				error_description: 'oauth_error',
+				ignored: 42,
+			},
+		} as unknown as Request;
+		const openIdClient = getOpenIdClient(req);
+
+		expect(openIdClient.callbackParams(req)).toEqual({
+			code: 'auth-code',
+			error_description: 'oauth_error',
+		});
+	});
+
+	test('callback and refresh preserve claims() helper semantics', async () => {
+		const tokenClaims = { sub: 'reader-id' };
+		const claims = jest.fn().mockReturnValue(tokenClaims);
+
+		(authorizationCodeGrant as jest.Mock).mockResolvedValue({
+			access_token: 'access-token',
+			id_token: 'id-token',
+			claims,
+		});
+		(refreshTokenGrant as jest.Mock).mockResolvedValue({
+			access_token: 'new-access-token',
+			id_token: 'new-id-token',
+			claims,
+		});
+
+		const req = {
+			ip: '127.0.0.1',
+			get: () => undefined,
+		} as unknown as Request;
+		const openIdClient = getOpenIdClient(req);
+
+		const callbackResult = await openIdClient.callback(
+			'https://profile.theguardian.com/oauth/authorization-code/callback',
+			{ code: 'abc', state: 'state-value' },
+			{ state: 'state-value', code_verifier: 'pkce-verifier' },
+		);
+		const refreshResult = await openIdClient.refresh('refresh-token');
+
+		expect(callbackResult.claims()).toEqual(tokenClaims);
+		expect(refreshResult.claims()).toEqual(tokenClaims);
+		expect(claims).toHaveBeenCalledTimes(2);
+		expect(authorizationCodeGrant).toHaveBeenCalledWith(
+			expect.anything(),
+			expect.any(URL),
+			{
+				pkceCodeVerifier: 'pkce-verifier',
+				expectedState: 'state-value',
+			},
+		);
+	});
+
+	test('claims() throws when id_token is absent', async () => {
+		(authorizationCodeGrant as jest.Mock).mockResolvedValue({
+			access_token: 'access-token',
+			// no id_token, no claims helper
+		});
+
+		const req = {
+			ip: '127.0.0.1',
+			get: () => undefined,
+		} as unknown as Request;
+		const openIdClient = getOpenIdClient(req);
+
+		const result = await openIdClient.callback(
+			'https://profile.theguardian.com/oauth/authorization-code/callback',
+			{ code: 'abc', state: 'state-value' },
+			{ state: 'state-value' },
+		);
+
+		expect(() => result.claims()).toThrow(
+			'id_token not present in token response',
+		);
+	});
+
+	test('adds X-Forwarded-For header to openid-client requests when ip is present', async () => {
+		const fetchMock = jest
+			.spyOn(globalThis, 'fetch')
+			.mockResolvedValue(new Response(null, { status: 200 }));
+
+		const req = {
+			ip: '203.0.113.10',
+			get: () => undefined,
+		} as unknown as Request;
+		const openIdClient = getOpenIdClient(req);
+		openIdClient.authorizationUrl({ state: 'abc' });
+
+		const [config] = (buildAuthorizationUrl as jest.Mock).mock.calls[0] as [
+			Record<
+				symbol,
+				(url: URL | string, options?: RequestInit) => Promise<Response>
+			>,
+			URLSearchParams,
+		];
+		await config[customFetch]('https://example.okta.com/oauth2/v1/token', {
+			headers: { Authorization: 'Bearer existing-token' },
+		});
+
+		expect(fetchMock).toHaveBeenCalledWith(
+			'https://example.okta.com/oauth2/v1/token',
+			expect.objectContaining({
+				headers: expect.objectContaining({
+					authorization: 'Bearer existing-token',
+					'X-Forwarded-For': '203.0.113.10',
+				}),
+			}),
+		);
+
+		fetchMock.mockRestore();
+	});
+
+	test('full authorization → callback → refresh flow with matching state and PKCE', async () => {
+		const req = {
+			ip: '10.0.0.1',
+			get: () => undefined,
+		} as unknown as Request;
+		const client = getOpenIdClient(req);
+
+		// Step 1 – build the authorization URL
+		const authUrl = client.authorizationUrl({
+			state: 'csrf-state-xyz',
+			code_challenge: 'challenge-abc',
+			code_challenge_method: 'S256',
+			scope: 'openid profile email',
+			redirect_uri:
+				'https://profile.theguardian.com/oauth/authorization-code/callback',
+		});
+
+		expect(buildAuthorizationUrl).toHaveBeenCalledTimes(1);
+		expect(authUrl).toContain('state=csrf-state-xyz');
+		expect(authUrl).toContain('code_challenge=challenge-abc');
+
+		// Step 2 – exchange the authorization code
+		const tokenClaims = { sub: 'user-123', email: 'user@example.com' };
+		const claimsFn = jest.fn().mockReturnValue(tokenClaims);
+		const mockAccessToken = 'access-token-step2';
+		const mockRefreshToken = 'refresh-token-step2';
+
+		(authorizationCodeGrant as jest.Mock).mockResolvedValue({
+			access_token: mockAccessToken,
+			id_token: 'id-token-step2',
+			refresh_token: mockRefreshToken,
+			claims: claimsFn,
+		});
+
+		const callbackResult = await client.callback(
+			'https://profile.theguardian.com/oauth/authorization-code/callback',
+			{ code: 'auth-code-123', state: 'csrf-state-xyz' },
+			{ state: 'csrf-state-xyz', code_verifier: 'pkce-verifier-xyz' },
+		);
+
+		expect(authorizationCodeGrant).toHaveBeenCalledWith(
+			expect.anything(),
+			expect.any(URL),
+			{
+				pkceCodeVerifier: 'pkce-verifier-xyz',
+				expectedState: 'csrf-state-xyz',
+			},
+		);
+		expect(callbackResult.access_token).toBe(mockAccessToken);
+		expect(callbackResult.refresh_token).toBe(mockRefreshToken);
+		expect(callbackResult.claims()).toEqual(tokenClaims);
+
+		// Step 3 – refresh using the token obtained in step 2
+		const newAccessToken = 'access-token-step3';
+		(refreshTokenGrant as jest.Mock).mockResolvedValue({
+			access_token: newAccessToken,
+			id_token: 'id-token-step3',
+			claims: claimsFn,
+		});
+
+		const refreshResult = await client.refresh(mockRefreshToken);
+
+		expect(refreshTokenGrant).toHaveBeenCalledWith(
+			expect.anything(),
+			mockRefreshToken,
+		);
+		expect(refreshResult.access_token).toBe(newAccessToken);
+		expect(refreshResult.claims()).toEqual(tokenClaims);
+	});
+
+	test('full application-token flow: callback without PKCE, then refresh', async () => {
+		// Some OAuth flows (e.g. application-callback) do not use PKCE.
+		// Confirm that code_verifier being absent maps to pkceCodeVerifier: undefined.
+		const claimsFn = jest.fn().mockReturnValue({ sub: 'app-user' });
+
+		(authorizationCodeGrant as jest.Mock).mockResolvedValue({
+			access_token: 'app-access-token',
+			id_token: 'app-id-token',
+			refresh_token: 'app-refresh-token',
+			claims: claimsFn,
+		});
+
+		const req = {
+			ip: '10.0.0.2',
+			get: () => undefined,
+		} as unknown as Request;
+		const client = getOpenIdClient(req);
+
+		const callbackResult = await client.callback(
+			'https://profile.theguardian.com/oauth/authorization-code/application-callback',
+			{ code: 'app-code', state: 'app-state' },
+			{ state: 'app-state' }, // no code_verifier → no PKCE
+		);
+
+		expect(authorizationCodeGrant).toHaveBeenCalledWith(
+			expect.anything(),
+			expect.any(URL),
+			{ pkceCodeVerifier: undefined, expectedState: 'app-state' },
+		);
+		expect(callbackResult.access_token).toBe('app-access-token');
+
+		// Refresh the application token
+		(refreshTokenGrant as jest.Mock).mockResolvedValue({
+			access_token: 'app-new-access-token',
+			id_token: 'app-new-id-token',
+			claims: claimsFn,
+		});
+
+		const refreshResult = await client.refresh('app-refresh-token');
+
+		expect(refreshTokenGrant).toHaveBeenCalledWith(
+			expect.anything(),
+			'app-refresh-token',
+		);
+		expect(refreshResult.access_token).toBe('app-new-access-token');
+	});
+
+	test('application callback rejects when PKCE verifier is wrong', async () => {
+		(authorizationCodeGrant as jest.Mock).mockRejectedValue(
+			new Error('PKCE verification failed'),
+		);
+
+		const req = {
+			ip: '10.0.0.4',
+			get: () => undefined,
+		} as unknown as Request;
+		const client = getOpenIdClient(req);
+
+		await expect(
+			client.callback(
+				'https://profile.theguardian.com/oauth/authorization-code/application-callback',
+				{ code: 'app-code', state: 'app-state' },
+				{ state: 'app-state', code_verifier: 'wrong-verifier' },
+			),
+		).rejects.toThrow('PKCE verification failed');
+
+		expect(authorizationCodeGrant).toHaveBeenCalledWith(
+			expect.anything(),
+			expect.any(URL),
+			{ pkceCodeVerifier: 'wrong-verifier', expectedState: 'app-state' },
+		);
+		expect(refreshTokenGrant).not.toHaveBeenCalled();
+	});
+
+	// This is deprecated, but there doesn't seem to be a direct replacement to do unsafe http in v6.
+	test('allowInsecureRequests is NOT called for a production HTTPS issuer', () => {
+		const req = {
+			ip: '127.0.0.1',
+			get: () => undefined,
+		} as unknown as Request;
+
+		getOpenIdClient(req).authorizationUrl({ state: 'test' });
+
+		expect(allowInsecureRequests).not.toHaveBeenCalled();
+	});
+});

--- a/src/server/lib/okta/idx/interact.ts
+++ b/src/server/lib/okta/idx/interact.ts
@@ -1,7 +1,10 @@
 import { Request } from 'express';
 import { ResponseWithRequestState } from '@/server/models/Express';
 import { logger } from '@/server/lib/serverSideLogger';
-import { AuthorizationParameters, generators } from 'openid-client';
+import {
+	randomPKCECodeVerifier,
+	calculatePKCECodeChallenge,
+} from 'openid-client';
 import { getConfiguration } from '@/server/lib/getConfiguration';
 import {
 	AuthorizationState,
@@ -76,8 +79,8 @@ export const interact = async (
 		// see https://www.oauth.com/oauth2-servers/pkce/authorization-request/
 		// the `code_verifier` is a cryptographically random string
 		// the `code_challenge` is the `code_verifier` hashed with SHA-256 and then base64url encoded
-		const codeVerifier = generators.codeVerifier(64);
-		const codeChallenge = generators.codeChallenge(codeVerifier);
+		const codeVerifier = randomPKCECodeVerifier();
+		const codeChallenge = await calculatePKCECodeChallenge(codeVerifier);
 
 		// generate and store a "state"
 		// as a http only, secure, signed session cookie
@@ -102,7 +105,7 @@ export const interact = async (
 		// set up the authorization parameters to send to the /interact endpoint
 		// in order to start the interaction code flow
 		// see https://developer.okta.com/docs/concepts/interaction-code/
-		const authorizationParams: AuthorizationParameters = {
+		const authorizationParams: Record<string, string> = {
 			// the client_id is the id of the client application
 			client_id: okta.clientId,
 			// only use the interaction code flow callback uri, everything else is handled by standard authorization code flow
@@ -117,9 +120,7 @@ export const interact = async (
 			state: authState.stateParam,
 		};
 
-		const authorizationSearchParams = new URLSearchParams(
-			authorizationParams as Record<string, string>,
-		);
+		const authorizationSearchParams = new URLSearchParams(authorizationParams);
 
 		const response = await fetch(
 			joinUrl(okta.orgUrl, '/oauth2/', okta.authServerId, '/v1/interact'),

--- a/src/server/lib/okta/oauth.ts
+++ b/src/server/lib/okta/oauth.ts
@@ -156,7 +156,7 @@ export const performAuthorizationCodeFlow = async (
 		// otherwise we'll use the prompt parameter provided
 		prompt: idp && !loginHint ? 'login' : prompt,
 		// The sessionToken from authentication to exchange for session cookie
-		sessionToken,
+		sessionToken: sessionToken ?? undefined,
 		// we send the generated stateParam as the state parameter
 		state: authState.stateParam,
 		// any scopes, by default the 'openid' scope is required

--- a/src/server/lib/okta/openid-connect.ts
+++ b/src/server/lib/okta/openid-connect.ts
@@ -1,4 +1,15 @@
-import { Issuer, IssuerMetadata, Client, custom } from 'openid-client';
+import {
+	Configuration,
+	ServerMetadata,
+	buildAuthorizationUrl,
+	authorizationCodeGrant,
+	refreshTokenGrant,
+	customFetch,
+	allowInsecureRequests,
+	type IDToken,
+	type TokenEndpointResponse,
+	type TokenEndpointResponseHelpers,
+} from 'openid-client';
 import { randomBytes } from 'crypto';
 import { Request, CookieOptions } from 'express';
 import { joinUrl } from '@guardian/libs';
@@ -9,7 +20,6 @@ import { ResponseWithRequestState } from '@/server/models/Express';
 import { logger } from '@/server/lib/serverSideLogger';
 import { RoutePaths } from '@/shared/model/Routes';
 import { SocialProvider } from '@/shared/model/Social';
-import type { OutgoingHttpHeaders } from 'http';
 
 export type UserFlow =
 	| 'sign-in-passcode'
@@ -54,22 +64,47 @@ export interface AuthorizationState {
 }
 
 /**
- * @interface OpenIdClient
- * Subset of properties of the 'openid-client' Client class.
- * This is so we can support a minimal set of mechanisms for
- * things we actually need to use.
+ * @interface OidcTokenSet
  *
- * @property `authorizationUrl` - Generate the `/authorize` url for the Authorization Code Flow (w or w/o PKCE)
- * @property `callbackParams` - Get OpenID Connect query parameters returned to the callback (redirect_uri)
- * @property `callback` - Method used in the callback (redirect_uri) endpoint to get OAuth tokens
- * @property `refresh` - Method used to refresh the OAuth tokens using a refresh token
- *
+ * Wraps the v6 `TokenEndpointResponse` plain object and adds
+ * back a `claims()` helper so that callers in oauth.ts do not
+ * need to change how they access ID-token claims.
  */
+export interface OidcTokenSet {
+	access_token?: string;
+	id_token?: string;
+	refresh_token?: string;
+	token_type?: string;
+	expires_in?: number;
+	scope?: string;
+	claims: () => IDToken;
+}
 
-export type OpenIdClient = Pick<
-	Client,
-	'authorizationUrl' | 'callbackParams' | 'callback' | 'refresh'
->;
+/**
+ * @interface OpenIdClient
+ *
+ * Internal abstraction over the openid-client library.  Exposes only the four
+ * operations that Gateway actually uses so that the rest of the codebase is
+ * isolated from library internals.
+ *
+ * @property `authorizationUrl`  - Build the /authorize redirect URL
+ * @property `callbackParams`    - Parse OIDC params from the callback request
+ * @property `callback`          - Exchange an authorisation code for tokens
+ * @property `refresh`           - Use a refresh token to obtain new tokens
+ */
+export interface OpenIdClient {
+	authorizationUrl(params: Record<string, string | undefined>): string;
+	callbackParams(req: Request): Record<string, string>;
+	callback(
+		redirectUri: string,
+		params: Record<string, string>,
+		checks: {
+			state?: string;
+			code_verifier?: string;
+		},
+	): Promise<OidcTokenSet>;
+	refresh(refreshToken: string): Promise<OidcTokenSet>;
+}
 
 /**
  * @interface OpenIdClientRedirectUris
@@ -104,7 +139,7 @@ const { okta, baseUri, stage } = getConfiguration();
  * we only expose the endpoints here
  */
 const issuer = joinUrl(okta.orgUrl, '/oauth2/', okta.authServerId);
-const OIDC_METADATA: IssuerMetadata = {
+const OIDC_METADATA: ServerMetadata = {
 	issuer,
 	authorization_endpoint: joinUrl(issuer, '/v1/authorize'),
 	token_endpoint: joinUrl(issuer, '/v1/token'),
@@ -115,12 +150,6 @@ const OIDC_METADATA: IssuerMetadata = {
 	revocation_endpoint: joinUrl(issuer, '/v1/revoke'),
 	end_session_endpoint: joinUrl(issuer, '/v1/logout'),
 };
-
-/**
- * Encapsulates a discovered or instantiated OpenID Connect Issuer (Issuer),
- * Identity Provider(IdP), Authorization Server(AS) and its metadata.
- */
-const OIDCIssuer = new Issuer(OIDC_METADATA);
 
 /**
  * Redirect uris used by the "profile" OAuth app in Okta
@@ -134,99 +163,179 @@ export const ProfileOpenIdClientRedirectUris: OpenIdClientRedirectUris = {
 	INTERACTION_CODE: `${getProfileUrl()}/oauth/authorization-code/interaction-code-callback`,
 };
 
-const withXForwardedForHeader = (
-	headers: OutgoingHttpHeaders | readonly string[],
-	ip: string,
-): OutgoingHttpHeaders | readonly string[] => {
-	if (isOutGoingHttpHeaders(headers)) {
-		return { ...headers, 'X-Forwarded-For': ip };
-	} else {
-		return [...headers, 'X-Forwarded-For', ip];
-	}
+type OidcTokenResponse = TokenEndpointResponse & TokenEndpointResponseHelpers;
+
+const toOidcTokenSet = (response: TokenEndpointResponse): OidcTokenSet => {
+	const withHelpers = response as OidcTokenResponse;
+
+	return {
+		...response,
+		claims: (): IDToken => {
+			const claimsData = withHelpers.claims?.();
+			if (!claimsData) {
+				throw new TypeError('id_token not present in token response');
+			}
+			return claimsData;
+		},
+	};
 };
 
-const isOutGoingHttpHeaders = (
-	headers: OutgoingHttpHeaders | readonly string[],
-): headers is OutgoingHttpHeaders => !Array.isArray(headers);
-
 /**
- * @class ProfileOpenIdClient
+ * Creates a v6 `Configuration` object that combines server metadata with
+ * client credentials. When an IP address is provided, a custom `fetch`
+ * implementation is attached so that every outgoing request to Okta carries
+ * an `X-Forwarded-For` header.  This lets Okta apply per-user rate-limiting
+ * and fraud detection instead of treating all requests as coming from the
+ * gateway's own IP.
  *
- * A subset of the 'openid-client' lib `Client` class
- * features/mechanisms to expose.
- * The client/app is the "profile" OAuth app in Okta
- * @property `authorizationUrl` - Generate the `/authorize` url for the Authorization Code Flow (w or w/o PKCE)
- * @property `callbackParams` - Get OpenID Connect query parameters returned to the callback (redirect_uri)
- * @property `oauthCallback` - Method used in the callback (redirect_uri) endpoint to get OAuth tokens
+ * When the issuer URL uses HTTP (e.g. in local development or CI tests),
+ * `allowInsecureRequests` is called so that openid-client v6 does not reject
+ * the non-TLS endpoints.
  */
-const ProfileOpenIdClient = (ip?: string) => {
-	const client = new OIDCIssuer.Client({
-		client_id: okta.clientId,
+const buildProfileConfig = (
+	serverMetadata: ServerMetadata,
+	ip?: string,
+): Configuration => {
+	const config = new Configuration(serverMetadata, okta.clientId, {
 		client_secret: okta.clientSecret,
-		redirect_uris: Object.values(ProfileOpenIdClientRedirectUris),
 	});
 
-	// Make sure we forward the IP address to Okta by adding it to the headers in the library calls
-	// https://github.com/panva/node-openid-client/blob/main/docs/README.md#customizing
-	// eslint-disable-next-line functional/immutable-data -- used to modify the client directly to add the IP address to the headers
-	client[custom.http_options] = (_, options) => {
-		// Add the IP address to the headers
-		const headers = options.headers || {};
+	// openid-client v6 enforces HTTPS-only by default; allow HTTP for
+	// non-production environments (e.g. local development and CI tests) where
+	// the Okta org URL is an http:// address.
+	if (!serverMetadata.issuer.startsWith('https:')) {
+		allowInsecureRequests(config);
+	}
 
-		const headersWithXForwardedFor = ip
-			? withXForwardedForHeader(headers, ip)
-			: headers;
+	if (ip) {
+		// eslint-disable-next-line functional/immutable-data -- required to attach customFetch symbol to the Configuration instance
+		config[customFetch] = ((
+			url: URL | string,
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any -- CustomFetchOptions is not a public export; using any avoids the FetchBody vs BodyInit incompatibility
+			options: any,
+		): Promise<Response> =>
+			fetch(url, {
+				...options,
+				headers: {
+					...Object.fromEntries(new Headers(options?.headers ?? {})),
+					'X-Forwarded-For': ip,
+				},
+			})) as NonNullable<Configuration[typeof customFetch]>;
+	}
 
-		return {
-			...options,
-			headers: headersWithXForwardedFor,
-		};
-	};
-
-	return client as OpenIdClient;
+	return config;
 };
 
 /**
- * @class DevProfileIdClient
+ * Wraps a v6 `Configuration` in the `OpenIdClient` interface that the rest of
+ * the application expects.
+ */
+const makeOpenIdClient = (config: Configuration): OpenIdClient => ({
+	authorizationUrl(params) {
+		const definedEntries = Object.entries(params).filter(
+			(e): e is [string, string] => e[1] !== undefined,
+		);
+		return buildAuthorizationUrl(config, new URLSearchParams(definedEntries))
+			.href;
+	},
+
+	callbackParams(req) {
+		// Parse the query string from the Express request into a flat string map.
+		// This preserves error params (error, error_description) so that the
+		// existing isOAuthError() check in the route handler still works.
+		const raw = (req.query ?? {}) as Record<string, unknown>;
+		return Object.fromEntries(
+			Object.entries(raw).filter(
+				(e): e is [string, string] => typeof e[1] === 'string',
+			),
+		);
+	},
+
+	async callback(redirectUri, params, checks) {
+		const callbackUrl = new URL(redirectUri);
+		Object.entries(params).forEach(([k, v]) =>
+			callbackUrl.searchParams.set(k, v),
+		);
+
+		const response: TokenEndpointResponse = await (async () => {
+			try {
+				return await authorizationCodeGrant(config, callbackUrl, {
+					pkceCodeVerifier: checks.code_verifier,
+					expectedState: checks.state,
+				});
+			} catch (error) {
+				const errorRecord = error as {
+					name?: string;
+					message?: string;
+					code?: string;
+					cause?: {
+						name?: string;
+						message?: string;
+						code?: string;
+						error?: string;
+						error_description?: string;
+					};
+				};
+
+				logger.error('openid authorizationCodeGrant failed', {
+					errorName: errorRecord.name,
+					errorMessage: errorRecord.message,
+					errorCode: errorRecord.code,
+					causeName: errorRecord.cause?.name,
+					causeMessage: errorRecord.cause?.message,
+					causeCode: errorRecord.cause?.code,
+					causeError: errorRecord.cause?.error,
+					causeErrorDescription: errorRecord.cause?.error_description,
+					callbackParamKeys: Object.keys(params),
+					hasCodeParam: typeof params.code === 'string',
+					hasStateParam: typeof params.state === 'string',
+					hasPkceCodeVerifier: typeof checks.code_verifier === 'string',
+					redirectPath: callbackUrl.pathname,
+				});
+
+				throw error;
+			}
+		})();
+
+		return toOidcTokenSet(response);
+	},
+
+	async refresh(refreshToken) {
+		const response = await refreshTokenGrant(config, refreshToken);
+		return toOidcTokenSet(response);
+	},
+});
+
+/**
+ * @function ProfileOpenIdClient
+ *
+ * Returns an `OpenIdClient` backed by the production Okta OIDC configuration.
+ */
+const ProfileOpenIdClient = (ip?: string): OpenIdClient => {
+	const config = buildProfileConfig(OIDC_METADATA, ip);
+	return makeOpenIdClient(config);
+};
+
+/**
+ * @function DevProfileIdClient
  *
  * DEV ONLY
  *
- * Generates a new issuer per request in dev env to simulate
- * custom domain as the issuer
- * this is because locally the issuer is probably profile.thegulocal.com
- * while okta tokens will be the okta url, so we need to replace the issuer
- * with the okta domain
- * @param devIssuer - The okta domain issuer url to use for development
+ * In local development the Gateway runs at profile.thegulocal.com while Okta
+ * tokens carry the real Okta org URL as their issuer.  This function generates
+ * a Configuration whose issuer URL matches the Okta domain so that token
+ * validation succeeds even though the redirect_uri uses the local domain.
+ *
+ * @param devIssuer - The Okta-domain issuer string extracted from X-GU-Okta-Env
+ * @param {string} [ip] - Optional user IP address forwarded to Okta as X-Forwarded-For
  */
-const DevProfileIdClient = (devIssuer: string, ip?: string) => {
-	const devOidcIssuer = new Issuer({
+const DevProfileIdClient = (devIssuer: string, ip?: string): OpenIdClient => {
+	const devMetadata: ServerMetadata = {
 		...OIDC_METADATA,
 		issuer: issuer.replace(okta.orgUrl.replace('https://', ''), devIssuer),
-	});
-
-	const devClient = new devOidcIssuer.Client({
-		client_id: okta.clientId,
-		client_secret: okta.clientSecret,
-		redirect_uris: Object.values(ProfileOpenIdClientRedirectUris),
-	});
-
-	// Make sure we forward the IP address to Okta by adding it to the headers in the library calls
-	// https://github.com/panva/node-openid-client/blob/main/docs/README.md#customizing
-	// eslint-disable-next-line functional/immutable-data -- used to modify the client directly to add the IP address to the headers
-	devClient[custom.http_options] = (_, options) => {
-		// Add the IP address to the headers
-		const headers = options.headers || {};
-		const headersWithXForwardedFor = ip
-			? withXForwardedForHeader(headers, ip)
-			: headers;
-
-		return {
-			...options,
-			headers: headersWithXForwardedFor,
-		};
 	};
-
-	return devClient as OpenIdClient;
+	const config = buildProfileConfig(devMetadata, ip);
+	return makeOpenIdClient(config);
 };
 
 /**
@@ -280,9 +389,11 @@ const isAuthorizationState = (obj: unknown): obj is AuthorizationState => {
  * Generate the `AuthorizationState` object to be stored as a
  * cookie on the client, and the `stateParam` used by the Authorization
  * Code flow.
- * @param {string} returnUrl
+ *
+ * @param queryParams - Persistable query params captured at flow start
  * @param confirmationPage (optional) - page to redirect the user to after authentication
  * @param doNotSetLastAccessCookie (optional) - if true, ignore the last access cookie when setting the other Idapi cookies
+ * @param data (optional) - additional non-sensitive state data to carry through the flow
  * @return {*} `AuthorizationState`
  */
 export const generateAuthorizationState = (

--- a/src/server/lib/okta/openid-connect.ts
+++ b/src/server/lib/okta/openid-connect.ts
@@ -255,6 +255,23 @@ const makeOpenIdClient = (config: Configuration): OpenIdClient => ({
 		// This preserves error params (error, error_description) so that the
 		// existing isOAuthError() check in the route handler still works.
 		const raw = (req.query ?? {}) as Record<string, unknown>;
+		const droppedParamTypes = Object.fromEntries(
+			Object.entries(raw).flatMap(([key, value]) => {
+				if (typeof value === 'string' || value === undefined) {
+					return [];
+				}
+
+				return [[key, Array.isArray(value) ? 'array' : typeof value]];
+			}),
+		);
+
+		if (Object.keys(droppedParamTypes).length > 0) {
+			logger.warn('OAuth callback params contained non-string values', {
+				rawQueryKeys: Object.keys(raw),
+				droppedParamTypes,
+			});
+		}
+
 		return Object.fromEntries(
 			Object.entries(raw).filter(
 				(e): e is [string, string] => typeof e[1] === 'string',

--- a/src/server/lib/okta/openid-connect.ts
+++ b/src/server/lib/okta/openid-connect.ts
@@ -103,7 +103,7 @@ export interface OpenIdClient {
 			state?: string;
 			code_verifier?: string;
 			logContext?: {
-				callbackParam?: string;
+				callbackParam?: string | string[];
 				authStateAgeMs?: number;
 				authStateFlow?: UserFlow;
 				authStateSocialProvider?: SocialProvider;

--- a/src/server/lib/okta/openid-connect.ts
+++ b/src/server/lib/okta/openid-connect.ts
@@ -46,6 +46,7 @@ export type UserFlow =
  */
 export interface AuthorizationState {
 	stateParam: string;
+	createdAt?: number;
 	queryParams: PersistableQueryParams;
 	confirmationPage?: RoutePaths;
 	doNotSetLastAccessCookie?: boolean;
@@ -101,6 +102,16 @@ export interface OpenIdClient {
 		checks: {
 			state?: string;
 			code_verifier?: string;
+			logContext?: {
+				callbackParam?: string;
+				authStateAgeMs?: number;
+				authStateFlow?: UserFlow;
+				authStateSocialProvider?: SocialProvider;
+				hasStateToken?: boolean;
+				hasConfirmationPage?: boolean;
+				callbackStateMatchesExpected?: boolean;
+				codeVerifierType?: string;
+			};
 		},
 	): Promise<OidcTokenSet>;
 	refresh(refreshToken: string): Promise<OidcTokenSet>;
@@ -290,7 +301,16 @@ const makeOpenIdClient = (config: Configuration): OpenIdClient => ({
 					hasCodeParam: typeof params.code === 'string',
 					hasStateParam: typeof params.state === 'string',
 					hasPkceCodeVerifier: typeof checks.code_verifier === 'string',
+					codeVerifierType: typeof checks.code_verifier,
 					redirectPath: callbackUrl.pathname,
+					callbackParam: checks.logContext?.callbackParam,
+					authStateAgeMs: checks.logContext?.authStateAgeMs,
+					authStateFlow: checks.logContext?.authStateFlow,
+					authStateSocialProvider: checks.logContext?.authStateSocialProvider,
+					hasStateToken: checks.logContext?.hasStateToken,
+					hasConfirmationPage: checks.logContext?.hasConfirmationPage,
+					callbackStateMatchesExpected:
+						checks.logContext?.callbackStateMatchesExpected,
 				});
 
 				throw error;
@@ -403,6 +423,7 @@ export const generateAuthorizationState = (
 	data?: AuthorizationState['data'],
 ): AuthorizationState => ({
 	stateParam: generateRandomString(),
+	createdAt: Date.now(),
 	queryParams,
 	confirmationPage,
 	doNotSetLastAccessCookie,

--- a/src/server/routes/oauth.ts
+++ b/src/server/routes/oauth.ts
@@ -20,7 +20,8 @@ import {
 	SignInErrors,
 } from '@/shared/model/Errors';
 import { addQueryParamsToPath } from '@/shared/lib/queryParams';
-import { IdTokenClaims, TokenSet } from 'openid-client';
+import type { IDToken } from 'openid-client';
+import type { OidcTokenSet } from '@/server/lib/okta/openid-connect';
 import { updateUser } from '@/server/lib/okta/api/users';
 import { setUserFeatureCookies } from '@/server/lib/user-features';
 import {
@@ -52,16 +53,17 @@ interface OAuthError {
 	error_description: string;
 }
 
-interface CustomClaims extends IdTokenClaims {
+interface CustomClaims extends IDToken {
 	user_groups?: string[];
 	email_validated?: boolean;
 	legacy_identity_id?: string;
+	email?: string;
 }
 
 /**
  * Type guard to check that a given error is an OAuth error.
  * By checking for the `error` and `error_description` properties
- * @param {unknown} obj
+ * @param {unknown} maybeOAuthError
  * @return {boolean}
  */
 const isOAuthError = (
@@ -97,7 +99,7 @@ const redirectForGenericError = (_: Request, res: ResponseWithRequestState) => {
 const authenticationHandler = async (
 	req: Request,
 	res: ResponseWithRequestState,
-	tokenSet: TokenSet,
+	tokenSet: OidcTokenSet,
 	authState: AuthorizationState,
 	openIdClient: OpenIdClient,
 ): Promise<void> => {
@@ -160,7 +162,7 @@ const authenticationHandler = async (
 		// Okta profile before carrying on. This is surfaced via the legacy_identity_id
 		// claim in the access token.
 		const refreshToken = tokenSet.refresh_token;
-		const { legacy_identity_id }: CustomClaims = tokenSet.claims();
+		const { legacy_identity_id } = tokenSet.claims() as CustomClaims;
 
 		if (!refreshToken && !legacy_identity_id) {
 			// We can't do this step without the refresh token, so if it's missing, just continue
@@ -608,7 +610,7 @@ const authenticationHandler = async (
 const applicationHandler = (
 	req: Request,
 	res: ResponseWithRequestState,
-	tokenSet: TokenSet,
+	tokenSet: OidcTokenSet,
 	authState: AuthorizationState,
 ) => {
 	try {
@@ -652,7 +654,7 @@ const applicationHandler = (
 const deleteHandler = async (
 	req: Request,
 	res: ResponseWithRequestState,
-	tokenSet: TokenSet,
+	tokenSet: OidcTokenSet,
 	authState: AuthorizationState,
 ) => {
 	try {
@@ -665,7 +667,7 @@ const deleteHandler = async (
 			return redirectForGenericError(req, res);
 		}
 
-		const claims = tokenSet.claims();
+		const claims = tokenSet.claims() as CustomClaims;
 
 		const response = await fetch(deleteAccountStepFunction.url, {
 			method: 'POST',
@@ -849,8 +851,6 @@ router.get(
 			callbackParams,
 			// checks to make sure that everything is valid
 			{
-				// we're doing the auth code flow, so check for the correct type
-				response_type: 'code',
 				// check that the stateParam is the same
 				state: authState.stateParam,
 				// code verifier is required for PKCE if we're using it

--- a/src/server/routes/oauth.ts
+++ b/src/server/routes/oauth.ts
@@ -759,6 +759,10 @@ router.get(
 		// and "returnUrl" so we can get the user back to the page they
 		// initially landed on sign in from
 		const authState = getAuthorizationStateCookie(req);
+		const authStateAgeMs =
+			typeof authState?.createdAt === 'number'
+				? Date.now() - authState.createdAt
+				: undefined;
 
 		// check if the state cookie exists, this should be set at the start of the OAuth flow
 		// e.g. at sign in
@@ -768,7 +772,12 @@ router.get(
 			// b) someone is trying to attack the oauth flow
 			// for example with an invalid state cookie, or without the state cookie
 			// the state cookie is used to prevent CSRF attacks
-			logger.warn('Missing auth state cookie on OAuth Callback!', undefined);
+			logger.warn('Missing auth state cookie on OAuth Callback!', {
+				callbackParam: req.params.callbackParam,
+				queryKeys: Object.keys(req.query ?? {}),
+				hasCodeParam: typeof req.query.code === 'string',
+				hasStateParam: typeof req.query.state === 'string',
+			});
 			trackMetric('OAuthAuthorization::Failure');
 			return redirectForGenericError(req, res);
 		}
@@ -801,6 +810,20 @@ router.get(
 		// if there were any errors, then an "error", and "error_description" params
 		// will be returned instead
 		const callbackParams = openIdClient.callbackParams(req);
+
+		logger.info('OAuth callback received', {
+			callbackParam: req.params.callbackParam,
+			callbackParamKeys: Object.keys(callbackParams),
+			authStateAgeMs,
+			authStateFlow: authState.data?.flow,
+			authStateSocialProvider: authState.data?.socialProvider,
+			hasPkceCodeVerifier: typeof authState.data?.codeVerifier === 'string',
+			codeVerifierType: typeof authState.data?.codeVerifier,
+			hasStateToken: typeof authState.data?.stateToken === 'string',
+			hasConfirmationPage: authState.confirmationPage !== undefined,
+			callbackStateMatchesExpected:
+				callbackParams.state === authState.stateParam,
+		});
 
 		// we have the Authorization State now, so the cookie is
 		// no longer required, so mark cookie for deletion in the response
@@ -855,6 +878,17 @@ router.get(
 				state: authState.stateParam,
 				// code verifier is required for PKCE if we're using it
 				code_verifier: authState.data?.codeVerifier,
+				logContext: {
+					callbackParam: req.params.callbackParam,
+					authStateAgeMs,
+					authStateFlow: authState.data?.flow,
+					authStateSocialProvider: authState.data?.socialProvider,
+					hasStateToken: typeof authState.data?.stateToken === 'string',
+					hasConfirmationPage: authState.confirmationPage !== undefined,
+					callbackStateMatchesExpected:
+						callbackParams.state === authState.stateParam,
+					codeVerifierType: typeof authState.data?.codeVerifier,
+				},
 			},
 		);
 


### PR DESCRIPTION
## What does this change?

Reverts the revert of my v5 -> v6 changes (putting them back) with some extra logging to try to figure out why it's not working.

## How has this change been tested?

I can't reproduce the errors in CODE, so the only thing I can think of is deploying to PROD, let it run for a few minutes, and revert the deploy once we have some logs.

## How can we measure success?

We figure out what the issue with moving from v5 to v6 is and fix it in a future PR.

## Have we considered potential risks?

There will be some users that will get errors on gateway, but last time it happened, it was a minority of users, so it shouldn't affect every user at once.

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
