### PR TITLE
Iframes show t c

### DIFF
--- a/src/client/__tests__/IframedRegisterWithEmail.test.tsx
+++ b/src/client/__tests__/IframedRegisterWithEmail.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom/jest-globals';
+import type { ComponentProps } from 'react';
+import { IframedRegisterWithEmail } from '../pages/IframedRegisterWithEmail';
+
+type IframedRegisterWithEmailProps = ComponentProps<
+	typeof IframedRegisterWithEmail
+>;
+
+const baseProps: IframedRegisterWithEmailProps = {
+	recaptchaSiteKey: '',
+	queryParams: {
+		returnUrl: 'https://www.theguardian.com/uk',
+	},
+};
+
+const setup = (extraProps?: Partial<IframedRegisterWithEmailProps>) =>
+	render(<IframedRegisterWithEmail {...baseProps} {...extraProps} />);
+
+const guardianTermsText =
+	'For more information about how we use your data, including the generation of random identifiers';
+
+test('shows GuardianTerms for multiple account flow', () => {
+	setup({
+		queryParams: {
+			returnUrl: 'https://www.theguardian.com/uk',
+			appClientId: 'maj',
+		},
+	});
+
+	expect(
+		screen.getByText(guardianTermsText, { exact: false }),
+	).toBeInTheDocument();
+});
+
+test('does not show GuardianTerms outside multiple account flow', () => {
+	setup();
+
+	expect(
+		screen.queryByText(guardianTermsText, { exact: false }),
+	).not.toBeInTheDocument();
+});
+
+test('keeps the iframe register flow email-only even for multiple account flow', () => {
+	setup({
+		queryParams: {
+			returnUrl: 'https://www.theguardian.com/uk',
+			appClientId: 'maj',
+		},
+	});
+
+	expect(screen.queryByText('Continue with Google')).not.toBeInTheDocument();
+	expect(screen.queryByText('Continue with Apple')).not.toBeInTheDocument();
+});

--- a/src/client/__tests__/IframedRegisterWithEmail.test.tsx
+++ b/src/client/__tests__/IframedRegisterWithEmail.test.tsx
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment jsdom
+ */
+
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom/jest-globals';
 import type { ComponentProps } from 'react';

--- a/src/client/__tests__/IframedSignIn.test.tsx
+++ b/src/client/__tests__/IframedSignIn.test.tsx
@@ -1,0 +1,74 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom/jest-globals';
+import { IframedSignIn, IframedSignInProps } from '../pages/IframedSignIn';
+import { SignInErrors } from '@/shared/model/Errors';
+
+const baseProps: IframedSignInProps = {
+	recaptchaSiteKey: '',
+	queryParams: {
+		returnUrl: 'https://www.theguardian.com/uk',
+	},
+};
+
+const setup = (extraProps?: Partial<IframedSignInProps>) =>
+	render(<IframedSignIn {...baseProps} {...extraProps} />);
+
+const guardianTermsText =
+	'For more information about how we use your data, including the generation of random identifiers';
+
+test('shows social auth buttons and GuardianTerms when social buttons are visible', () => {
+	setup();
+
+	expect(screen.getByText('Continue with Google')).toBeInTheDocument();
+	expect(screen.getByText('Continue with Apple')).toBeInTheDocument();
+	expect(
+		screen.getByText(guardianTermsText, { exact: false }),
+	).toBeInTheDocument();
+});
+
+test('shows GuardianTerms for multiple account flow when social buttons are hidden', () => {
+	setup({
+		hideSocialButtons: true,
+		queryParams: {
+			returnUrl: 'https://www.theguardian.com/uk',
+			appClientId: 'maj',
+		},
+	});
+
+	expect(screen.queryByText('Continue with Google')).not.toBeInTheDocument();
+	expect(screen.queryByText('Continue with Apple')).not.toBeInTheDocument();
+	expect(
+		screen.getByText(guardianTermsText, { exact: false }),
+	).toBeInTheDocument();
+});
+
+test('shows GuardianTerms for multiple account flow when social buttons are hidden even if social sign-in is blocked', () => {
+	setup({
+		hideSocialButtons: true,
+		pageError: SignInErrors.SOCIAL_SIGNIN_ERROR,
+		queryParams: {
+			returnUrl: 'https://www.theguardian.com/uk',
+			appClientId: 'maj',
+		},
+	});
+
+	expect(screen.queryByText('Continue with Google')).not.toBeInTheDocument();
+	expect(screen.queryByText('Continue with Apple')).not.toBeInTheDocument();
+	expect(
+		screen.getAllByText(guardianTermsText, { exact: false }).length,
+	).toBeGreaterThan(0);
+});
+
+test('does not show GuardianTerms when social buttons are hidden outside multiple account flow', () => {
+	setup({ hideSocialButtons: true });
+
+	expect(screen.queryByText('Continue with Google')).not.toBeInTheDocument();
+	expect(screen.queryByText('Continue with Apple')).not.toBeInTheDocument();
+	expect(
+		screen.queryByText(guardianTermsText, { exact: false }),
+	).not.toBeInTheDocument();
+});

--- a/src/client/pages/IframedRegisterWithEmail.tsx
+++ b/src/client/pages/IframedRegisterWithEmail.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { MainForm } from '@/client/components/MainForm';
 import { EmailInput } from '@/client/components/EmailInput';
 import { buildUrlWithQueryParams } from '@/shared/lib/routeUtils';
@@ -6,6 +5,8 @@ import { usePageLoadOphanInteraction } from '@/client/lib/hooks/usePageLoadOphan
 import { RegistrationProps } from '@/client/pages/Registration';
 import { registrationFormSubmitOphanTracking } from '@/client/lib/consentsTracking';
 import { MinimalLayout } from '@/client/layouts/MinimalLayout';
+import { GuardianTerms } from '@/client/components/Terms';
+import { InformationBox } from '@/client/components/InformationBox';
 import ThemedLink from '@/client/components/ThemedLink';
 import locations from '@/shared/lib/locations';
 import { SUPPORT_EMAIL } from '@/shared/model/Configuration';
@@ -40,6 +41,18 @@ const getErrorContext = (pageError?: string) => {
 	}
 };
 
+const renderGuardianTerms = (isMultipleAccountFlow: boolean) => {
+	if (!isMultipleAccountFlow) {
+		return null;
+	}
+
+	return (
+		<InformationBox>
+			<GuardianTerms />
+		</InformationBox>
+	);
+};
+
 export const IframedRegisterWithEmail = ({
 	email,
 	recaptchaSiteKey,
@@ -66,6 +79,7 @@ export const IframedRegisterWithEmail = ({
 			errorOverride={pageError}
 			overrideTheme="iframe-light"
 		>
+			{renderGuardianTerms(isMultipleAccountFlow)}
 			<MainForm
 				formAction={buildUrlWithQueryParams('/register', {}, queryParams)}
 				submitButtonText="Create your account"

--- a/src/client/pages/IframedRegisterWithEmail.tsx
+++ b/src/client/pages/IframedRegisterWithEmail.tsx
@@ -41,18 +41,6 @@ const getErrorContext = (pageError?: string) => {
 	}
 };
 
-const renderGuardianTerms = (isMultipleAccountFlow: boolean) => {
-	if (!isMultipleAccountFlow) {
-		return null;
-	}
-
-	return (
-		<InformationBox>
-			<GuardianTerms />
-		</InformationBox>
-	);
-};
-
 export const IframedRegisterWithEmail = ({
 	email,
 	recaptchaSiteKey,

--- a/src/client/pages/IframedRegisterWithEmail.tsx
+++ b/src/client/pages/IframedRegisterWithEmail.tsx
@@ -79,7 +79,11 @@ export const IframedRegisterWithEmail = ({
 			errorOverride={pageError}
 			overrideTheme="iframe-light"
 		>
-			{renderGuardianTerms(isMultipleAccountFlow)}
+			{isMultipleAccountFlow && (
+				<InformationBox>
+					<GuardianTerms />
+				</InformationBox>
+			)}
 			<MainForm
 				formAction={buildUrlWithQueryParams('/register', {}, queryParams)}
 				submitButtonText="Create your account"

--- a/src/client/pages/IframedSignIn.tsx
+++ b/src/client/pages/IframedSignIn.tsx
@@ -128,6 +128,32 @@ const showAuthProviderButtons = (
 	}
 };
 
+const renderPreFormSection = ({
+	hideSocialButtons,
+	isMultipleAccountFlow,
+	socialSigninBlocked,
+	queryParams,
+}: {
+	hideSocialButtons: boolean;
+	isMultipleAccountFlow: boolean;
+	socialSigninBlocked: boolean;
+	queryParams: QueryParams;
+}) => {
+	if (!hideSocialButtons) {
+		return showAuthProviderButtons(socialSigninBlocked, queryParams);
+	}
+
+	if (isMultipleAccountFlow) {
+		return (
+			<InformationBox>
+				<GuardianTerms />
+			</InformationBox>
+		);
+	}
+
+	return null;
+};
+
 export const IframedSignIn = ({
 	email,
 	pageError,
@@ -160,9 +186,12 @@ export const IframedSignIn = ({
 			shortRequestId={shortRequestId}
 			overrideTheme="iframe-light"
 		>
-			{/* AuthProviderButtons component with show boolean */}
-			{!hideSocialButtons &&
-				showAuthProviderButtons(socialSigninBlocked, queryParams)}
+			{renderPreFormSection({
+				hideSocialButtons,
+				isMultipleAccountFlow,
+				socialSigninBlocked,
+				queryParams,
+			})}
 			<MainForm
 				shortRequestId={shortRequestId}
 				formErrorMessageFromParent={formError}


### PR DESCRIPTION
## What does this change?

Adds the Terms & Conditions text to the register and signin iframes.

The Sign-In iFrame was showing it together with social login buttons, so had to make sure that for multiple accounts we only show the t&cs without socials.

The Register was not showing it at all, so simply added it but only when it's multiple accounts, leaving every other flow unchanged - Emily is going to check if this omission is a problem, but that will be tackled later.

## How has this change been tested?

Wrote tests to verify these flows work as intended and show the elements we expect.

Also tested locally using the very useful `dev.ts` page with custom links to initiate these flows. And tested in CODE.

## How can we measure success?

The T&Cs appear when it's multiple account sign in and registration.

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
