### PR TITLE
Revert "Fix undefined Ophan value for identity-onboarding-newsletter component"

### DIFF
--- a/src/server/lib/__tests__/idapi/newsletters.test.ts
+++ b/src/server/lib/__tests__/idapi/newsletters.test.ts
@@ -34,7 +34,7 @@ describe('idapi newsletters calls', () => {
 		it('maps listId to newsletter id', async () => {
 			mockIdapiFetch.mockResolvedValue([
 				{
-					identityName: 'morning-briefing-uk',
+					id: 'morning-briefing-uk',
 					name: 'Morning Briefing',
 					theme: 'news',
 					frequency: 'Every weekday',
@@ -107,7 +107,7 @@ describe('idapi newsletters calls', () => {
 		it('maps all fields correctly', async () => {
 			mockIdapiFetch.mockResolvedValue([
 				{
-					identityName: 'morning-briefing-uk',
+					id: 'morning-briefing-uk',
 					name: 'Morning Briefing',
 					theme: 'news',
 					frequency: 'Every weekday',

--- a/src/server/lib/idapi/newsletters.ts
+++ b/src/server/lib/idapi/newsletters.ts
@@ -12,7 +12,7 @@ import { IdapiError } from '@/server/models/Error';
 import { NewsletterPatch } from '@/shared/model/NewsletterPatch';
 
 interface NewsletterAPIResponse {
-	identityName: string;
+	id: string;
 	theme: string;
 	name: string;
 	signUpDescription?: string | null;
@@ -32,14 +32,14 @@ const responseToEntity = (newsletter: NewsletterAPIResponse): NewsLetter => {
 		signUpEmbedDescription,
 		frequency,
 		listId,
-		identityName,
+		id,
 	} = newsletter;
 	return {
 		id: listId.toString(),
 		description: signUpDescription ?? signUpEmbedDescription ?? '',
 		name,
 		frequency,
-		nameId: identityName,
+		nameId: id,
 	};
 };
 


### PR DESCRIPTION
Reverts guardian/gateway#3460

Was fixed by: 
* https://github.com/guardian/identity/pull/3116 
so there's no need for this fix

Tested in CODE with identity main deployed.

<img width="1511" height="568" alt="image" src="https://github.com/user-attachments/assets/98937b3c-b23c-460f-bbd1-18763d8c2fde" />
