### PR TITLE
Update policies to use immutable subject claim.

### DIFF
--- a/cdk/lib/__snapshots__/identity-gateway.test.ts.snap
+++ b/cdk/lib/__snapshots__/identity-gateway.test.ts.snap
@@ -382,10 +382,7 @@ exports[`The IdentityGateway stack matches the snapshot 1`] = `
               "Action": "sts:AssumeRoleWithWebIdentity",
               "Condition": {
                 "StringLike": {
-                  "token.actions.githubusercontent.com:sub": [
-                    "repo:guardian/gateway:*",
-                    "repo:guardian@164318/gateway@226145935:*",
-                  ],
+                  "token.actions.githubusercontent.com:sub": "repo:guardian@164318/gateway@226145935:*",
                 },
               },
               "Effect": "Allow",

--- a/cdk/lib/__snapshots__/identity-gateway.test.ts.snap
+++ b/cdk/lib/__snapshots__/identity-gateway.test.ts.snap
@@ -382,7 +382,10 @@ exports[`The IdentityGateway stack matches the snapshot 1`] = `
               "Action": "sts:AssumeRoleWithWebIdentity",
               "Condition": {
                 "StringLike": {
-                  "token.actions.githubusercontent.com:sub": "repo:guardian@164318/gateway@226145935:*",
+                  "token.actions.githubusercontent.com:sub": [
+                    "repo:guardian/gateway:*",
+                    "repo:guardian@164318/gateway@226145935:*",
+                  ],
                 },
               },
               "Effect": "Allow",

--- a/cdk/lib/__snapshots__/identity-gateway.test.ts.snap
+++ b/cdk/lib/__snapshots__/identity-gateway.test.ts.snap
@@ -382,7 +382,7 @@ exports[`The IdentityGateway stack matches the snapshot 1`] = `
               "Action": "sts:AssumeRoleWithWebIdentity",
               "Condition": {
                 "StringLike": {
-                  "token.actions.githubusercontent.com:sub": "repo:guardian/gateway:*",
+                  "token.actions.githubusercontent.com:sub": "repo:guardian@164318/gateway:*",
                 },
               },
               "Effect": "Allow",

--- a/cdk/lib/__snapshots__/identity-gateway.test.ts.snap
+++ b/cdk/lib/__snapshots__/identity-gateway.test.ts.snap
@@ -382,7 +382,7 @@ exports[`The IdentityGateway stack matches the snapshot 1`] = `
               "Action": "sts:AssumeRoleWithWebIdentity",
               "Condition": {
                 "StringLike": {
-                  "token.actions.githubusercontent.com:sub": "repo:guardian@164318/gateway:*",
+                  "token.actions.githubusercontent.com:sub": "repo:guardian@164318/gateway@226145935:*",
                 },
               },
               "Effect": "Allow",

--- a/cdk/lib/identity-gateway.ts
+++ b/cdk/lib/identity-gateway.ts
@@ -557,7 +557,7 @@ systemctl start ${app}
 				assumedBy: new WebIdentityPrincipal(`arn:aws:iam::${this.account}:oidc-provider/token.actions.githubusercontent.com`,
 					{
 						StringLike: {
-							'token.actions.githubusercontent.com:sub': 'repo:guardian@164318/gateway:*',
+							'token.actions.githubusercontent.com:sub': 'repo:guardian@164318/gateway@226145935:*',
 						}
 					}
 				),

--- a/cdk/lib/identity-gateway.ts
+++ b/cdk/lib/identity-gateway.ts
@@ -557,10 +557,7 @@ systemctl start ${app}
 				assumedBy: new WebIdentityPrincipal(`arn:aws:iam::${this.account}:oidc-provider/token.actions.githubusercontent.com`,
 					{
 						StringLike: {
-							'token.actions.githubusercontent.com:sub': [
-								'repo:guardian/gateway:*',
-								'repo:guardian@164318/gateway:*'
-							]
+							'token.actions.githubusercontent.com:sub': 'repo:guardian@164318/gateway:*',
 						}
 					}
 				),

--- a/cdk/lib/identity-gateway.ts
+++ b/cdk/lib/identity-gateway.ts
@@ -557,7 +557,7 @@ systemctl start ${app}
 				assumedBy: new WebIdentityPrincipal(`arn:aws:iam::${this.account}:oidc-provider/token.actions.githubusercontent.com`,
 					{
 						StringLike: {
-							'token.actions.githubusercontent.com:sub': 'repo:guardian/gateway:*',
+							'token.actions.githubusercontent.com:sub': 'repo:guardian@164318/gateway:*',
 						}
 					}
 				),

--- a/cdk/lib/identity-gateway.ts
+++ b/cdk/lib/identity-gateway.ts
@@ -557,7 +557,10 @@ systemctl start ${app}
 				assumedBy: new WebIdentityPrincipal(`arn:aws:iam::${this.account}:oidc-provider/token.actions.githubusercontent.com`,
 					{
 						StringLike: {
-							'token.actions.githubusercontent.com:sub': 'repo:guardian@164318/gateway@226145935:*',
+							'token.actions.githubusercontent.com:sub': [
+								'repo:guardian/gateway:*',
+								'repo:guardian@164318/gateway@226145935:*',
+							]
 						}
 					}
 				),

--- a/cdk/lib/identity-gateway.ts
+++ b/cdk/lib/identity-gateway.ts
@@ -557,7 +557,10 @@ systemctl start ${app}
 				assumedBy: new WebIdentityPrincipal(`arn:aws:iam::${this.account}:oidc-provider/token.actions.githubusercontent.com`,
 					{
 						StringLike: {
-							'token.actions.githubusercontent.com:sub': 'repo:guardian@164318/gateway:*',
+							'token.actions.githubusercontent.com:sub': [
+								'repo:guardian/gateway:*',
+								'repo:guardian@164318/gateway:*'
+							]
 						}
 					}
 				),

--- a/cdk/lib/identity-gateway.ts
+++ b/cdk/lib/identity-gateway.ts
@@ -557,10 +557,7 @@ systemctl start ${app}
 				assumedBy: new WebIdentityPrincipal(`arn:aws:iam::${this.account}:oidc-provider/token.actions.githubusercontent.com`,
 					{
 						StringLike: {
-							'token.actions.githubusercontent.com:sub': [
-								'repo:guardian/gateway:*',
-								'repo:guardian@164318/gateway@226145935:*',
-							]
+							'token.actions.githubusercontent.com:sub': 'repo:guardian@164318/gateway@226145935:*',
 						}
 					}
 				),


### PR DESCRIPTION
## What does this change?

DevEx has asked us to switch to Immutable subject claims, as per [this](https://metrics.gutools.co.uk/d/as56xpl/gha-oidc-helper?folderUid=Wfz5MulWk&orgId=1&from=2026-08-20T09:20:17.528Z&to=2026-08-20T15:20:17.528Z&timezone=browser&var-query0=&var-repository=us-abortion-tracker&var-full_name=guardian%2Fgateway&var-query0-2=&var-repository_id=226145935&var-query0-3=&var-organization_id=164318&var-copy_of_repository_id=621081925&var-repository_name=gateway&var-copy_of_organization_id=guardian&var-organization_name=guardian&showCategory=Text).

This PR does that.

## How has this change been tested?

Broke the pipeline on purpose by only setting the new name on one side, then fixed it by checking the checkbox in repo setting, as per instructions.

This only affects CODE (using in tests).

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
